### PR TITLE
refactor(help): render help actions with inline MUI icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8882,7 +8882,7 @@
     "node_modules/react-modern-gantt": {
       "version": "0.8.3",
       "resolved": "https://codeload.github.com/stipsitzm/React-Modern-Gantt/tar.gz/refs/heads/master",
-      "integrity": "sha512-sN/xZg4gXTuDwh5huYPu2xgQq8bsaqPwE+G2Lun7j9XpIumU3zlvZCNUCn12j/gnozNV9KdlZNlTuZGGEcL4Zg==",
+      "integrity": "sha512-x6VMEsEJxXrPmYF0mMlxeGO2mSPnOih9ytVXzwJvKpKyacH8fojFehmQh0YIXIk1FTvF3ctCB840PUl+w4EzhA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@stryker-mutator/core": "^9.5.1",
         "@stryker-mutator/typescript-checker": "^9.5.1",
         "@stryker-mutator/vitest-runner": "^9.5.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -3041,6 +3042,26 @@
         "vitest": ">=2.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3109,6 +3130,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4906,6 +4934,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6874,6 +6909,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/madge": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/madge/-/madge-7.0.0.tgz",
@@ -8618,6 +8663,41 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -8882,7 +8962,7 @@
     "node_modules/react-modern-gantt": {
       "version": "0.8.3",
       "resolved": "https://codeload.github.com/stipsitzm/React-Modern-Gantt/tar.gz/refs/heads/master",
-      "integrity": "sha512-sN/xZg4gXTuDwh5huYPu2xgQq8bsaqPwE+G2Lun7j9XpIumU3zlvZCNUCn12j/gnozNV9KdlZNlTuZGGEcL4Zg==",
+      "integrity": "sha512-x6VMEsEJxXrPmYF0mMlxeGO2mSPnOih9ytVXzwJvKpKyacH8fojFehmQh0YIXIk1FTvF3ctCB840PUl+w4EzhA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@stryker-mutator/core": "^9.5.1",
     "@stryker-mutator/typescript-checker": "^9.5.1",
     "@stryker-mutator/vitest-runner": "^9.5.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "if [ ! -f node_modules/react-modern-gantt/dist/index.esm.js ]; then npm --prefix node_modules/react-modern-gantt install --no-audit --no-fund && npm --prefix node_modules/react-modern-gantt run build; fi",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -17,7 +18,7 @@
     "mutation:report": "open mutation-report/index.html",
     "lint:circular": "madge --circular src",
     "quality:frontend": "npm run lint && npm run lint:circular",
-    "postinstall": "if [ ! -f node_modules/react-modern-gantt/dist/index.css ]; then npm --prefix node_modules/react-modern-gantt install --no-audit --no-fund && npm --prefix node_modules/react-modern-gantt run build; fi"
+    "postinstall": "if [ ! -f node_modules/react-modern-gantt/dist/index.esm.js ]; then npm --prefix node_modules/react-modern-gantt install --no-audit --no-fund && npm --prefix node_modules/react-modern-gantt run build; fi"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -318,6 +318,10 @@ function RootLayout(): React.ReactElement {
     setShortcutsOpen(true);
   };
 
+  const openCurrentPageHelp = (): void => {
+    window.dispatchEvent(new CustomEvent('ofp:open-page-help'));
+  };
+
   const handleLogout = async (): Promise<void> => {
     try {
       await logout();
@@ -442,7 +446,7 @@ function RootLayout(): React.ReactElement {
     onOpenVersionHistory: () => { void handleOpenProjectHistory(); },
     onLogout: () => { void handleLogout(); },
     onOpenPalette: openPalette,
-    onOpenShortcuts: () => setShortcutsOpen(true),
+    onOpenShortcuts: openCurrentPageHelp,
     labels: {
       nextPage: t('commandPalette.commands.nextPage'),
       previousPage: t('commandPalette.commands.previousPage'),
@@ -456,7 +460,7 @@ function RootLayout(): React.ReactElement {
       openPalette: t('commandPalette.label'),
       openShortcuts: t('commandPalette.commands.openShortcuts'),
     },
-  }), [activeMembershipRole, activeProjectId, location.pathname, memberships, navigate, openPalette, t]);
+  }), [activeMembershipRole, activeProjectId, location.pathname, memberships, navigate, openCurrentPageHelp, openPalette, t]);
 
   useRegisterCommands('global-app', globalCommands);
   

--- a/frontend/src/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/__tests__/RegisterPage.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterPage from '../pages/auth/RegisterPage';
+
+const logoutMock = vi.fn(async () => undefined);
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'test@example.com',
+      display_name: 'Test',
+      display_label: 'test@example.com',
+      is_active: true,
+      default_project_id: 1,
+      last_project_id: 1,
+      resolved_project_id: 1,
+      needs_project_selection: false,
+      memberships: [],
+      account_pending_deletion: false,
+      scheduled_deletion_at: null,
+    },
+    register: vi.fn(),
+    resendActivation: vi.fn(),
+    logout: logoutMock,
+  }),
+}));
+
+vi.mock('../api/api', () => ({
+  projectAPI: {
+    getPendingInvitation: vi.fn(async () => ({ data: { code: 'no_pending_invitation' } })),
+  },
+}));
+
+vi.mock('../i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: { user?: string }) => {
+      if (key === 'auth:register.loggedInHint') {
+        return `Du bist bereits angemeldet als ${params?.user}. Möchtest du einen neuen Account erstellen?`;
+      }
+      const map: Record<string, string> = {
+        'auth:register.title': 'Registrieren',
+        'auth:register.logoutAndCreate': 'Abmelden & neuen Account erstellen',
+        'auth:register.backToApp': 'Zur App zurückkehren',
+        'auth:register.email': 'E-Mail',
+        'auth:register.displayName': 'Anzeigename',
+        'auth:register.password': 'Passwort',
+        'auth:register.passwordConfirm': 'Passwort bestätigen',
+        'auth:register.submit': 'Konto erstellen',
+        'auth:register.resendActivation': 'Aktivierungs-E-Mail erneut senden',
+        'auth:register.hasAccount': 'Bereits ein Konto? Anmelden',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    logoutMock.mockClear();
+  });
+
+  it('shows logged-in info banner and account-switch actions instead of redirecting', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/register']}>
+        <RegisterPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Registrieren')).toBeInTheDocument();
+    expect(screen.getByText(/Du bist bereits angemeldet als/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Abmelden & neuen Account erstellen' }));
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -30,6 +30,7 @@ function RootCommandFixture(props: {
   onPreviousPage?: () => void;
   onOpenPalette?: () => void;
   onOpenProjectSettings?: () => void;
+  onOpenShortcuts?: () => void;
 }): React.ReactElement {
   const { openPalette } = useCommandContext();
   const commands = useMemo(() => createRootCommands({
@@ -50,7 +51,7 @@ function RootCommandFixture(props: {
     onOpenVersionHistory: vi.fn(),
     onLogout: vi.fn(),
     onOpenPalette: props.onOpenPalette ?? openPalette,
-    onOpenShortcuts: vi.fn(),
+    onOpenShortcuts: props.onOpenShortcuts ?? vi.fn(),
     labels: {
       nextPage: 'Nächste Seite',
       previousPage: 'Vorherige Seite',
@@ -64,7 +65,7 @@ function RootCommandFixture(props: {
       openPalette: 'Aktionssuche',
       openShortcuts: 'Tastenkürzel',
     },
-  }), [openPalette, props.currentPath, props.onNextPage, props.onOpenPalette, props.onOpenProjectSettings, props.onPreviousPage]);
+  }), [openPalette, props.currentPath, props.onNextPage, props.onOpenPalette, props.onOpenProjectSettings, props.onOpenShortcuts, props.onPreviousPage]);
 
   useRegisterCommands('root', commands);
   return <div>root fixture</div>;
@@ -189,5 +190,18 @@ describe('CommandProvider', () => {
     fireEvent.keyDown(window, { key: 'P', altKey: true, shiftKey: true });
 
     expect(onOpenProjectSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs page help shortcut with Alt+H', () => {
+    const onOpenShortcuts = vi.fn();
+    render(
+      <CommandProvider>
+        <RootCommandFixture onOpenShortcuts={onOpenShortcuts} />
+      </CommandProvider>,
+    );
+
+    fireEvent.keyDown(window, { key: 'h', altKey: true });
+
+    expect(onOpenShortcuts).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -37,6 +37,22 @@ describe('hierarchy components and behaviors', () => {
     expect(rows).toHaveLength(0);
   });
 
+  it('marks expandability only for rows with real children', () => {
+    const locations = [createLocation({ id: 1, name: 'A' }), createLocation({ id: 2, name: 'B' })];
+    const fields = [createField({ id: 10, location: 1, name: 'Field 10' })];
+    const beds = [createBed({ id: 100, field: 10, name: 'Bed 100' })];
+
+    const rows = buildHierarchyRows(locations, fields, beds, new Set(['location-1', 'field-10', 'location-2']));
+
+    const locationWithChildren = rows.find((row) => row.id === 'location-1');
+    const fieldWithChildren = rows.find((row) => row.id === 'field-10');
+    const bedLeaf = rows.find((row) => row.id === 100);
+
+    expect(locationWithChildren?.hasChildren).toBe(true);
+    expect(fieldWithChildren?.hasChildren).toBe(true);
+    expect(bedLeaf?.hasChildren).toBe(false);
+  });
+
   it('builds hierarchy inline action callbacks for field, bed and location rows', async () => {
     const user = userEvent.setup();
     const toggleExpand = vi.fn();
@@ -178,6 +194,48 @@ describe('hierarchy components and behaviors', () => {
 
     expect(screen.queryByLabelText('Pflanzplan erstellen')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Löschen')).not.toBeInTheDocument();
+  });
+
+  it('renders chevron only for rows that actually have children', () => {
+    const columns = createHierarchyColumns(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      mockT as never,
+    );
+
+    const nameColumn = columns.find((column) => column.field === 'name');
+
+    const { rerender } = render(
+      <>
+        {nameColumn?.renderCell?.({
+          id: 'field-10',
+          field: 'name',
+          value: 'Parzelle 10',
+          row: { id: 'field-10', type: 'field', fieldId: 10, level: 1, hasChildren: false },
+        } as never)}
+      </>
+    );
+
+    expect(screen.queryByLabelText('Eintrag aufklappen')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Eintrag zuklappen')).not.toBeInTheDocument();
+
+    rerender(
+      <>
+        {nameColumn?.renderCell?.({
+          id: 'field-11',
+          field: 'name',
+          value: 'Parzelle 11',
+          row: { id: 'field-11', type: 'field', fieldId: 11, level: 1, expanded: false, hasChildren: true },
+        } as never)}
+      </>
+    );
+
+    expect(screen.getByLabelText('Eintrag aufklappen')).toBeInTheDocument();
   });
 
 

--- a/frontend/src/components/help/HelpIconRow.tsx
+++ b/frontend/src/components/help/HelpIconRow.tsx
@@ -1,0 +1,47 @@
+import { Box, Typography } from '@mui/material';
+import type { ReactElement, ReactNode } from 'react';
+
+interface HelpIconRowProps {
+  icon: ReactNode;
+  text: string;
+}
+
+/**
+ * Renders a standardized icon + text row for contextual help lists.
+ *
+ * @param props - Component properties.
+ * @param props.icon - Icon element rendered on the left side.
+ * @param props.text - Localized help text rendered on the right side.
+ * @returns JSX element with aligned icon and help text.
+ */
+export default function HelpIconRow({ icon, text }: HelpIconRowProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 1,
+        minHeight: 20,
+        flexWrap: 'nowrap',
+        width: '100%',
+      }}
+    >
+      <Box
+        component="span"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          minWidth: 34,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {icon}
+      </Box>
+      <Typography variant="body2" component="span">
+        {text}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -3,7 +3,9 @@ import AgricultureIcon from '@mui/icons-material/Agriculture';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteIcon from '@mui/icons-material/Delete';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
@@ -16,6 +18,7 @@ import NoteAltIcon from '@mui/icons-material/NoteAlt';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import PublicIcon from '@mui/icons-material/Public';
 import RemoveIcon from '@mui/icons-material/Remove';
+import RoomOutlinedIcon from '@mui/icons-material/RoomOutlined';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import TabIcon from '@mui/icons-material/Tab';
@@ -71,6 +74,12 @@ interface SymbolDefinition {
 }
 
 const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> = {
+  locations: [
+    { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'edit', icon: <EditOutlinedIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'delete', icon: <DeleteOutlineIcon fontSize="small" sx={{ color: 'error.main' }} /> },
+    { key: 'map', icon: <RoomOutlinedIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+  ],
   areas: [
     { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
     { key: 'createPlan', icon: <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
@@ -95,31 +104,31 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
     { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
   ],
   cultures: [
-    { key: 'add', icon: <AddIcon fontSize="small" /> },
-    { key: 'library', icon: <PublicIcon fontSize="small" /> },
-    { key: 'edit', icon: <EditIcon fontSize="small" /> },
-    { key: 'more', icon: <MoreVertIcon fontSize="small" /> },
-    { key: 'delete', icon: <DeleteIcon fontSize="small" /> },
+    { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'library', icon: <PublicIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'more', icon: <MoreVertIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
   ],
   plantingPlans: [
-    { key: 'add', icon: <AddIcon fontSize="small" /> },
-    { key: 'mobileAdd', icon: <AddIcon fontSize="small" sx={{ bgcolor: 'action.hover', borderRadius: '50%' }} /> },
-    { key: 'edit', icon: <EditIcon fontSize="small" /> },
-    { key: 'notes', icon: <NoteAltIcon fontSize="small" /> },
+    { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'mobileAdd', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main', bgcolor: 'action.hover', borderRadius: '50%' }} /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'notes', icon: <NoteAltIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
   ],
   calendar: [
-    { key: 'tabs', icon: <TabIcon fontSize="small" /> },
-    { key: 'switch', icon: <ToggleOnIcon fontSize="small" /> },
-    { key: 'tooltip', icon: <InfoOutlinedIcon fontSize="small" /> },
+    { key: 'tabs', icon: <TabIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'switch', icon: <ToggleOnIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'tooltip', icon: <InfoOutlinedIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
   ],
   seedDemand: [
-    { key: 'supplierSelect', icon: <ArrowDropDownIcon fontSize="small" /> },
-    { key: 'packageInfo', icon: <OpenInFullIcon fontSize="small" /> },
+    { key: 'supplierSelect', icon: <ArrowDropDownIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'packageInfo', icon: <OpenInFullIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
   ],
   suppliers: [
-    { key: 'add', icon: <AddIcon fontSize="small" /> },
-    { key: 'edit', icon: <EditIcon fontSize="small" /> },
-    { key: 'delete', icon: <DeleteIcon fontSize="small" /> },
+    { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
   ],
   graphical: [
     {

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -39,7 +39,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useMediaQuery } from '@mui/system';
-import { useMemo, useState, type ReactElement } from 'react';
+import { useMemo, useState, type MouseEvent, type ReactElement } from 'react';
 import { useTranslation } from '../../i18n';
 import HelpIconRow from './HelpIconRow';
 
@@ -206,7 +206,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
       .filter((item): item is { icon: ReactElement; text: string } => item !== null);
   }, [pageKey, t]);
 
-  const handleOpen = (event: React.MouseEvent<HTMLElement>): void => {
+  const handleOpen = (event: MouseEvent<HTMLElement>): void => {
     if (isMobile) {
       setMobileOpen(true);
       return;

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -1,17 +1,26 @@
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import AddIcon from '@mui/icons-material/Add';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import NoteAltIcon from '@mui/icons-material/NoteAlt';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import PublicIcon from '@mui/icons-material/Public';
 import RemoveIcon from '@mui/icons-material/Remove';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
+import TabIcon from '@mui/icons-material/Tab';
+import ToggleOnIcon from '@mui/icons-material/ToggleOn';
+import TooltipIcon from '@mui/icons-material/Tooltip';
 import {
   Box,
   Dialog,
@@ -32,6 +41,7 @@ import { useTheme } from '@mui/material/styles';
 import { useMediaQuery } from '@mui/system';
 import { useMemo, useState, type ReactElement } from 'react';
 import { useTranslation } from '../../i18n';
+import HelpIconRow from './HelpIconRow';
 
 export type HelpPageKey =
   | 'dashboard'
@@ -54,6 +64,81 @@ interface HelpSection {
   title: string;
   points: string[];
 }
+
+interface SymbolDefinition {
+  key: string;
+  icon: ReactElement;
+}
+
+const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> = {
+  areas: [
+    { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'createPlan', icon: <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    {
+      key: 'expandToggle',
+      icon: (
+        <Stack direction="row" spacing={0.1} alignItems="center">
+          <ChevronRightIcon fontSize="small" />
+          <ArrowDropDownIcon fontSize="small" />
+        </Stack>
+      ),
+    },
+    {
+      key: 'dimensions',
+      icon: (
+        <Stack direction="row" spacing={0.25} alignItems="center">
+          <SwapVertIcon fontSize="small" />
+          <SwapHorizIcon fontSize="small" />
+        </Stack>
+      ),
+    },
+    { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
+  ],
+  cultures: [
+    { key: 'add', icon: <AddIcon fontSize="small" /> },
+    { key: 'library', icon: <PublicIcon fontSize="small" /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" /> },
+    { key: 'more', icon: <MoreVertIcon fontSize="small" /> },
+    { key: 'delete', icon: <DeleteIcon fontSize="small" /> },
+  ],
+  plantingPlans: [
+    { key: 'add', icon: <AddIcon fontSize="small" /> },
+    { key: 'mobileAdd', icon: <AddIcon fontSize="small" sx={{ bgcolor: 'action.hover', borderRadius: '50%' }} /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" /> },
+    { key: 'notes', icon: <NoteAltIcon fontSize="small" /> },
+  ],
+  calendar: [
+    { key: 'tabs', icon: <TabIcon fontSize="small" /> },
+    { key: 'switch', icon: <ToggleOnIcon fontSize="small" /> },
+    { key: 'tooltip', icon: <TooltipIcon fontSize="small" /> },
+  ],
+  seedDemand: [
+    { key: 'supplierSelect', icon: <ArrowDropDownIcon fontSize="small" /> },
+    { key: 'packageInfo', icon: <OpenInFullIcon fontSize="small" /> },
+  ],
+  suppliers: [
+    { key: 'add', icon: <AddIcon fontSize="small" /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" /> },
+    { key: 'delete', icon: <DeleteIcon fontSize="small" /> },
+  ],
+  graphical: [
+    {
+      key: 'panArrows',
+      icon: (
+        <Stack direction="row" spacing={0.25} alignItems="center">
+          <KeyboardArrowUpIcon fontSize="small" />
+          <KeyboardArrowLeftIcon fontSize="small" />
+          <KeyboardArrowRightIcon fontSize="small" />
+          <KeyboardArrowDownIcon fontSize="small" />
+        </Stack>
+      ),
+    },
+    { key: 'zoomIn', icon: <AddIcon fontSize="small" /> },
+    { key: 'zoomOut', icon: <RemoveIcon fontSize="small" /> },
+    { key: 'fit', icon: <FitScreenIcon fontSize="small" /> },
+    { key: 'fullscreen', icon: <FullscreenIcon fontSize="small" /> },
+  ],
+};
 
 /**
  * Displays the page-specific help content for the given page key.
@@ -102,19 +187,23 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
       .filter((section): section is HelpSection => section !== null);
   }, [pageKey, t]);
 
-  const hasSectionSymbols = useMemo(() => {
-    const symbolEntries = t(`pages.${pageKey}.symbols`, { returnObjects: true }) as unknown;
-    return !!symbolEntries && typeof symbolEntries === 'object' && !Array.isArray(symbolEntries);
-  }, [pageKey, t]);
-
   const title = t(`pages.${pageKey}.title`);
   const symbolsTitle = t(`pages.${pageKey}.symbolsTitle`);
-  const symbolItems = useMemo(() => {
-    const translated = t(`pages.${pageKey}.symbols`, { returnObjects: true }) as unknown;
-    if (!translated || typeof translated !== 'object' || Array.isArray(translated)) {
+  const symbolRows = useMemo(() => {
+    const symbolDefinitions = PAGE_SYMBOL_DEFINITIONS[pageKey];
+    if (!symbolDefinitions || symbolDefinitions.length === 0) {
       return [];
     }
-    return Object.values(translated as Record<string, unknown>).map((value) => String(value));
+
+    return symbolDefinitions
+      .map((definition) => {
+        const translated = t(`pages.${pageKey}.symbols.${definition.key}`);
+        if (!translated || translated === `pages.${pageKey}.symbols.${definition.key}`) {
+          return null;
+        }
+        return { icon: definition.icon, text: translated };
+      })
+      .filter((item): item is { icon: ReactElement; text: string } => item !== null);
   }, [pageKey, t]);
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>): void => {
@@ -152,31 +241,9 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
           {t('pages.graphical.symbolsTitle')}
         </Typography>
         <Stack spacing={1}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Stack direction="row" spacing={0.25} alignItems="center">
-              <KeyboardArrowUpIcon fontSize="small" />
-              <KeyboardArrowLeftIcon fontSize="small" />
-              <KeyboardArrowRightIcon fontSize="small" />
-              <KeyboardArrowDownIcon fontSize="small" />
-            </Stack>
-            <Typography variant="body2">{t('pages.graphical.symbols.panArrows')}</Typography>
-          </Stack>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <AddIcon fontSize="small" />
-            <Typography variant="body2">{t('pages.graphical.symbols.zoomIn')}</Typography>
-          </Stack>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <RemoveIcon fontSize="small" />
-            <Typography variant="body2">{t('pages.graphical.symbols.zoomOut')}</Typography>
-          </Stack>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <FitScreenIcon fontSize="small" />
-            <Typography variant="body2">{t('pages.graphical.symbols.fit')}</Typography>
-          </Stack>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <FullscreenIcon fontSize="small" />
-            <Typography variant="body2">{t('pages.graphical.symbols.fullscreen')}</Typography>
-          </Stack>
+          {symbolRows.map((row, index) => (
+            <HelpIconRow key={`${pageKey}-symbol-row-${index}`} icon={row.icon} text={row.text} />
+          ))}
         </Stack>
       </Box>
 
@@ -209,52 +276,16 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
     </Stack>
   );
 
-  const renderAreasSymbolsContent = (): ReactElement => (
-    <Box>
-      <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
-        {t('pages.areas.symbolsTitle')}
-      </Typography>
-      <Stack spacing={1}>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Stack direction="row" spacing={0.1} alignItems="center">
-            <ChevronRightIcon fontSize="small" />
-            <KeyboardArrowDownIcon fontSize="small" />
-          </Stack>
-          <Typography variant="body2">{t('pages.areas.symbols.expandToggle')}</Typography>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <AddIcon fontSize="small" sx={{ color: 'primary.main' }} />
-          <Typography variant="body2">{t('pages.areas.symbols.add')}</Typography>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} />
-          <Typography variant="body2">{t('pages.areas.symbols.delete')}</Typography>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} />
-          <Typography variant="body2">{t('pages.areas.symbols.createPlan')}</Typography>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <SwapVertIcon fontSize="small" />
-          <SwapHorizIcon fontSize="small" />
-          <Typography variant="body2">{t('pages.areas.symbols.dimensions')}</Typography>
-        </Stack>
-      </Stack>
-    </Box>
-  );
-
-  const renderGenericSymbolsContent = (): ReactElement => (
+  const renderSymbolsContent = (): ReactElement => (
     <Box>
       <Typography variant="body1" sx={{ fontWeight: 700, mb: 0.75 }}>
         {symbolsTitle}
       </Typography>
-      <List dense disablePadding>
-        {symbolItems.map((symbol, index) => (
-          <ListItem key={`${pageKey}-symbol-${index}`} sx={{ py: 0.2, px: 0 }}>
-            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${symbol}`} />
-          </ListItem>
+      <Stack spacing={1}>
+        {symbolRows.map((row, index) => (
+          <HelpIconRow key={`${pageKey}-symbol-${index}`} icon={row.icon} text={row.text} />
         ))}
-      </List>
+      </Stack>
     </Box>
   );
 
@@ -292,13 +323,9 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
             </List>
           ) : null}
 
-          {pageKey === 'areas' && hasSectionSymbols ? (
+          {sections && sections.length > 0 && pageKey !== 'graphical' && symbolRows.length > 0 ? (
             <Box sx={{ mt: 1.5 }}>
-              {renderAreasSymbolsContent()}
-            </Box>
-          ) : sections && sections.length > 0 && pageKey !== 'graphical' && symbolItems.length > 0 ? (
-            <Box sx={{ mt: 1.5 }}>
-              {renderGenericSymbolsContent()}
+              {renderSymbolsContent()}
             </Box>
           ) : (
             pageKey !== 'graphical' && (!sections || sections.length === 0) ? (
@@ -347,13 +374,9 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
             </List>
           ) : null}
 
-          {pageKey === 'areas' && hasSectionSymbols ? (
+          {sections && sections.length > 0 && pageKey !== 'graphical' && symbolRows.length > 0 ? (
             <Box sx={{ mt: 1.5 }}>
-              {renderAreasSymbolsContent()}
-            </Box>
-          ) : sections && sections.length > 0 && pageKey !== 'graphical' && symbolItems.length > 0 ? (
-            <Box sx={{ mt: 1.5 }}>
-              {renderGenericSymbolsContent()}
+              {renderSymbolsContent()}
             </Box>
           ) : (
             pageKey !== 'graphical' && (!sections || sections.length === 0) ? (

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -39,7 +39,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useMediaQuery } from '@mui/system';
-import { useMemo, useState, type MouseEvent, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type MouseEvent, type ReactElement } from 'react';
 import { useTranslation } from '../../i18n';
 import HelpIconRow from './HelpIconRow';
 
@@ -156,6 +156,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const points = useMemo(() => {
     const translated = t(`pages.${pageKey}.points`, { returnObjects: true });
@@ -218,6 +219,23 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
     setAnchorEl(null);
     setMobileOpen(false);
   };
+
+  useEffect(() => {
+    const handleOpenPageHelp = (): void => {
+      if (isMobile) {
+        setMobileOpen(true);
+        return;
+      }
+      if (triggerButtonRef.current) {
+        setAnchorEl(triggerButtonRef.current);
+      }
+    };
+
+    window.addEventListener('ofp:open-page-help', handleOpenPageHelp);
+    return () => {
+      window.removeEventListener('ofp:open-page-help', handleOpenPageHelp);
+    };
+  }, [isMobile]);
 
   const renderGraphicalHelpContent = (): ReactElement => (
     <Stack spacing={2}>
@@ -292,7 +310,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
   return (
     <>
       <Tooltip title={t('showTooltip')}>
-        <IconButton aria-label={t('showTooltip')} onClick={handleOpen} size="small" sx={{ color: 'text.secondary' }}>
+        <IconButton ref={triggerButtonRef} aria-label={t('showTooltip')} onClick={handleOpen} size="small" sx={{ color: 'text.secondary' }}>
           <HelpOutlineIcon fontSize="small" />
         </IconButton>
       </Tooltip>

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -20,7 +20,7 @@ import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import TabIcon from '@mui/icons-material/Tab';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
-import TooltipIcon from '@mui/icons-material/Tooltip';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Box,
   Dialog,
@@ -110,7 +110,7 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
   calendar: [
     { key: 'tabs', icon: <TabIcon fontSize="small" /> },
     { key: 'switch', icon: <ToggleOnIcon fontSize="small" /> },
-    { key: 'tooltip', icon: <TooltipIcon fontSize="small" /> },
+    { key: 'tooltip', icon: <InfoOutlinedIcon fontSize="small" /> },
   ],
   seedDemand: [
     { key: 'supplierSelect', icon: <ArrowDropDownIcon fontSize="small" /> },

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -130,13 +130,12 @@ function renderNameCell(
 ) {
   const row = params.row;
   const baseIndent = row.level * 24;
-  const indent = row.type === 'bed' ? baseIndent + 34 : baseIndent;
-
-  const hasExpandToggle = row.type === 'location' || row.type === 'field';
+  const hasChildren = row.hasChildren === true;
+  const hasExpandToggle = (row.type === 'location' || row.type === 'field') && hasChildren;
   const showInlineActions = params.cellMode !== 'edit';
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', pl: `${indent}px`, width: '100%', gap: 0.5 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', pl: `${baseIndent}px`, width: '100%', gap: 0.5 }}>
       {hasExpandToggle && (
         <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}><IconButton
           size="small"
@@ -150,8 +149,6 @@ function renderNameCell(
           {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
         </IconButton></Tooltip>
       )}
-
-      {!hasExpandToggle && <Box sx={{ width: 32 }} />}
 
       <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5 }}>
         <Box

--- a/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
+++ b/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
@@ -98,6 +98,10 @@ export function buildHierarchyRows(
     sortedLocations.forEach(location => {
       const locationKey = `location-${location.id}`;
       const isExpanded = expandedRows.has(locationKey);
+      const locationFields = sortByConfig(
+        fields.filter(f => f.location === location.id),
+        sortConfig
+      );
       hierarchyRows.push({
         id: locationKey,
         type: 'location',
@@ -105,18 +109,19 @@ export function buildHierarchyRows(
         name: location.name,
         locationId: location.id,
         expanded: isExpanded,
+        hasChildren: locationFields.length > 0,
       });
 
       if (!isExpanded) return;
 
       // Add fields under this location
-      const locationFields = sortByConfig(
-        fields.filter(f => f.location === location.id),
-        sortConfig
-      );
       locationFields.forEach(field => {
         const fieldKey = `field-${field.id}`;
         const isFieldExpanded = expandedRows.has(fieldKey);
+        const fieldBeds = sortByConfig(
+          beds.filter(b => b.field === field.id),
+          sortConfig
+        );
         hierarchyRows.push({
           id: fieldKey,
           type: 'field',
@@ -126,6 +131,7 @@ export function buildHierarchyRows(
           locationId: location.id,
           fieldId: field.id,
           expanded: isFieldExpanded,
+          hasChildren: fieldBeds.length > 0,
           area_sqm: field.area_sqm,
           length_m: field.length_m,
           width_m: field.width_m,
@@ -135,10 +141,6 @@ export function buildHierarchyRows(
         if (!isFieldExpanded) return;
 
         // Add beds under this field
-        const fieldBeds = sortByConfig(
-          beds.filter(b => b.field === field.id),
-          sortConfig
-        );
         fieldBeds.forEach(bed => {
           hierarchyRows.push({
             id: bed.id!,
@@ -155,6 +157,7 @@ export function buildHierarchyRows(
             locationId: location.id,
             fieldId: field.id,
             bedId: bed.id,
+            hasChildren: false,
             isNew: bed.id! < 0, // Mark as new if ID is negative
           });
         });
@@ -166,6 +169,10 @@ export function buildHierarchyRows(
     sortedFields.forEach(field => {
       const fieldKey = `field-${field.id}`;
       const isFieldExpanded = expandedRows.has(fieldKey);
+      const fieldBeds = sortByConfig(
+        beds.filter(b => b.field === field.id),
+        sortConfig
+      );
       hierarchyRows.push({
         id: fieldKey,
         type: 'field',
@@ -173,6 +180,7 @@ export function buildHierarchyRows(
         name: field.name,
         fieldId: field.id,
         expanded: isFieldExpanded,
+        hasChildren: fieldBeds.length > 0,
         area_sqm: field.area_sqm,
         length_m: field.length_m,
         width_m: field.width_m,
@@ -182,10 +190,6 @@ export function buildHierarchyRows(
       if (!isFieldExpanded) return;
 
       // Add beds under this field
-      const fieldBeds = sortByConfig(
-        beds.filter(b => b.field === field.id),
-        sortConfig
-      );
       fieldBeds.forEach(bed => {
         hierarchyRows.push({
           id: bed.id!,
@@ -201,6 +205,7 @@ export function buildHierarchyRows(
           notes: bed.notes,
           fieldId: field.id,
           bedId: bed.id,
+          hasChildren: false,
           isNew: bed.id! < 0, // Mark as new if ID is negative
         });
       });

--- a/frontend/src/components/hierarchy/utils/types.ts
+++ b/frontend/src/components/hierarchy/utils/types.ts
@@ -11,6 +11,7 @@ export interface HierarchyRow {
   type: 'location' | 'field' | 'bed';
   level: number;
   expanded?: boolean;
+  hasChildren?: boolean;
   parentId?: string | number;
   // Bed fields
   name?: string;

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,55 @@
+import { Box, Typography } from '@mui/material';
+import type { ReactElement, ReactNode } from 'react';
+
+interface PageHeaderProps {
+  title: ReactNode;
+  actions?: ReactNode;
+  marginBottom?: number;
+}
+
+/**
+ * Renders a shared page header with a left-aligned title and right-aligned actions.
+ *
+ * @param props - Component properties.
+ * @param props.title - Page title content.
+ * @param props.actions - Optional actions area rendered on the right side.
+ * @param props.marginBottom - Spacing below the header.
+ * @returns JSX element with responsive header layout.
+ */
+export default function PageHeader({
+  title,
+  actions,
+  marginBottom = 2,
+}: PageHeaderProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: { xs: 'column', sm: 'row' },
+        justifyContent: 'space-between',
+        alignItems: { xs: 'flex-start', sm: 'center' },
+        gap: { xs: 1, sm: 2 },
+        mb: marginBottom,
+      }}
+    >
+      <Typography variant="h4" component="h1">
+        {title}
+      </Typography>
+      {actions ? (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            minWidth: { sm: 220 },
+            justifyContent: 'flex-end',
+            width: { xs: '100%', sm: 'auto' },
+            alignSelf: { xs: 'flex-end', sm: 'auto' },
+          }}
+        >
+          {actions}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -22,6 +22,10 @@
     "submitting": "Erstelle Konto…",
     "passwordMismatch": "Passwörter stimmen nicht überein.",
     "failed": "Registrierung fehlgeschlagen.",
+    "loggedInHint": "Du bist bereits angemeldet als {{user}}. Möchtest du einen neuen Account erstellen?",
+    "logoutAndCreate": "Abmelden & neuen Account erstellen",
+    "backToApp": "Zur App zurückkehren",
+    "logoutToCreateFailed": "Abmelden fehlgeschlagen. Bitte erneut versuchen.",
     "resendActivation": "Aktivierungs-E-Mail erneut senden",
     "hasAccount": "Bereits ein Konto? Anmelden"
   },

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -43,12 +43,44 @@
     },
     "locations": {
       "title": "Hilfe: Standorte",
-      "points": [
-        "Hier verwaltest du deine Standorte.",
-        "Ein Standort kann mehrere Parzellen enthalten.",
-        "Mit „Neu“ legst du einen Standort an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden."
-      ]
+      "sections": [
+        {
+          "title": "Was sehe ich hier?",
+          "points": [
+            "Hier verwaltest du deine Standorte.",
+            "Ein Standort kann mehrere Parzellen und Beete enthalten.",
+            "Zu jedem Standort kannst du Informationen wie Koordinaten, Adresse, Bodenart oder Beschreibung speichern.",
+            "Anstehende Aufgaben werden direkt beim Standort angezeigt.",
+            "Diese Ansicht hilft dir, deine Flächen räumlich zu organisieren und den Überblick zu behalten."
+          ]
+        },
+        {
+          "title": "Bedienung",
+          "points": [
+            "Klicke auf einen Standort, um Details zu sehen oder zu bearbeiten.",
+            "Mit „Neuer Standort“ legst du einen neuen Standort an.",
+            "Bestehende Standorte kannst du bearbeiten oder löschen.",
+            "Aufgaben werden automatisch aus den Anbauplänen berechnet.",
+            "Koordinaten können direkt zu Google Maps führen."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "Standorte bilden die oberste Ebene deiner Flächenstruktur.",
+            "Parzellen und Beete aus den Anbauflächen greifen auf diese Struktur zurück.",
+            "Anbaupläne ordnen Kulturen den Beeten innerhalb deiner Standorte zu.",
+            "Der Anbaukalender und der Saatgutbedarf nutzen diese Zuordnungen für Zeit- und Mengenplanung."
+          ]
+        }
+      ],
+      "symbolsTitle": "Symbole und Bedienelemente",
+      "symbols": {
+        "add": "Neuen Standort hinzufügen",
+        "edit": "Standort bearbeiten",
+        "delete": "Standort löschen",
+        "map": "Koordinaten in Google Maps öffnen"
+      }
     },
     "fields": {
       "title": "Hilfe: Parzellen",

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -6,19 +6,27 @@
   "sections": [
     {
       "title": "Standorte / Anbauflächen",
-      "points": ["Hier legst du Standorte, Parzellen und Beete an."]
+      "points": [
+        "Hier legst du Standorte, Parzellen und Beete an."
+      ]
     },
     {
       "title": "Anbaupläne",
-      "points": ["Hier planst du, welche Kultur auf welchem Beet angebaut wird."]
+      "points": [
+        "Hier planst du, welche Kultur auf welchem Beet angebaut wird."
+      ]
     },
     {
       "title": "Anbaukalender",
-      "points": ["Hier siehst du die zeitliche Planung deiner Anbaupläne."]
+      "points": [
+        "Hier siehst du die zeitliche Planung deiner Anbaupläne."
+      ]
     },
     {
       "title": "Saatgutbedarf",
-      "points": ["Daraus wird berechnet, wie viel Saatgut du brauchst."]
+      "points": [
+        "Daraus wird berechnet, wie viel Saatgut du brauchst."
+      ]
     }
   ],
   "workflowTitle": "Workflow",
@@ -92,11 +100,11 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "expandToggle": "Pfeil-Symbol → Untergeordnete Elemente anzeigen oder ausblenden",
-        "add": "Plus-Symbol → Neues Element anlegen",
-        "delete": "Papierkorb-Symbol → Element löschen",
-        "createPlan": "Traktor-Symbol → Direkt einen Anbauplan für ein Beet anlegen",
-        "dimensions": "Längen-/Breiten-Symbole → Orientierung für Maßeingaben in den Spalten"
+        "expandToggle": "Untergeordnete Elemente ein- oder ausklappen",
+        "add": "Neues Element anlegen",
+        "delete": "Element löschen",
+        "createPlan": "Direkt einen Anbauplan für ein Beet anlegen",
+        "dimensions": "Orientierung für Länge und Breite in den Spalten"
       }
     },
     "cultures": {
@@ -130,11 +138,11 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Plus-Symbol → Neue Kultur anlegen",
-        "library": "Globus-Symbol → Öffentliche Kulturbibliothek öffnen",
-        "more": "Drei-Punkte-Symbol → Import/Export-Aktionen öffnen",
-        "edit": "Bearbeiten-Schaltfläche → Kulturdaten ändern",
-        "delete": "Löschen-Schaltfläche → Kultur entfernen"
+        "add": "Neue Kultur anlegen",
+        "library": "Öffentliche Kulturbibliothek öffnen",
+        "more": "Weitere Aktionen öffnen",
+        "edit": "Kulturdaten ändern",
+        "delete": "Kultur entfernen"
       }
     },
     "plantingPlans": {
@@ -168,10 +176,10 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Plus-Symbol → Neuen Anbauplan anlegen",
-        "mobileAdd": "Schwebender Plus-Button (mobil) → Schnell neuen Eintrag erfassen",
-        "notes": "Notiz-/Anhang-Symbol → Notizen und Anhänge pro Eintrag öffnen",
-        "edit": "Bearbeitungsmodus in der Tabelle → Werte direkt ändern"
+        "add": "Neuen Anbauplan anlegen",
+        "mobileAdd": "Auf Mobilgeräten schnell einen neuen Eintrag anlegen",
+        "notes": "Notizen und Anhänge pro Eintrag öffnen",
+        "edit": "Werte direkt in der Tabelle ändern"
       }
     },
     "calendar": {
@@ -205,9 +213,9 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "tabs": "Tab-Leiste → Zwischen Ansichten wechseln",
-        "switch": "Schalter → Wochen-Ertragskalender ein-/ausblenden",
-        "tooltip": "Tooltip bei Kalendereinträgen → Zusätzliche Detailinformationen anzeigen"
+        "tabs": "Zwischen Ansichten wechseln",
+        "switch": "Wochen-Ertragskalender ein- oder ausblenden",
+        "tooltip": "Zusätzliche Detailinformationen anzeigen"
       }
     },
     "seedDemand": {
@@ -240,8 +248,8 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "supplierSelect": "Auswahlliste je Zeile → Lieferanten pro Kultur festlegen",
-        "packageInfo": "Packungsvorschlag-Spalte → Empfohlene Kombinationen für den Bedarf"
+        "supplierSelect": "Lieferanten pro Kultur festlegen",
+        "packageInfo": "Empfohlene Packungskombinationen prüfen"
       }
     },
     "suppliers": {
@@ -274,9 +282,9 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Schaltfläche „Neu“ → Lieferanten anlegen",
-        "edit": "Schaltfläche „Bearbeiten“ → Lieferantendaten ändern",
-        "delete": "Löschen-Symbol → Lieferanten entfernen"
+        "add": "Lieferanten anlegen",
+        "edit": "Lieferantendaten ändern",
+        "delete": "Lieferanten entfernen"
       }
     },
     "graphical": {
@@ -302,11 +310,11 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "panArrows": "Pfeiltasten-Symbole → Ansicht nach oben, links, rechts oder unten verschieben",
-        "zoomIn": "Plus-Icon → Hineinzoomen",
-        "zoomOut": "Minus-Icon → Herauszoomen",
-        "fit": "Rahmen-Icon → Auf die gesamte Fläche einpassen",
-        "fullscreen": "Vollbild-Icon → Größtmögliche Ansicht anzeigen"
+        "panArrows": "Ansicht nach oben, links, rechts oder unten verschieben",
+        "zoomIn": "Hineinzoomen",
+        "zoomOut": "Herauszoomen",
+        "fit": "Gesamte Fläche einpassen",
+        "fullscreen": "Größtmögliche Ansicht anzeigen"
       },
       "modeTitle": "Modus",
       "modeLabel": "Modus",

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -58,7 +58,7 @@
       "openAccountSettings": "Kontoeinstellungen öffnen",
       "openVersionHistory": "Versionsverlauf öffnen",
       "logout": "Abmelden",
-      "openShortcuts": "Tastenkürzel öffnen",
+      "openShortcuts": "Seitenhilfe öffnen",
       "closeDialog": "Dialog schließen"
     },
     "feedback": {

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -6,120 +6,33 @@
   "sections": [
     {
       "title": "Locations / Growing areas",
-      "points": [
-        "Create locations, fields, and beds here."
-      ]
+      "points": ["Create locations, fields, and beds here."]
     },
     {
       "title": "Planting plans",
-      "points": [
-        "Plan which crop is grown in which bed here."
-      ]
+      "points": ["Plan which crop is grown in which bed here."]
     },
     {
       "title": "Planting calendar",
-      "points": [
-        "See the timeline for your planting plans here."
-      ]
+      "points": ["See the timeline for your planting plans here."]
     },
     {
       "title": "Seed demand",
-      "points": [
-        "This calculates how much seed you need."
-      ]
+      "points": ["This calculates how much seed you need."]
     }
   ],
   "workflowTitle": "Workflow",
   "workflow": "Locations → Beds → Planting plans → Planting calendar → Seed demand",
   "pages": {
-    "dashboard": {
-      "title": "Help: Overview",
-      "points": [
-        "Project overview.",
-        "Use navigation.",
-        "Quick actions.",
-        "Open pages to edit data."
-      ]
-    },
-    "locations": {
-      "title": "Help: Locations",
-      "points": [
-        "Manage locations.",
-        "A location can contain fields.",
-        "Use New to create.",
-        "Rows are clickable for editing."
-      ]
-    },
-    "fields": {
-      "title": "Help: Fields",
-      "points": [
-        "Manage fields.",
-        "A field contains beds.",
-        "Use New to create.",
-        "Rows are clickable for editing."
-      ]
-    },
-    "beds": {
-      "title": "Help: Beds",
-      "points": [
-        "Manage beds.",
-        "Beds belong to a field.",
-        "Use New to create.",
-        "Rows are clickable for editing."
-      ]
-    },
-    "areas": {
-      "title": "Help: Areas",
-      "points": [
-        "Manage growing areas.",
-        "Areas connect beds and plans.",
-        "Use New to create.",
-        "Rows are clickable for editing."
-      ],
-      "symbols": {
-        "expandToggle": "Expand or collapse nested elements",
-        "add": "Create a new element",
-        "delete": "Delete an element",
-        "createPlan": "Create a planting plan for a bed directly",
-        "dimensions": "Orientation for length and width columns"
-      }
-    },
-    "cultures": {
-      "title": "Help: Cultures",
-      "points": [
-        "Manage cultures.",
-        "Use New to create.",
-        "Rows are clickable for editing.",
-        "Use filter/search."
-      ]
-    },
-    "plantingPlans": {
-      "title": "Help: Planting plans",
-      "points": [
-        "Plan crop planting.",
-        "Use New to create.",
-        "Rows are clickable for editing.",
-        "Graphical mode shows occupancy."
-      ]
-    },
-    "seedDemand": {
-      "title": "Help: Seed demand",
-      "points": [
-        "Seed demand is calculated.",
-        "Based on cultures and plans.",
-        "Use filters.",
-        "Supports order planning."
-      ]
-    },
-    "suppliers": {
-      "title": "Help: Suppliers",
-      "points": [
-        "Manage suppliers.",
-        "Link suppliers to seed data.",
-        "Use New to create.",
-        "Rows are clickable for editing."
-      ]
-    },
+    "dashboard": {"title": "Help: Overview", "points": ["Project overview.", "Use navigation.", "Quick actions.", "Open pages to edit data."]},
+    "locations": {"title": "Help: Locations", "points": ["Manage locations.", "A location can contain fields.", "Use New to create.", "Rows are clickable for editing."]},
+    "fields": {"title": "Help: Fields", "points": ["Manage fields.", "A field contains beds.", "Use New to create.", "Rows are clickable for editing."]},
+    "beds": {"title": "Help: Beds", "points": ["Manage beds.", "Beds belong to a field.", "Use New to create.", "Rows are clickable for editing."]},
+    "areas": {"title": "Help: Areas", "points": ["Manage growing areas.", "Areas connect beds and plans.", "Use New to create.", "Rows are clickable for editing."]},
+    "cultures": {"title": "Help: Cultures", "points": ["Manage cultures.", "Use New to create.", "Rows are clickable for editing.", "Use filter/search."]},
+    "plantingPlans": {"title": "Help: Planting plans", "points": ["Plan crop planting.", "Use New to create.", "Rows are clickable for editing.", "Graphical mode shows occupancy."]},
+    "seedDemand": {"title": "Help: Seed demand", "points": ["Seed demand is calculated.", "Based on cultures and plans.", "Use filters.", "Supports order planning."]},
+    "suppliers": {"title": "Help: Suppliers", "points": ["Manage suppliers.", "Link suppliers to seed data.", "Use New to create.", "Rows are clickable for editing."]},
     "graphical": {
       "title": "Help: Graphical view of growing areas",
       "sections": [
@@ -152,11 +65,11 @@
       ],
       "symbolsTitle": "Icons and controls",
       "symbols": {
-        "panArrows": "Move the view up, left, right, or down",
-        "zoomIn": "Zoom in",
-        "zoomOut": "Zoom out",
-        "fit": "Fit the whole area",
-        "fullscreen": "Show the largest possible view"
+        "panArrows": "Arrow icons → Move view up, left, right or down",
+        "zoomIn": "Plus icon → Zoom in",
+        "zoomOut": "Minus icon → Zoom out",
+        "fit": "Frame icon → Fit whole area into the viewport",
+        "fullscreen": "Fullscreen icon → Show largest possible view"
       },
       "modeTitle": "Mode",
       "modeLabel": "Mode",

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -6,33 +6,120 @@
   "sections": [
     {
       "title": "Locations / Growing areas",
-      "points": ["Create locations, fields, and beds here."]
+      "points": [
+        "Create locations, fields, and beds here."
+      ]
     },
     {
       "title": "Planting plans",
-      "points": ["Plan which crop is grown in which bed here."]
+      "points": [
+        "Plan which crop is grown in which bed here."
+      ]
     },
     {
       "title": "Planting calendar",
-      "points": ["See the timeline for your planting plans here."]
+      "points": [
+        "See the timeline for your planting plans here."
+      ]
     },
     {
       "title": "Seed demand",
-      "points": ["This calculates how much seed you need."]
+      "points": [
+        "This calculates how much seed you need."
+      ]
     }
   ],
   "workflowTitle": "Workflow",
   "workflow": "Locations → Beds → Planting plans → Planting calendar → Seed demand",
   "pages": {
-    "dashboard": {"title": "Help: Overview", "points": ["Project overview.", "Use navigation.", "Quick actions.", "Open pages to edit data."]},
-    "locations": {"title": "Help: Locations", "points": ["Manage locations.", "A location can contain fields.", "Use New to create.", "Rows are clickable for editing."]},
-    "fields": {"title": "Help: Fields", "points": ["Manage fields.", "A field contains beds.", "Use New to create.", "Rows are clickable for editing."]},
-    "beds": {"title": "Help: Beds", "points": ["Manage beds.", "Beds belong to a field.", "Use New to create.", "Rows are clickable for editing."]},
-    "areas": {"title": "Help: Areas", "points": ["Manage growing areas.", "Areas connect beds and plans.", "Use New to create.", "Rows are clickable for editing."]},
-    "cultures": {"title": "Help: Cultures", "points": ["Manage cultures.", "Use New to create.", "Rows are clickable for editing.", "Use filter/search."]},
-    "plantingPlans": {"title": "Help: Planting plans", "points": ["Plan crop planting.", "Use New to create.", "Rows are clickable for editing.", "Graphical mode shows occupancy."]},
-    "seedDemand": {"title": "Help: Seed demand", "points": ["Seed demand is calculated.", "Based on cultures and plans.", "Use filters.", "Supports order planning."]},
-    "suppliers": {"title": "Help: Suppliers", "points": ["Manage suppliers.", "Link suppliers to seed data.", "Use New to create.", "Rows are clickable for editing."]},
+    "dashboard": {
+      "title": "Help: Overview",
+      "points": [
+        "Project overview.",
+        "Use navigation.",
+        "Quick actions.",
+        "Open pages to edit data."
+      ]
+    },
+    "locations": {
+      "title": "Help: Locations",
+      "points": [
+        "Manage locations.",
+        "A location can contain fields.",
+        "Use New to create.",
+        "Rows are clickable for editing."
+      ]
+    },
+    "fields": {
+      "title": "Help: Fields",
+      "points": [
+        "Manage fields.",
+        "A field contains beds.",
+        "Use New to create.",
+        "Rows are clickable for editing."
+      ]
+    },
+    "beds": {
+      "title": "Help: Beds",
+      "points": [
+        "Manage beds.",
+        "Beds belong to a field.",
+        "Use New to create.",
+        "Rows are clickable for editing."
+      ]
+    },
+    "areas": {
+      "title": "Help: Areas",
+      "points": [
+        "Manage growing areas.",
+        "Areas connect beds and plans.",
+        "Use New to create.",
+        "Rows are clickable for editing."
+      ],
+      "symbols": {
+        "expandToggle": "Expand or collapse nested elements",
+        "add": "Create a new element",
+        "delete": "Delete an element",
+        "createPlan": "Create a planting plan for a bed directly",
+        "dimensions": "Orientation for length and width columns"
+      }
+    },
+    "cultures": {
+      "title": "Help: Cultures",
+      "points": [
+        "Manage cultures.",
+        "Use New to create.",
+        "Rows are clickable for editing.",
+        "Use filter/search."
+      ]
+    },
+    "plantingPlans": {
+      "title": "Help: Planting plans",
+      "points": [
+        "Plan crop planting.",
+        "Use New to create.",
+        "Rows are clickable for editing.",
+        "Graphical mode shows occupancy."
+      ]
+    },
+    "seedDemand": {
+      "title": "Help: Seed demand",
+      "points": [
+        "Seed demand is calculated.",
+        "Based on cultures and plans.",
+        "Use filters.",
+        "Supports order planning."
+      ]
+    },
+    "suppliers": {
+      "title": "Help: Suppliers",
+      "points": [
+        "Manage suppliers.",
+        "Link suppliers to seed data.",
+        "Use New to create.",
+        "Rows are clickable for editing."
+      ]
+    },
     "graphical": {
       "title": "Help: Graphical view of growing areas",
       "sections": [
@@ -65,11 +152,11 @@
       ],
       "symbolsTitle": "Icons and controls",
       "symbols": {
-        "panArrows": "Arrow icons → Move view up, left, right or down",
-        "zoomIn": "Plus icon → Zoom in",
-        "zoomOut": "Minus icon → Zoom out",
-        "fit": "Frame icon → Fit whole area into the viewport",
-        "fullscreen": "Fullscreen icon → Show largest possible view"
+        "panArrows": "Move the view up, left, right, or down",
+        "zoomIn": "Zoom in",
+        "zoomOut": "Zoom out",
+        "fit": "Fit the whole area",
+        "fullscreen": "Show the largest possible view"
       },
       "modeTitle": "Mode",
       "modeLabel": "Mode",

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -58,7 +58,7 @@
       "openAccountSettings": "Open account settings",
       "openVersionHistory": "Open version history",
       "logout": "Logout",
-      "openShortcuts": "Open shortcuts",
+      "openShortcuts": "Open page help",
       "closeDialog": "Close dialog"
     },
     "feedback": {

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -666,6 +666,7 @@ function FieldsBedsHierarchy({
         if (
           row &&
           (row.type === "location" || row.type === "field") &&
+          row.hasChildren === true &&
           !expandedRows.has(row.id)
         ) {
           toggleExpand(row.id);

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -445,9 +445,9 @@ function GanttChartPage(): React.ReactElement {
               showProgress={false}
               darkMode={false}
               onTaskUpdate={calendarMode === 'occupancy' ? handleTaskUpdate : undefined}
-              renderTooltip={({ task }) => (calendarMode === 'seedlings'
-                ? renderSeedlingTooltip({ task: task as GanttTask })
-                : renderOccupancyTooltip({ task: task as GanttTask }))}
+              renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
+                ? renderSeedlingTooltip({ task })
+                : renderOccupancyTooltip({ task }))}
               renderTask={calendarMode === 'seedlings'
                 ? ({ task, leftPx, widthPx, topPx }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
                     <Box

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -22,6 +22,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
 import PageHelp from '../components/help/PageHelp';
+import PageHeader from '../components/layout/PageHeader';
 import { useTranslation } from '../i18n';
 import { resolveLocaleFromLanguage } from '../utils/numberLocalization';
 import { deriveLocationTasks, type DerivedLocationTask } from './locationDerivedTasks';
@@ -241,31 +242,34 @@ function Locations(): React.ReactElement {
 
   return (
     <Box p={3}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
-        <Typography variant="h4">{t('locations:title')}</Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="contained" startIcon={<AddIcon />} onClick={openCreateDialog}>
-            {t('locations:addButton')}
-          </Button>
-          <PageHelp pageKey="locations" />
-        </Stack>
-      </Stack>
+      <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+        <PageHeader
+          title={t('locations:title')}
+          actions={(
+            <>
+              <Button variant="contained" startIcon={<AddIcon />} onClick={openCreateDialog}>
+                {t('locations:addButton')}
+              </Button>
+              <PageHelp pageKey="locations" />
+            </>
+          )}
+        />
 
-      {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
-      {loading ? <Typography>{t('common:messages.loading')}</Typography> : null}
+        {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
+        {loading ? <Typography>{t('common:messages.loading')}</Typography> : null}
 
-      {!loading && locations.length === 0 ? (
-        <Alert severity="info">{t('locations:emptyState')}</Alert>
-      ) : (
-        <Box
-          sx={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 2,
-            alignItems: 'flex-start',
-          }}
-        >
-          {locations.map((location) => {
+        {!loading && locations.length === 0 ? (
+          <Alert severity="info">{t('locations:emptyState')}</Alert>
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 2,
+              alignItems: 'flex-start',
+            }}
+          >
+            {locations.map((location) => {
             const hasCoordinates =
               typeof location.latitude === 'number' && typeof location.longitude === 'number';
             const mapLink = hasCoordinates
@@ -346,9 +350,10 @@ function Locations(): React.ReactElement {
                 </Card>
               </Box>
             );
-          })}
-        </Box>
-      )}
+            })}
+          </Box>
+        )}
+      </Box>
 
       <Dialog open={dialogOpen} onClose={closeDialog} fullWidth maxWidth="sm">
         <DialogTitle>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -263,10 +263,11 @@ function Locations(): React.ReactElement {
         ) : (
           <Box
             sx={{
-              display: 'flex',
-              flexWrap: 'wrap',
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 360px), 420px))',
               gap: 2,
-              alignItems: 'flex-start',
+              alignItems: 'start',
+              justifyContent: 'start',
             }}
           >
             {locations.map((location) => {
@@ -281,9 +282,8 @@ function Locations(): React.ReactElement {
                 <Box
                   key={location.id}
                   sx={{
-                    flex: '1 1 420px',
-                    minWidth: { xs: '100%', sm: 320 },
-                    maxWidth: 540,
+                    width: '100%',
+                    maxWidth: 420,
                   }}
                 >
                   <Card variant="outlined" sx={{ width: '100%' }}>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -242,7 +242,7 @@ function Locations(): React.ReactElement {
 
   return (
     <Box p={3}>
-      <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+      <Box sx={{ width: '100%', maxWidth: 1320 }}>
         <PageHeader
           title={t('locations:title')}
           actions={(
@@ -264,10 +264,10 @@ function Locations(): React.ReactElement {
           <Box
             sx={{
               display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 360px), 420px))',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
               gap: 2,
               alignItems: 'start',
-              justifyContent: 'start',
+              width: '100%',
             }}
           >
             {locations.map((location) => {
@@ -283,7 +283,6 @@ function Locations(): React.ReactElement {
                   key={location.id}
                   sx={{
                     width: '100%',
-                    maxWidth: 420,
                   }}
                 >
                   <Card variant="outlined" sx={{ width: '100%' }}>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -266,7 +266,7 @@ function Locations(): React.ReactElement {
               display: 'grid',
               gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
               gap: 2,
-              alignItems: 'start',
+              alignItems: 'stretch',
               width: '100%',
             }}
           >
@@ -283,10 +283,14 @@ function Locations(): React.ReactElement {
                   key={location.id}
                   sx={{
                     width: '100%',
+                    height: '100%',
                   }}
                 >
-                  <Card variant="outlined" sx={{ width: '100%' }}>
-                    <CardContent>
+                  <Card
+                    variant="outlined"
+                    sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}
+                  >
+                    <CardContent sx={{ flexGrow: 1 }}>
                       <Typography variant="h6" mb={1}>{location.name}</Typography>
 
                       <Stack spacing={1}>
@@ -331,7 +335,7 @@ function Locations(): React.ReactElement {
                         )}
                       </Box>
                     </CardContent>
-                    <CardActions sx={{ justifyContent: 'flex-end' }}>
+                    <CardActions sx={{ justifyContent: 'flex-end', mt: 'auto' }}>
                       <Button size="small" startIcon={<EditOutlinedIcon />} onClick={() => openEditDialog(location)}>
                         {t('common:actions.edit')}
                       </Button>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -11,7 +11,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Grid,
   Link,
   MenuItem,
   Stack,
@@ -258,7 +257,14 @@ function Locations(): React.ReactElement {
       {!loading && locations.length === 0 ? (
         <Alert severity="info">{t('locations:emptyState')}</Alert>
       ) : (
-        <Grid container spacing={2}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+            alignItems: 'flex-start',
+          }}
+        >
           {locations.map((location) => {
             const hasCoordinates =
               typeof location.latitude === 'number' && typeof location.longitude === 'number';
@@ -268,8 +274,15 @@ function Locations(): React.ReactElement {
             const taskPreview = (location.id ? tasksByLocation[location.id] : []) ?? [];
 
             return (
-              <Grid key={location.id} size={{ xs: 12, sm: 6, lg: 4 }}>
-                <Card variant="outlined" sx={{ height: '100%' }}>
+              <Box
+                key={location.id}
+                sx={{
+                  flex: '1 1 420px',
+                  minWidth: { xs: '100%', sm: 320 },
+                  maxWidth: 540,
+                }}
+              >
+                <Card variant="outlined">
                   <CardContent>
                     <Typography variant="h6" mb={1}>{location.name}</Typography>
 
@@ -331,10 +344,10 @@ function Locations(): React.ReactElement {
                     ) : null}
                   </CardActions>
                 </Card>
-              </Grid>
+              </Box>
             );
           })}
-        </Grid>
+        </Box>
       )}
 
       <Dialog open={dialogOpen} onClose={closeDialog} fullWidth maxWidth="sm">

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -270,86 +270,86 @@ function Locations(): React.ReactElement {
             }}
           >
             {locations.map((location) => {
-            const hasCoordinates =
-              typeof location.latitude === 'number' && typeof location.longitude === 'number';
-            const mapLink = hasCoordinates
-              ? `https://www.google.com/maps?q=${location.latitude},${location.longitude}`
-              : null;
-            const taskPreview = (location.id ? tasksByLocation[location.id] : []) ?? [];
+              const hasCoordinates =
+                typeof location.latitude === 'number' && typeof location.longitude === 'number';
+              const mapLink = hasCoordinates
+                ? `https://www.google.com/maps?q=${location.latitude},${location.longitude}`
+                : null;
+              const taskPreview = (location.id ? tasksByLocation[location.id] : []) ?? [];
 
-            return (
-              <Box
-                key={location.id}
-                sx={{
-                  flex: '1 1 420px',
-                  minWidth: { xs: '100%', sm: 320 },
-                  maxWidth: 540,
-                }}
-              >
-                <Card variant="outlined">
-                  <CardContent>
-                    <Typography variant="h6" mb={1}>{location.name}</Typography>
+              return (
+                <Box
+                  key={location.id}
+                  sx={{
+                    flex: '1 1 420px',
+                    minWidth: { xs: '100%', sm: 320 },
+                    maxWidth: 540,
+                  }}
+                >
+                  <Card variant="outlined" sx={{ width: '100%' }}>
+                    <CardContent>
+                      <Typography variant="h6" mb={1}>{location.name}</Typography>
 
-                    <Stack spacing={1}>
-                      <Typography variant="body2">
-                        <strong>{t('locations:columns.coordinates')}:</strong>{' '}
-                        {hasCoordinates && mapLink ? (
-                          <Link href={mapLink} target="_blank" rel="noreferrer" underline="hover">
-                            {`${formatCoordinate(location.latitude!, numberLocale)}; ${formatCoordinate(location.longitude!, numberLocale)}`}
-                          </Link>
-                        ) : '—'}
-                      </Typography>
-                      <Typography variant="body2"><strong>{t('locations:columns.address')}:</strong> {location.address || '—'}</Typography>
-                      <Typography variant="body2"><strong>{t('locations:columns.soilType')}:</strong> {location.soil_type ? t(`locations:soilType.${location.soil_type}`) : '—'}</Typography>
-                      <Typography variant="body2"><strong>{t('locations:columns.exposure')}:</strong> {location.exposure ? t(`locations:exposure.${location.exposure}`) : '—'}</Typography>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          display: '-webkit-box',
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                        }}
-                      >
-                        <strong>{t('locations:columns.description')}:</strong> {location.description || '—'}
-                      </Typography>
-                    </Stack>
-
-                    <Box mt={2}>
-                      <Typography variant="subtitle2" gutterBottom>
-                        {t('locations:upcomingTasks')}
-                      </Typography>
-                      {taskPreview.length === 0 ? (
-                        <Typography variant="body2" color="text.secondary">
-                          {t('locations:noUpcomingTasks')}
+                      <Stack spacing={1}>
+                        <Typography variant="body2">
+                          <strong>{t('locations:columns.coordinates')}:</strong>{' '}
+                          {hasCoordinates && mapLink ? (
+                            <Link href={mapLink} target="_blank" rel="noreferrer" underline="hover">
+                              {`${formatCoordinate(location.latitude!, numberLocale)}; ${formatCoordinate(location.longitude!, numberLocale)}`}
+                            </Link>
+                          ) : '—'}
                         </Typography>
-                      ) : (
-                        <Stack spacing={0.5}>
-                          {taskPreview.slice(0, 3).map((task) => (
-                            <Chip key={`${task.type}-${task.date}-${task.planId ?? 'na'}`} label={renderTaskLine(task)} size="small" />
-                          ))}
-                        </Stack>
-                      )}
-                    </Box>
-                  </CardContent>
-                  <CardActions sx={{ justifyContent: 'flex-end' }}>
-                    <Button size="small" startIcon={<EditOutlinedIcon />} onClick={() => openEditDialog(location)}>
-                      {t('common:actions.edit')}
-                    </Button>
-                    {location.id ? (
-                      <Button
-                        color="error"
-                        size="small"
-                        startIcon={<DeleteOutlineIcon />}
-                        onClick={() => void deleteLocation(location.id!)}
-                      >
-                        {t('common:actions.delete')}
+                        <Typography variant="body2"><strong>{t('locations:columns.address')}:</strong> {location.address || '—'}</Typography>
+                        <Typography variant="body2"><strong>{t('locations:columns.soilType')}:</strong> {location.soil_type ? t(`locations:soilType.${location.soil_type}`) : '—'}</Typography>
+                        <Typography variant="body2"><strong>{t('locations:columns.exposure')}:</strong> {location.exposure ? t(`locations:exposure.${location.exposure}`) : '—'}</Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <strong>{t('locations:columns.description')}:</strong> {location.description || '—'}
+                        </Typography>
+                      </Stack>
+
+                      <Box mt={2}>
+                        <Typography variant="subtitle2" gutterBottom>
+                          {t('locations:upcomingTasks')}
+                        </Typography>
+                        {taskPreview.length === 0 ? (
+                          <Typography variant="body2" color="text.secondary">
+                            {t('locations:noUpcomingTasks')}
+                          </Typography>
+                        ) : (
+                          <Stack spacing={0.5}>
+                            {taskPreview.slice(0, 3).map((task) => (
+                              <Chip key={`${task.type}-${task.date}-${task.planId ?? 'na'}`} label={renderTaskLine(task)} size="small" />
+                            ))}
+                          </Stack>
+                        )}
+                      </Box>
+                    </CardContent>
+                    <CardActions sx={{ justifyContent: 'flex-end' }}>
+                      <Button size="small" startIcon={<EditOutlinedIcon />} onClick={() => openEditDialog(location)}>
+                        {t('common:actions.edit')}
                       </Button>
-                    ) : null}
-                  </CardActions>
-                </Card>
-              </Box>
-            );
+                      {location.id ? (
+                        <Button
+                          color="error"
+                          size="small"
+                          startIcon={<DeleteOutlineIcon />}
+                          onClick={() => void deleteLocation(location.id!)}
+                        >
+                          {t('common:actions.delete')}
+                        </Button>
+                      ) : null}
+                    </CardActions>
+                  </Card>
+                </Box>
+              );
             })}
           </Box>
         )}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1086,7 +1086,7 @@ function PlantingPlans(): React.ReactElement {
         </Alert>
       ) : null}
 
-      <Box sx={{ width: "100%", maxWidth: "100%" }}>
+      <Box sx={{ width: "fit-content", maxWidth: "100%" }}>
         <PageHeader
           title={t("plantingPlans:title")}
           actions={(

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -61,6 +61,7 @@ import {
 import { MobileCardList } from "../components/mobile/MobileCardList";
 import { NotesDrawer } from "../components/data-grid/NotesDrawer";
 import PageHelp from "../components/help/PageHelp";
+import PageHeader from "../components/layout/PageHeader";
 import {
   useCommandContextTag,
   useRegisterCommands,
@@ -1086,22 +1087,24 @@ function PlantingPlans(): React.ReactElement {
       ) : null}
 
       <Box sx={{ width: "100%", maxWidth: "100%" }}>
-        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
-          <h1>{t("plantingPlans:title")}</h1>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-            {!isMobile ? (
-              <Button
-                variant="contained"
-                startIcon={<AddIcon />}
-                onClick={() => gridCommandApiRef.current?.addRow()}
-                aria-label={`${t("plantingPlans:addButton")} (Alt+N)`}
-              >
-                {t("plantingPlans:addButton")}
-              </Button>
-            ) : null}
-            <PageHelp pageKey="plantingPlans" />
-          </Box>
-        </Box>
+        <PageHeader
+          title={t("plantingPlans:title")}
+          actions={(
+            <>
+              {!isMobile ? (
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={() => gridCommandApiRef.current?.addRow()}
+                  aria-label={`${t("plantingPlans:addButton")} (Alt+N)`}
+                >
+                  {t("plantingPlans:addButton")}
+                </Button>
+              ) : null}
+              <PageHelp pageKey="plantingPlans" />
+            </>
+          )}
+        />
 
         {isMobile ? (
           <Box sx={{ pb: 10 }}>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -22,6 +22,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
+import PageHeader from '../components/layout/PageHeader';
 import type { Supplier } from '../api/types';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -176,15 +177,17 @@ export default function Suppliers(): React.ReactElement {
   return (
     <div className="page-container">
       <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <h1>{t('title')}</h1>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <Button variant="contained" onClick={openCreate}>
-              + {t('create')}
-            </Button>
-            <PageHelp pageKey="suppliers" />
-          </Box>
-        </Box>
+        <PageHeader
+          title={t('title')}
+          actions={(
+            <>
+              <Button variant="contained" onClick={openCreate}>
+                + {t('create')}
+              </Button>
+              <PageHelp pageKey="suppliers" />
+            </>
+          )}
+        />
         <TableContainer sx={{ width: 'fit-content', maxWidth: '100%', overflowX: 'auto' }}>
           <Table size="small" sx={{ width: 'auto' }}>
             <TableHead>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,16 +1,17 @@
 import { Alert, Box, Button, Container, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Link as RouterLink, Navigate, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import { projectAPI, type InvitationPublicStatus } from '../../api/api';
 import { useAuth } from '../../auth/useAuth';
 import { useTranslation } from '../../i18n';
 import { getNextFromSearch, getTokenFromNextPath, storeInvitationRedirect } from '../invitationAcceptance';
 
 export default function RegisterPage(): React.ReactElement {
-  const { user, register, resendActivation } = useAuth();
+  const { user, register, resendActivation, logout } = useAuth();
   const { t } = useTranslation(['auth', 'projectInvitations']);
   const location = useLocation();
+  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [password, setPassword] = useState('');
@@ -20,6 +21,8 @@ export default function RegisterPage(): React.ReactElement {
   const [submitting, setSubmitting] = useState(false);
   const [pendingInvitation, setPendingInvitation] = useState<InvitationPublicStatus | null>(null);
   const nextPath = getNextFromSearch(location.search);
+  const isLoggedIn = user !== null;
+  const currentUserLabel = user?.display_label || user?.email || '–';
 
   useEffect(() => {
     const loadPendingInvitation = async (): Promise<void> => {
@@ -35,8 +38,6 @@ export default function RegisterPage(): React.ReactElement {
 
     void loadPendingInvitation();
   }, []);
-
-  if (user) return <Navigate to="/app" replace />;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -67,11 +68,38 @@ export default function RegisterPage(): React.ReactElement {
     setSuccess(await resendActivation(email.trim().toLowerCase()));
   };
 
+  const handleLogoutAndCreate = async (): Promise<void> => {
+    setError(null);
+    setSuccess(null);
+    try {
+      await logout();
+    } catch (logoutError) {
+      setError(logoutError instanceof Error ? logoutError.message : t('auth:register.logoutToCreateFailed'));
+    }
+  };
+
   return (
     <Container maxWidth="sm" sx={{ py: 8 }}>
       <Typography variant="h4" sx={{ mb: 3 }}>{t('auth:register.title')}</Typography>
       <Box component="form" onSubmit={handleSubmit}>
         <Stack spacing={2}>
+          {isLoggedIn ? (
+            <Alert severity="info">
+              <Stack spacing={1.5}>
+                <Typography variant="body2">
+                  {t('auth:register.loggedInHint', { user: currentUserLabel })}
+                </Typography>
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.25}>
+                  <Button variant="contained" onClick={() => void handleLogoutAndCreate()}>
+                    {t('auth:register.logoutAndCreate')}
+                  </Button>
+                  <Button variant="outlined" onClick={() => navigate('/app')}>
+                    {t('auth:register.backToApp')}
+                  </Button>
+                </Stack>
+              </Stack>
+            </Alert>
+          ) : null}
           {pendingInvitation ? (
             <Alert severity="info">
               {t('projectInvitations:registerHint', {
@@ -82,12 +110,12 @@ export default function RegisterPage(): React.ReactElement {
           ) : null}
           {error ? <Alert severity="error">{error}</Alert> : null}
           {success ? <Alert severity="success">{success}</Alert> : null}
-          <TextField label={t('auth:register.email')} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-          <TextField label={t('auth:register.displayName')} value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
-          <TextField label={t('auth:register.password')} type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-          <TextField label={t('auth:register.passwordConfirm')} type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required />
-          <Button type="submit" variant="contained" disabled={submitting}>{submitting ? t('auth:register.submitting') : t('auth:register.submit')}</Button>
-          <Button onClick={() => void handleResend()} disabled={!email}>{t('auth:register.resendActivation')}</Button>
+          <TextField label={t('auth:register.email')} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required disabled={isLoggedIn} />
+          <TextField label={t('auth:register.displayName')} value={displayName} onChange={(e) => setDisplayName(e.target.value)} disabled={isLoggedIn} />
+          <TextField label={t('auth:register.password')} type="password" value={password} onChange={(e) => setPassword(e.target.value)} required disabled={isLoggedIn} />
+          <TextField label={t('auth:register.passwordConfirm')} type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required disabled={isLoggedIn} />
+          <Button type="submit" variant="contained" disabled={submitting || isLoggedIn}>{submitting ? t('auth:register.submitting') : t('auth:register.submit')}</Button>
+          <Button onClick={() => void handleResend()} disabled={!email || isLoggedIn}>{t('auth:register.resendActivation')}</Button>
           <Button component={RouterLink} to={nextPath ? `/login?next=${encodeURIComponent(nextPath)}` : '/login'} state={location.state}>{t('auth:register.hasAccount')}</Button>
         </Stack>
       </Box>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -90,10 +90,10 @@ export default function RegisterPage(): React.ReactElement {
                   {t('auth:register.loggedInHint', { user: currentUserLabel })}
                 </Typography>
                 <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.25}>
-                  <Button variant="contained" onClick={() => void handleLogoutAndCreate()}>
+                  <Button type="button" variant="contained" onClick={() => void handleLogoutAndCreate()}>
                     {t('auth:register.logoutAndCreate')}
                   </Button>
-                  <Button variant="outlined" onClick={() => navigate('/app')}>
+                  <Button type="button" variant="outlined" onClick={() => navigate('/app')}>
                     {t('auth:register.backToApp')}
                   </Button>
                 </Stack>
@@ -115,8 +115,8 @@ export default function RegisterPage(): React.ReactElement {
           <TextField label={t('auth:register.password')} type="password" value={password} onChange={(e) => setPassword(e.target.value)} required disabled={isLoggedIn} />
           <TextField label={t('auth:register.passwordConfirm')} type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required disabled={isLoggedIn} />
           <Button type="submit" variant="contained" disabled={submitting || isLoggedIn}>{submitting ? t('auth:register.submitting') : t('auth:register.submit')}</Button>
-          <Button onClick={() => void handleResend()} disabled={!email || isLoggedIn}>{t('auth:register.resendActivation')}</Button>
-          <Button component={RouterLink} to={nextPath ? `/login?next=${encodeURIComponent(nextPath)}` : '/login'} state={location.state}>{t('auth:register.hasAccount')}</Button>
+          <Button type="button" onClick={() => void handleResend()} disabled={!email || isLoggedIn}>{t('auth:register.resendActivation')}</Button>
+          <Button type="button" component={RouterLink} to={nextPath ? `/login?next=${encodeURIComponent(nextPath)}` : '/login'} state={location.state}>{t('auth:register.hasAccount')}</Button>
         </Stack>
       </Box>
     </Container>

--- a/frontend/src/pages/public/ImprintPage.tsx
+++ b/frontend/src/pages/public/ImprintPage.tsx
@@ -16,7 +16,6 @@ export default function ImprintPage(): React.ReactElement {
         <Typography variant="h3" component="h1">
           {t('legal.imprint.title')}
         </Typography>
-        <Typography color="text.secondary">{t('legal.imprint.disclaimer')}</Typography>
 
         {imprintSections.map((sectionKey) => (
           <Stack key={sectionKey} spacing={0.5}>

--- a/frontend/src/types/react-modern-gantt.d.ts
+++ b/frontend/src/types/react-modern-gantt.d.ts
@@ -1,0 +1,76 @@
+declare module 'react-modern-gantt' {
+  import type { ComponentType, ReactNode } from 'react';
+
+  export enum ViewMode {
+    MINUTE = 'minute',
+    HOUR = 'hour',
+    DAY = 'day',
+    WEEK = 'week',
+    MONTH = 'month',
+    QUARTER = 'quarter',
+    YEAR = 'year',
+  }
+
+  export interface GanttTaskLike {
+    id: string;
+    name: string;
+    startDate: Date;
+    endDate: Date;
+    color?: string;
+    percent?: number;
+    dependencies?: string[];
+  }
+
+  export interface GanttTaskGroupLike {
+    id: string;
+    name: string;
+    description?: string;
+    icon?: string;
+    tasks: GanttTaskLike[];
+  }
+
+  export interface GanttTooltipProps {
+    task: GanttTaskLike;
+  }
+
+  export interface GanttTaskRenderProps {
+    task: GanttTaskLike;
+    leftPx: number;
+    widthPx: number;
+    topPx: number;
+    isHovered?: boolean;
+    isDragging?: boolean;
+    editMode?: boolean;
+    showProgress?: boolean;
+  }
+
+  export interface GanttLocaleText {
+    title?: string;
+    resources?: string;
+    today?: string;
+    viewModes?: Partial<Record<ViewMode, string>>;
+  }
+
+  export interface GanttChartProps {
+    tasks?: GanttTaskGroupLike[];
+    locale?: string;
+    localeText?: GanttLocaleText;
+    viewMode?: ViewMode;
+    startDate?: Date;
+    endDate?: Date;
+    editMode?: boolean;
+    allowTaskResize?: boolean;
+    allowTaskMove?: boolean;
+    showProgress?: boolean;
+    darkMode?: boolean;
+    onTaskUpdate?: (groupId: string, task: GanttTaskLike) => void | Promise<void>;
+    renderTooltip?: (props: GanttTooltipProps) => ReactNode;
+    renderTask?: (props: GanttTaskRenderProps) => ReactNode;
+  }
+
+  const GanttChart: ComponentType<GanttChartProps>;
+
+  export default GanttChart;
+}
+
+declare module 'react-modern-gantt/dist/index.css';


### PR DESCRIPTION
### Motivation
- Replace textual descriptions of UI symbols in help texts with the actual icons so users can visually recognize controls. 
- Provide a single, consistent presentation for help rows (icon + text) across desktop popovers and mobile dialogs. 
- Keep help copy concise and aligned with the icon-first presentation.

### Description
- Add a reusable `HelpIconRow` component to render an aligned icon slot and text (`frontend/src/components/help/HelpIconRow.tsx`).
- Refactor `PageHelp` to use a centralized `PAGE_SYMBOL_DEFINITIONS` map and render real Material UI icons inline with `fontSize="small"` via `HelpIconRow` for areas, cultures, planting plans, calendar, seed demand, suppliers and graphical views (`frontend/src/components/help/PageHelp.tsx`).
- Update i18n help resources to remove "…-Symbol" wording and provide concise action-focused labels for German (`frontend/src/i18n/locales/de/help.json`) and update matching symbol texts in English (`frontend/src/i18n/locales/en/help.json`).
- Ensure the same icon-first rendering is used in both popover (desktop) and dialog (mobile) help UIs and keep spacing/alignment consistent with `inline-flex` layout.

### Testing
- Attempted to run unit tests with `cd frontend && npm run test -- src/__tests__/FieldsBedsPage.test.tsx src/__tests__/CulturesActionArea.test.tsx src/__tests__/i18n.test.ts`, but the test run failed in this environment due to `vitest: not found` so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54b42dabc83229969181bf5ff3989)