### PR TITLE
fix(frontend): show bed labels earlier and at max zoom

### DIFF
--- a/frontend/src/__tests__/graphicalViewport.test.ts
+++ b/frontend/src/__tests__/graphicalViewport.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  GRAPHICAL_MAX_SCALE,
   GRAPHICAL_MANUAL_MIN_SCALE,
+  BED_LABEL_MIN_SCALE,
   clampViewportToStage,
   fitBoundsToStage,
   fitContentToStage,
@@ -35,12 +37,21 @@ describe('graphicalViewport helpers', () => {
     });
   });
 
-  it('shows labels only when zoom and size are sufficient', () => {
+  it('shows labels when zoom is sufficient or when the bed is large enough on screen', () => {
     expect(shouldShowFieldLabel({ width: 150, height: 80 }, 1)).toBe(true);
     expect(shouldShowFieldLabel({ width: 80, height: 30 }, 1)).toBe(false);
     expect(shouldShowBedLabel({ width: 120, height: 50 }, ZOOM_LEVEL_DETAIL)).toBe(true);
-    expect(shouldShowBedLabel({ width: 60, height: 20 }, ZOOM_LEVEL_DETAIL)).toBe(false);
-    expect(shouldShowBedLabel({ width: 120, height: 50 }, ZOOM_LEVEL_OVERVIEW)).toBe(false);
+    expect(shouldShowBedLabel({ width: 60, height: 20 }, ZOOM_LEVEL_DETAIL)).toBe(true);
+    expect(shouldShowBedLabel({ width: 120, height: 50 }, ZOOM_LEVEL_OVERVIEW)).toBe(true);
+    expect(shouldShowBedLabel({ width: 80, height: 28 }, BED_LABEL_MIN_SCALE - 0.05)).toBe(true);
+  });
+
+  it('shows bed labels at maximum zoom even for moderately sized beds', () => {
+    expect(shouldShowBedLabel({ width: 28, height: 14 }, GRAPHICAL_MAX_SCALE)).toBe(true);
+  });
+
+  it('keeps bed labels hidden when beds are truly too small', () => {
+    expect(shouldShowBedLabel({ width: 12, height: 5 }, GRAPHICAL_MAX_SCALE)).toBe(false);
   });
 
   it('fits content into the available stage size', () => {

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1518,31 +1518,48 @@ export default function GraphicalFields({
                                       },
                                       viewport.scale,
                                     ) ? (
-                                      <Text
-                                        x={
-                                          currentFieldRect.x +
-                                          FIELD_INNER_OFFSET_X +
-                                          4 +
-                                          bedVm.x
-                                        }
-                                        y={
-                                          currentFieldRect.y +
-                                          FIELD_INNER_OFFSET_Y +
-                                          4 +
-                                          bedVm.y
-                                        }
-                                        text={
-                                          visibility.showDetailedBedLabels
+                                      (() => {
+                                        const bedScreenWidth =
+                                          bedVm.width * viewport.scale;
+                                        const bedScreenHeight =
+                                          bedVm.height * viewport.scale;
+                                        const shouldUseCompactLabel =
+                                          bedScreenWidth < 120 ||
+                                          bedScreenHeight < 42;
+                                        const labelText =
+                                          visibility.showDetailedBedLabels &&
+                                          !shouldUseCompactLabel
                                             ? `${bedVm.name} (${bedVm.area || "-"} m²)`
-                                            : bedVm.name
-                                        }
-                                        fontSize={12}
-                                        width={Math.max(40, bedVm.width - 8)}
-                                        wrap="word"
-                                        listening={false}
-                                        scaleX={1 / viewport.scale}
-                                        scaleY={1 / viewport.scale}
-                                      />
+                                            : bedVm.name;
+                                        return (
+                                          <Text
+                                            x={
+                                              currentFieldRect.x +
+                                              FIELD_INNER_OFFSET_X +
+                                              4 +
+                                              bedVm.x
+                                            }
+                                            y={
+                                              currentFieldRect.y +
+                                              FIELD_INNER_OFFSET_Y +
+                                              4 +
+                                              bedVm.y
+                                            }
+                                            text={labelText}
+                                            fontSize={
+                                              shouldUseCompactLabel ? 11 : 12
+                                            }
+                                            width={Math.max(
+                                              36,
+                                              bedScreenWidth - 8,
+                                            )}
+                                            wrap="word"
+                                            listening={false}
+                                            scaleX={1 / viewport.scale}
+                                            scaleY={1 / viewport.scale}
+                                          />
+                                        );
+                                      })()
                                     ) : null}
                                   </Group>
                                 ))

--- a/frontend/src/pages/graphicalViewport.ts
+++ b/frontend/src/pages/graphicalViewport.ts
@@ -12,6 +12,11 @@ export const FIELD_LABEL_MIN_WIDTH = 110;
 export const FIELD_LABEL_MIN_HEIGHT = 48;
 export const BED_LABEL_MIN_WIDTH = 88;
 export const BED_LABEL_MIN_HEIGHT = 36;
+export const BED_LABEL_MIN_SCALE = Math.min(1, GRAPHICAL_MAX_SCALE);
+export const BED_LABEL_MIN_SCREEN_WIDTH = 76;
+export const BED_LABEL_MIN_SCREEN_HEIGHT = 26;
+export const BED_LABEL_ABSOLUTE_MIN_SCREEN_WIDTH = 46;
+export const BED_LABEL_ABSOLUTE_MIN_SCREEN_HEIGHT = 18;
 
 export interface ViewportState {
   scale: number;
@@ -134,7 +139,21 @@ export function shouldShowFieldLabel(size: RectSize, scale: number): boolean {
 }
 
 export function shouldShowBedLabel(size: RectSize, scale: number): boolean {
-  return scale >= ZOOM_LEVEL_MEDIUM && size.width >= BED_LABEL_MIN_WIDTH && size.height >= BED_LABEL_MIN_HEIGHT;
+  const screenWidth = size.width * scale;
+  const screenHeight = size.height * scale;
+  const hasAbsoluteSpace =
+    screenWidth >= BED_LABEL_ABSOLUTE_MIN_SCREEN_WIDTH &&
+    screenHeight >= BED_LABEL_ABSOLUTE_MIN_SCREEN_HEIGHT;
+  if (!hasAbsoluteSpace) {
+    return false;
+  }
+
+  const hasComfortableSpace =
+    screenWidth >= BED_LABEL_MIN_SCREEN_WIDTH &&
+    screenHeight >= BED_LABEL_MIN_SCREEN_HEIGHT;
+  const reachedZoomThreshold = scale >= BED_LABEL_MIN_SCALE;
+  const reachedMaxZoom = scale >= GRAPHICAL_MAX_SCALE;
+  return reachedZoomThreshold || hasComfortableSpace || reachedMaxZoom;
 }
 
 export function fitBoundsToStage(


### PR DESCRIPTION
### Motivation
- Bed labels could remain hidden even at the maximum allowed zoom, making some beds never show readable names.
- The goal is to guarantee labels are visible at max zoom, show them earlier than before, and allow labels to appear based on on-screen pixel size as well as zoom.

### Description
- Replace prior bed-label rule with combined logic that shows labels when either a zoom threshold is reached or the bed has enough on-screen pixel size, and keep a strict absolute pixel minimum to hide truly tiny beds (`frontend/src/pages/graphicalViewport.ts`).
- Bound the label zoom threshold so it never exceeds `GRAPHICAL_MAX_SCALE` and add new pixel-size constants used for the on-screen checks (`BED_LABEL_MIN_SCALE`, `BED_LABEL_MIN_SCREEN_*`, `BED_LABEL_ABSOLUTE_MIN_SCREEN_*`).
- Update canvas rendering for bed labels to pick a compact label form (name-only) and slightly reduced font when on-screen space is tight, and compute text width based on on-screen bed size so labels fit better (`frontend/src/pages/GraphicalFields.tsx`).
- Extend and update tests to cover: label visibility at maximum zoom, label visibility for sufficiently large beds, and suppression for truly tiny beds (`frontend/src/__tests__/graphicalViewport.test.ts`).

### Testing
- Ran unit tests: `cd frontend && npm run test -- src/__tests__/graphicalViewport.test.ts`, all tests passed.
- Ran linter: `cd frontend && npx eslint src/pages/graphicalViewport.ts src/pages/GraphicalFields.tsx src/__tests__/graphicalViewport.test.ts`, which completed with existing React hook warnings in `GraphicalFields.tsx` and no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8ec3f978832289aa82f202cfe333)