### PR TITLE
refactor(help): rework graphical help dialog and remove persistent hide option

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,7 @@ import AddIcon from '@mui/icons-material/Add';
 import { cultureAPI, projectAPI, versionAPI } from './api/api';
 import type { CultureHistoryEntry } from './api/types';
 import './App.css';
+import { HelpIcon } from './components/help/HelpIcon';
 import { useAuth } from './auth/useAuth';
 import ProtectedRoute from './auth/ProtectedRoute';
 import HomePage from './pages/public/HomePage';
@@ -528,6 +529,7 @@ function RootLayout(): React.ReactElement {
           >
             <MoreVertIcon fontSize="small" />
           </IconButton>
+          <HelpIcon buttonSx={{ color: 'white' }} size="small" />
           <GlobalMenu
             anchorEl={globalMenuAnchor}
             open={Boolean(globalMenuAnchor)}

--- a/frontend/src/components/help/HelpDialog.tsx
+++ b/frontend/src/components/help/HelpDialog.tsx
@@ -1,0 +1,143 @@
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import type { ReactElement } from 'react';
+import { useTranslation } from '../../i18n';
+
+interface HelpSection {
+  title: string;
+  points: string[];
+}
+
+interface HelpDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Displays the global OpenFarmPlanner help dialog.
+ *
+ * @remarks
+ * This dialog presents the shared workflow overview for the main application pages.
+ *
+ * @param props - Component properties.
+ * @param props.open - Controls whether the dialog is visible.
+ * @param props.onClose - Callback invoked when the dialog should be closed.
+ * @returns JSX element rendering the help dialog.
+ */
+export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
+  const { t } = useTranslation('help');
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const sections = t('sections', { returnObjects: true }) as unknown;
+  const helpSections = Array.isArray(sections)
+    ? sections
+        .map((section) => {
+          if (!section || typeof section !== 'object') {
+            return null;
+          }
+          const typedSection = section as { title?: unknown; points?: unknown };
+          if (typeof typedSection.title !== 'string' || !Array.isArray(typedSection.points)) {
+            return null;
+          }
+          return {
+            title: typedSection.title,
+            points: typedSection.points.map((point) => String(point)),
+          } satisfies HelpSection;
+        })
+        .filter((section): section is HelpSection => section !== null)
+    : [];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      fullScreen={isMobile}
+      PaperProps={{
+        sx: {
+          borderRadius: isMobile ? 0 : 3,
+        },
+      }}
+    >
+      <DialogTitle sx={{ pr: 6 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
+          <Typography variant="h6" component="span">
+            {t('title')}
+          </Typography>
+          <IconButton
+            aria-label={t('common:actions.close')}
+            onClick={onClose}
+            size="small"
+            sx={{ position: 'absolute', top: 8, right: 8 }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent sx={{ pb: 3 }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+              {t('heading')}
+            </Typography>
+            <Typography variant="body1">
+              {t('intro')}
+            </Typography>
+          </Box>
+
+          <Stack spacing={1.5}>
+            {helpSections.map((section) => (
+              <Box key={section.title}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  {section.title}
+                </Typography>
+                <List dense disablePadding>
+                  {section.points.map((point) => (
+                    <ListItem key={`${section.title}-${point}`} disableGutters sx={{ py: 0.125 }}>
+                      <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
+            ))}
+          </Stack>
+
+          <Box sx={{ pt: 1 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.5 }}>
+              {t('workflowTitle')}
+            </Typography>
+            <Box
+              sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 2,
+                px: 2,
+                py: 1.25,
+                backgroundColor: 'action.hover',
+              }}
+            >
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {t('workflow')}
+              </Typography>
+            </Box>
+          </Box>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/help/HelpIcon.tsx
+++ b/frontend/src/components/help/HelpIcon.tsx
@@ -1,0 +1,46 @@
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import { IconButton, Tooltip } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { useState, type ReactElement } from 'react';
+import { useTranslation } from '../../i18n';
+import { HelpDialog } from './HelpDialog';
+
+interface HelpIconProps {
+  buttonSx?: SxProps<Theme>;
+  size?: 'small' | 'medium' | 'large';
+}
+
+/**
+ * Renders the global help icon and opens the shared help dialog.
+ *
+ * @remarks
+ * Intended for the persistent application header so users always have access to the same help entry point.
+ *
+ * @param props - Component properties.
+ * @param props.buttonSx - Optional styling for the icon button.
+ * @param props.size - Optional button size.
+ * @returns JSX element rendering the help icon and dialog.
+ */
+export function HelpIcon({ buttonSx, size = 'small' }: HelpIconProps): ReactElement {
+  const { t } = useTranslation('help');
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = (): void => {
+    setOpen(true);
+  };
+
+  const handleClose = (): void => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Tooltip title={t('showTooltip')}>
+        <IconButton aria-label={t('showTooltip')} onClick={handleOpen} size={size} sx={buttonSx}>
+          <HelpOutlineIcon fontSize={size === 'small' ? 'small' : 'inherit'} />
+        </IconButton>
+      </Tooltip>
+      <HelpDialog open={open} onClose={handleClose} />
+    </>
+  );
+}

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -1,21 +1,30 @@
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import AddIcon from '@mui/icons-material/Add';
+import FitScreenIcon from '@mui/icons-material/FitScreen';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import RemoveIcon from '@mui/icons-material/Remove';
 import {
   Box,
-  Checkbox,
   Dialog,
   DialogContent,
   DialogTitle,
-  FormControlLabel,
   IconButton,
   List,
   ListItem,
   ListItemText,
   Popover,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useMediaQuery } from '@mui/system';
 import { useTranslation } from '../../i18n';
 
@@ -40,21 +49,12 @@ interface HelpSection {
   points: string[];
 }
 
-function storageKey(pageKey: HelpPageKey): string {
-  return `pageHelpHidden:${pageKey}`;
-}
-
 export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement | null {
   const { t } = useTranslation('help');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [isHidden, setIsHidden] = useState(false);
-
-  useEffect(() => {
-    setIsHidden(window.localStorage.getItem(storageKey(pageKey)) === '1');
-  }, [pageKey]);
 
   const points = useMemo(() => {
     const translated = t(`pages.${pageKey}.points`, { returnObjects: true });
@@ -100,20 +100,84 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
     setMobileOpen(false);
   };
 
-  const handleHiddenToggle = (checked: boolean): void => {
-    if (checked) {
-      window.localStorage.setItem(storageKey(pageKey), '1');
-      setIsHidden(true);
-      handleClose();
-      return;
-    }
-    window.localStorage.removeItem(storageKey(pageKey));
-    setIsHidden(false);
-  };
+  const renderGraphicalHelpContent = (): React.ReactElement => (
+    <Stack spacing={2}>
+      {sections?.map((section, sectionIndex) => (
+        <Box key={`${pageKey}-graphical-section-${sectionIndex}`}>
+          <Typography variant="body1" sx={{ fontWeight: 700, mb: 0.75 }}>
+            {section.title}
+          </Typography>
+          <List dense disablePadding>
+            {section.points.map((point, pointIndex) => (
+              <ListItem key={`${pageKey}-graphical-${sectionIndex}-${pointIndex}`} sx={{ py: 0.2, px: 0 }}>
+                <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      ))}
 
-  if (isHidden) {
-    return null;
-  }
+      <Box>
+        <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
+          {t('pages.graphical.symbolsTitle')}
+        </Typography>
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Stack direction="row" spacing={0.25} alignItems="center">
+              <KeyboardArrowUpIcon fontSize="small" />
+              <KeyboardArrowLeftIcon fontSize="small" />
+              <KeyboardArrowRightIcon fontSize="small" />
+              <KeyboardArrowDownIcon fontSize="small" />
+            </Stack>
+            <Typography variant="body2">{t('pages.graphical.symbols.panArrows')}</Typography>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <AddIcon fontSize="small" />
+            <Typography variant="body2">{t('pages.graphical.symbols.zoomIn')}</Typography>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <RemoveIcon fontSize="small" />
+            <Typography variant="body2">{t('pages.graphical.symbols.zoomOut')}</Typography>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <FitScreenIcon fontSize="small" />
+            <Typography variant="body2">{t('pages.graphical.symbols.fit')}</Typography>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <FullscreenIcon fontSize="small" />
+            <Typography variant="body2">{t('pages.graphical.symbols.fullscreen')}</Typography>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Box>
+        <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
+          {t('pages.graphical.modeTitle')}
+        </Typography>
+        <Box sx={{ display: 'inline-flex', flexDirection: 'column', gap: 1, p: 1.25, borderRadius: 1.5, border: '1px solid', borderColor: 'divider' }}>
+          <Typography variant="caption" sx={{ fontWeight: 700 }}>
+            {t('pages.graphical.modeLabel')}
+          </Typography>
+          <ToggleButtonGroup value="view" exclusive size="small" aria-label={t('pages.graphical.modeLabel')}>
+            <ToggleButton value="view" disabled>
+              {t('pages.graphical.modeView')}
+            </ToggleButton>
+            <ToggleButton value="edit" disabled>
+              {t('pages.graphical.modeEdit')}
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        <List dense disablePadding sx={{ mt: 1 }}>
+          <ListItem sx={{ py: 0.2, px: 0 }}>
+            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${t('pages.graphical.modeViewDescription')}`} />
+          </ListItem>
+          <ListItem sx={{ py: 0.2, px: 0 }}>
+            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${t('pages.graphical.modeEditDescription')}`} />
+          </ListItem>
+        </List>
+      </Box>
+    </Stack>
+  );
 
   return (
     <>
@@ -130,9 +194,9 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
-        <Box sx={{ maxWidth: 560, p: 2 }}>
+        <Box sx={{ maxWidth: 720, width: { xs: 1, sm: 680 }, p: 2.5 }}>
           <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>{title}</Typography>
-          {sections && sections.length > 0 ? (
+          {pageKey === 'graphical' ? renderGraphicalHelpContent() : sections && sections.length > 0 ? (
             <List dense disablePadding>
               {sections.map((section, sectionIndex) => (
                 <Box key={`${pageKey}-section-${sectionIndex}`} sx={{ mb: 1.25 }}>
@@ -156,11 +220,6 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
               ))}
             </List>
           )}
-          <FormControlLabel
-            sx={{ mt: 1 }}
-            control={<Checkbox size="small" onChange={(event) => handleHiddenToggle(event.target.checked)} />}
-            label={<Typography variant="caption">{t('hideForPage')}</Typography>}
-          />
         </Box>
       </Popover>
 
@@ -168,18 +227,19 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
         open={mobileOpen}
         onClose={handleClose}
         fullWidth
-        maxWidth="sm"
+        maxWidth="md"
         PaperProps={{
           sx: {
             m: 0,
             mt: 'auto',
             borderRadius: '16px 16px 0 0',
+            maxHeight: '85vh',
           },
         }}
       >
         <DialogTitle>{title}</DialogTitle>
         <DialogContent>
-          {sections && sections.length > 0 ? (
+          {pageKey === 'graphical' ? renderGraphicalHelpContent() : sections && sections.length > 0 ? (
             <List dense disablePadding>
               {sections.map((section, sectionIndex) => (
                 <Box key={`${pageKey}-mobile-section-${sectionIndex}`} sx={{ mb: 1.25 }}>
@@ -203,11 +263,6 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
               ))}
             </List>
           )}
-          <FormControlLabel
-            sx={{ mt: 1 }}
-            control={<Checkbox size="small" onChange={(event) => handleHiddenToggle(event.target.checked)} />}
-            label={<Typography variant="caption">{t('hideForPage')}</Typography>}
-          />
         </DialogContent>
       </Dialog>
     </>

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -1,5 +1,8 @@
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import AddIcon from '@mui/icons-material/Add';
+import AgricultureIcon from '@mui/icons-material/Agriculture';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import DeleteIcon from '@mui/icons-material/Delete';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -7,6 +10,8 @@ import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import RemoveIcon from '@mui/icons-material/Remove';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
 import {
   Box,
   Dialog,
@@ -24,12 +29,13 @@ import {
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useMemo, useState } from 'react';
 import { useMediaQuery } from '@mui/system';
+import { useMemo, useState, type ReactElement } from 'react';
 import { useTranslation } from '../../i18n';
 
 export type HelpPageKey =
   | 'dashboard'
+  | 'calendar'
   | 'locations'
   | 'fields'
   | 'beds'
@@ -49,7 +55,17 @@ interface HelpSection {
   points: string[];
 }
 
-export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement | null {
+/**
+ * Displays the page-specific help content for the given page key.
+ *
+ * @remarks
+ * Used in page headers to keep the previous contextual help texts available.
+ *
+ * @param props - Component properties.
+ * @param props.pageKey - The help page key to render.
+ * @returns JSX element with the page help entry point and content.
+ */
+export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | null {
   const { t } = useTranslation('help');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -63,6 +79,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
     }
     return translated.map((point) => String(point));
   }, [pageKey, t]);
+
   const sections = useMemo(() => {
     const translated = t(`pages.${pageKey}.sections`, { returnObjects: true });
     if (!Array.isArray(translated)) {
@@ -85,7 +102,20 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
       .filter((section): section is HelpSection => section !== null);
   }, [pageKey, t]);
 
+  const hasSectionSymbols = useMemo(() => {
+    const symbolEntries = t(`pages.${pageKey}.symbols`, { returnObjects: true }) as unknown;
+    return !!symbolEntries && typeof symbolEntries === 'object' && !Array.isArray(symbolEntries);
+  }, [pageKey, t]);
+
   const title = t(`pages.${pageKey}.title`);
+  const symbolsTitle = t(`pages.${pageKey}.symbolsTitle`);
+  const symbolItems = useMemo(() => {
+    const translated = t(`pages.${pageKey}.symbols`, { returnObjects: true }) as unknown;
+    if (!translated || typeof translated !== 'object' || Array.isArray(translated)) {
+      return [];
+    }
+    return Object.values(translated as Record<string, unknown>).map((value) => String(value));
+  }, [pageKey, t]);
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>): void => {
     if (isMobile) {
@@ -100,7 +130,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
     setMobileOpen(false);
   };
 
-  const renderGraphicalHelpContent = (): React.ReactElement => (
+  const renderGraphicalHelpContent = (): ReactElement => (
     <Stack spacing={2}>
       {sections?.map((section, sectionIndex) => (
         <Box key={`${pageKey}-graphical-section-${sectionIndex}`}>
@@ -179,6 +209,55 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
     </Stack>
   );
 
+  const renderAreasSymbolsContent = (): ReactElement => (
+    <Box>
+      <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
+        {t('pages.areas.symbolsTitle')}
+      </Typography>
+      <Stack spacing={1}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Stack direction="row" spacing={0.1} alignItems="center">
+            <ChevronRightIcon fontSize="small" />
+            <KeyboardArrowDownIcon fontSize="small" />
+          </Stack>
+          <Typography variant="body2">{t('pages.areas.symbols.expandToggle')}</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <AddIcon fontSize="small" sx={{ color: 'primary.main' }} />
+          <Typography variant="body2">{t('pages.areas.symbols.add')}</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} />
+          <Typography variant="body2">{t('pages.areas.symbols.delete')}</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} />
+          <Typography variant="body2">{t('pages.areas.symbols.createPlan')}</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <SwapVertIcon fontSize="small" />
+          <SwapHorizIcon fontSize="small" />
+          <Typography variant="body2">{t('pages.areas.symbols.dimensions')}</Typography>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+
+  const renderGenericSymbolsContent = (): ReactElement => (
+    <Box>
+      <Typography variant="body1" sx={{ fontWeight: 700, mb: 0.75 }}>
+        {symbolsTitle}
+      </Typography>
+      <List dense disablePadding>
+        {symbolItems.map((symbol, index) => (
+          <ListItem key={`${pageKey}-symbol-${index}`} sx={{ py: 0.2, px: 0 }}>
+            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${symbol}`} />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
   return (
     <>
       <Tooltip title={t('showTooltip')}>
@@ -211,14 +290,26 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
                 </Box>
               ))}
             </List>
+          ) : null}
+
+          {pageKey === 'areas' && hasSectionSymbols ? (
+            <Box sx={{ mt: 1.5 }}>
+              {renderAreasSymbolsContent()}
+            </Box>
+          ) : sections && sections.length > 0 && pageKey !== 'graphical' && symbolItems.length > 0 ? (
+            <Box sx={{ mt: 1.5 }}>
+              {renderGenericSymbolsContent()}
+            </Box>
           ) : (
-            <List dense disablePadding>
-              {points.map((point, index) => (
-                <ListItem key={`${pageKey}-${index}`} sx={{ py: 0.25, px: 0 }}>
-                  <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
-                </ListItem>
-              ))}
-            </List>
+            pageKey !== 'graphical' && (!sections || sections.length === 0) ? (
+              <List dense disablePadding>
+                {points.map((point, index) => (
+                  <ListItem key={`${pageKey}-${index}`} sx={{ py: 0.25, px: 0 }}>
+                    <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                  </ListItem>
+                ))}
+              </List>
+            ) : null
           )}
         </Box>
       </Popover>
@@ -254,14 +345,26 @@ export default function PageHelp({ pageKey }: PageHelpProps): React.ReactElement
                 </Box>
               ))}
             </List>
+          ) : null}
+
+          {pageKey === 'areas' && hasSectionSymbols ? (
+            <Box sx={{ mt: 1.5 }}>
+              {renderAreasSymbolsContent()}
+            </Box>
+          ) : sections && sections.length > 0 && pageKey !== 'graphical' && symbolItems.length > 0 ? (
+            <Box sx={{ mt: 1.5 }}>
+              {renderGenericSymbolsContent()}
+            </Box>
           ) : (
-            <List dense disablePadding>
-              {points.map((point, index) => (
-                <ListItem key={`${pageKey}-mobile-${index}`} sx={{ py: 0.25, px: 0 }}>
-                  <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
-                </ListItem>
-              ))}
-            </List>
+            pageKey !== 'graphical' && (!sections || sections.length === 0) ? (
+              <List dense disablePadding>
+                {points.map((point, index) => (
+                  <ListItem key={`${pageKey}-mobile-${index}`} sx={{ py: 0.25, px: 0 }}>
+                    <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                  </ListItem>
+                ))}
+              </List>
+            ) : null
           )}
         </DialogContent>
       </Dialog>

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -1,6 +1,5 @@
 {
   "showTooltip": "Hilfe anzeigen",
-  "hideForPage": "Nicht mehr auf dieser Seite anzeigen",
   "pages": {
     "dashboard": {
       "title": "Hilfe: Übersicht",
@@ -90,41 +89,43 @@
           "title": "Was sehe ich hier?",
           "points": [
             "Hier siehst du deine Standorte, Parzellen und Beete grafisch angeordnet.",
-            "Diese Ansicht hilft dir, deine Anbauflächen übersichtlich zu planen.",
-            "Die Positionen entsprechen der realen Anordnung deiner Beete."
+            "Diese Ansicht hilft dir, deine Anbauflächen räumlich zu verstehen und übersichtlich zu planen.",
+            "Die Anordnung kann der realen Lage deiner Beete entsprechen."
           ]
         },
         {
           "title": "Bedienung",
           "points": [
-            "Klick auf ein Beet → Details anzeigen oder bearbeiten",
-            "Ziehen im Bearbeitungsmodus → Beete verschieben",
-            "Leere Fläche ziehen → Ansicht verschieben (Pan)",
-            "Scrollrad / Pinch → Zoomen"
+            "Klick auf ein Beet oder eine Parzelle → Element öffnen",
+            "Im Modus „Bearbeiten“ kannst du Elemente verschieben.",
+            "Leere Fläche ziehen → Ansicht verschieben",
+            "Scrollrad oder Pinch-Geste → Zoomen"
           ]
         },
         {
-          "title": "Icons erklären",
+          "title": "Wie hängt diese Seite mit den anderen Seiten zusammen?",
           "points": [
-            "Pfeile → Ansicht verschieben",
-            "+ → Hineinzoomen",
-            "− → Herauszoomen",
-            "Rahmen-Icon → Auf gesamte Fläche zoomen",
-            "Vollbild-Icon → Maximale Ansicht anzeigen",
-            "Ansicht → Nur betrachten",
-            "Bearbeiten → Elemente verschieben und anpassen"
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "1. Anbauflächen → Hier definierst du deine Beete und Parzellen",
-            "2. Anbaupläne → Hier planst du, was auf welchem Beet wächst",
-            "3. Anbaukalender → Hier siehst du die zeitliche Planung",
-            "4. Saatgutbedarf → Hier wird automatisch berechnet, wie viel Saatgut benötigt wird"
+            "Anbauflächen → Hier legst du Standorte, Parzellen und Beete an.",
+            "Anbaupläne → Hier planst du, welche Kultur auf welchem Beet angebaut wird.",
+            "Anbaukalender → Hier siehst du die zeitliche Planung deiner Anbaupläne.",
+            "Saatgutbedarf → Daraus wird berechnet, wie viel Saatgut du brauchst."
           ]
         }
-      ]
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "panArrows": "Pfeiltasten-Symbole → Ansicht nach oben, links, rechts oder unten verschieben",
+        "zoomIn": "Plus-Icon → Hineinzoomen",
+        "zoomOut": "Minus-Icon → Herauszoomen",
+        "fit": "Rahmen-Icon → Auf die gesamte Fläche einpassen",
+        "fullscreen": "Vollbild-Icon → Größtmögliche Ansicht anzeigen"
+      },
+      "modeTitle": "Modus",
+      "modeLabel": "Modus",
+      "modeView": "Ansicht",
+      "modeEdit": "Bearbeiten",
+      "modeViewDescription": "„Ansicht“ = nur ansehen und navigieren",
+      "modeEditDescription": "„Bearbeiten“ = Elemente verschieben und anordnen"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -1,5 +1,28 @@
 {
   "showTooltip": "Hilfe anzeigen",
+  "title": "Hilfe",
+  "heading": "So funktioniert OpenFarmPlanner",
+  "intro": "OpenFarmPlanner besteht aus mehreren Seiten, die zusammenarbeiten:",
+  "sections": [
+    {
+      "title": "Standorte / Anbauflächen",
+      "points": ["Hier legst du Standorte, Parzellen und Beete an."]
+    },
+    {
+      "title": "Anbaupläne",
+      "points": ["Hier planst du, welche Kultur auf welchem Beet angebaut wird."]
+    },
+    {
+      "title": "Anbaukalender",
+      "points": ["Hier siehst du die zeitliche Planung deiner Anbaupläne."]
+    },
+    {
+      "title": "Saatgutbedarf",
+      "points": ["Daraus wird berechnet, wie viel Saatgut du brauchst."]
+    }
+  ],
+  "workflowTitle": "Workflow",
+  "workflow": "Standorte → Beete → Anbaupläne → Anbaukalender → Saatgutbedarf",
   "pages": {
     "dashboard": {
       "title": "Hilfe: Übersicht",
@@ -38,49 +61,223 @@
       ]
     },
     "areas": {
-      "title": "Hilfe: Anbauflächen",
-      "points": [
-        "Hier verwaltest du Anbauflächen.",
-        "Anbauflächen verbinden Beete mit Kulturen oder Planungen.",
-        "Mit „Neu“ legst du eine Fläche an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden."
-      ]
+      "title": "Hilfe: Listenansicht der Anbauflächen",
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier siehst du deine Standorte, Parzellen und Beete in einer übersichtlichen Listenansicht.",
+            "Die Einträge sind hierarchisch aufgebaut: Standorte enthalten Parzellen, Parzellen enthalten Beete.",
+            "Diese Ansicht ist besonders geeignet, um Flächen strukturiert zu verwalten und Eigenschaften schnell zu erfassen oder zu ändern."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Klicke auf den Pfeil vor einem Eintrag, um untergeordnete Elemente ein- oder auszuklappen.",
+            "Klicke auf einen Eintrag, um Details direkt zu sehen oder zu bearbeiten.",
+            "Über Plus-Symbole kannst du neue Standorte, Parzellen oder Beete anlegen.",
+            "Die Listenansicht eignet sich besonders gut für Verwaltung, Bearbeitung und den schnellen Überblick über viele Flächen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Hier legst du die Flächenstruktur fest, die später in anderen Bereichen verwendet wird.",
+            "In den Anbauplänen ordnest du Kulturen bestimmten Beeten zu.",
+            "Im Anbaukalender siehst du die zeitliche Planung dieser Anbaupläne.",
+            "Aus den Anbauplänen wird der Saatgutbedarf berechnet."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "expandToggle": "Pfeil-Symbol → Untergeordnete Elemente anzeigen oder ausblenden",
+        "add": "Plus-Symbol → Neues Element anlegen",
+        "delete": "Papierkorb-Symbol → Element löschen",
+        "createPlan": "Traktor-Symbol → Direkt einen Anbauplan für ein Beet anlegen",
+        "dimensions": "Längen-/Breiten-Symbole → Orientierung für Maßeingaben in den Spalten"
+      }
     },
     "cultures": {
       "title": "Hilfe: Kulturen",
-      "points": [
-        "Hier verwaltest du alle Kulturen.",
-        "Mit „Neu“ legst du eine Kultur an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden.",
-        "Nutze Filter oder Suche zum Eingrenzen."
-      ]
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier verwaltest du alle Kulturen und ihre wichtigsten Eigenschaften.",
+            "Zu jeder Kultur kannst du zum Beispiel Name, Sorte, Abstände, Zeiträume sowie Saatgut- und Planungshinweise pflegen.",
+            "Diese Daten werden später in den Anbauplänen verwendet."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Wähle eine Kultur aus der Liste aus, um Details zu sehen oder zu bearbeiten.",
+            "Mit „Neu“ legst du eine neue Kultur an.",
+            "Bestehende Einträge kannst du bearbeiten, exportieren, löschen oder direkt für einen Anbauplan verwenden.",
+            "Über die Bibliothek kannst du Kulturen aus der öffentlichen Sammlung übernehmen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Kulturen liefern die fachlichen Eigenschaften für deine Planung.",
+            "In den Anbauplänen ordnest du Kulturen konkreten Beeten und Zeiträumen zu.",
+            "Der Anbaukalender und der Saatgutbedarf nutzen diese Daten für Zeit- und Mengenplanung."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "add": "Plus-Symbol → Neue Kultur anlegen",
+        "library": "Globus-Symbol → Öffentliche Kulturbibliothek öffnen",
+        "more": "Drei-Punkte-Symbol → Import/Export-Aktionen öffnen",
+        "edit": "Bearbeiten-Schaltfläche → Kulturdaten ändern",
+        "delete": "Löschen-Schaltfläche → Kultur entfernen"
+      }
     },
     "plantingPlans": {
-      "title": "Hilfe: Anbauplan",
-      "points": [
-        "Hier planst du den Anbau deiner Kulturen.",
-        "Mit „Neu“ legst du einen Eintrag an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden.",
-        "Die grafische Ansicht zeigt die Belegung der Beete."
-      ]
+      "title": "Hilfe: Anbaupläne",
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier planst du, welche Kultur auf welchem Beet angebaut wird.",
+            "Jeder Eintrag verbindet Kultur, Beet und Zeitraum miteinander.",
+            "Damit legst du die Grundlage für Kalenderansicht und Saatgutbedarf fest."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Einträge kannst du direkt in der Tabelle erstellen und bearbeiten.",
+            "Mit „Neu“ legst du einen zusätzlichen Plan an.",
+            "Änderungen zu Fläche, Zeitraum oder Kultur werden direkt in der Planung übernommen.",
+            "Auf Mobilgeräten kannst du neue Einträge über den schwebenden Plus-Button anlegen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Anbaupläne verbinden die Flächenstruktur aus den Anbauflächen mit den Kulturdaten.",
+            "Im Anbaukalender siehst du daraus die zeitliche Abfolge.",
+            "Der Saatgutbedarf wird aus diesen Planungen berechnet."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "add": "Plus-Symbol → Neuen Anbauplan anlegen",
+        "mobileAdd": "Schwebender Plus-Button (mobil) → Schnell neuen Eintrag erfassen",
+        "notes": "Notiz-/Anhang-Symbol → Notizen und Anhänge pro Eintrag öffnen",
+        "edit": "Bearbeitungsmodus in der Tabelle → Werte direkt ändern"
+      }
+    },
+    "calendar": {
+      "title": "Hilfe: Anbaukalender",
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier siehst du die zeitliche Planung deiner Anbaupläne als Kalenderansicht.",
+            "Die Ansicht zeigt, wann Kulturen geplant, vorgezogen, gepflanzt oder geerntet werden.",
+            "So erkennst du Engpässe und Überschneidungen frühzeitig."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Über die Tabs wechselst du zwischen Belegungs- und Anzuchtansicht.",
+            "Nutze den Schalter, um den Wochen-Ertragskalender ein- oder auszublenden.",
+            "Bewege dich durch die Zeitleiste, um kommende Zeiträume und Belegungen zu prüfen.",
+            "Fahre über Einträge, um Detailinformationen im Tooltip zu sehen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Der Kalender basiert auf den Daten aus den Anbauplänen.",
+            "Wenn du Zeiträume in den Anbauplänen änderst, aktualisiert sich diese Ansicht entsprechend.",
+            "Die Kalenderansicht unterstützt dich bei der operativen Saisonplanung."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "tabs": "Tab-Leiste → Zwischen Ansichten wechseln",
+        "switch": "Schalter → Wochen-Ertragskalender ein-/ausblenden",
+        "tooltip": "Tooltip bei Kalendereinträgen → Zusätzliche Detailinformationen anzeigen"
+      }
     },
     "seedDemand": {
       "title": "Hilfe: Saatgutbedarf",
-      "points": [
-        "Hier wird der Saatgutbedarf berechnet.",
-        "Die Daten basieren auf Kulturen und Anbauplanung.",
-        "Nutze Filter zum Eingrenzen der Anzeige.",
-        "Die Ansicht hilft dir bei der Bestellvorbereitung."
-      ]
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier siehst du, wie viel Saatgut du für deine geplanten Anbaupläne benötigst.",
+            "Die Mengen werden aus Kulturdaten, Flächen und Planungseinträgen abgeleitet.",
+            "Die Tabelle hilft dir, den Einkauf gezielt vorzubereiten."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Wähle pro Kultur einen Lieferanten aus, um passende Packungsvorschläge zu erhalten.",
+            "Prüfe benötigte Mengen und vorgeschlagene Packungskombinationen direkt in der Tabelle.",
+            "Nutze die Ansicht, um Bestellungen konsistent mit deiner Planung abzustimmen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Die Grundlage kommt aus den Anbauplänen und den Kulturdaten.",
+            "Lieferanten- und Packungsinformationen ergänzen die Mengenplanung für den Einkauf.",
+            "Änderungen in Kultur oder Planung wirken sich direkt auf den Bedarf aus."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "supplierSelect": "Auswahlliste je Zeile → Lieferanten pro Kultur festlegen",
+        "packageInfo": "Packungsvorschlag-Spalte → Empfohlene Kombinationen für den Bedarf"
+      }
     },
     "suppliers": {
       "title": "Hilfe: Lieferanten",
-      "points": [
-        "Hier verwaltest du Saatgutlieferanten.",
-        "Lieferanten können Kulturen und Saatgutdaten zugeordnet werden.",
-        "Mit „Neu“ legst du einen Lieferanten an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden."
-      ]
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier verwaltest du Saatgutlieferanten und Bezugsquellen.",
+            "Zu jedem Lieferanten kannst du wichtige Bezugsinformationen wie Name und Website hinterlegen.",
+            "Diese Daten werden später in Kulturen und Saatgutbedarf verwendet."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Mit „Neu“ legst du einen weiteren Lieferanten an.",
+            "Bestehende Einträge kannst du bearbeiten und speichern.",
+            "Nicht mehr benötigte Lieferanten kannst du direkt in der Tabelle entfernen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Lieferanten ergänzen Kulturen um Bezugs- und Einkaufsinformationen.",
+            "Im Saatgutbedarf helfen sie dir, passende Packungen und Quellen auszuwählen.",
+            "So verbindest du Planung und Einkauf an einer zentralen Stelle."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "add": "Schaltfläche „Neu“ → Lieferanten anlegen",
+        "edit": "Schaltfläche „Bearbeiten“ → Lieferantendaten ändern",
+        "delete": "Löschen-Symbol → Lieferanten entfernen"
+      }
     },
     "graphical": {
       "title": "Hilfe: Grafische Ansicht der Anbauflächen",
@@ -89,26 +286,17 @@
           "title": "Was sehe ich hier?",
           "points": [
             "Hier siehst du deine Standorte, Parzellen und Beete grafisch angeordnet.",
-            "Diese Ansicht hilft dir, deine Anbauflächen räumlich zu verstehen und übersichtlich zu planen.",
-            "Die Anordnung kann der realen Lage deiner Beete entsprechen."
+            "Diese Ansicht hilft dir, die Anbauflächen räumlich zu erfassen und die Planung übersichtlich zu halten.",
+            "Die Anordnung kann der realen Position deiner Beete entsprechen."
           ]
         },
         {
           "title": "Bedienung",
           "points": [
-            "Klick auf ein Beet oder eine Parzelle → Element öffnen",
+            "Klick auf ein Beet oder eine Parzelle um Details anzuzeigen.",
             "Im Modus „Bearbeiten“ kannst du Elemente verschieben.",
             "Leere Fläche ziehen → Ansicht verschieben",
             "Scrollrad oder Pinch-Geste → Zoomen"
-          ]
-        },
-        {
-          "title": "Wie hängt diese Seite mit den anderen Seiten zusammen?",
-          "points": [
-            "Anbauflächen → Hier legst du Standorte, Parzellen und Beete an.",
-            "Anbaupläne → Hier planst du, welche Kultur auf welchem Beet angebaut wird.",
-            "Anbaukalender → Hier siehst du die zeitliche Planung deiner Anbaupläne.",
-            "Saatgutbedarf → Daraus wird berechnet, wie viel Saatgut du brauchst."
           ]
         }
       ],

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -1,6 +1,5 @@
 {
   "showTooltip": "Show help",
-  "hideForPage": "Do not show again on this page",
   "pages": {
     "dashboard": {"title": "Help: Overview", "points": ["Project overview.", "Use navigation.", "Quick actions.", "Open pages to edit data."]},
     "locations": {"title": "Help: Locations", "points": ["Manage locations.", "A location can contain fields.", "Use New to create.", "Rows are clickable for editing."]},
@@ -11,6 +10,50 @@
     "plantingPlans": {"title": "Help: Planting plans", "points": ["Plan crop planting.", "Use New to create.", "Rows are clickable for editing.", "Graphical mode shows occupancy."]},
     "seedDemand": {"title": "Help: Seed demand", "points": ["Seed demand is calculated.", "Based on cultures and plans.", "Use filters.", "Supports order planning."]},
     "suppliers": {"title": "Help: Suppliers", "points": ["Manage suppliers.", "Link suppliers to seed data.", "Use New to create.", "Rows are clickable for editing."]},
-    "graphical": {"title": "Help: Graphical view", "points": ["See fields and beds layout.", "Edit mode allows moving.", "Use zoom and pan.", "Click elements to edit."]}
+    "graphical": {
+      "title": "Help: Graphical view of growing areas",
+      "sections": [
+        {
+          "title": "What do I see here?",
+          "points": [
+            "You can see your locations, fields and beds arranged visually.",
+            "This view helps you understand your growing areas spatially and keep planning clear.",
+            "The arrangement can match the real position of your beds."
+          ]
+        },
+        {
+          "title": "How to use it",
+          "points": [
+            "Click a bed or field → Open element",
+            "In “Edit” mode you can move elements.",
+            "Drag empty space → Pan the view",
+            "Mouse wheel or pinch gesture → Zoom"
+          ]
+        },
+        {
+          "title": "How is this page connected to other pages?",
+          "points": [
+            "Growing areas → Create locations, fields and beds.",
+            "Planting plans → Plan which crop is planted in which bed.",
+            "Planting calendar → See timeline planning for planting plans.",
+            "Seed demand → Calculates how much seed you need."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "panArrows": "Arrow icons → Move view up, left, right or down",
+        "zoomIn": "Plus icon → Zoom in",
+        "zoomOut": "Minus icon → Zoom out",
+        "fit": "Frame icon → Fit whole area into the viewport",
+        "fullscreen": "Fullscreen icon → Show largest possible view"
+      },
+      "modeTitle": "Mode",
+      "modeLabel": "Mode",
+      "modeView": "View",
+      "modeEdit": "Edit",
+      "modeViewDescription": "\"View\" = only view and navigate",
+      "modeEditDescription": "\"Edit\" = move and arrange elements"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -1,5 +1,28 @@
 {
   "showTooltip": "Show help",
+  "title": "Help",
+  "heading": "How OpenFarmPlanner works",
+  "intro": "OpenFarmPlanner consists of several pages that work together:",
+  "sections": [
+    {
+      "title": "Locations / Growing areas",
+      "points": ["Create locations, fields, and beds here."]
+    },
+    {
+      "title": "Planting plans",
+      "points": ["Plan which crop is grown in which bed here."]
+    },
+    {
+      "title": "Planting calendar",
+      "points": ["See the timeline for your planting plans here."]
+    },
+    {
+      "title": "Seed demand",
+      "points": ["This calculates how much seed you need."]
+    }
+  ],
+  "workflowTitle": "Workflow",
+  "workflow": "Locations → Beds → Planting plans → Planting calendar → Seed demand",
   "pages": {
     "dashboard": {"title": "Help: Overview", "points": ["Project overview.", "Use navigation.", "Quick actions.", "Open pages to edit data."]},
     "locations": {"title": "Help: Locations", "points": ["Manage locations.", "A location can contain fields.", "Use New to create.", "Rows are clickable for editing."]},

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -892,7 +892,6 @@ function Cultures(): React.ReactElement {
       >
         <h1>{t('title')}</h1>
         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap', ml: 'auto' }}>
-          <PageHelp pageKey="cultures" />
           <Button variant="contained" startIcon={<AddIcon />} onClick={handleAddNew}>
             {t('buttons.addNew')}
           </Button>
@@ -908,6 +907,7 @@ function Cultures(): React.ReactElement {
           >
             <MoreVertIcon />
           </IconButton>
+          <PageHelp pageKey="cultures" />
         </Box>
         <Menu
           id="culture-import-menu"

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -381,7 +381,7 @@ function GanttChartPage(): React.ReactElement {
       <div className="page-container">
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
           <h1>{t('ganttChart:title')}</h1>
-          <PageHelp pageKey="graphical" />
+          <PageHelp pageKey="calendar" />
         </Box>
         <p>{t('ganttChart:loading')}</p>
       </div>
@@ -392,7 +392,7 @@ function GanttChartPage(): React.ReactElement {
     <div className="page-container">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
         <h1>{t('ganttChart:title')}</h1>
-        <PageHelp pageKey="graphical" />
+        <PageHelp pageKey="calendar" />
       </Box>
 
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import {
   Alert,
   Box,
@@ -111,7 +111,7 @@ function Locations(): React.ReactElement {
   const [formState, setFormState] = useState<LocationFormState>(emptyForm);
   const [formError, setFormError] = useState<string>('');
 
-  const loadData = async (): Promise<void> => {
+  const loadData = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError('');
     try {
@@ -132,11 +132,11 @@ function Locations(): React.ReactElement {
     } finally {
       setLoading(false);
     }
-  };
+  }, [t]);
 
   useEffect(() => {
     void loadData();
-  }, []);
+  }, [loadData]);
 
   const tasksByLocation = useMemo(
     () =>
@@ -245,10 +245,10 @@ function Locations(): React.ReactElement {
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
         <Typography variant="h4">{t('locations:title')}</Typography>
         <Stack direction="row" spacing={1} alignItems="center">
-          <PageHelp pageKey="locations" />
           <Button variant="contained" startIcon={<AddIcon />} onClick={openCreateDialog}>
             {t('locations:addButton')}
           </Button>
+          <PageHelp pageKey="locations" />
         </Stack>
       </Stack>
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1089,7 +1089,6 @@ function PlantingPlans(): React.ReactElement {
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
           <h1>{t("plantingPlans:title")}</h1>
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-            <PageHelp pageKey="plantingPlans" />
             {!isMobile ? (
               <Button
                 variant="contained"
@@ -1100,6 +1099,7 @@ function PlantingPlans(): React.ReactElement {
                 {t("plantingPlans:addButton")}
               </Button>
             ) : null}
+            <PageHelp pageKey="plantingPlans" />
           </Box>
         </Box>
 

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -179,10 +179,10 @@ export default function Suppliers(): React.ReactElement {
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <h1>{t('title')}</h1>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <PageHelp pageKey="suppliers" />
             <Button variant="contained" onClick={openCreate}>
               + {t('create')}
             </Button>
+            <PageHelp pageKey="suppliers" />
           </Box>
         </Box>
         <TableContainer sx={{ width: 'fit-content', maxWidth: '100%', overflowX: 'auto' }}>


### PR DESCRIPTION
### Motivation
- Provide a clearer, German-language onboarding experience for the "Grafische Ansicht der Anbauflächen" by replacing compact help text with clearly separated sections and visual cues.
- Make symbol explanations immediately recognizable by showing the same MUI icons used in the viewport next to their descriptions.
- Simplify UX by removing the persistent "Nicht mehr auf dieser Seite anzeigen" option and its localStorage-based logic.

### Description
- Reworked the help rendering for the `graphical` page in `frontend/src/components/help/PageHelp.tsx` to render structured sections, display MUI icons (arrows, plus/minus, fit/fullscreen), and include a visual `ToggleButtonGroup` preview for the "Modus" control.
- Removed the checkbox and all localStorage hide/restore logic from `PageHelp.tsx` so the help cannot be permanently dismissed per page anymore.
- Increased popover/dialog width and improved spacing and responsive sizing so the dialog is slightly wider on desktop while remaining usable on small screens.
- Updated i18n keys and copy in `frontend/src/i18n/locales/de/help.json` and `frontend/src/i18n/locales/en/help.json` to the new structure and to match the requested German wording and mode descriptions.

### Testing
- Attempted to run frontend lint (`cd frontend && npm run lint -- src/components/help/PageHelp.tsx src/i18n/locales/de/help.json src/i18n/locales/en/help.json`), but the check failed in this environment because frontend dev dependencies are not installed (missing `@eslint/js`), so automated linting could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d516d8523c8322a77bb9f33cc99d10)