### PR TITLE
refactor(hierarchy): optimize mobile usability in area tree

### DIFF
--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -24,6 +24,12 @@ export interface HierarchyColumnWidths {
   notes: number;
 }
 
+export interface HierarchyColumnOptions {
+  isMobile?: boolean;
+  expandedMobileDetailRows?: Set<string | number>;
+  onToggleMobileDetails?: (rowId: string | number) => void;
+}
+
 export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
   name: 280,
   area: 120,
@@ -38,6 +44,8 @@ interface NameCellCallbacks {
   onAddField: (locationId?: number) => void;
   onDeleteField: (fieldId: number) => void;
   onCreatePlantingPlan: (bedId: number) => void;
+  onOpenNotes: (rowId: string | number, field: string) => void;
+  onToggleMobileDetails: (rowId: string | number) => void;
 }
 
 function renderActionIconButton({
@@ -45,11 +53,13 @@ function renderActionIconButton({
   color,
   onClick,
   icon,
+  touchFriendly,
 }: {
   label: string;
   color?: 'default' | 'primary' | 'error';
   onClick: (event: MouseEvent) => void;
   icon: ReactElement;
+  touchFriendly?: boolean;
 }): ReactElement {
   return (
     <Tooltip title={label}>
@@ -57,6 +67,14 @@ function renderActionIconButton({
         size="small"
         color={color}
         aria-label={label}
+        sx={
+          touchFriendly
+            ? {
+                width: 40,
+                height: 40,
+              }
+            : undefined
+        }
         onClick={(event) => {
           event.stopPropagation();
           onClick(event);
@@ -71,7 +89,8 @@ function renderActionIconButton({
 function renderInlineActions(
   row: HierarchyRow,
   callbacks: NameCellCallbacks,
-  t: TFunction
+  t: TFunction,
+  isMobile?: boolean,
 ): ReactElement | null {
   if (row.type === 'location') {
     return renderActionIconButton({
@@ -79,6 +98,7 @@ function renderInlineActions(
       color: 'primary',
       onClick: () => callbacks.onAddField(row.locationId),
       icon: <AddIcon fontSize="small" />,
+      touchFriendly: isMobile,
     });
   }
 
@@ -90,12 +110,14 @@ function renderInlineActions(
           color: 'primary',
           onClick: () => callbacks.onAddBed(row.fieldId!),
           icon: <AddIcon fontSize="small" />,
+          touchFriendly: isMobile,
         })}
         {renderActionIconButton({
           label: t('common:actions.delete'),
           color: 'error',
           onClick: () => callbacks.onDeleteField(row.fieldId!),
           icon: <DeleteIcon fontSize="small" />,
+          touchFriendly: isMobile,
         })}
       </>
     );
@@ -109,12 +131,14 @@ function renderInlineActions(
           color: 'primary',
           onClick: () => callbacks.onCreatePlantingPlan(row.bedId!),
           icon: <AgricultureIcon fontSize="small" />,
+          touchFriendly: isMobile,
         })}
         {renderActionIconButton({
           label: t('common:actions.delete'),
           color: 'error',
           onClick: () => callbacks.onDeleteBed(row.bedId!),
           icon: <DeleteIcon fontSize="small" />,
+          touchFriendly: isMobile,
         })}
       </>
     );
@@ -126,51 +150,98 @@ function renderInlineActions(
 function renderNameCell(
   params: GridRenderCellParams<HierarchyRow>,
   callbacks: NameCellCallbacks,
-  t: TFunction
+  t: TFunction,
+  options?: HierarchyColumnOptions,
 ) {
   const row = params.row;
+  const isMobile = options?.isMobile ?? false;
   const baseIndent = row.level * 24;
-  const indent = row.type === 'bed' ? baseIndent + 34 : baseIndent;
+  const indent = row.type === 'bed' ? baseIndent + (isMobile ? 22 : 34) : baseIndent;
 
   const hasExpandToggle = row.type === 'location' || row.type === 'field';
+  const hasMobileDetails = isMobile && row.type !== 'location';
+  const detailsExpanded = options?.expandedMobileDetailRows?.has(row.id) ?? false;
   const showInlineActions = params.cellMode !== 'edit';
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', pl: `${indent}px`, width: '100%', gap: 0.5 }}>
-      {hasExpandToggle && (
-        <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}><IconButton
-          size="small"
-          aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
-          onClick={(event) => {
-            event.stopPropagation();
-            callbacks.onToggleExpand(row.id);
-          }}
-          sx={{ mr: 1 }}
-        >
-          {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-        </IconButton></Tooltip>
-      )}
+    <Box sx={{ display: 'flex', flexDirection: 'column', pl: `${indent}px`, width: '100%', py: isMobile ? 0.5 : 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', gap: 0.5 }}>
+        {hasExpandToggle && (
+          <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}>
+            <IconButton
+              size="small"
+              aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
+              onClick={(event) => {
+                event.stopPropagation();
+                callbacks.onToggleExpand(row.id);
+              }}
+              sx={{ mr: 0.5, width: isMobile ? 40 : undefined, height: isMobile ? 40 : undefined }}
+            >
+              {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+            </IconButton>
+          </Tooltip>
+        )}
 
-      {!hasExpandToggle && <Box sx={{ width: 32 }} />}
+        {!hasExpandToggle && <Box sx={{ width: isMobile ? 40 : 32 }} />}
 
-      <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5 }}>
-        <Box
-          component="span"
-          sx={{
-            fontWeight: row.type === 'location' ? 'bold' : 'normal',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            maxWidth: '100%',
-          }}
-        >
-          {params.value}
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5, flex: 1 }}>
+          <Box
+            component="span"
+            sx={{
+              fontWeight: row.type === 'location' ? 'bold' : 'normal',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '100%',
+            }}
+          >
+            {params.value}
+          </Box>
+
+          {hasMobileDetails && showInlineActions && (
+            <Tooltip title={detailsExpanded ? t('tooltips.collapse') : t('tooltips.expand')}>
+              <IconButton
+                size="small"
+                aria-label={detailsExpanded ? t('tooltips.collapse') : t('tooltips.expand')}
+                sx={{ width: 40, height: 40 }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  callbacks.onToggleMobileDetails(row.id);
+                }}
+              >
+                {detailsExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+              </IconButton>
+            </Tooltip>
+          )}
         </Box>
 
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
-          {showInlineActions ? renderInlineActions(row, callbacks, t) : null}
+          {showInlineActions ? renderInlineActions(row, callbacks, t, isMobile) : null}
         </Box>
       </Box>
+
+      {hasMobileDetails && detailsExpanded && (
+        <Box
+          sx={{
+            mt: 0.5,
+            ml: hasExpandToggle ? 5 : 6,
+            fontSize: '0.75rem',
+            color: 'text.secondary',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+            gap: 0.5,
+          }}
+        >
+          <Box>{t('columns.length')}: {row.length_m ?? '—'}</Box>
+          <Box>{t('columns.width')}: {row.width_m ?? '—'}</Box>
+          <Box
+            sx={{ gridColumn: '1 / -1', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            onClick={() => callbacks.onOpenNotes(row.id, 'notes')}
+          >
+            {t('common:fields.notes')}: {row.notes?.trim() ? getPlainExcerpt(row.notes, 80) : '—'}
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -198,7 +269,8 @@ export function createHierarchyColumns(
   onCreatePlantingPlan: (bedId: number) => void,
   onOpenNotes: (rowId: string | number, field: string) => void,
   t: TFunction,
-  columnWidths?: Partial<HierarchyColumnWidths>
+  columnWidths?: Partial<HierarchyColumnWidths>,
+  options?: HierarchyColumnOptions,
 ): GridColDef<HierarchyRow>[] {
   const widths: HierarchyColumnWidths = {
     ...DEFAULT_HIERARCHY_COLUMN_WIDTHS,
@@ -212,6 +284,8 @@ export function createHierarchyColumns(
     onAddField,
     onDeleteField,
     onCreatePlantingPlan,
+    onOpenNotes,
+    onToggleMobileDetails: options?.onToggleMobileDetails ?? (() => undefined),
   };
 
   return [
@@ -220,7 +294,7 @@ export function createHierarchyColumns(
       headerName: t('hierarchy:columns.name'),
       width: widths.name,
       editable: true,
-      renderCell: (params) => renderNameCell(params, callbacks, t),
+      renderCell: (params) => renderNameCell(params, callbacks, t, options),
       preProcessEditCellProps: (params) => {
         const hasError = !params.props.value || params.props.value.trim() === '';
         return { ...params.props, error: hasError };

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -19,7 +19,7 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "../i18n";
 import { DataGrid, GridRowModes } from "@mui/x-data-grid";
 import type { GridRowsProp, GridRowModesModel } from "@mui/x-data-grid";
-import { Box, Alert } from "@mui/material";
+import { Box, Alert, useMediaQuery, useTheme } from "@mui/material";
 import { dataGridSx } from "../components/data-grid/styles";
 import {
   handleRowEditStop,
@@ -58,11 +58,14 @@ function FieldsBedsHierarchy({
 }: FieldsBedsHierarchyProps): React.ReactElement {
   const { t } = useTranslation("hierarchy");
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
   const [selectedRowId, setSelectedRowId] = useState<string | number | null>(
     null,
   );
   const [treeActive, setTreeActive] = useState(false);
+  const [expandedMobileDetailRows, setExpandedMobileDetailRows] = useState<Set<string | number>>(new Set());
   const hasInitiallyExpandedRef = useRef(false);
   const tableWrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -738,6 +741,21 @@ function FieldsBedsHierarchy({
         ...DEFAULT_HIERARCHY_COLUMN_WIDTHS,
         name: nameColumnWidth,
       },
+      {
+        isMobile,
+        expandedMobileDetailRows,
+        onToggleMobileDetails: (rowId) => {
+          setExpandedMobileDetailRows((previous) => {
+            const next = new Set(previous);
+            if (next.has(rowId)) {
+              next.delete(rowId);
+            } else {
+              next.add(rowId);
+            }
+            return next;
+          });
+        },
+      },
     );
   }, [
     toggleExpand,
@@ -749,6 +767,8 @@ function FieldsBedsHierarchy({
     notesEditor.handleOpen,
     t,
     nameColumnWidth,
+    isMobile,
+    expandedMobileDetailRows,
   ]);
 
   return (
@@ -764,7 +784,7 @@ function FieldsBedsHierarchy({
 
         <Box
           ref={tableWrapperRef}
-          sx={{ width: "100%", overflowX: "auto" }}
+          sx={{ width: "100%", overflowX: isMobile ? "hidden" : "auto" }}
           onClick={() => setTreeActive(true)}
         >
           <DataGrid
@@ -783,6 +803,18 @@ function FieldsBedsHierarchy({
             sortModel={sortModel}
             onSortModelChange={setSortModel}
             isRowSelectable={() => true}
+            columnVisibilityModel={{
+              length_m: !isMobile,
+              width_m: !isMobile,
+              notes: !isMobile,
+            }}
+            getRowHeight={(params) => {
+              if (!isMobile) {
+                return null;
+              }
+              const rowId = params.id;
+              return expandedMobileDetailRows.has(rowId) ? 102 : 56;
+            }}
             isCellEditable={(params) => {
               if (params.row.type === "field") {
                 return (


### PR DESCRIPTION
### Motivation
- Improve usability of the existing Standort → Schlag → Beet hierarchy on small screens while keeping the nested expand/collapse model unchanged. 
- Reduce horizontal scrolling on mobile and surface only the most important information (`Name`, `Fläche`) in the main row. 
- Make touch targets for expand/collapse and inline actions more comfortable for finger input without changing data or hierarchy logic.

### Description
- Added responsive detection and mobile state to `FieldsBedsHierarchy.tsx` and passed mobile options into `createHierarchyColumns` to enable mobile-aware rendering. 
- Hid less-important columns on small viewports via `columnVisibilityModel` and implemented mobile row heights via `getRowHeight` to allow a compact default row and a taller expanded detail row. 
- Implemented an in-row mobile detail area inside `HierarchyColumns.tsx` that shows `Länge`, `Breite` and `Notizen` on demand for field/bed rows, preserving the hierarchical layout. 
- Increased tappable sizes for expand/collapse and inline action buttons by adding touch-friendly `sx` values to the action `IconButton`s (no change to underlying APIs or data structures). 

### Testing
- Ran the focused unit tests `npm test -- --run src/__tests__/hierarchyComponents.test.tsx` and they passed. 
- Linted the modified files with `npx eslint src/components/hierarchy/HierarchyColumns.tsx src/pages/FieldsBedsHierarchy.tsx` and the checks passed for those files. 
- A full repository lint `npm run lint` surfaced pre-existing, unrelated lint issues in other files (reported but not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccbc8e2ee883228f6a9b8a8e8af521)