### PR TITLE
refactor: reserve expand icon slot for leaf hierarchy rows

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -130,6 +130,14 @@ body.hide-version-footer .app-version-footer {
   margin: 0 auto;
 }
 
+.content--workspace {
+  width: 100%;
+  max-width: 1600px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  margin: 0 auto;
+}
+
 .content--full {
   width: 100%;
   box-sizing: border-box;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -138,6 +138,15 @@ body.hide-version-footer .app-version-footer {
   margin: 0 auto;
 }
 
+
+.content--xwide {
+  width: 100%;
+  max-width: 2200px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  margin: 0 auto;
+}
+
 .content--full {
   width: 100%;
   box-sizing: border-box;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -113,12 +113,27 @@ body.hide-version-footer .app-version-footer {
 }
 
 /* Page Container */
+.content,
 .page-container {
   width: 100%;
   max-width: 1200px;
   box-sizing: border-box;
-  padding: 20px;
+  padding: 0 24px;
   margin: 0 auto;
+}
+
+.content--wide {
+  width: 100%;
+  max-width: 1800px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  margin: 0 auto;
+}
+
+.content--full {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 24px;
 }
 
 /* Error Message */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -132,7 +132,7 @@ body.hide-version-footer .app-version-footer {
 
 .content--workspace {
   width: 100%;
-  max-width: 1600px;
+  max-width: min(1800px, calc(100vw - 48px));
   box-sizing: border-box;
   padding: 0 24px;
   margin: 0 auto;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -141,7 +141,7 @@ body.hide-version-footer .app-version-footer {
 
 .content--xwide {
   width: 100%;
-  max-width: 2200px;
+  max-width: 1900px;
   box-sizing: border-box;
   padding: 0 24px;
   margin: 0 auto;

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -25,6 +25,10 @@ describe('FieldsBedsPage', () => {
 
     expect(screen.getByText('Hierarchieansicht')).toBeInTheDocument();
     expect(screen.queryByText('Editiermodus')).not.toBeInTheDocument();
+    expect(screen.getByText('Darstellung')).toBeInTheDocument();
+    expect(screen.getByText('Modus')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ansicht' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bearbeiten' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Grafik' }));
 

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -7,7 +7,9 @@ vi.mock('../pages/FieldsBedsHierarchy', () => ({
 }));
 
 vi.mock('../pages/GraphicalFields', () => ({
-  default: () => <div>Editiermodus</div>,
+  default: ({ interactionMode }: { interactionMode?: 'view' | 'edit' }) => (
+    <div>{`Editiermodus-${interactionMode ?? 'none'}`}</div>
+  ),
 }));
 
 vi.mock('../commands/useCommandContext', () => ({
@@ -24,19 +26,23 @@ describe('FieldsBedsPage', () => {
     render(<FieldsBedsPage />);
 
     expect(screen.getByText('Hierarchieansicht')).toBeInTheDocument();
-    expect(screen.queryByText('Editiermodus')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Editiermodus-/)).not.toBeInTheDocument();
     expect(screen.getByText('Darstellung')).toBeInTheDocument();
+    expect(screen.queryByText('Modus')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ansicht' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bearbeiten' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grafik' }));
+
+    expect(screen.getByText('Editiermodus-view')).toBeInTheDocument();
     expect(screen.getByText('Modus')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ansicht' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Bearbeiten' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Grafik' }));
-
-    expect(screen.getByText('Editiermodus')).toBeInTheDocument();
-
     fireEvent.click(screen.getByRole('button', { name: 'Liste' }));
 
     expect(screen.getByText('Hierarchieansicht')).toBeInTheDocument();
-    expect(screen.queryByText('Editiermodus')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Editiermodus-/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Modus')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -100,7 +100,8 @@ describe('GanttChartPage', () => {
 
     await waitFor(() => expect(screen.getByText('Feldbelegung')).toBeInTheDocument());
     expect(screen.queryByText(/Belegung von Parzellen und Beeten im Jahresverlauf/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('switch')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ansicht' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bearbeiten' })).toBeInTheDocument();
     expect(screen.getByText('Beet 1')).toBeInTheDocument();
     expect(mocks.ganttProps).toHaveBeenCalled();
     const latestProps = mocks.ganttProps.mock.calls.at(-1)?.[0];
@@ -160,7 +161,8 @@ describe('GanttChartPage', () => {
     expect(screen.getByText('Fläche: 8.00 m²')).toBeInTheDocument();
     expect(screen.getByText('Pflanzenanzahl: 24')).toBeInTheDocument();
     expect(screen.queryByText(/Anbauplan/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ansicht' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bearbeiten' })).not.toBeInTheDocument();
   });
 
   it('toggles occupancy edit mode with Alt+E', async () => {
@@ -186,12 +188,12 @@ describe('GanttChartPage', () => {
       </CommandProvider>,
     );
 
-    const editSwitch = await screen.findByRole('switch');
-    expect(editSwitch).not.toBeChecked();
+    const editButton = await screen.findByRole('button', { name: 'Bearbeiten' });
+    expect(editButton).toHaveAttribute('aria-pressed', 'false');
 
     fireEvent.keyDown(window, { key: 'e', altKey: true });
 
-    await waitFor(() => expect(editSwitch).toBeChecked());
+    await waitFor(() => expect(editButton).toHaveAttribute('aria-pressed', 'true'));
   });
 
   it('fills empty yield weeks between available week entries', async () => {

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -221,8 +221,10 @@ describe('hierarchy components and behaviors', () => {
       </>
     );
 
+    expect(screen.getByTestId('expand-icon-slot')).toBeInTheDocument();
     expect(screen.queryByLabelText('Eintrag aufklappen')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Eintrag zuklappen')).not.toBeInTheDocument();
+    expect(screen.getByText('Parzelle 10')).toBeInTheDocument();
 
     rerender(
       <>
@@ -235,6 +237,7 @@ describe('hierarchy components and behaviors', () => {
       </>
     );
 
+    expect(screen.getByTestId('expand-icon-slot')).toBeInTheDocument();
     expect(screen.getByLabelText('Eintrag aufklappen')).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -105,7 +105,6 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    expect(screen.getByTestId('location-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Parzelle hinzufügen'));
     expect(addField).toHaveBeenCalledWith(2);
 
@@ -119,7 +118,6 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    expect(screen.getByTestId('field-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Beet hinzufügen'));
     await user.click(screen.getByLabelText('Löschen'));
     expect(addBed).toHaveBeenCalledWith(10);
@@ -135,7 +133,6 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    expect(screen.getByTestId('bed-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Pflanzplan erstellen'));
     await user.click(screen.getByLabelText('Löschen'));
     expect(createPlan).toHaveBeenCalledWith(100);

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -105,6 +105,7 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
+    expect(screen.getByTestId('location-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Parzelle hinzufügen'));
     expect(addField).toHaveBeenCalledWith(2);
 
@@ -118,6 +119,7 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
+    expect(screen.getByTestId('field-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Beet hinzufügen'));
     await user.click(screen.getByLabelText('Löschen'));
     expect(addBed).toHaveBeenCalledWith(10);
@@ -133,6 +135,7 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
+    expect(screen.getByTestId('bed-type-icon')).toBeInTheDocument();
     await user.click(screen.getByLabelText('Pflanzplan erstellen'));
     await user.click(screen.getByLabelText('Löschen'));
     expect(createPlan).toHaveBeenCalledWith(100);

--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from 'react';
+import { Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+
+export type ModeToggleValue = 'view' | 'edit';
+
+interface ModeToggleProps {
+  label: string;
+  ariaLabel: string;
+  viewLabel: string;
+  editLabel: string;
+  value: ModeToggleValue;
+  onChange: (value: ModeToggleValue) => void;
+  fullWidth?: boolean;
+}
+
+function ModeToggle({
+  label,
+  ariaLabel,
+  viewLabel,
+  editLabel,
+  value,
+  onChange,
+  fullWidth = true,
+}: ModeToggleProps): ReactElement {
+  return (
+    <Stack spacing={0.5} sx={{ width: fullWidth ? '100%' : 'auto' }}>
+      <Stack direction="row" spacing={0.5} alignItems="center" justifyContent={{ xs: 'space-between', sm: 'flex-start' }}>
+        <Typography variant="subtitle2">{label}</Typography>
+      </Stack>
+      <ToggleButtonGroup
+        value={value}
+        exclusive
+        size="small"
+        color="primary"
+        fullWidth={fullWidth}
+        aria-label={ariaLabel}
+        onChange={(_, selectedMode: ModeToggleValue | null) => {
+          if (selectedMode !== null) {
+            onChange(selectedMode);
+          }
+        }}
+      >
+        <ToggleButton value="view" aria-label={viewLabel}>
+          {viewLabel}
+        </ToggleButton>
+        <ToggleButton value="edit" aria-label={editLabel}>
+          {editLabel}
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Stack>
+  );
+}
+
+export default ModeToggle;

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -92,7 +92,6 @@ export interface EditableDataGridProps<T extends EditableRow> {
   showFooterEditControls?: boolean;
   showRowEditActions?: boolean;
   onRowsStateChange?: (rows: T[]) => void;
-  stretchToContainer?: boolean;
 }
 
 export function EditableDataGrid<T extends EditableRow>({
@@ -120,7 +119,6 @@ export function EditableDataGrid<T extends EditableRow>({
   showFooterEditControls = true,
   showRowEditActions = false,
   onRowsStateChange,
-  stretchToContainer = false,
 }: EditableDataGridProps<T>): React.ReactElement {
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
@@ -699,13 +697,7 @@ export function EditableDataGrid<T extends EditableRow>({
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
       <Box sx={{ width: '100%', overflowX: 'auto', overflowY: 'visible' }}>
-        <Box
-          sx={
-            stretchToContainer
-              ? { display: 'block', width: '100%', minWidth: 0 }
-              : { display: 'inline-block', width: 'fit-content', minWidth: 0 }
-          }
-        >
+        <Box sx={{ display: 'inline-block', width: 'fit-content', minWidth: 0 }}>
           <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -726,7 +718,7 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: stretchToContainer ? '100%' : 'auto' }}
+          sx={{ ...dataGridSx, width: 'auto' }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -92,6 +92,7 @@ export interface EditableDataGridProps<T extends EditableRow> {
   showFooterEditControls?: boolean;
   showRowEditActions?: boolean;
   onRowsStateChange?: (rows: T[]) => void;
+  stretchToContainer?: boolean;
 }
 
 export function EditableDataGrid<T extends EditableRow>({
@@ -119,6 +120,7 @@ export function EditableDataGrid<T extends EditableRow>({
   showFooterEditControls = true,
   showRowEditActions = false,
   onRowsStateChange,
+  stretchToContainer = false,
 }: EditableDataGridProps<T>): React.ReactElement {
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
@@ -697,7 +699,13 @@ export function EditableDataGrid<T extends EditableRow>({
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
       <Box sx={{ width: '100%', overflowX: 'auto', overflowY: 'visible' }}>
-        <Box sx={{ display: 'inline-block', width: 'fit-content', minWidth: 0 }}>
+        <Box
+          sx={
+            stretchToContainer
+              ? { display: 'block', width: '100%', minWidth: 0 }
+              : { display: 'inline-block', width: 'fit-content', minWidth: 0 }
+          }
+        >
           <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -718,7 +726,7 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: 'auto' }}
+          sx={{ ...dataGridSx, width: stretchToContainer ? '100%' : 'auto' }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -31,6 +31,8 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
   notes: 320,
 };
 
+const EXPAND_ICON_SLOT_SIZE = 32;
+
 interface NameCellCallbacks {
   onToggleExpand: (rowId: string | number) => void;
   onAddBed: (fieldId: number) => void;
@@ -136,19 +138,41 @@ function renderNameCell(
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', pl: `${baseIndent}px`, width: '100%', gap: 0.5 }}>
-      {hasExpandToggle && (
-        <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}><IconButton
-          size="small"
-          aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
-          onClick={(event) => {
-            event.stopPropagation();
-            callbacks.onToggleExpand(row.id);
-          }}
-          sx={{ mr: 1 }}
-        >
-          {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-        </IconButton></Tooltip>
-      )}
+      <Box
+        sx={{
+          width: EXPAND_ICON_SLOT_SIZE,
+          minWidth: EXPAND_ICON_SLOT_SIZE,
+          height: EXPAND_ICON_SLOT_SIZE,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mr: 1,
+          pointerEvents: hasExpandToggle ? 'auto' : 'none',
+        }}
+        data-testid="expand-icon-slot"
+      >
+        {hasExpandToggle ? (
+          <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}>
+            <IconButton
+              size="small"
+              aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
+              onClick={(event) => {
+                event.stopPropagation();
+                callbacks.onToggleExpand(row.id);
+              }}
+            >
+              {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Box
+            aria-hidden="true"
+            sx={{ width: EXPAND_ICON_SLOT_SIZE, height: EXPAND_ICON_SLOT_SIZE, visibility: 'hidden' }}
+          >
+            <ChevronRightIcon />
+          </Box>
+        )}
+      </Box>
 
       <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5 }}>
         <Box

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -13,9 +13,6 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
-import PlaceOutlinedIcon from '@mui/icons-material/PlaceOutlined';
-import CropSquareIcon from '@mui/icons-material/CropSquare';
-import SpaOutlinedIcon from '@mui/icons-material/SpaOutlined';
 import type { HierarchyRow } from './utils/types';
 import { NotesCell } from '../data-grid/NotesCell';
 import { getPlainExcerpt } from '../data-grid/markdown';
@@ -35,19 +32,6 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
 };
 
 const EXPAND_ICON_SLOT_SIZE = 32;
-const TYPE_ICON_SIZE = 18;
-
-const getTypeIcon = (rowType: HierarchyRow['type']): ReactElement => {
-  if (rowType === 'location') {
-    return <PlaceOutlinedIcon fontSize="inherit" data-testid="location-type-icon" />;
-  }
-
-  if (rowType === 'field') {
-    return <CropSquareIcon fontSize="inherit" data-testid="field-type-icon" />;
-  }
-
-  return <SpaOutlinedIcon fontSize="inherit" data-testid="bed-type-icon" />;
-};
 
 interface NameCellCallbacks {
   onToggleExpand: (rowId: string | number) => void;
@@ -191,20 +175,6 @@ function renderNameCell(
       </Box>
 
       <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5 }}>
-        <Box
-          sx={{
-            width: TYPE_ICON_SIZE,
-            minWidth: TYPE_ICON_SIZE,
-            height: TYPE_ICON_SIZE,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: row.type === 'bed' ? 'text.secondary' : 'text.primary',
-            fontSize: `${TYPE_ICON_SIZE}px`,
-          }}
-        >
-          {getTypeIcon(row.type)}
-        </Box>
         <Box
           component="span"
           sx={{

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -180,8 +180,8 @@ function renderNameCell(
           sx={{
             fontWeight: row.type === 'location' ? 600 : 400,
             fontSize: row.type === 'location' ? '1.02rem' : row.type === 'bed' ? '0.95rem' : '1rem',
-            color: row.type === 'bed' ? 'text.secondary' : 'text.primary',
-            bgcolor: row.type === 'bed' ? 'action.hover' : 'transparent',
+            color: 'text.primary',
+            bgcolor: 'transparent',
             borderRadius: 0.5,
             px: row.type === 'bed' ? 0.5 : 0,
             overflow: 'hidden',

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -13,6 +13,9 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
+import PlaceOutlinedIcon from '@mui/icons-material/PlaceOutlined';
+import CropSquareIcon from '@mui/icons-material/CropSquare';
+import SpaOutlinedIcon from '@mui/icons-material/SpaOutlined';
 import type { HierarchyRow } from './utils/types';
 import { NotesCell } from '../data-grid/NotesCell';
 import { getPlainExcerpt } from '../data-grid/markdown';
@@ -32,6 +35,19 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
 };
 
 const EXPAND_ICON_SLOT_SIZE = 32;
+const TYPE_ICON_SIZE = 18;
+
+const getTypeIcon = (rowType: HierarchyRow['type']): ReactElement => {
+  if (rowType === 'location') {
+    return <PlaceOutlinedIcon fontSize="inherit" data-testid="location-type-icon" />;
+  }
+
+  if (rowType === 'field') {
+    return <CropSquareIcon fontSize="inherit" data-testid="field-type-icon" />;
+  }
+
+  return <SpaOutlinedIcon fontSize="inherit" data-testid="bed-type-icon" />;
+};
 
 interface NameCellCallbacks {
   onToggleExpand: (rowId: string | number) => void;
@@ -176,9 +192,28 @@ function renderNameCell(
 
       <Box sx={{ display: 'inline-flex', alignItems: 'center', minWidth: 0, gap: 0.5 }}>
         <Box
+          sx={{
+            width: TYPE_ICON_SIZE,
+            minWidth: TYPE_ICON_SIZE,
+            height: TYPE_ICON_SIZE,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: row.type === 'bed' ? 'text.secondary' : 'text.primary',
+            fontSize: `${TYPE_ICON_SIZE}px`,
+          }}
+        >
+          {getTypeIcon(row.type)}
+        </Box>
+        <Box
           component="span"
           sx={{
-            fontWeight: row.type === 'location' ? 'bold' : 'normal',
+            fontWeight: row.type === 'location' ? 600 : 400,
+            fontSize: row.type === 'location' ? '1.02rem' : row.type === 'bed' ? '0.95rem' : '1rem',
+            color: row.type === 'bed' ? 'text.secondary' : 'text.primary',
+            bgcolor: row.type === 'bed' ? 'action.hover' : 'transparent',
+            borderRadius: 0.5,
+            px: row.type === 'bed' ? 0.5 : 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement, ReactNode } from 'react';
+
+type PageContainerVariant = 'standard' | 'wide' | 'full';
+
+interface PageContainerProps {
+  children: ReactNode;
+  variant?: PageContainerVariant;
+  className?: string;
+}
+
+const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
+  standard: 'content',
+  wide: 'content content--wide',
+  full: 'content--full',
+};
+
+function PageContainer({
+  children,
+  variant = 'standard',
+  className,
+}: PageContainerProps): ReactElement {
+  const containerClassName = className
+    ? `${VARIANT_CLASSNAME[variant]} ${className}`
+    : VARIANT_CLASSNAME[variant];
+
+  return (
+    <div className={containerClassName}>
+      {children}
+    </div>
+  );
+}
+
+export default PageContainer;

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 
-type PageContainerVariant = 'standard' | 'wide' | 'full';
+type PageContainerVariant = 'standard' | 'wide' | 'workspace' | 'full';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -11,6 +11,7 @@ interface PageContainerProps {
 const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   standard: 'content',
   wide: 'content content--wide',
+  workspace: 'content content--workspace',
   full: 'content--full',
 };
 

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 
-type PageContainerVariant = 'standard' | 'wide' | 'workspace' | 'full';
+type PageContainerVariant = 'standard' | 'wide' | 'workspace' | 'xwide' | 'full';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -12,6 +12,7 @@ const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   standard: 'content',
   wide: 'content content--wide',
   workspace: 'content content--workspace',
+  xwide: 'content content--xwide',
   full: 'content--full',
 };
 

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -51,6 +51,10 @@
     "notes": "Hinweis"
   },
   "noData": "Keine Anbaupläne vorhanden",
+  "modeLabel": "Modus",
+  "modeAriaLabel": "Modus auswählen",
+  "modeViewOption": "Ansicht",
+  "modeEditOption": "Bearbeiten",
   "viewMode": "Ansichtsmodus",
   "editMode": "Bearbeitungsmodus",
   "viewSelectorAriaLabel": "Kalenderansicht auswählen",

--- a/frontend/src/i18n/locales/de/locations.json
+++ b/frontend/src/i18n/locales/de/locations.json
@@ -7,9 +7,9 @@
   },
   "validation": {
     "nameRequired": "Name ist ein Pflichtfeld",
-    "latitudeRange": "Latitude muss zwischen -90 und 90 liegen.",
-    "longitudeRange": "Longitude muss zwischen -180 und 180 liegen.",
-    "coordinateInvalid": "{{field}} muss eine gültige Zahl sein."
+    "latitudeRange": "Der Breitengrad muss zwischen -90 und 90 liegen.",
+    "longitudeRange": "Der Längengrad muss zwischen -180 und 180 liegen.",
+    "coordinateFormat": "Bitte Koordinaten im Format „Breitengrad, Längengrad“ eingeben."
   },
   "confirmDelete": "Möchten Sie diesen Standort wirklich löschen?",
   "addButton": "Neuen Standort hinzufügen",
@@ -34,7 +34,8 @@
     "exposure": "Exposition"
   },
   "helpers": {
-    "optionalField": "Optional"
+    "optionalField": "Optional",
+    "coordinatesExample": "Beispiel: 46.6473, 13.8688"
   },
   "soilType": {
     "sand": "Sand",
@@ -49,7 +50,6 @@
     "flat": "Eben"
   },
   "placeholders": {
-    "latitude": "z.B. 46,6145",
-    "longitude": "z.B. 13,8503"
+    "coordinates": "z.B. 46.6473, 13.8688"
   }
 }

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from '../i18n';
+import PageContainer from '../components/layout/PageContainer';
 import { cultureAPI, publicCultureAPI, type Culture, type EnrichmentResult } from '../api/api';
 import type {
   CultivationType,
@@ -879,7 +880,7 @@ function Cultures(): React.ReactElement {
 
 
   return (
-    <div className="page-container">
+    <PageContainer>
       <Box
         sx={{
           display: 'flex',
@@ -1317,7 +1318,7 @@ function Cultures(): React.ReactElement {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </div>
+    </PageContainer>
   );
 }
 export default Cultures;

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -753,7 +753,7 @@ function FieldsBedsHierarchy({
   ]);
 
   return (
-    <div className="page-container">
+    <div className={showTitle ? "page-container" : undefined}>
       <Box sx={{ width: "fit-content", maxWidth: "100%" }}>
         {showTitle && <h1>{t("title")}</h1>}
 

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -6,6 +6,7 @@ import { useCommandContextTag, useRegisterCommands } from '../commands/useComman
 import type { CommandSpec } from '../commands/types';
 import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
+import PageContainer from '../components/layout/PageContainer';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 
@@ -63,7 +64,7 @@ export default function FieldsBedsPage(): React.ReactElement {
   }, [viewMode]);
 
   return (
-    <div className="page-container">
+    <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
         <h1>{t('hierarchy:title')}</h1>
         <PageHelp pageKey={viewMode === 'graphical' ? 'graphical' : 'areas'} />
@@ -93,6 +94,6 @@ export default function FieldsBedsPage(): React.ReactElement {
       </Stack>
 
       {viewMode === 'graphical' ? <GraphicalFields showTitle={false} /> : <FieldsBedsHierarchy showTitle={false} />}
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -8,10 +8,12 @@ import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
 import PageContainer from '../components/layout/PageContainer';
 import PageHeader from '../components/layout/PageHeader';
+import ModeToggle from '../components/ModeToggle';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 
 type ViewMode = 'table' | 'graphical';
+type InteractionMode = 'view' | 'edit';
 
 export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
@@ -19,6 +21,7 @@ export default function FieldsBedsPage(): React.ReactElement {
     const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
     return stored === 'graphical' ? 'graphical' : 'table';
   });
+  const [interactionMode, setInteractionMode] = useState<InteractionMode>('view');
 
   useCommandContextTag('areas');
 
@@ -72,33 +75,58 @@ export default function FieldsBedsPage(): React.ReactElement {
           actions={<PageHelp pageKey={viewMode === 'graphical' ? 'graphical' : 'areas'} />}
           marginBottom={1}
         />
-        <Stack spacing={0.75} sx={{ mb: 2, width: { xs: '100%', sm: 'fit-content' } }}>
-          <Typography variant="subtitle2">{t('fields:representation.label')}</Typography>
-          <ToggleButtonGroup
-            value={viewMode}
-            exclusive
-            onChange={(_, selectedViewMode: ViewMode | null) => {
-              if (selectedViewMode !== null) {
-                setViewMode(selectedViewMode);
-              }
-            }}
-            size="small"
-            color="primary"
-            aria-label={t('fields:representation.ariaLabel')}
-            fullWidth
-          >
-            <ToggleButton value="table" aria-label={t('fields:representation.table')}>
-              {t('fields:representation.table')}
-            </ToggleButton>
-            <ToggleButton value="graphical" aria-label={t('fields:representation.graphical')}>
-              {t('fields:representation.graphical')}
-            </ToggleButton>
-          </ToggleButtonGroup>
+        <Stack
+          direction={{ xs: 'column', lg: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'stretch', lg: 'flex-end' }}
+          sx={{ mb: 2 }}
+        >
+          <Stack spacing={0.75} sx={{ width: { xs: '100%', sm: 'fit-content' } }}>
+            <Typography variant="subtitle2">{t('fields:representation.label')}</Typography>
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={(_, selectedViewMode: ViewMode | null) => {
+                if (selectedViewMode !== null) {
+                  setViewMode(selectedViewMode);
+                }
+              }}
+              size="small"
+              color="primary"
+              aria-label={t('fields:representation.ariaLabel')}
+              fullWidth
+            >
+              <ToggleButton value="table" aria-label={t('fields:representation.table')}>
+                {t('fields:representation.table')}
+              </ToggleButton>
+              <ToggleButton value="graphical" aria-label={t('fields:representation.graphical')}>
+                {t('fields:representation.graphical')}
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+          <ModeToggle
+            label={t('fields:graphical.viewMode')}
+            ariaLabel={t('fields:graphical.modeAriaLabel')}
+            viewLabel={t('fields:graphical.viewModeOption')}
+            editLabel={t('fields:graphical.editModeOption')}
+            value={interactionMode}
+            onChange={setInteractionMode}
+            fullWidth={false}
+          />
         </Stack>
       </PageContainer>
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
-        {viewMode === 'graphical' ? <GraphicalFields showTitle={false} /> : <FieldsBedsHierarchy showTitle={false} />}
+        {viewMode === 'graphical' ? (
+          <GraphicalFields
+            showTitle={false}
+            interactionMode={interactionMode}
+            onInteractionModeChange={setInteractionMode}
+            showModeToggle={false}
+          />
+        ) : (
+          <FieldsBedsHierarchy showTitle={false} />
+        )}
       </PageContainer>
     </>
   );

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
 import GraphicalFields from './GraphicalFields';

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -7,6 +7,7 @@ import type { CommandSpec } from '../commands/types';
 import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
 import PageContainer from '../components/layout/PageContainer';
+import PageHeader from '../components/layout/PageHeader';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 
@@ -64,36 +65,41 @@ export default function FieldsBedsPage(): React.ReactElement {
   }, [viewMode]);
 
   return (
-    <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-        <h1>{t('hierarchy:title')}</h1>
-        <PageHelp pageKey={viewMode === 'graphical' ? 'graphical' : 'areas'} />
-      </Box>
-      <Stack spacing={0.75} sx={{ mb: 2, width: { xs: '100%', sm: 'fit-content' } }}>
-        <Typography variant="subtitle2">{t('fields:representation.label')}</Typography>
-        <ToggleButtonGroup
-          value={viewMode}
-          exclusive
-          onChange={(_, selectedViewMode: ViewMode | null) => {
-            if (selectedViewMode !== null) {
-              setViewMode(selectedViewMode);
-            }
-          }}
-          size="small"
-          color="primary"
-          aria-label={t('fields:representation.ariaLabel')}
-          fullWidth
-        >
-          <ToggleButton value="table" aria-label={t('fields:representation.table')}>
-            {t('fields:representation.table')}
-          </ToggleButton>
-          <ToggleButton value="graphical" aria-label={t('fields:representation.graphical')}>
-            {t('fields:representation.graphical')}
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </Stack>
+    <>
+      <PageContainer variant="standard">
+        <PageHeader
+          title={t('hierarchy:title')}
+          actions={<PageHelp pageKey={viewMode === 'graphical' ? 'graphical' : 'areas'} />}
+          marginBottom={1}
+        />
+        <Stack spacing={0.75} sx={{ mb: 2, width: { xs: '100%', sm: 'fit-content' } }}>
+          <Typography variant="subtitle2">{t('fields:representation.label')}</Typography>
+          <ToggleButtonGroup
+            value={viewMode}
+            exclusive
+            onChange={(_, selectedViewMode: ViewMode | null) => {
+              if (selectedViewMode !== null) {
+                setViewMode(selectedViewMode);
+              }
+            }}
+            size="small"
+            color="primary"
+            aria-label={t('fields:representation.ariaLabel')}
+            fullWidth
+          >
+            <ToggleButton value="table" aria-label={t('fields:representation.table')}>
+              {t('fields:representation.table')}
+            </ToggleButton>
+            <ToggleButton value="graphical" aria-label={t('fields:representation.graphical')}>
+              {t('fields:representation.graphical')}
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
+      </PageContainer>
 
-      {viewMode === 'graphical' ? <GraphicalFields showTitle={false} /> : <FieldsBedsHierarchy showTitle={false} />}
-    </PageContainer>
+      <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
+        {viewMode === 'graphical' ? <GraphicalFields showTitle={false} /> : <FieldsBedsHierarchy showTitle={false} />}
+      </PageContainer>
+    </>
   );
 }

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -67,6 +67,12 @@ export default function FieldsBedsPage(): React.ReactElement {
     window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
   }, [viewMode]);
 
+  useEffect(() => {
+    if (viewMode === 'graphical') {
+      setInteractionMode('view');
+    }
+  }, [viewMode]);
+
   return (
     <>
       <PageContainer variant="standard">
@@ -104,15 +110,17 @@ export default function FieldsBedsPage(): React.ReactElement {
               </ToggleButton>
             </ToggleButtonGroup>
           </Stack>
-          <ModeToggle
-            label={t('fields:graphical.viewMode')}
-            ariaLabel={t('fields:graphical.modeAriaLabel')}
-            viewLabel={t('fields:graphical.viewModeOption')}
-            editLabel={t('fields:graphical.editModeOption')}
-            value={interactionMode}
-            onChange={setInteractionMode}
-            fullWidth={false}
-          />
+          {viewMode === 'graphical' ? (
+            <ModeToggle
+              label={t('fields:graphical.viewMode')}
+              ariaLabel={t('fields:graphical.modeAriaLabel')}
+              viewLabel={t('fields:graphical.viewModeOption')}
+              editLabel={t('fields:graphical.editModeOption')}
+              value={interactionMode}
+              onChange={setInteractionMode}
+              fullWidth={false}
+            />
+          ) : null}
         </Stack>
       </PageContainer>
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -39,6 +39,7 @@ import { useCommandContextTag, useRegisterCommands } from '../commands/useComman
 import PageHelp from '../components/help/PageHelp';
 import ModeToggle from '../components/ModeToggle';
 import PageContainer from '../components/layout/PageContainer';
+import PageHeader from '../components/layout/PageHeader';
 import type { CommandSpec } from '../commands/types';
 import {
   buildFieldOccupancyTaskGroups,
@@ -378,22 +379,16 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="wide">
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-          <h1>{t('ganttChart:title')}</h1>
-          <PageHelp pageKey="calendar" />
-        </Box>
+      <PageContainer variant="full">
+        <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
         <p>{t('ganttChart:loading')}</p>
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer variant="wide">
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-        <h1>{t('ganttChart:title')}</h1>
-        <PageHelp pageKey="calendar" />
-      </Box>
+    <PageContainer variant="full">
+      <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
 
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -379,7 +379,7 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="full">
+      <PageContainer variant="workspace">
         <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
         <p>{t('ganttChart:loading')}</p>
       </PageContainer>
@@ -387,7 +387,7 @@ function GanttChartPage(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="full">
+    <PageContainer variant="workspace">
       <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -379,24 +379,17 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <>
-        <PageContainer variant="full">
-          <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
-        </PageContainer>
-        <PageContainer variant="workspace">
-          <p>{t('ganttChart:loading')}</p>
-        </PageContainer>
-      </>
+      <PageContainer variant="workspace">
+        <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
+        <p>{t('ganttChart:loading')}</p>
+      </PageContainer>
     );
   }
 
   return (
-    <>
-      <PageContainer variant="full">
-        <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
-      </PageContainer>
-      <PageContainer variant="workspace">
-        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+    <PageContainer variant="workspace">
+      <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
         <Box sx={{ mb: 2 }}>
           <Tabs
@@ -550,8 +543,7 @@ function GanttChartPage(): React.ReactElement {
             )}
           </Paper>
         ) : null}
-      </PageContainer>
-    </>
+    </PageContainer>
   );
 }
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -379,172 +379,179 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="full">
-        <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
-        <p>{t('ganttChart:loading')}</p>
-      </PageContainer>
+      <>
+        <PageContainer variant="full">
+          <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
+        </PageContainer>
+        <PageContainer variant="workspace">
+          <p>{t('ganttChart:loading')}</p>
+        </PageContainer>
+      </>
     );
   }
 
   return (
-    <PageContainer variant="full">
-      <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
+    <>
+      <PageContainer variant="full">
+        <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
+      </PageContainer>
+      <PageContainer variant="workspace">
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-
-      <Box sx={{ mb: 2 }}>
-        <Tabs
-          value={calendarMode}
-          onChange={(_, value: CalendarMode) => setCalendarMode(value)}
-          aria-label={t('ganttChart:viewSelectorAriaLabel')}
-        >
-          <Tab label={t('ganttChart:modes.occupancy')} value="occupancy" />
-          <Tab label={t('ganttChart:modes.seedlings')} value="seedlings" />
-        </Tabs>
-      </Box>
-
-      {calendarMode === 'occupancy' ? (
-        <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <ModeToggle
-            label={t('ganttChart:modeLabel')}
-            ariaLabel={t('ganttChart:modeAriaLabel')}
-            viewLabel={t('ganttChart:modeViewOption')}
-            editLabel={t('ganttChart:modeEditOption')}
-            value={editMode ? 'edit' : 'view'}
-            onChange={(selectedMode) => setEditMode(selectedMode === 'edit')}
-            fullWidth={false}
-          />
+        <Box sx={{ mb: 2 }}>
+          <Tabs
+            value={calendarMode}
+            onChange={(_, value: CalendarMode) => setCalendarMode(value)}
+            aria-label={t('ganttChart:viewSelectorAriaLabel')}
+          >
+            <Tab label={t('ganttChart:modes.occupancy')} value="occupancy" />
+            <Tab label={t('ganttChart:modes.seedlings')} value="seedlings" />
+          </Tabs>
         </Box>
-      ) : null}
 
-      <Paper className="gantt-container-wrapper">
-        {activeTaskGroups.length === 0 ? (
-          <div className="gantt-no-data">
-            {calendarMode === 'occupancy'
-              ? t('ganttChart:noData')
-              : t('ganttChart:seedlings.emptyState')}
-          </div>
-        ) : (
-          <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
-            <GanttChart
-              tasks={activeTaskGroups}
-              locale={resolvedLocale}
-              localeText={ganttLocaleText}
-              viewMode={ViewMode.MONTH}
-              startDate={startDate}
-              endDate={endDate}
-              editMode={calendarMode === 'occupancy' ? editMode : false}
-              allowTaskResize={false}
-              allowTaskMove={calendarMode === 'occupancy'}
-              showProgress={false}
-              darkMode={false}
-              onTaskUpdate={calendarMode === 'occupancy' ? handleTaskUpdate : undefined}
-              renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
-                ? renderSeedlingTooltip({ task })
-                : renderOccupancyTooltip({ task }))}
-              renderTask={calendarMode === 'seedlings'
-                ? ({ task, leftPx, widthPx, topPx }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
-                    <Box
-                      sx={{
-                        position: 'absolute',
-                        left: `${leftPx}px`,
-                        top: `${topPx}px`,
-                        width: `${widthPx}px`,
-                        minWidth: `${widthPx}px`,
-                        height: 26,
-                        px: 1,
-                        borderRadius: 1,
-                        backgroundColor: task.color || '#3b82f6',
-                        color: '#fff',
-                        display: 'flex',
-                        alignItems: 'center',
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap',
-                        textOverflow: 'ellipsis',
-                        boxSizing: 'border-box',
-                        cursor: 'default',
-                      }}
-                    >
-                      <Typography variant="caption" sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {task.name}
-                      </Typography>
-                    </Box>
-                  )
-                : undefined}
+        {calendarMode === 'occupancy' ? (
+          <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <ModeToggle
+              label={t('ganttChart:modeLabel')}
+              ariaLabel={t('ganttChart:modeAriaLabel')}
+              viewLabel={t('ganttChart:modeViewOption')}
+              editLabel={t('ganttChart:modeEditOption')}
+              value={editMode ? 'edit' : 'view'}
+              onChange={(selectedMode) => setEditMode(selectedMode === 'edit')}
+              fullWidth={false}
             />
-          </GanttRenderBoundary>
-        )}
-      </Paper>
+          </Box>
+        ) : null}
 
-      {calendarMode === 'occupancy' ? (
-        <Paper className="gantt-container-wrapper" sx={{ mt: 3, p: 2 }}>
-          <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
-            {t('ganttChart:yieldDistributionTitle')}
-          </Typography>
-          {chartData.length === 0 ? (
-            <div className="gantt-no-data">{t('ganttChart:noYieldData')}</div>
+        <Paper className="gantt-container-wrapper">
+          {activeTaskGroups.length === 0 ? (
+            <div className="gantt-no-data">
+              {calendarMode === 'occupancy'
+                ? t('ganttChart:noData')
+                : t('ganttChart:seedlings.emptyState')}
+            </div>
           ) : (
-            <Box sx={{ width: '100%' }}>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
-                {chartCultures.map((culture) => (
-                  <Box key={culture.id} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                    <Box sx={{ width: 12, height: 12, borderRadius: '2px', backgroundColor: culture.color }} />
-                    <Typography variant="body2">{culture.name}</Typography>
-                  </Box>
-                ))}
-              </Box>
-
-              <Box sx={{ display: 'grid', gridTemplateColumns: '72px 1fr', gap: 1, alignItems: 'start' }}>
-                <Box>
-                  <Box sx={{ display: 'flex', flexDirection: 'column-reverse', justifyContent: 'space-between', height: 260, pr: 1 }}>
-                    {yAxisTicks.map((tick, index) => (
-                      <Typography key={`${tick}-${index}`} variant="caption" sx={{ textAlign: 'right', color: 'text.secondary' }}>
-                        {tick.toFixed(1)} kg
-                      </Typography>
-                    ))}
-                  </Box>
-                  <Box sx={{ height: 44 }} />
-                </Box>
-
-                <Box sx={{ overflowX: 'auto', pb: 0.5 }}>
-                  <Box sx={{ width: Math.max(chartData.length * 40, 420) }}>
-                    <Box sx={{ borderLeft: '1px solid #d1d5db', borderBottom: '1px solid #d1d5db', height: 260, px: 1, display: 'flex', alignItems: 'flex-end', gap: 0.75 }}>
-                      {chartData.map((week) => (
-                        <Box key={week.isoWeek} sx={{ width: 34, flex: '0 0 34px', height: '100%', display: 'flex', alignItems: 'flex-end' }}>
-                          <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column-reverse', justifyContent: 'flex-start' }}>
-                            {week.cultures.map((culture) => (
-                              <Tooltip key={`${week.isoWeek}-${culture.culture_id}`} title={`${culture.culture_name}: ${culture.yield.toFixed(2)} kg`}>
-                                <Box
-                                  sx={{
-                                    width: '100%',
-                                    height: `${maxTotalYield > 0 ? (culture.yield / maxTotalYield) * 100 : 0}%`,
-                                    minHeight: culture.yield > 0 ? '2px' : 0,
-                                    backgroundColor: culture.color,
-                                  }}
-                                />
-                              </Tooltip>
-                            ))}
-                          </Box>
-                        </Box>
-                      ))}
-                    </Box>
-
-                    <Box sx={{ height: 44, px: 1, display: 'flex', gap: 0.75, alignItems: 'flex-start' }}>
-                      {chartData.map((week) => (
-                        <Box key={`${week.isoWeek}-axis`} sx={{ width: 34, flex: '0 0 34px', textAlign: 'center' }}>
-                          <Typography variant="caption" sx={{ display: 'block', fontWeight: 600, lineHeight: 1.2 }}>{week.weekLabel}</Typography>
-                          <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', lineHeight: 1.2 }}>{week.monthLabel}</Typography>
-                        </Box>
-                      ))}
-                    </Box>
-                  </Box>
-                </Box>
-              </Box>
-            </Box>
+            <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
+              <GanttChart
+                tasks={activeTaskGroups}
+                locale={resolvedLocale}
+                localeText={ganttLocaleText}
+                viewMode={ViewMode.MONTH}
+                startDate={startDate}
+                endDate={endDate}
+                editMode={calendarMode === 'occupancy' ? editMode : false}
+                allowTaskResize={false}
+                allowTaskMove={calendarMode === 'occupancy'}
+                showProgress={false}
+                darkMode={false}
+                onTaskUpdate={calendarMode === 'occupancy' ? handleTaskUpdate : undefined}
+                renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
+                  ? renderSeedlingTooltip({ task })
+                  : renderOccupancyTooltip({ task }))}
+                renderTask={calendarMode === 'seedlings'
+                  ? ({ task, leftPx, widthPx, topPx }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          left: `${leftPx}px`,
+                          top: `${topPx}px`,
+                          width: `${widthPx}px`,
+                          minWidth: `${widthPx}px`,
+                          height: 26,
+                          px: 1,
+                          borderRadius: 1,
+                          backgroundColor: task.color || '#3b82f6',
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap',
+                          textOverflow: 'ellipsis',
+                          boxSizing: 'border-box',
+                          cursor: 'default',
+                        }}
+                      >
+                        <Typography variant="caption" sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {task.name}
+                        </Typography>
+                      </Box>
+                    )
+                  : undefined}
+              />
+            </GanttRenderBoundary>
           )}
         </Paper>
-      ) : null}
-    </PageContainer>
+
+        {calendarMode === 'occupancy' ? (
+          <Paper className="gantt-container-wrapper" sx={{ mt: 3, p: 2 }}>
+            <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+              {t('ganttChart:yieldDistributionTitle')}
+            </Typography>
+            {chartData.length === 0 ? (
+              <div className="gantt-no-data">{t('ganttChart:noYieldData')}</div>
+            ) : (
+              <Box sx={{ width: '100%' }}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                  {chartCultures.map((culture) => (
+                    <Box key={culture.id} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                      <Box sx={{ width: 12, height: 12, borderRadius: '2px', backgroundColor: culture.color }} />
+                      <Typography variant="body2">{culture.name}</Typography>
+                    </Box>
+                  ))}
+                </Box>
+
+                <Box sx={{ display: 'grid', gridTemplateColumns: '72px 1fr', gap: 1, alignItems: 'start' }}>
+                  <Box>
+                    <Box sx={{ display: 'flex', flexDirection: 'column-reverse', justifyContent: 'space-between', height: 260, pr: 1 }}>
+                      {yAxisTicks.map((tick, index) => (
+                        <Typography key={`${tick}-${index}`} variant="caption" sx={{ textAlign: 'right', color: 'text.secondary' }}>
+                          {tick.toFixed(1)} kg
+                        </Typography>
+                      ))}
+                    </Box>
+                    <Box sx={{ height: 44 }} />
+                  </Box>
+
+                  <Box sx={{ overflowX: 'auto', pb: 0.5 }}>
+                    <Box sx={{ width: Math.max(chartData.length * 40, 420) }}>
+                      <Box sx={{ borderLeft: '1px solid #d1d5db', borderBottom: '1px solid #d1d5db', height: 260, px: 1, display: 'flex', alignItems: 'flex-end', gap: 0.75 }}>
+                        {chartData.map((week) => (
+                          <Box key={week.isoWeek} sx={{ width: 34, flex: '0 0 34px', height: '100%', display: 'flex', alignItems: 'flex-end' }}>
+                            <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column-reverse', justifyContent: 'flex-start' }}>
+                              {week.cultures.map((culture) => (
+                                <Tooltip key={`${week.isoWeek}-${culture.culture_id}`} title={`${culture.culture_name}: ${culture.yield.toFixed(2)} kg`}>
+                                  <Box
+                                    sx={{
+                                      width: '100%',
+                                      height: `${maxTotalYield > 0 ? (culture.yield / maxTotalYield) * 100 : 0}%`,
+                                      minHeight: culture.yield > 0 ? '2px' : 0,
+                                      backgroundColor: culture.color,
+                                    }}
+                                  />
+                                </Tooltip>
+                              ))}
+                            </Box>
+                          </Box>
+                        ))}
+                      </Box>
+
+                      <Box sx={{ height: 44, px: 1, display: 'flex', gap: 0.75, alignItems: 'flex-start' }}>
+                        {chartData.map((week) => (
+                          <Box key={`${week.isoWeek}-axis`} sx={{ width: 34, flex: '0 0 34px', textAlign: 'center' }}>
+                            <Typography variant="caption" sx={{ display: 'block', fontWeight: 600, lineHeight: 1.2 }}>{week.weekLabel}</Typography>
+                            <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', lineHeight: 1.2 }}>{week.monthLabel}</Typography>
+                          </Box>
+                        ))}
+                      </Box>
+                    </Box>
+                  </Box>
+                </Box>
+              </Box>
+            )}
+          </Paper>
+        ) : null}
+      </PageContainer>
+    </>
   );
 }
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -379,7 +379,7 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="workspace">
+      <PageContainer variant="xwide">
         <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
         <p>{t('ganttChart:loading')}</p>
       </PageContainer>
@@ -387,7 +387,7 @@ function GanttChartPage(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="workspace">
+    <PageContainer variant="xwide">
       <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -379,7 +379,7 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="workspace">
+      <PageContainer variant="full">
         <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
         <p>{t('ganttChart:loading')}</p>
       </PageContainer>
@@ -387,7 +387,7 @@ function GanttChartPage(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="workspace">
+    <PageContainer variant="full">
       <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -38,6 +38,7 @@ import './GanttChart.css';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
 import PageHelp from '../components/help/PageHelp';
 import ModeToggle from '../components/ModeToggle';
+import PageContainer from '../components/layout/PageContainer';
 import type { CommandSpec } from '../commands/types';
 import {
   buildFieldOccupancyTaskGroups,
@@ -377,18 +378,18 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <div className="page-container">
+      <PageContainer variant="wide">
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
           <h1>{t('ganttChart:title')}</h1>
           <PageHelp pageKey="calendar" />
         </Box>
         <p>{t('ganttChart:loading')}</p>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="page-container">
+    <PageContainer variant="wide">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
         <h1>{t('ganttChart:title')}</h1>
         <PageHelp pageKey="calendar" />
@@ -548,7 +549,7 @@ function GanttChartPage(): React.ReactElement {
           )}
         </Paper>
       ) : null}
-    </div>
+    </PageContainer>
   );
 }
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -12,9 +12,7 @@ import { useTranslation } from '../i18n';
 import {
   Alert,
   Box,
-  FormControlLabel,
   Paper,
-  Switch,
   Tab,
   Tabs,
   Tooltip,
@@ -39,6 +37,7 @@ import 'react-modern-gantt/dist/index.css';
 import './GanttChart.css';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
 import PageHelp from '../components/help/PageHelp';
+import ModeToggle from '../components/ModeToggle';
 import type { CommandSpec } from '../commands/types';
 import {
   buildFieldOccupancyTaskGroups,
@@ -410,15 +409,14 @@ function GanttChartPage(): React.ReactElement {
 
       {calendarMode === 'occupancy' ? (
         <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <FormControlLabel
-            control={(
-              <Switch
-                checked={editMode}
-                onChange={(event) => setEditMode(event.target.checked)}
-                color="primary"
-              />
-            )}
-            label={editMode ? t('ganttChart:editMode') : t('ganttChart:viewMode')}
+          <ModeToggle
+            label={t('ganttChart:modeLabel')}
+            ariaLabel={t('ganttChart:modeAriaLabel')}
+            viewLabel={t('ganttChart:modeViewOption')}
+            editLabel={t('ganttChart:modeEditOption')}
+            value={editMode ? 'edit' : 'view'}
+            onChange={(selectedMode) => setEditMode(selectedMode === 'edit')}
+            fullWidth={false}
           />
         </Box>
       ) : null}

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -110,6 +110,9 @@ interface SelectedElement {
 
 interface GraphicalFieldsProps {
   showTitle?: boolean;
+  interactionMode?: InteractionMode;
+  onInteractionModeChange?: (mode: InteractionMode) => void;
+  showModeToggle?: boolean;
 }
 
 type InteractionMode = "view" | "edit";
@@ -235,6 +238,9 @@ const snapToNeighbors = (
 
 export default function GraphicalFields({
   showTitle = true,
+  interactionMode: controlledInteractionMode,
+  onInteractionModeChange,
+  showModeToggle = true,
 }: GraphicalFieldsProps): React.ReactElement {
   const { t } = useTranslation(["fields", "common"]);
   const { loading, error, locations, fields, beds } = useHierarchyData();
@@ -268,8 +274,15 @@ export default function GraphicalFields({
     ),
   );
   const [activeGuides, setActiveGuides] = useState<GuideLine[]>([]);
-  const [interactionMode, setInteractionMode] =
+  const [localInteractionMode, setLocalInteractionMode] =
     useState<InteractionMode>("view");
+  const interactionMode = controlledInteractionMode ?? localInteractionMode;
+  const setInteractionMode = (mode: InteractionMode): void => {
+    if (controlledInteractionMode === undefined) {
+      setLocalInteractionMode(mode);
+    }
+    onInteractionModeChange?.(mode);
+  };
   const isEditMode = interactionMode === "edit";
   const isViewMode = interactionMode === "view";
   const [viewportByLocation, setViewportByLocation] = useState<
@@ -434,9 +447,7 @@ export default function GraphicalFields({
         keys: { alt: true, key: "e" },
         contexts: [],
         action: () => {
-          setInteractionMode((previous) =>
-            previous === "edit" ? "view" : "edit",
-          );
+          setInteractionMode(interactionMode === "edit" ? "view" : "edit");
         },
       },
     ],
@@ -1136,16 +1147,18 @@ export default function GraphicalFields({
             </Typography>
           ) : null}
         </Box>
-        <Stack spacing={0.5} sx={{ width: { xs: "100%", sm: "auto" } }}>
-          <ModeToggle
-            label={t("fields:graphical.viewMode")}
-            ariaLabel={t("fields:graphical.modeAriaLabel")}
-            viewLabel={t("fields:graphical.viewModeOption")}
-            editLabel={t("fields:graphical.editModeOption")}
-            value={interactionMode}
-            onChange={setInteractionMode}
-          />
-        </Stack>
+        {showModeToggle ? (
+          <Stack spacing={0.5} sx={{ width: { xs: "100%", sm: "auto" } }}>
+            <ModeToggle
+              label={t("fields:graphical.viewMode")}
+              ariaLabel={t("fields:graphical.modeAriaLabel")}
+              viewLabel={t("fields:graphical.viewModeOption")}
+              editLabel={t("fields:graphical.editModeOption")}
+              value={interactionMode}
+              onChange={setInteractionMode}
+            />
+          </Stack>
+        ) : null}
       </Stack>
 
       {isEditMode ? (

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -14,8 +14,6 @@ import {
   IconButton,
   Paper,
   Stack,
-  ToggleButton,
-  ToggleButtonGroup,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -40,6 +38,7 @@ import {
 } from "../api/api";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useTranslation } from "../i18n";
+import ModeToggle from "../components/ModeToggle";
 import {
   clampInsideParent,
   getBedRectSizeWithinField,
@@ -1138,29 +1137,14 @@ export default function GraphicalFields({
           ) : null}
         </Box>
         <Stack spacing={0.5} sx={{ width: { xs: "100%", sm: "auto" } }}>
-          <Stack direction="row" spacing={0.5} alignItems="center" justifyContent={{ xs: "space-between", sm: "flex-start" }}>
-            <Typography variant="subtitle2">{t("fields:graphical.viewMode")}</Typography>
-          </Stack>
-          <ToggleButtonGroup
+          <ModeToggle
+            label={t("fields:graphical.viewMode")}
+            ariaLabel={t("fields:graphical.modeAriaLabel")}
+            viewLabel={t("fields:graphical.viewModeOption")}
+            editLabel={t("fields:graphical.editModeOption")}
             value={interactionMode}
-            exclusive
-            size="small"
-            color="primary"
-            fullWidth
-            aria-label={t("fields:graphical.modeAriaLabel")}
-            onChange={(_, selectedMode: InteractionMode | null) => {
-              if (selectedMode !== null) {
-                setInteractionMode(selectedMode);
-              }
-            }}
-          >
-            <ToggleButton value="view" aria-label={t("fields:graphical.viewModeOption")}>
-              {t("fields:graphical.viewModeOption")}
-            </ToggleButton>
-            <ToggleButton value="edit" aria-label={t("fields:graphical.editModeOption")}>
-              {t("fields:graphical.editModeOption")}
-            </ToggleButton>
-          </ToggleButtonGroup>
+            onChange={setInteractionMode}
+          />
         </Stack>
       </Stack>
 

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -33,8 +33,7 @@ type Exposure = NonNullable<Location['exposure']>;
 
 interface LocationFormState {
   name: string;
-  latitude: string;
-  longitude: string;
+  coordinates: string;
   address: string;
   description: string;
   soil_type: SoilType | '';
@@ -58,8 +57,7 @@ const EXPOSURE_OPTIONS: Array<{ value: Exposure; labelKey: string }> = [
 
 const emptyForm: LocationFormState = {
   name: '',
-  latitude: '',
-  longitude: '',
+  coordinates: '',
   address: '',
   description: '',
   soil_type: '',
@@ -67,11 +65,32 @@ const emptyForm: LocationFormState = {
   notes: '',
 };
 
-const parseCoordinateInput = (value: string): number | null => {
-  const normalized = value.trim().replace(',', '.');
+const parseCoordinateValue = (value: string): number | null => {
+  const normalized = value.trim();
   if (!normalized) return null;
   const parsed = Number(normalized);
   return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseCoordinatesInput = (value: string): { latitude: number; longitude: number } | null => {
+  const normalized = value.trim();
+  if (!normalized) return null;
+
+  const rawParts = normalized.includes(',')
+    ? normalized.split(/\s*,\s*/)
+    : normalized.split(/\s+/);
+
+  if (rawParts.length !== 2) {
+    return null;
+  }
+
+  const latitude = parseCoordinateValue(rawParts[0]);
+  const longitude = parseCoordinateValue(rawParts[1]);
+  if (latitude === null || longitude === null) {
+    return null;
+  }
+
+  return { latitude, longitude };
 };
 
 const validateCoordinateRange = (value: number | null, min: number, max: number): boolean =>
@@ -88,8 +107,10 @@ const formatTaskDate = (value: string, locale: string): string => {
 
 const toFormState = (location: Location | null): LocationFormState => ({
   name: location?.name ?? '',
-  latitude: typeof location?.latitude === 'number' ? String(location.latitude) : '',
-  longitude: typeof location?.longitude === 'number' ? String(location.longitude) : '',
+  coordinates:
+    typeof location?.latitude === 'number' && typeof location?.longitude === 'number'
+      ? `${location.latitude}, ${location.longitude}`
+      : '',
   address: location?.address ?? '',
   description: location?.description ?? '',
   soil_type: location?.soil_type ?? '',
@@ -111,6 +132,7 @@ function Locations(): React.ReactElement {
   const [editingLocation, setEditingLocation] = useState<Location | null>(null);
   const [formState, setFormState] = useState<LocationFormState>(emptyForm);
   const [formError, setFormError] = useState<string>('');
+  const [formErrorField, setFormErrorField] = useState<'name' | 'coordinates' | null>(null);
 
   const loadData = useCallback(async (): Promise<void> => {
     setLoading(true);
@@ -155,6 +177,7 @@ function Locations(): React.ReactElement {
     setEditingLocation(null);
     setFormState(emptyForm);
     setFormError('');
+    setFormErrorField(null);
     setDialogOpen(true);
   };
 
@@ -162,6 +185,7 @@ function Locations(): React.ReactElement {
     setEditingLocation(location);
     setFormState(toFormState(location));
     setFormError('');
+    setFormErrorField(null);
     setDialogOpen(true);
   };
 
@@ -170,31 +194,42 @@ function Locations(): React.ReactElement {
     setEditingLocation(null);
     setFormState(emptyForm);
     setFormError('');
+    setFormErrorField(null);
   };
 
   const validateForm = (): { latitude: number | null; longitude: number | null } | null => {
     if (!formState.name.trim()) {
       setFormError(t('locations:validation.nameRequired'));
+      setFormErrorField('name');
       return null;
     }
-    const latitude = parseCoordinateInput(formState.latitude);
-    const longitude = parseCoordinateInput(formState.longitude);
-    if (formState.latitude.trim() && latitude === null) {
-      setFormError(t('locations:validation.coordinateInvalid', { field: t('locations:columns.latitude') }));
+
+    if (!formState.coordinates.trim()) {
+      setFormError('');
+      setFormErrorField(null);
+      return { latitude: null, longitude: null };
+    }
+
+    const parsedCoordinates = parseCoordinatesInput(formState.coordinates);
+    if (!parsedCoordinates) {
+      setFormError(t('locations:validation.coordinateFormat'));
+      setFormErrorField('coordinates');
       return null;
     }
-    if (formState.longitude.trim() && longitude === null) {
-      setFormError(t('locations:validation.coordinateInvalid', { field: t('locations:columns.longitude') }));
-      return null;
-    }
+
+    const { latitude, longitude } = parsedCoordinates;
     if (!validateCoordinateRange(latitude, -90, 90)) {
       setFormError(t('locations:validation.latitudeRange'));
+      setFormErrorField('coordinates');
       return null;
     }
     if (!validateCoordinateRange(longitude, -180, 180)) {
       setFormError(t('locations:validation.longitudeRange'));
+      setFormErrorField('coordinates');
       return null;
     }
+    setFormError('');
+    setFormErrorField(null);
     return { latitude, longitude };
   };
 
@@ -222,6 +257,7 @@ function Locations(): React.ReactElement {
       await loadData();
     } catch {
       setFormError(t('locations:errors.save'));
+      setFormErrorField(null);
     }
   };
 
@@ -370,20 +406,16 @@ function Locations(): React.ReactElement {
             label={t('common:fields.name')}
             value={formState.name}
             onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
-            error={Boolean(formError)}
-            helperText={formError || ' '}
+            error={formErrorField === 'name'}
+            helperText={formErrorField === 'name' ? formError : ' '}
           />
           <TextField
-            label={t('locations:columns.latitude')}
-            value={formState.latitude}
-            onChange={(event) => setFormState((prev) => ({ ...prev, latitude: event.target.value }))}
-            placeholder={t('locations:placeholders.latitude')}
-          />
-          <TextField
-            label={t('locations:columns.longitude')}
-            value={formState.longitude}
-            onChange={(event) => setFormState((prev) => ({ ...prev, longitude: event.target.value }))}
-            placeholder={t('locations:placeholders.longitude')}
+            label={t('locations:columns.coordinates')}
+            value={formState.coordinates}
+            onChange={(event) => setFormState((prev) => ({ ...prev, coordinates: event.target.value }))}
+            placeholder={t('locations:placeholders.coordinates')}
+            error={formErrorField === 'coordinates'}
+            helperText={formErrorField === 'coordinates' ? formError : t('locations:helpers.coordinatesExample')}
           />
           <TextField
             label={t('locations:columns.address')}

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -23,6 +23,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
 import PageHelp from '../components/help/PageHelp';
 import PageHeader from '../components/layout/PageHeader';
+import PageContainer from '../components/layout/PageContainer';
 import { useTranslation } from '../i18n';
 import { resolveLocaleFromLanguage } from '../utils/numberLocalization';
 import { deriveLocationTasks, type DerivedLocationTask } from './locationDerivedTasks';
@@ -241,8 +242,8 @@ function Locations(): React.ReactElement {
   };
 
   return (
-    <Box p={3}>
-      <Box sx={{ width: '100%', maxWidth: 1320 }}>
+    <PageContainer>
+      <Box sx={{ width: '100%' }}>
         <PageHeader
           title={t('locations:title')}
           actions={(
@@ -437,7 +438,7 @@ function Locations(): React.ReactElement {
           <Button variant="contained" onClick={() => void saveLocation()}>{t('common:actions.save')}</Button>
         </DialogActions>
       </Dialog>
-    </Box>
+    </PageContainer>
   );
 }
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1348,7 +1348,6 @@ function PlantingPlans(): React.ReactElement {
           showDeleteAction={true}
           showFooterEditControls={false}
           showRowEditActions={true}
-          stretchToContainer={true}
           tableKey="plantingPlans"
           defaultSortModel={[{ field: "planting_date", sort: "asc" }]}
           persistSortInUrl={true}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,7 +1077,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="full">
+    <PageContainer variant="workspace">
       <PageHeader
         title={t("plantingPlans:title")}
         actions={(

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,7 +1077,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="workspace">
+    <PageContainer variant="xwide">
       <PageHeader
         title={t("plantingPlans:title")}
         actions={(

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,7 +1077,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="wide">
+    <PageContainer variant="full">
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
           {areaWarning}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -34,6 +34,7 @@ import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
 import { useTranslation } from "../i18n";
+import PageContainer from "../components/layout/PageContainer";
 import {
   plantingPlanAPI,
   cultureAPI,
@@ -1076,10 +1077,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <div
-      className="page-container"
-      style={{ maxWidth: "none", margin: 0, paddingLeft: 16, paddingRight: 16 }}
-    >
+    <PageContainer variant="wide">
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
           {areaWarning}
@@ -1515,7 +1513,7 @@ function PlantingPlans(): React.ReactElement {
         focusAttachments
         focusRequestId={mobileNotesTarget?.id ?? 0}
       />
-    </div>
+    </PageContainer>
   );
 }
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,7 +1077,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="workspace">
+    <PageContainer variant="full">
       <PageHeader
         title={t("plantingPlans:title")}
         actions={(

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1348,6 +1348,7 @@ function PlantingPlans(): React.ReactElement {
           showDeleteAction={true}
           showFooterEditControls={false}
           showRowEditActions={true}
+          stretchToContainer={true}
           tableKey="plantingPlans"
           defaultSortModel={[{ field: "planting_date", sort: "asc" }]}
           persistSortInUrl={true}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,36 +1077,33 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <>
-      <PageContainer variant="full">
-        <PageHeader
-          title={t("plantingPlans:title")}
-          actions={(
-            <>
-              {!isMobile ? (
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => gridCommandApiRef.current?.addRow()}
-                  aria-label={`${t("plantingPlans:addButton")} (Alt+N)`}
-                >
-                  {t("plantingPlans:addButton")}
-                </Button>
-              ) : null}
-              <PageHelp pageKey="plantingPlans" />
-            </>
-          )}
-        />
-      </PageContainer>
+    <PageContainer variant="workspace">
+      <PageHeader
+        title={t("plantingPlans:title")}
+        actions={(
+          <>
+            {!isMobile ? (
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => gridCommandApiRef.current?.addRow()}
+                aria-label={`${t("plantingPlans:addButton")} (Alt+N)`}
+              >
+                {t("plantingPlans:addButton")}
+              </Button>
+            ) : null}
+            <PageHelp pageKey="plantingPlans" />
+          </>
+        )}
+      />
 
-      <PageContainer variant="workspace">
-        {areaWarning ? (
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            {areaWarning}
-          </Alert>
-        ) : null}
+      {areaWarning ? (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {areaWarning}
+        </Alert>
+      ) : null}
 
-        <Box sx={{ width: "100%" }}>
+      <Box sx={{ width: "100%" }}>
 
         {isMobile ? (
           <Box sx={{ pb: 10 }}>
@@ -1517,8 +1514,7 @@ function PlantingPlans(): React.ReactElement {
         focusAttachments
         focusRequestId={mobileNotesTarget?.id ?? 0}
       />
-      </PageContainer>
-    </>
+    </PageContainer>
   );
 }
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1077,14 +1077,8 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="full">
-      {areaWarning ? (
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          {areaWarning}
-        </Alert>
-      ) : null}
-
-      <Box sx={{ width: "fit-content", maxWidth: "100%" }}>
+    <>
+      <PageContainer variant="full">
         <PageHeader
           title={t("plantingPlans:title")}
           actions={(
@@ -1103,6 +1097,16 @@ function PlantingPlans(): React.ReactElement {
             </>
           )}
         />
+      </PageContainer>
+
+      <PageContainer variant="workspace">
+        {areaWarning ? (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {areaWarning}
+          </Alert>
+        ) : null}
+
+        <Box sx={{ width: "100%" }}>
 
         {isMobile ? (
           <Box sx={{ pb: 10 }}>
@@ -1513,7 +1517,8 @@ function PlantingPlans(): React.ReactElement {
         focusAttachments
         focusRequestId={mobileNotesTarget?.id ?? 0}
       />
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -21,6 +21,7 @@ import { seedDemandAPI, type SeedDemand } from '../api/api';
 import { useTranslation } from '../i18n';
 import { useCommandContextTag } from '../commands/useCommandContext';
 import PageHelp from '../components/help/PageHelp';
+import PageContainer from '../components/layout/PageContainer';
 
 const formatUnit = (unit: 'g' | 'seeds', t: (key: string) => string): string => (
   unit === 'seeds' ? t('seedDemand.unitSeeds') : t('seedDemand.unitGrams')
@@ -73,7 +74,7 @@ export default function SeedDemandPage(): React.ReactElement {
   }, []);
 
   return (
-    <Box sx={{ p: 3 }}>
+    <PageContainer>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Typography variant="h4">
           {t('seedDemand.title')}
@@ -169,6 +170,6 @@ export default function SeedDemandPage(): React.ReactElement {
           </Table>
         </TableContainer>
       )}
-    </Box>
+    </PageContainer>
   );
 }

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -23,6 +23,7 @@ import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
 import PageHeader from '../components/layout/PageHeader';
+import PageContainer from '../components/layout/PageContainer';
 import type { Supplier } from '../api/types';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -175,7 +176,7 @@ export default function Suppliers(): React.ReactElement {
   };
 
   return (
-    <div className="page-container">
+    <PageContainer>
       <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
         <PageHeader
           title={t('title')}
@@ -247,6 +248,6 @@ export default function Suppliers(): React.ReactElement {
           <Button onClick={() => void saveSupplier()} disabled={!canSave} variant="contained">{t('save')}</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent name and action icon shifting in the hierarchy list by reserving space for the expand/chevron control even for leaf nodes, while still showing the chevron only for rows that actually have children.
- Ensure connection/hierarchy lines and interactivity remain unchanged so only rows with real children appear expandable.

### Description
- Introduced a fixed expand icon slot constant `EXPAND_ICON_SLOT_SIZE` and always render a fixed-width container at the left of the name cell to reserve space for the chevron (`frontend/src/components/hierarchy/HierarchyColumns.tsx`).
- Render the chevron toggle only when `hasChildren === true` and render a non-interactive, hidden spacer (`visibility: 'hidden'` and `pointerEvents: 'none'`) for leaf nodes so alignment is preserved but the slot is not clickable.
- Updated component tests to assert that the expand slot exists for both leaf and parent rows and that the chevron is present only for rows with children (`frontend/src/__tests__/hierarchyComponents.test.tsx`).

### Testing
- Ran `cd frontend && npm ci` to install dependencies, which completed successfully.
- Ran `cd frontend && npm test -- --run src/__tests__/hierarchyComponents.test.tsx` and the test file executed successfully with all tests passing (10 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62472ae24832288c7c906e7f0ef79)