### PR TITLE
fix: harden project isolation and production security defaults

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -153,6 +153,7 @@ class CsrfTokenView(APIView):
 
 class RegisterView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_register'
 
     def post(self, request: Request) -> Response:
         serializer = RegisterSerializer(data=request.data)
@@ -165,6 +166,7 @@ class RegisterView(APIView):
 
 class ActivateView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_activation'
 
     def post(self, request: Request) -> Response:
         serializer = ActivateSerializer(data=request.data)
@@ -192,6 +194,7 @@ class ActivateView(APIView):
 
 class LoginView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_login'
 
     def post(self, request: Request) -> Response:
         serializer = LoginSerializer(data=request.data)
@@ -316,6 +319,7 @@ class AccountStatusView(APIView):
 
 class ResendActivationView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_resend_activation'
 
     def post(self, request: Request) -> Response:
         serializer = ResendActivationSerializer(data=request.data)
@@ -332,6 +336,7 @@ class ResendActivationView(APIView):
 
 class PasswordResetRequestView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_password_reset_request'
 
     def post(self, request: Request) -> Response:
         serializer = PasswordResetRequestSerializer(data=request.data)
@@ -347,6 +352,7 @@ class PasswordResetRequestView(APIView):
 
 class PasswordResetConfirmView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_scope = 'auth_password_reset_confirm'
 
     def post(self, request: Request) -> Response:
         serializer = PasswordResetConfirmSerializer(data=request.data)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -213,6 +213,8 @@ _public_frontend_url_from_env = _env_str('PUBLIC_FRONTEND_URL', '')
 PUBLIC_FRONTEND_URL = _public_frontend_url_from_env or FRONTEND_URL
 
 if not DEBUG:
+    if SECRET_KEY == 'django-insecure-ov1io#b(%s+zc#ue30exe(t(sa3d7xf*i4biy7zh*yx95pzitd':
+        raise ImproperlyConfigured('SECRET_KEY must be set explicitly when DEBUG is False.')
     parsed_public_frontend_url = urlparse(PUBLIC_FRONTEND_URL)
     if not parsed_public_frontend_url.scheme or not parsed_public_frontend_url.netloc:
         raise ImproperlyConfigured('PUBLIC_FRONTEND_URL must be an absolute URL when DEBUG is False.')
@@ -270,6 +272,19 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.ScopedRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'auth_login': _env_str('THROTTLE_AUTH_LOGIN', '10/minute'),
+        'auth_register': _env_str('THROTTLE_AUTH_REGISTER', '5/minute'),
+        'auth_activation': _env_str('THROTTLE_AUTH_ACTIVATION', '10/minute'),
+        'auth_resend_activation': _env_str('THROTTLE_AUTH_RESEND_ACTIVATION', '5/minute'),
+        'auth_password_reset_request': _env_str('THROTTLE_AUTH_PASSWORD_RESET_REQUEST', '5/minute'),
+        'auth_password_reset_confirm': _env_str('THROTTLE_AUTH_PASSWORD_RESET_CONFIRM', '10/minute'),
+        'invitation_accept': _env_str('THROTTLE_INVITATION_ACCEPT', '20/hour'),
+        'agent_login_consume': _env_str('THROTTLE_AGENT_LOGIN_CONSUME', '30/hour'),
+    },
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100,
 }

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -49,7 +49,7 @@ SECRET_KEY = os.getenv(
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # In production, explicitly set DEBUG=False via environment variable
-DEBUG = os.getenv('DEBUG', 'True').lower() in ('true', '1', 'yes')
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 # Environment selector used for security-sensitive development overrides.
 DJANGO_ENV = _env_str('DJANGO_ENV', 'production').lower()
@@ -246,6 +246,22 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 _csrf_origins_str = os.getenv('CSRF_TRUSTED_ORIGINS', '')
 CSRF_TRUSTED_ORIGINS = [origin.strip() for origin in _csrf_origins_str.split(',') if origin.strip()]
 
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = _env_str('SESSION_COOKIE_SAMESITE', 'Lax')
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SAMESITE = _env_str('CSRF_COOKIE_SAMESITE', 'Lax')
+
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_SSL_REDIRECT = _env_str('SECURE_SSL_REDIRECT', 'True').lower() in ('true', '1', 'yes')
+    SECURE_HSTS_SECONDS = int(_env_str('SECURE_HSTS_SECONDS', '31536000') or '31536000')
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = _env_str('SECURE_HSTS_INCLUDE_SUBDOMAINS', 'True').lower() in ('true', '1', 'yes')
+    SECURE_HSTS_PRELOAD = _env_str('SECURE_HSTS_PRELOAD', 'True').lower() in ('true', '1', 'yes')
+    SECURE_REFERRER_POLICY = _env_str('SECURE_REFERRER_POLICY', 'strict-origin-when-cross-origin')
+    X_FRAME_OPTIONS = _env_str('X_FRAME_OPTIONS', 'DENY')
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+
 # REST Framework settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
@@ -258,10 +274,11 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
 }
 
-CSRF_COOKIE_SAMESITE = os.getenv('CSRF_COOKIE_SAMESITE', 'Lax')
-SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
-CSRF_COOKIE_SECURE = os.getenv('CSRF_COOKIE_SECURE', 'False').lower() in ('true', '1', 'yes')
-SESSION_COOKIE_SECURE = os.getenv('SESSION_COOKIE_SECURE', 'False').lower() in ('true', '1', 'yes')
+CSRF_COOKIE_SAMESITE = _env_str('CSRF_COOKIE_SAMESITE', CSRF_COOKIE_SAMESITE)
+SESSION_COOKIE_SAMESITE = _env_str('SESSION_COOKIE_SAMESITE', SESSION_COOKIE_SAMESITE)
+if DEBUG:
+    CSRF_COOKIE_SECURE = _env_str('CSRF_COOKIE_SECURE', 'False').lower() in ('true', '1', 'yes')
+    SESSION_COOKIE_SECURE = _env_str('SESSION_COOKIE_SECURE', 'False').lower() in ('true', '1', 'yes')
 
 
 

--- a/backend/config/settings_test.py
+++ b/backend/config/settings_test.py
@@ -1,5 +1,10 @@
 """Test settings for running tests with SQLite database."""
 
+import os
+
+os.environ.setdefault('DEBUG', 'True')
+os.environ.setdefault('PUBLIC_FRONTEND_URL', 'http://localhost:5173')
+
 from .settings import *  # noqa: F403, F401
 
 # Override database to use SQLite for tests
@@ -15,3 +20,4 @@ DATABASES = {
 REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = [  # type: ignore[name-defined]
     'rest_framework.permissions.AllowAny',
 ]
+REST_FRAMEWORK['DEFAULT_THROTTLE_CLASSES'] = []  # type: ignore[name-defined]

--- a/backend/farm/serializers.py
+++ b/backend/farm/serializers.py
@@ -39,6 +39,19 @@ from .models import (
 )
 
 
+def _resolve_active_project_from_serializer(serializer) -> Project | None:
+    """Resolve active project from serializer context or bound instance."""
+    request = serializer.context.get('request')
+    if request is not None:
+        active_project = getattr(request, 'active_project', None)
+        if active_project is not None:
+            return active_project
+    instance = getattr(serializer, 'instance', None)
+    if instance is not None and hasattr(instance, 'project'):
+        return instance.project
+    return None
+
+
 class AuditUserSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     email = serializers.EmailField()
@@ -154,6 +167,14 @@ class FieldSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError('Width must be greater than or equal to 0.')
         return value
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        project = _resolve_active_project_from_serializer(self)
+        location = attrs.get('location') or getattr(self.instance, 'location', None)
+        if project is not None and location is not None and location.project_id != project.id:
+            raise serializers.ValidationError({'location': 'Location does not belong to the active project.'})
+        return attrs
+
 
 class BedSerializer(serializers.ModelSerializer):
     field_name = serializers.CharField(source='field.name', read_only=True)
@@ -194,6 +215,14 @@ class BedSerializer(serializers.ModelSerializer):
         if value is not None and value < 0:
             raise serializers.ValidationError('Width must be greater than or equal to 0.')
         return value
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        project = _resolve_active_project_from_serializer(self)
+        field = attrs.get('field') or getattr(self.instance, 'field', None)
+        if project is not None and field is not None and field.project_id != project.id:
+            raise serializers.ValidationError({'field': 'Field does not belong to the active project.'})
+        return attrs
 
 
 class FieldLayoutSerializer(serializers.ModelSerializer):
@@ -273,10 +302,16 @@ class SeedPackageSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
+        project = _resolve_active_project_from_serializer(self)
 
         culture = attrs.get('culture')
+        if culture is None and self.instance is not None:
+            culture = self.instance.culture
         size_value = attrs.get('size_value')
         size_unit = attrs.get('size_unit')
+
+        if project is not None and culture is not None and culture.project_id != project.id:
+            raise serializers.ValidationError({'culture': 'Culture does not belong to the active project.'})
 
         if culture is None or size_value is None or size_unit is None:
             return attrs
@@ -371,16 +406,18 @@ class CultureSupplierDataSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
+        project = _resolve_active_project_from_serializer(self)
+        culture = self._resolve_culture_for_validation(attrs)
+        supplier = attrs.get('supplier') or (self.instance.supplier if self.instance is not None else None)
+        if project is not None and culture is not None and culture.project_id != project.id:
+            raise serializers.ValidationError({'culture': 'Culture does not belong to the active project.'})
+        if project is not None and supplier is not None and supplier.project_id != project.id:
+            raise serializers.ValidationError({'supplier_id': 'Supplier does not belong to the active project.'})
         supplier_name_input = attrs.pop('supplier_name_input', None)
         if not attrs.get('supplier') and supplier_name_input:
             from .utils import normalize_supplier_name
 
-            project = None
-            request = self.context.get('request')
-            if request is not None:
-                project = getattr(request, 'active_project', None)
-            if project is None and self.instance is not None:
-                project = self.instance.project
+            project = _resolve_active_project_from_serializer(self)
             if project is None:
                 raise serializers.ValidationError({'supplier': 'Supplier is required.'})
 
@@ -962,6 +999,15 @@ class CultureSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(errors)
 
         supplier = attrs.get('supplier', getattr(self.instance, 'supplier', None) if self.instance else None)
+        project = attrs.get('project') or _resolve_active_project_from_serializer(self)
+        if project is not None and supplier is not None and supplier.project_id != project.id:
+            errors['supplier'] = 'Supplier does not belong to the active project.'
+        selected_supplier = attrs.get(
+            'selected_seed_demand_supplier',
+            getattr(self.instance, 'selected_seed_demand_supplier', None) if self.instance else None,
+        )
+        if project is not None and selected_supplier is not None and selected_supplier.project_id != project.id:
+            errors['selected_seed_demand_supplier'] = 'Selected supplier does not belong to the active project.'
         supplier_product_url = attrs.get(
             'supplier_product_url',
             getattr(self.instance, 'supplier_product_url', None) if self.instance else None,
@@ -1060,6 +1106,13 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
         return round(obj.area_usage_sqm * plants_per_m2)
 
     def validate(self, attrs):
+        project = _resolve_active_project_from_serializer(self)
+        culture = attrs.get('culture') or (self.instance.culture if self.instance else None)
+        bed = attrs.get('bed') or (self.instance.bed if self.instance else None)
+        if project is not None and culture is not None and culture.project_id != project.id:
+            raise serializers.ValidationError({'culture': 'Culture does not belong to the active project.'})
+        if project is not None and bed is not None and bed.project_id != project.id:
+            raise serializers.ValidationError({'bed': 'Bed does not belong to the active project.'})
         
         # Handle area input conversion
         area_input_value = attrs.pop('area_input_value', None)
@@ -1151,6 +1204,14 @@ class TaskSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = '__all__'
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        project = _resolve_active_project_from_serializer(self)
+        planting_plan = attrs.get('planting_plan') or getattr(self.instance, 'planting_plan', None)
+        if project is not None and planting_plan is not None and planting_plan.project_id != project.id:
+            raise serializers.ValidationError({'planting_plan': 'Planting plan does not belong to the active project.'})
+        return attrs
 
 
 class CultureImportPreviewItemSerializer(serializers.Serializer):

--- a/backend/farm/serializers.py
+++ b/backend/farm/serializers.py
@@ -967,7 +967,7 @@ class CultureSerializer(serializers.ModelSerializer):
         supplier_explicitly_set = 'supplier' in attrs
         if supplier_name and not supplier_explicitly_set and not attrs.get('supplier'):
             from .utils import normalize_supplier_name
-            project = None
+            project = attrs.get('project')
             if self.instance is not None:
                 project = self.instance.project
             if project is None:

--- a/backend/farm/tests/test_projects_api.py
+++ b/backend/farm/tests/test_projects_api.py
@@ -78,6 +78,30 @@ class ProjectsApiTests(APITestCase):
         settings_obj = UserProjectSettings.objects.get(user=self.user)
         self.assertEqual(settings_obj.last_project_id, self.project2.id)
 
+    def test_project_history_restore_does_not_delete_other_project_data(self) -> None:
+        Location.objects.create(name='P1 before restore', project=self.project)
+        Location.objects.create(name='P2 untouched', project=self.project2)
+
+        history_response = self.client.get(
+            '/openfarmplanner/api/history/project/',
+            HTTP_X_PROJECT_ID=str(self.project.id),
+        )
+        self.assertEqual(history_response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(history_response.data), 1)
+        history_id = history_response.data[0]['history_id']
+
+        Location.objects.filter(project=self.project).delete()
+
+        restore_response = self.client.post(
+            '/openfarmplanner/api/history/project/restore/',
+            {'history_id': history_id},
+            format='json',
+            HTTP_X_PROJECT_ID=str(self.project.id),
+        )
+        self.assertEqual(restore_response.status_code, status.HTTP_200_OK)
+        self.assertTrue(Location.objects.filter(project=self.project, name='P1 before restore').exists())
+        self.assertTrue(Location.objects.filter(project=self.project2, name='P2 untouched').exists())
+
     def test_create_project_without_slug_succeeds(self) -> None:
         response = self.client.post('/openfarmplanner/api/projects/', {'name': 'Neues Projekt', 'description': ''}, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/farm/tests/test_projects_api.py
+++ b/backend/farm/tests/test_projects_api.py
@@ -79,7 +79,13 @@ class ProjectsApiTests(APITestCase):
         self.assertEqual(settings_obj.last_project_id, self.project2.id)
 
     def test_project_history_restore_does_not_delete_other_project_data(self) -> None:
-        Location.objects.create(name='P1 before restore', project=self.project)
+        create_response = self.client.post(
+            '/openfarmplanner/api/locations/',
+            {'name': 'P1 before restore', 'address': '', 'notes': ''},
+            format='json',
+            HTTP_X_PROJECT_ID=str(self.project.id),
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
         Location.objects.create(name='P2 untouched', project=self.project2)
 
         history_response = self.client.get(

--- a/backend/farm/tests/test_views.py
+++ b/backend/farm/tests/test_views.py
@@ -153,6 +153,17 @@ class ApiEndpointsTest(DRFAPITestCase):
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, f'Should accept domain-only URL: {input_url}')
             self.assertEqual(response.data['homepage_url'], expected_url, f'Should normalize {input_url} to {expected_url}')
 
+    def test_media_upload_rejects_non_image_file(self):
+        upload = SimpleUploadedFile('payload.txt', b'not-an-image', content_type='text/plain')
+        response = self.client.post(
+            '/openfarmplanner/api/media-files/upload/',
+            {'file': upload},
+            format='multipart',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('file', response.data)
+
 
 
     def test_field_update_with_length_and_width_overwrites_area(self):

--- a/backend/farm/tests/test_views.py
+++ b/backend/farm/tests/test_views.py
@@ -195,6 +195,43 @@ class ApiEndpointsTest(DRFAPITestCase):
         self.assertEqual(self.field.length_m, 25.0)
         self.assertIsNone(self.field.width_m)
 
+    def test_field_create_rejects_location_from_other_project(self):
+        other_project = Project.objects.create(name='Other project', slug='other-project')
+        foreign_location = Location.objects.create(name='Foreign location', project=other_project)
+
+        response = self.client.post(
+            '/openfarmplanner/api/fields/',
+            {
+                'name': 'Cross-project field',
+                'location': foreign_location.id,
+                'area_sqm': 10.0,
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('location', response.data)
+
+    def test_planting_plan_create_rejects_bed_from_other_project(self):
+        other_project = Project.objects.create(name='Other project 2', slug='other-project-2')
+        other_location = Location.objects.create(name='Other location', project=other_project)
+        other_field = Field.objects.create(name='Other field', location=other_location, project=other_project)
+        other_bed = Bed.objects.create(name='Other bed', field=other_field, area_sqm=5.0, project=other_project)
+
+        response = self.client.post(
+            '/openfarmplanner/api/planting-plans/',
+            {
+                'culture': self.culture.id,
+                'bed': other_bed.id,
+                'planting_date': date(2026, 3, 1).isoformat(),
+                'area_usage_sqm': 1.0,
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('bed', response.data)
+
     def test_bed_update_with_length_and_width_overwrites_area(self):
         response = self.client.put(
             f'/openfarmplanner/api/beds/{self.bed.id}/',

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -102,6 +102,13 @@ logger = logging.getLogger(__name__)
 
 BOOTSTRAP_PROJECT_NAME = 'Gelawi Zwiebelzopf'
 BOOTSTRAP_PROJECT_SLUG = 'gelawi-zwiebelzopf'
+MAX_MEDIA_UPLOAD_BYTES = 10 * 1024 * 1024
+ALLOWED_MEDIA_UPLOAD_CONTENT_TYPES = {
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+}
 
 
 def _invitation_error_response(exc: InvitationFlowError) -> Response:
@@ -1808,6 +1815,11 @@ class MediaFileUploadView(APIView):
         upload = request.FILES.get('file')
         if upload is None:
             return Response({'file': ['This field is required.']}, status=status.HTTP_400_BAD_REQUEST)
+        if upload.size > MAX_MEDIA_UPLOAD_BYTES:
+            return Response({'file': ['File is too large. Maximum allowed size is 10 MB.']}, status=status.HTTP_400_BAD_REQUEST)
+        content_type = (getattr(upload, 'content_type', '') or '').lower()
+        if content_type not in ALLOWED_MEDIA_UPLOAD_CONTENT_TYPES:
+            return Response({'file': ['Unsupported file type. Only image uploads are allowed.']}, status=status.HTTP_400_BAD_REQUEST)
 
         rel_path = culture_media_upload_path(None, upload.name)
         saved_path = default_storage.save(rel_path, upload)
@@ -2426,6 +2438,7 @@ class AcceptProjectInvitationByTokenView(APIView):
     """Accept invitation by token path parameter."""
 
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = 'invitation_accept'
 
     def post(self, request, token: str):
         logger.info('Invitation accept endpoint reached', extra={'user_id': request.user.id, 'path': request.path})
@@ -2453,6 +2466,7 @@ class AcceptProjectInvitationView(APIView):
     """Accept invitation token from request body for backward compatibility."""
 
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = 'invitation_accept'
 
     def post(self, request):
         serializer = InvitationTokenSerializer(data=request.data)
@@ -2466,6 +2480,7 @@ class AcceptPendingProjectInvitationView(APIView):
     """Accept the invitation token currently stored in the session."""
 
     permission_classes = [permissions.IsAuthenticated]
+    throttle_scope = 'invitation_accept'
 
     def post(self, request):
         logger.info('Pending invitation accept endpoint reached', extra={'user_id': request.user.id, 'path': request.path})

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -237,20 +237,19 @@ def _iso_week_key(day: date) -> str:
     return f"{iso_year}-W{iso_week:02d}"
 
 
-def _serialize_project_state() -> dict[str, list[dict]]:
-    """Serialize all major project entities to JSON-compatible dictionaries."""
+def _serialize_project_state(project: Project) -> dict[str, list[dict]]:
+    """Serialize project-scoped entities to JSON-compatible dictionaries."""
     return {
-        'locations': list(Location.objects.order_by('id').values()),
-        'fields': list(Field.objects.order_by('id').values()),
-        'beds': list(Bed.objects.order_by('id').values()),
-        'bed_layouts': list(BedLayout.objects.order_by('id').values()),
-        'field_layouts': list(FieldLayout.objects.order_by('id').values()),
-        'suppliers': list(Supplier.objects.order_by('id').values()),
-        'media_files': list(MediaFile.objects.order_by('id').values()),
-        'cultures': list(Culture.all_objects.order_by('id').values()),
-        'planting_plans': list(PlantingPlan.objects.order_by('id').values()),
-        'tasks': list(Task.objects.order_by('id').values()),
-        'note_attachments': list(NoteAttachment.objects.order_by('id').values()),
+        'locations': list(Location.objects.filter(project=project).order_by('id').values()),
+        'fields': list(Field.objects.filter(project=project).order_by('id').values()),
+        'beds': list(Bed.objects.filter(project=project).order_by('id').values()),
+        'bed_layouts': list(BedLayout.objects.filter(project=project).order_by('id').values()),
+        'field_layouts': list(FieldLayout.objects.filter(project=project).order_by('id').values()),
+        'suppliers': list(Supplier.objects.filter(project=project).order_by('id').values()),
+        'cultures': list(Culture.all_objects.filter(project=project).order_by('id').values()),
+        'planting_plans': list(PlantingPlan.objects.filter(project=project).order_by('id').values()),
+        'tasks': list(Task.objects.filter(project=project).order_by('id').values()),
+        'note_attachments': list(NoteAttachment.objects.filter(project=project).order_by('id').values()),
     }
 
 
@@ -264,8 +263,8 @@ def _get_bootstrap_project() -> Project:
 
 
 def _create_project_revision(summary: str, project: Project | None = None) -> None:
-    snapshot = json.loads(json.dumps(_serialize_project_state(), cls=DjangoJSONEncoder))
     target_project = project or _get_bootstrap_project()
+    snapshot = json.loads(json.dumps(_serialize_project_state(target_project), cls=DjangoJSONEncoder))
     ProjectRevision.objects.create(snapshot=snapshot, summary=summary, project=target_project)
 
 
@@ -407,19 +406,18 @@ def _resolve_project_object_display_name(snapshot: dict, object_type: str, objec
     return None
 
 
-def _restore_project_state(snapshot: dict[str, list[dict]]) -> None:
+def _restore_project_state(snapshot: dict[str, list[dict]], *, project: Project) -> None:
     with transaction.atomic():
-        Task.objects.all().delete()
-        NoteAttachment.objects.all().delete()
-        PlantingPlan.objects.all().delete()
-        Culture.all_objects.all().delete()
-        BedLayout.objects.all().delete()
-        FieldLayout.objects.all().delete()
-        Bed.objects.all().delete()
-        Field.objects.all().delete()
-        Location.objects.all().delete()
-        Supplier.objects.all().delete()
-        MediaFile.objects.all().delete()
+        Task.objects.filter(project=project).delete()
+        NoteAttachment.objects.filter(project=project).delete()
+        PlantingPlan.objects.filter(project=project).delete()
+        Culture.all_objects.filter(project=project).delete()
+        BedLayout.objects.filter(project=project).delete()
+        FieldLayout.objects.filter(project=project).delete()
+        Bed.objects.filter(project=project).delete()
+        Field.objects.filter(project=project).delete()
+        Location.objects.filter(project=project).delete()
+        Supplier.objects.filter(project=project).delete()
 
         for model, key in [
             (Location, 'locations'),
@@ -428,7 +426,6 @@ def _restore_project_state(snapshot: dict[str, list[dict]]) -> None:
             (BedLayout, 'bed_layouts'),
             (FieldLayout, 'field_layouts'),
             (Supplier, 'suppliers'),
-            (MediaFile, 'media_files'),
             (Culture, 'cultures'),
             (PlantingPlan, 'planting_plans'),
             (Task, 'tasks'),
@@ -437,7 +434,13 @@ def _restore_project_state(snapshot: dict[str, list[dict]]) -> None:
             rows = snapshot.get(key, [])
             if not rows:
                 continue
-            model.objects.bulk_create([model(**row) for row in rows])
+            project_rows = []
+            for row in rows:
+                row_data = dict(row)
+                if 'project_id' in row_data:
+                    row_data['project_id'] = project.id
+                project_rows.append(model(**row_data))
+            model.objects.bulk_create(project_rows)
 
 
 
@@ -1729,7 +1732,7 @@ class ProjectHistoryRestoreView(APIView):
         revision_id = serializer.validated_data['history_id']
 
         revision = get_object_or_404(ProjectRevision.objects.filter(project=active_project), id=revision_id)
-        _restore_project_state(revision.snapshot)
+        _restore_project_state(revision.snapshot, project=active_project)
         _create_project_revision(f"Project restored from snapshot #{revision_id}", project=revision.project)
 
         return Response({'detail': 'Project restored successfully.'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
### Motivation
- Prevent cross-project data loss and cross-tenant side effects when creating/restoring project snapshots.  
- Close an authorization gap where serializers accepted foreign keys pointing to objects in other projects (IDOR-style risk).  
- Improve production security posture by tightening defaults for `DEBUG`, cookies, HSTS and related transport protections.

### Description
- Scope project snapshots and restores to the active project by changing `_serialize_project_state` to accept a `project`, making `_create_project_revision` use the scoped serializer, and changing `_restore_project_state` to only delete/create rows for the given `project` while reassigning `project_id` on restored rows (`backend/farm/views.py`).
- Add serializer-level ownership validation via `_resolve_active_project_from_serializer` and checks that foreign-key targets belong to the active project for `Field`, `Bed`, `SeedPackage`, `CultureSupplierData`, `Culture`, `PlantingPlan`, and `Task` to block cross-project FK abuse (`backend/farm/serializers.py`).
- Harden Django settings: default `DEBUG=False`, enable production-oriented secure cookie and transport defaults (secure cookies in prod, HSTS, `SECURE_SSL_REDIRECT`, referrer policy, `X_FRAME_OPTIONS`, `SECURE_CONTENT_TYPE_NOSNIFF`) while keeping environment overrides (`backend/config/settings.py`).
- Add regression tests validating project-restore isolation and rejection of cross-project references: `test_project_history_restore_does_not_delete_other_project_data`, `test_field_create_rejects_location_from_other_project`, and `test_planting_plan_create_rejects_bed_from_other_project` (`backend/farm/tests/*`).

### Testing
- Compiled modified modules with `python -m compileall backend/config/settings.py backend/farm/serializers.py backend/farm/views.py backend/farm/tests/test_projects_api.py backend/farm/tests/test_views.py`, which succeeded.  
- Attempted to run selected tests with `pytest -o addopts='' ...` (targeting the new regression tests), but the test run failed in the current runtime due to missing Django/pytest-django dependencies (environment limitation).  
- Tests were added to the suite and are intended to run in CI or a developer environment with Django and test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf91866a208322bb72dddb716fe65f)