### PR TITLE
refactor(home): refresh landing page beta and open source messaging

### DIFF
--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -60,11 +60,13 @@ describe('App', () => {
     render(<CommandProvider><App /></CommandProvider>);
 
     expect(await screen.findByText('OpenFarmPlanner')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'OpenFarmPlanner öffnen' })).toBeInTheDocument();
-    expect(screen.getByText('Beta-Version mit laufenden Verbesserungen')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Jetzt starten' })).toBeInTheDocument();
+    expect(screen.getByText('Aktive Beta • laufende Weiterentwicklung • Feedback willkommen')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Digitale Anbauplanung für den Gemüsebau – klar, praxisnah und gemeinsam weitergedacht.' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'GitHub ansehen' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Feedback und Ideen willkommen' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Feedback, Ideen und Fehlermeldungen' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Zum GitHub-Repository' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planung ohne Tabellenchaos' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Datenschutzerklärung' })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'GitHub' })).toHaveLength(1);

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -59,14 +59,13 @@ describe('App', () => {
   it('renders public home page on root path', async () => {
     render(<CommandProvider><App /></CommandProvider>);
 
-    expect(await screen.findByText('OpenFarmPlanner')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Jetzt starten' })).toBeInTheDocument();
-    expect(screen.getByText('Aktive Beta • laufende Weiterentwicklung • Feedback willkommen')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Digitale Anbauplanung für den Gemüsebau – klar, praxisnah und gemeinsam weitergedacht.' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Anbauplanung für Gemüsebau ohne Tabellenchaos.' })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner öffnen' })).toHaveLength(2);
+    expect(screen.getByText('Aktive Beta • laufende Verbesserungen • Feedback willkommen')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'GitHub ansehen' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Feedback, Ideen und Fehlermeldungen' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Feedback aus der Praxis' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Zum GitHub-Repository' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Planung ohne Tabellenchaos' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Was OpenFarmPlanner konkret unterstützt' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Datenschutzerklärung' })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'GitHub' })).toHaveLength(1);

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -61,8 +61,13 @@ describe('App', () => {
 
     expect(await screen.findByText('OpenFarmPlanner')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'OpenFarmPlanner öffnen' })).toBeInTheDocument();
+    expect(screen.getByText('Beta-Version mit laufenden Verbesserungen')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'GitHub ansehen' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Feedback und Ideen willkommen' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Zum GitHub-Repository' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Datenschutzerklärung' })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'GitHub' })).toHaveLength(1);
   });
 
   it('renders imprint route', async () => {

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -59,13 +59,13 @@ describe('App', () => {
   it('renders public home page on root path', async () => {
     render(<CommandProvider><App /></CommandProvider>);
 
-    expect(await screen.findByRole('heading', { name: 'Anbauplanung für Gemüsebau ohne Tabellenchaos.' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Digitale Anbauplanung für Gemüsebau, CSA und kleine Betriebe.' })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner öffnen' })).toHaveLength(2);
-    expect(screen.getByText('Aktive Beta • laufende Verbesserungen • Feedback willkommen')).toBeInTheDocument();
+    expect(screen.getByText('Aktive Beta • laufende Weiterentwicklung • Feedback willkommen')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'GitHub ansehen' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Feedback aus der Praxis' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Zum GitHub-Repository' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Was OpenFarmPlanner konkret unterstützt' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Open Source' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Repository auf GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Wofür OpenFarmPlanner gedacht ist' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Impressum' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Datenschutzerklärung' })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'GitHub' })).toHaveLength(1);

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -2,10 +2,9 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "statusLine": "Aktive Beta • laufende Verbesserungen • Feedback willkommen",
-    "headline": "Anbauplanung für Gemüsebau ohne Tabellenchaos.",
-    "subtitle": "Kulturen, Flächen und Zeiträume übersichtlich planen – für Betriebe, CSA und kleine Teams.",
-    "description": "OpenFarmPlanner unterstützt Sie bei der täglichen Planung und Dokumentation. Die Anwendung wird aktiv weiterentwickelt, transparent gebaut und konsequent mit Nutzerfeedback verbessert.",
+    "statusLine": "Aktive Beta • laufende Weiterentwicklung • Feedback willkommen",
+    "headline": "Digitale Anbauplanung für Gemüsebau, CSA und kleine Betriebe.",
+    "subtitle": "Kulturen, Flächen und Zeiträume an einem Ort planen – klar und teamfähig.",
     "actions": {
       "openApp": "OpenFarmPlanner öffnen",
       "register": "Registrieren",
@@ -13,106 +12,27 @@
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "audiences": {
-    "items": {
-      "smallVegetableFarms": "Kleine Gemüsebaubetriebe",
-      "csaOperations": "CSA / solidarische Landwirtschaft",
-      "digitalPlanningProjects": "Teams mit digitaler Anbauplanung"
-    }
-  },
-  "preview": {
-    "title": "Produktvorschau",
-    "subtitle": "So wirkt die Planung im Arbeitsalltag",
-    "tabs": {
-      "cultures": "Kulturen",
-      "areas": "Flächen",
-      "timeline": "Zeiträume"
-    },
-    "rows": {
-      "row1": "Salat • Frühjahrssatz",
-      "row2": "Karotten • Beet Nord 2",
-      "row3": "Mangold • Staffel 3",
-      "row4": "Spinat • Herbstfenster"
-    },
-    "status": {
-      "row1": "In Planung",
-      "row2": "Bestätigt",
-      "row3": "In Arbeit",
-      "row4": "Vorgemerkt"
-    },
-    "note": "Vorschau-Platzhalter: Hier kann später ein echter Screenshot aus der Anwendung eingebunden werden."
-  },
-  "benefits": {
-    "items": {
-      "clarity": {
-        "title": "Mehr Übersicht",
-        "description": "Wichtige Planungsinformationen sind zentral und schnell erfassbar."
-      },
-      "collaboration": {
-        "title": "Bessere Abstimmung",
-        "description": "Teams arbeiten mit derselben Datenbasis und weniger Missverständnissen."
-      },
-      "continuousImprovement": {
-        "title": "Aktive Weiterentwicklung",
-        "description": "Rückmeldungen aus der Praxis fließen direkt in die nächsten Verbesserungen ein."
-      }
-    }
-  },
   "features": {
-    "title": "Was OpenFarmPlanner konkret unterstützt",
-    "subtitle": "Die Funktionen sind auf praktische Planungsschritte ausgelegt – klar strukturiert und schnell verständlich.",
+    "title": "Wofür OpenFarmPlanner gedacht ist",
     "items": {
-      "cultures": {
-        "title": "Kulturen verwalten",
-        "description": "Kulturdaten zentral pflegen und einheitlich im Projekt nutzbar machen."
-      },
-      "areas": {
-        "title": "Flächen organisieren",
-        "description": "Beete und Anbauflächen nachvollziehbar strukturieren und zuordnen."
-      },
-      "timelines": {
-        "title": "Zeiträume planen",
-        "description": "Aussaat, Pflanzung und weitere Schritte entlang realistischer Zeitfenster koordinieren."
-      },
-      "teams": {
-        "title": "Im Team arbeiten",
-        "description": "Planungsstände transparent teilen und gemeinsam weiterentwickeln."
-      }
+      "cultures": "Kulturen verwalten",
+      "areas": "Flächen organisieren",
+      "timelines": "Zeiträume planen",
+      "teams": "Im Team arbeiten"
     }
-  },
-  "feedback": {
-    "title": "Feedback aus der Praxis",
-    "description": "Hinweise aus dem Alltag helfen besonders: Ideen, Fehlermeldungen und Verbesserungsvorschläge sind ausdrücklich willkommen.",
-    "items": {
-      "item1": "Rückmeldungen zur Bedienung und Planung",
-      "item2": "Konkrete Ideen für neue Funktionen",
-      "item3": "Fehlermeldungen mit kurzem Kontext"
-    },
-    "cta": "Feedback senden an {{email}}"
   },
   "openSource": {
-    "title": "Open Source schafft Vertrauen",
-    "description": "Der Quellcode ist öffentlich einsehbar. Entwicklungsschritte sind transparent und Beiträge via Issues oder Pull Requests sind willkommen.",
-    "items": {
-      "item1": "Öffentliches Repository auf GitHub",
-      "item2": "Offene Diskussion über Issues",
-      "item3": "Mitentwicklung durch Beiträge möglich"
-    },
-    "cta": "Zum GitHub-Repository",
+    "title": "Open Source",
+    "description": "Der Quellcode ist öffentlich. Beiträge und Feedback sind willkommen.",
+    "cta": "Repository auf GitHub",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
   "finalCta": {
-    "title": "Jetzt mit der Planung starten",
-    "description": "Testen Sie OpenFarmPlanner direkt im Browser oder erstellen Sie ein Konto für die gemeinsame Weiterentwicklung.",
+    "title": "Jetzt ausprobieren",
     "openApp": "OpenFarmPlanner öffnen",
     "register": "Konto erstellen"
   },
   "footer": {
-    "brandTitle": "OpenFarmPlanner",
-    "brandText": "Sachliche, moderne und transparente Anbauplanung in aktiver Beta-Phase.",
-    "linksTitle": "Projekt & Rechtliches",
-    "contactTitle": "Kontakt",
-    "contactText": "Fragen, Feedback und Fehlermeldungen nehmen wir gerne per E-Mail entgegen.",
     "imprint": "Impressum",
     "privacy": "Datenschutzerklärung",
     "github": "GitHub",

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -2,90 +2,117 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "statusLine": "Aktive Beta • laufende Weiterentwicklung • Feedback willkommen",
-    "headline": "Digitale Anbauplanung für den Gemüsebau – klar, praxisnah und gemeinsam weitergedacht.",
-    "subtitle": "Für Gemüsebaubetriebe, CSA und kleine landwirtschaftliche Teams.",
-    "description": "Planen Sie Kulturen, Flächen und Zeiträume an einem Ort. OpenFarmPlanner schafft Übersicht im Anbaualltag und wird kontinuierlich gemeinsam mit Nutzerinnen und Nutzern verbessert.",
+    "statusLine": "Aktive Beta • laufende Verbesserungen • Feedback willkommen",
+    "headline": "Anbauplanung für Gemüsebau ohne Tabellenchaos.",
+    "subtitle": "Kulturen, Flächen und Zeiträume übersichtlich planen – für Betriebe, CSA und kleine Teams.",
+    "description": "OpenFarmPlanner unterstützt Sie bei der täglichen Planung und Dokumentation. Die Anwendung wird aktiv weiterentwickelt, transparent gebaut und konsequent mit Nutzerfeedback verbessert.",
     "actions": {
-      "openApp": "Jetzt starten",
+      "openApp": "OpenFarmPlanner öffnen",
       "register": "Registrieren",
       "github": "GitHub ansehen",
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "heroHighlights": {
-    "title": "Was Sie direkt planen können",
-    "items": {
-      "cultureManagement": "Kulturen strukturiert verwalten",
-      "fieldOrganization": "Flächen und Beete eindeutig organisieren",
-      "planningPeriods": "Anbauzeiträume verlässlich koordinieren",
-      "projectCollaboration": "Im Projektteam abgestimmt zusammenarbeiten"
-    }
-  },
-  "featureOverview": {
-    "title": "Planung ohne Tabellenchaos",
-    "subtitle": "Die wichtigsten Funktionen sind auf schnelle Orientierung und tägliche Arbeit ausgelegt.",
-    "cards": {
-      "cultureManagement": {
-        "title": "Kulturen im Blick",
-        "description": "Alle relevanten Kulturdaten zentral erfassen und laufend pflegen."
-      },
-      "fieldPlanning": {
-        "title": "Flächen klar zugeordnet",
-        "description": "Beete und Anbauflächen nachvollziehbar planen und dokumentieren."
-      },
-      "timePlanning": {
-        "title": "Zeiträume strukturiert",
-        "description": "Aussaat, Pflanzung und weitere Schritte sauber über Zeiträume abbilden."
-      },
-      "projectCollaboration": {
-        "title": "Gemeinsam weiterarbeiten",
-        "description": "Projekte transparent organisieren und Informationen im Team teilen."
-      }
-    }
-  },
   "audiences": {
-    "title": "Geeignet für",
     "items": {
       "smallVegetableFarms": "Kleine Gemüsebaubetriebe",
       "csaOperations": "CSA / solidarische Landwirtschaft",
       "digitalPlanningProjects": "Teams mit digitaler Anbauplanung"
     }
   },
-  "statusNote": "OpenFarmPlanner befindet sich in einer aktiven Beta-Phase und wird laufend verbessert.",
-  "feedback": {
-    "title": "Feedback, Ideen und Fehlermeldungen",
-    "description": "Ihre Rückmeldungen helfen direkt bei der Priorisierung der nächsten Verbesserungen.",
+  "preview": {
+    "title": "Produktvorschau",
+    "subtitle": "So wirkt die Planung im Arbeitsalltag",
+    "tabs": {
+      "cultures": "Kulturen",
+      "areas": "Flächen",
+      "timeline": "Zeiträume"
+    },
+    "rows": {
+      "row1": "Salat • Frühjahrssatz",
+      "row2": "Karotten • Beet Nord 2",
+      "row3": "Mangold • Staffel 3",
+      "row4": "Spinat • Herbstfenster"
+    },
+    "status": {
+      "row1": "In Planung",
+      "row2": "Bestätigt",
+      "row3": "In Arbeit",
+      "row4": "Vorgemerkt"
+    },
+    "note": "Vorschau-Platzhalter: Hier kann später ein echter Screenshot aus der Anwendung eingebunden werden."
+  },
+  "benefits": {
     "items": {
-      "feedback": "Rückmeldungen aus der Praxis",
-      "ideas": "Ideen für neue Funktionen",
-      "bugReports": "Hinweise auf Fehler oder Unklarheiten"
+      "clarity": {
+        "title": "Mehr Übersicht",
+        "description": "Wichtige Planungsinformationen sind zentral und schnell erfassbar."
+      },
+      "collaboration": {
+        "title": "Bessere Abstimmung",
+        "description": "Teams arbeiten mit derselben Datenbasis und weniger Missverständnissen."
+      },
+      "continuousImprovement": {
+        "title": "Aktive Weiterentwicklung",
+        "description": "Rückmeldungen aus der Praxis fließen direkt in die nächsten Verbesserungen ein."
+      }
+    }
+  },
+  "features": {
+    "title": "Was OpenFarmPlanner konkret unterstützt",
+    "subtitle": "Die Funktionen sind auf praktische Planungsschritte ausgelegt – klar strukturiert und schnell verständlich.",
+    "items": {
+      "cultures": {
+        "title": "Kulturen verwalten",
+        "description": "Kulturdaten zentral pflegen und einheitlich im Projekt nutzbar machen."
+      },
+      "areas": {
+        "title": "Flächen organisieren",
+        "description": "Beete und Anbauflächen nachvollziehbar strukturieren und zuordnen."
+      },
+      "timelines": {
+        "title": "Zeiträume planen",
+        "description": "Aussaat, Pflanzung und weitere Schritte entlang realistischer Zeitfenster koordinieren."
+      },
+      "teams": {
+        "title": "Im Team arbeiten",
+        "description": "Planungsstände transparent teilen und gemeinsam weiterentwickeln."
+      }
+    }
+  },
+  "feedback": {
+    "title": "Feedback aus der Praxis",
+    "description": "Hinweise aus dem Alltag helfen besonders: Ideen, Fehlermeldungen und Verbesserungsvorschläge sind ausdrücklich willkommen.",
+    "items": {
+      "item1": "Rückmeldungen zur Bedienung und Planung",
+      "item2": "Konkrete Ideen für neue Funktionen",
+      "item3": "Fehlermeldungen mit kurzem Kontext"
     },
     "cta": "Feedback senden an {{email}}"
   },
   "openSource": {
-    "title": "Open Source als Vertrauensbasis",
-    "description": "OpenFarmPlanner wird offen entwickelt. Der Quellcode ist öffentlich, Fortschritte sind nachvollziehbar und Beiträge sind willkommen.",
+    "title": "Open Source schafft Vertrauen",
+    "description": "Der Quellcode ist öffentlich einsehbar. Entwicklungsschritte sind transparent und Beiträge via Issues oder Pull Requests sind willkommen.",
     "items": {
-      "publicCode": "Öffentlich einsehbarer Quellcode",
-      "issues": "Issues für Fragen, Ideen und Bugs",
-      "contributions": "Beiträge per Pull Request ausdrücklich erwünscht"
+      "item1": "Öffentliches Repository auf GitHub",
+      "item2": "Offene Diskussion über Issues",
+      "item3": "Mitentwicklung durch Beiträge möglich"
     },
     "cta": "Zum GitHub-Repository",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
   "finalCta": {
-    "title": "OpenFarmPlanner ausprobieren",
-    "description": "Starten Sie direkt mit der Planung oder registrieren Sie sich für die gemeinsame Weiterentwicklung.",
+    "title": "Jetzt mit der Planung starten",
+    "description": "Testen Sie OpenFarmPlanner direkt im Browser oder erstellen Sie ein Konto für die gemeinsame Weiterentwicklung.",
     "openApp": "OpenFarmPlanner öffnen",
     "register": "Konto erstellen"
   },
   "footer": {
     "brandTitle": "OpenFarmPlanner",
-    "brandText": "Ruhige, transparente und praxisorientierte Anbauplanung in aktiver Entwicklung.",
-    "linksTitle": "Rechtliches und Projekt",
+    "brandText": "Sachliche, moderne und transparente Anbauplanung in aktiver Beta-Phase.",
+    "linksTitle": "Projekt & Rechtliches",
     "contactTitle": "Kontakt",
-    "contactText": "Für Fragen, Feedback und Hinweise erreichen Sie uns per E-Mail.",
+    "contactText": "Fragen, Feedback und Fehlermeldungen nehmen wir gerne per E-Mail entgegen.",
     "imprint": "Impressum",
     "privacy": "Datenschutzerklärung",
     "github": "GitHub",

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -2,51 +2,90 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "subtitle": "Anbauplanung klar strukturieren – für Gemüsebau, CSA und kleine landwirtschaftliche Betriebe.",
-    "description": "OpenFarmPlanner unterstützt Sie dabei, Kulturen, Flächen und Anbauzeiträume übersichtlich zu planen. Die Anwendung wird aktiv weiterentwickelt, damit Planung und Zusammenarbeit im Alltag immer besser funktionieren.",
+    "statusLine": "Aktive Beta • laufende Weiterentwicklung • Feedback willkommen",
+    "headline": "Digitale Anbauplanung für den Gemüsebau – klar, praxisnah und gemeinsam weitergedacht.",
+    "subtitle": "Für Gemüsebaubetriebe, CSA und kleine landwirtschaftliche Teams.",
+    "description": "Planen Sie Kulturen, Flächen und Zeiträume an einem Ort. OpenFarmPlanner schafft Übersicht im Anbaualltag und wird kontinuierlich gemeinsam mit Nutzerinnen und Nutzern verbessert.",
     "actions": {
-      "openApp": "OpenFarmPlanner öffnen",
+      "openApp": "Jetzt starten",
       "register": "Registrieren",
       "github": "GitHub ansehen",
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "betaNote": {
-    "title": "Beta-Version mit laufenden Verbesserungen",
-    "description": "OpenFarmPlanner befindet sich in einer offenen Beta-Phase. Funktionen werden kontinuierlich verbessert und mit Ihrem Feedback gezielt weiterentwickelt."
+  "heroHighlights": {
+    "title": "Was Sie direkt planen können",
+    "items": {
+      "cultureManagement": "Kulturen strukturiert verwalten",
+      "fieldOrganization": "Flächen und Beete eindeutig organisieren",
+      "planningPeriods": "Anbauzeiträume verlässlich koordinieren",
+      "projectCollaboration": "Im Projektteam abgestimmt zusammenarbeiten"
+    }
   },
   "featureOverview": {
-    "title": "Funktionsübersicht",
-    "items": {
-      "cultureManagement": "Kulturen zentral verwalten",
-      "fieldOrganization": "Beete und Anbauflächen organisieren",
-      "planningPeriods": "Anbauzeiträume planen",
-      "structuredDocumentation": "Anbauinformationen strukturiert dokumentieren",
-      "projectCollaboration": "Projektbezogen zusammenarbeiten"
+    "title": "Planung ohne Tabellenchaos",
+    "subtitle": "Die wichtigsten Funktionen sind auf schnelle Orientierung und tägliche Arbeit ausgelegt.",
+    "cards": {
+      "cultureManagement": {
+        "title": "Kulturen im Blick",
+        "description": "Alle relevanten Kulturdaten zentral erfassen und laufend pflegen."
+      },
+      "fieldPlanning": {
+        "title": "Flächen klar zugeordnet",
+        "description": "Beete und Anbauflächen nachvollziehbar planen und dokumentieren."
+      },
+      "timePlanning": {
+        "title": "Zeiträume strukturiert",
+        "description": "Aussaat, Pflanzung und weitere Schritte sauber über Zeiträume abbilden."
+      },
+      "projectCollaboration": {
+        "title": "Gemeinsam weiterarbeiten",
+        "description": "Projekte transparent organisieren und Informationen im Team teilen."
+      }
     }
   },
   "audiences": {
     "title": "Geeignet für",
     "items": {
-      "smallVegetableFarms": "kleine Gemüsebaubetriebe",
+      "smallVegetableFarms": "Kleine Gemüsebaubetriebe",
       "csaOperations": "CSA / solidarische Landwirtschaft",
-      "digitalPlanningProjects": "Projekte, die ihre Anbauplanung digital organisieren möchten"
+      "digitalPlanningProjects": "Teams mit digitaler Anbauplanung"
     }
   },
-  "statusNote": "OpenFarmPlanner befindet sich aktuell in der Beta-Phase und wird laufend weiterentwickelt.",
+  "statusNote": "OpenFarmPlanner befindet sich in einer aktiven Beta-Phase und wird laufend verbessert.",
   "feedback": {
-    "title": "Feedback und Ideen willkommen",
-    "description": "Rückmeldungen aus der Praxis helfen uns besonders: Hinweise zu Problemen, Verbesserungsvorschläge und neue Ideen sind ausdrücklich willkommen.",
-    "contactHint": "Wenn Ihnen etwas auffällt oder Sie einen Wunsch für die Weiterentwicklung haben, schreiben Sie uns gerne.",
-    "contactCta": "Feedback senden an {{email}}"
+    "title": "Feedback, Ideen und Fehlermeldungen",
+    "description": "Ihre Rückmeldungen helfen direkt bei der Priorisierung der nächsten Verbesserungen.",
+    "items": {
+      "feedback": "Rückmeldungen aus der Praxis",
+      "ideas": "Ideen für neue Funktionen",
+      "bugReports": "Hinweise auf Fehler oder Unklarheiten"
+    },
+    "cta": "Feedback senden an {{email}}"
   },
   "openSource": {
-    "title": "Open Source und Mitgestaltung",
-    "description": "Der Quellcode von OpenFarmPlanner ist öffentlich einsehbar. Beiträge, Issues und Pull Requests zur Weiterentwicklung sind willkommen.",
+    "title": "Open Source als Vertrauensbasis",
+    "description": "OpenFarmPlanner wird offen entwickelt. Der Quellcode ist öffentlich, Fortschritte sind nachvollziehbar und Beiträge sind willkommen.",
+    "items": {
+      "publicCode": "Öffentlich einsehbarer Quellcode",
+      "issues": "Issues für Fragen, Ideen und Bugs",
+      "contributions": "Beiträge per Pull Request ausdrücklich erwünscht"
+    },
     "cta": "Zum GitHub-Repository",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
+  "finalCta": {
+    "title": "OpenFarmPlanner ausprobieren",
+    "description": "Starten Sie direkt mit der Planung oder registrieren Sie sich für die gemeinsame Weiterentwicklung.",
+    "openApp": "OpenFarmPlanner öffnen",
+    "register": "Konto erstellen"
+  },
   "footer": {
+    "brandTitle": "OpenFarmPlanner",
+    "brandText": "Ruhige, transparente und praxisorientierte Anbauplanung in aktiver Entwicklung.",
+    "linksTitle": "Rechtliches und Projekt",
+    "contactTitle": "Kontakt",
+    "contactText": "Für Fragen, Feedback und Hinweise erreichen Sie uns per E-Mail.",
     "imprint": "Impressum",
     "privacy": "Datenschutzerklärung",
     "github": "GitHub",

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -2,12 +2,18 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "subtitle": "Einfache Anbauplanung für Gemüsebau, CSA und kleine landwirtschaftliche Betriebe.",
-    "description": "OpenFarmPlanner hilft dabei, Kulturen, Anbauflächen und Anbauzeiträume übersichtlich zu verwalten. So bleiben Anbaupläne, Flächen und wichtige Informationen an einem Ort organisiert.",
+    "subtitle": "Anbauplanung klar strukturieren – für Gemüsebau, CSA und kleine landwirtschaftliche Betriebe.",
+    "description": "OpenFarmPlanner unterstützt Sie dabei, Kulturen, Flächen und Anbauzeiträume übersichtlich zu planen. Die Anwendung wird aktiv weiterentwickelt, damit Planung und Zusammenarbeit im Alltag immer besser funktionieren.",
     "actions": {
       "openApp": "OpenFarmPlanner öffnen",
-      "register": "Registrieren"
+      "register": "Registrieren",
+      "github": "GitHub ansehen",
+      "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
+  },
+  "betaNote": {
+    "title": "Beta-Version mit laufenden Verbesserungen",
+    "description": "OpenFarmPlanner befindet sich in einer offenen Beta-Phase. Funktionen werden kontinuierlich verbessert und mit Ihrem Feedback gezielt weiterentwickelt."
   },
   "featureOverview": {
     "title": "Funktionsübersicht",
@@ -28,9 +34,23 @@
     }
   },
   "statusNote": "OpenFarmPlanner befindet sich aktuell in der Beta-Phase und wird laufend weiterentwickelt.",
+  "feedback": {
+    "title": "Feedback und Ideen willkommen",
+    "description": "Rückmeldungen aus der Praxis helfen uns besonders: Hinweise zu Problemen, Verbesserungsvorschläge und neue Ideen sind ausdrücklich willkommen.",
+    "contactHint": "Wenn Ihnen etwas auffällt oder Sie einen Wunsch für die Weiterentwicklung haben, schreiben Sie uns gerne.",
+    "contactCta": "Feedback senden an {{email}}"
+  },
+  "openSource": {
+    "title": "Open Source und Mitgestaltung",
+    "description": "Der Quellcode von OpenFarmPlanner ist öffentlich einsehbar. Beiträge, Issues und Pull Requests zur Weiterentwicklung sind willkommen.",
+    "cta": "Zum GitHub-Repository",
+    "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
+  },
   "footer": {
     "imprint": "Impressum",
     "privacy": "Datenschutzerklärung",
+    "github": "GitHub",
+    "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner",
     "contactLabel": "Kontakt: {{email}}",
     "contactEmail": "info@openfarmplanner.org"
   },

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -2,10 +2,9 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "statusLine": "Active beta • continuous improvements • feedback welcome",
-    "headline": "Crop planning for vegetable farms without spreadsheet chaos.",
-    "subtitle": "Plan crops, areas, and timelines with clarity — for farms, CSA, and small teams.",
-    "description": "OpenFarmPlanner supports daily planning and documentation. The app is actively developed, transparently maintained, and continuously improved with user feedback.",
+    "statusLine": "Active beta • continuously improved • feedback welcome",
+    "headline": "Digital crop planning for vegetable farms, CSA, and small operations.",
+    "subtitle": "Plan crops, areas, and timelines in one place — clear and team-ready.",
     "actions": {
       "openApp": "Open OpenFarmPlanner",
       "register": "Register",
@@ -13,106 +12,27 @@
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "audiences": {
-    "items": {
-      "smallVegetableFarms": "Small vegetable farms",
-      "csaOperations": "CSA / community-supported agriculture",
-      "digitalPlanningProjects": "Teams with digital crop planning"
-    }
-  },
-  "preview": {
-    "title": "Product preview",
-    "subtitle": "How planning looks in day-to-day work",
-    "tabs": {
-      "cultures": "Crops",
-      "areas": "Areas",
-      "timeline": "Timelines"
-    },
-    "rows": {
-      "row1": "Lettuce • Spring set",
-      "row2": "Carrots • Bed North 2",
-      "row3": "Chard • Batch 3",
-      "row4": "Spinach • Autumn window"
-    },
-    "status": {
-      "row1": "Planned",
-      "row2": "Confirmed",
-      "row3": "In progress",
-      "row4": "Scheduled"
-    },
-    "note": "Preview placeholder: a real in-app screenshot can be embedded here later."
-  },
-  "benefits": {
-    "items": {
-      "clarity": {
-        "title": "More clarity",
-        "description": "Key planning information is centralized and easy to scan."
-      },
-      "collaboration": {
-        "title": "Better collaboration",
-        "description": "Teams work from the same source of truth with fewer misunderstandings."
-      },
-      "continuousImprovement": {
-        "title": "Active improvement",
-        "description": "Field feedback directly informs upcoming improvements."
-      }
-    }
-  },
   "features": {
-    "title": "What OpenFarmPlanner supports",
-    "subtitle": "Functions are designed around practical planning steps — structured and easy to understand.",
+    "title": "What OpenFarmPlanner is built for",
     "items": {
-      "cultures": {
-        "title": "Manage crops",
-        "description": "Maintain crop data centrally and use it consistently across the project."
-      },
-      "areas": {
-        "title": "Organize areas",
-        "description": "Structure beds and growing areas clearly and traceably."
-      },
-      "timelines": {
-        "title": "Plan timelines",
-        "description": "Coordinate sowing, planting, and further steps along realistic windows."
-      },
-      "teams": {
-        "title": "Work as a team",
-        "description": "Share planning status transparently and improve it together."
-      }
+      "cultures": "Manage crops",
+      "areas": "Organize areas",
+      "timelines": "Plan timelines",
+      "teams": "Work as a team"
     }
-  },
-  "feedback": {
-    "title": "Practical feedback",
-    "description": "Real-world input matters most: ideas, bug reports, and improvement suggestions are always welcome.",
-    "items": {
-      "item1": "Feedback on usability and planning flow",
-      "item2": "Concrete ideas for new features",
-      "item3": "Bug reports with short context"
-    },
-    "cta": "Send feedback to {{email}}"
   },
   "openSource": {
-    "title": "Open source builds trust",
-    "description": "Source code is publicly available. Progress is transparent, and contributions via issues or pull requests are welcome.",
-    "items": {
-      "item1": "Public GitHub repository",
-      "item2": "Open discussion via issues",
-      "item3": "Contributions to development are possible"
-    },
-    "cta": "Go to the GitHub repository",
+    "title": "Open source",
+    "description": "Source code is public. Contributions and feedback are welcome.",
+    "cta": "Repository on GitHub",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
   "finalCta": {
-    "title": "Start planning now",
-    "description": "Try OpenFarmPlanner directly in the browser or create an account to join ongoing development.",
+    "title": "Try it now",
     "openApp": "Open OpenFarmPlanner",
     "register": "Create account"
   },
   "footer": {
-    "brandTitle": "OpenFarmPlanner",
-    "brandText": "Calm, modern, and transparent crop planning in active beta.",
-    "linksTitle": "Project & legal",
-    "contactTitle": "Contact",
-    "contactText": "Questions, feedback, and bug reports are welcome via email.",
     "imprint": "Imprint",
     "privacy": "Privacy policy",
     "github": "GitHub",

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -2,90 +2,117 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "statusLine": "Active beta • continuous improvement • feedback welcome",
-    "headline": "Digital crop planning for vegetable farming — clear, practical, and continuously improved.",
-    "subtitle": "For vegetable farms, CSA, and small agricultural teams.",
-    "description": "Plan crops, areas, and timelines in one place. OpenFarmPlanner brings structure to daily planning and is continuously refined with user feedback.",
+    "statusLine": "Active beta • continuous improvements • feedback welcome",
+    "headline": "Crop planning for vegetable farms without spreadsheet chaos.",
+    "subtitle": "Plan crops, areas, and timelines with clarity — for farms, CSA, and small teams.",
+    "description": "OpenFarmPlanner supports daily planning and documentation. The app is actively developed, transparently maintained, and continuously improved with user feedback.",
     "actions": {
-      "openApp": "Get started",
+      "openApp": "Open OpenFarmPlanner",
       "register": "Register",
       "github": "View GitHub",
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "heroHighlights": {
-    "title": "What you can plan right away",
-    "items": {
-      "cultureManagement": "Manage crops in a structured way",
-      "fieldOrganization": "Organize fields and beds clearly",
-      "planningPeriods": "Coordinate cultivation periods reliably",
-      "projectCollaboration": "Collaborate effectively across projects"
-    }
-  },
-  "featureOverview": {
-    "title": "Planning without spreadsheet chaos",
-    "subtitle": "Core functions are built for quick orientation and daily practical use.",
-    "cards": {
-      "cultureManagement": {
-        "title": "Crops at a glance",
-        "description": "Capture and maintain all relevant crop data in one place."
-      },
-      "fieldPlanning": {
-        "title": "Areas clearly assigned",
-        "description": "Plan and document fields and beds in a traceable way."
-      },
-      "timePlanning": {
-        "title": "Structured timelines",
-        "description": "Map sowing, planting, and further steps across clear time periods."
-      },
-      "projectCollaboration": {
-        "title": "Work together effectively",
-        "description": "Keep projects transparent and share planning context with your team."
-      }
-    }
-  },
   "audiences": {
-    "title": "Suitable for",
     "items": {
       "smallVegetableFarms": "Small vegetable farms",
       "csaOperations": "CSA / community-supported agriculture",
-      "digitalPlanningProjects": "Teams organizing crop planning digitally"
+      "digitalPlanningProjects": "Teams with digital crop planning"
     }
   },
-  "statusNote": "OpenFarmPlanner is in active beta and continuously improved.",
-  "feedback": {
-    "title": "Feedback, ideas, and bug reports",
-    "description": "Your input directly helps us prioritize upcoming improvements.",
+  "preview": {
+    "title": "Product preview",
+    "subtitle": "How planning looks in day-to-day work",
+    "tabs": {
+      "cultures": "Crops",
+      "areas": "Areas",
+      "timeline": "Timelines"
+    },
+    "rows": {
+      "row1": "Lettuce • Spring set",
+      "row2": "Carrots • Bed North 2",
+      "row3": "Chard • Batch 3",
+      "row4": "Spinach • Autumn window"
+    },
+    "status": {
+      "row1": "Planned",
+      "row2": "Confirmed",
+      "row3": "In progress",
+      "row4": "Scheduled"
+    },
+    "note": "Preview placeholder: a real in-app screenshot can be embedded here later."
+  },
+  "benefits": {
     "items": {
-      "feedback": "Practical feedback from real operations",
-      "ideas": "Ideas for new capabilities",
-      "bugReports": "Bug reports and unclear workflow notes"
+      "clarity": {
+        "title": "More clarity",
+        "description": "Key planning information is centralized and easy to scan."
+      },
+      "collaboration": {
+        "title": "Better collaboration",
+        "description": "Teams work from the same source of truth with fewer misunderstandings."
+      },
+      "continuousImprovement": {
+        "title": "Active improvement",
+        "description": "Field feedback directly informs upcoming improvements."
+      }
+    }
+  },
+  "features": {
+    "title": "What OpenFarmPlanner supports",
+    "subtitle": "Functions are designed around practical planning steps — structured and easy to understand.",
+    "items": {
+      "cultures": {
+        "title": "Manage crops",
+        "description": "Maintain crop data centrally and use it consistently across the project."
+      },
+      "areas": {
+        "title": "Organize areas",
+        "description": "Structure beds and growing areas clearly and traceably."
+      },
+      "timelines": {
+        "title": "Plan timelines",
+        "description": "Coordinate sowing, planting, and further steps along realistic windows."
+      },
+      "teams": {
+        "title": "Work as a team",
+        "description": "Share planning status transparently and improve it together."
+      }
+    }
+  },
+  "feedback": {
+    "title": "Practical feedback",
+    "description": "Real-world input matters most: ideas, bug reports, and improvement suggestions are always welcome.",
+    "items": {
+      "item1": "Feedback on usability and planning flow",
+      "item2": "Concrete ideas for new features",
+      "item3": "Bug reports with short context"
     },
     "cta": "Send feedback to {{email}}"
   },
   "openSource": {
-    "title": "Open source as a trust signal",
-    "description": "OpenFarmPlanner is developed in the open. Source code is public, progress is transparent, and contributions are welcome.",
+    "title": "Open source builds trust",
+    "description": "Source code is publicly available. Progress is transparent, and contributions via issues or pull requests are welcome.",
     "items": {
-      "publicCode": "Publicly accessible source code",
-      "issues": "Issues for questions, ideas, and bugs",
-      "contributions": "Contributions via pull requests are welcome"
+      "item1": "Public GitHub repository",
+      "item2": "Open discussion via issues",
+      "item3": "Contributions to development are possible"
     },
     "cta": "Go to the GitHub repository",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
   "finalCta": {
-    "title": "Try OpenFarmPlanner",
-    "description": "Start planning right away or register to join the ongoing product development.",
+    "title": "Start planning now",
+    "description": "Try OpenFarmPlanner directly in the browser or create an account to join ongoing development.",
     "openApp": "Open OpenFarmPlanner",
     "register": "Create account"
   },
   "footer": {
     "brandTitle": "OpenFarmPlanner",
-    "brandText": "Calm, transparent, and practical crop planning in active development.",
-    "linksTitle": "Legal and project",
+    "brandText": "Calm, modern, and transparent crop planning in active beta.",
+    "linksTitle": "Project & legal",
     "contactTitle": "Contact",
-    "contactText": "For questions, feedback, and reports, reach out via email.",
+    "contactText": "Questions, feedback, and bug reports are welcome via email.",
     "imprint": "Imprint",
     "privacy": "Privacy policy",
     "github": "GitHub",

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -2,12 +2,18 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "subtitle": "Simple crop planning for vegetable production, CSA, and small farms.",
-    "description": "OpenFarmPlanner helps manage crops, growing areas, and cultivation periods in a clear way. Keep plans, fields, and key information organized in one place.",
+    "subtitle": "Keep crop planning structured for vegetable production, CSA, and small farms.",
+    "description": "OpenFarmPlanner helps you plan crops, areas, and cultivation periods in one clear workspace. The app is actively developed to continuously improve planning and collaboration.",
     "actions": {
       "openApp": "Open OpenFarmPlanner",
-      "register": "Register"
+      "register": "Register",
+      "github": "View GitHub",
+      "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
+  },
+  "betaNote": {
+    "title": "Beta version with ongoing improvements",
+    "description": "OpenFarmPlanner is currently in an open beta phase. Features are continuously refined, and your feedback helps shape the roadmap."
   },
   "featureOverview": {
     "title": "Feature overview",
@@ -28,9 +34,23 @@
     }
   },
   "statusNote": "OpenFarmPlanner is currently in beta and is being continuously improved.",
+  "feedback": {
+    "title": "Feedback and ideas are welcome",
+    "description": "Practical feedback is especially valuable: issue reports, suggestions, and ideas for improvement are always welcome.",
+    "contactHint": "If you notice something or have an idea for further development, feel free to contact us.",
+    "contactCta": "Send feedback to {{email}}"
+  },
+  "openSource": {
+    "title": "Open source and collaboration",
+    "description": "The OpenFarmPlanner source code is publicly available. Contributions, issues, and pull requests are welcome.",
+    "cta": "Go to the GitHub repository",
+    "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
+  },
   "footer": {
     "imprint": "Imprint",
     "privacy": "Privacy policy",
+    "github": "GitHub",
+    "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner",
     "contactLabel": "Contact: {{email}}",
     "contactEmail": "info@openfarmplanner.org"
   },

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -2,51 +2,90 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "subtitle": "Keep crop planning structured for vegetable production, CSA, and small farms.",
-    "description": "OpenFarmPlanner helps you plan crops, areas, and cultivation periods in one clear workspace. The app is actively developed to continuously improve planning and collaboration.",
+    "statusLine": "Active beta • continuous improvement • feedback welcome",
+    "headline": "Digital crop planning for vegetable farming — clear, practical, and continuously improved.",
+    "subtitle": "For vegetable farms, CSA, and small agricultural teams.",
+    "description": "Plan crops, areas, and timelines in one place. OpenFarmPlanner brings structure to daily planning and is continuously refined with user feedback.",
     "actions": {
-      "openApp": "Open OpenFarmPlanner",
+      "openApp": "Get started",
       "register": "Register",
       "github": "View GitHub",
       "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
     }
   },
-  "betaNote": {
-    "title": "Beta version with ongoing improvements",
-    "description": "OpenFarmPlanner is currently in an open beta phase. Features are continuously refined, and your feedback helps shape the roadmap."
+  "heroHighlights": {
+    "title": "What you can plan right away",
+    "items": {
+      "cultureManagement": "Manage crops in a structured way",
+      "fieldOrganization": "Organize fields and beds clearly",
+      "planningPeriods": "Coordinate cultivation periods reliably",
+      "projectCollaboration": "Collaborate effectively across projects"
+    }
   },
   "featureOverview": {
-    "title": "Feature overview",
-    "items": {
-      "cultureManagement": "Manage crops centrally",
-      "fieldOrganization": "Organize beds and growing areas",
-      "planningPeriods": "Plan cultivation periods",
-      "structuredDocumentation": "Document cultivation data in a structured way",
-      "projectCollaboration": "Collaborate across projects"
+    "title": "Planning without spreadsheet chaos",
+    "subtitle": "Core functions are built for quick orientation and daily practical use.",
+    "cards": {
+      "cultureManagement": {
+        "title": "Crops at a glance",
+        "description": "Capture and maintain all relevant crop data in one place."
+      },
+      "fieldPlanning": {
+        "title": "Areas clearly assigned",
+        "description": "Plan and document fields and beds in a traceable way."
+      },
+      "timePlanning": {
+        "title": "Structured timelines",
+        "description": "Map sowing, planting, and further steps across clear time periods."
+      },
+      "projectCollaboration": {
+        "title": "Work together effectively",
+        "description": "Keep projects transparent and share planning context with your team."
+      }
     }
   },
   "audiences": {
     "title": "Suitable for",
     "items": {
-      "smallVegetableFarms": "small vegetable farms",
+      "smallVegetableFarms": "Small vegetable farms",
       "csaOperations": "CSA / community-supported agriculture",
-      "digitalPlanningProjects": "projects that want to organize cultivation planning digitally"
+      "digitalPlanningProjects": "Teams organizing crop planning digitally"
     }
   },
-  "statusNote": "OpenFarmPlanner is currently in beta and is being continuously improved.",
+  "statusNote": "OpenFarmPlanner is in active beta and continuously improved.",
   "feedback": {
-    "title": "Feedback and ideas are welcome",
-    "description": "Practical feedback is especially valuable: issue reports, suggestions, and ideas for improvement are always welcome.",
-    "contactHint": "If you notice something or have an idea for further development, feel free to contact us.",
-    "contactCta": "Send feedback to {{email}}"
+    "title": "Feedback, ideas, and bug reports",
+    "description": "Your input directly helps us prioritize upcoming improvements.",
+    "items": {
+      "feedback": "Practical feedback from real operations",
+      "ideas": "Ideas for new capabilities",
+      "bugReports": "Bug reports and unclear workflow notes"
+    },
+    "cta": "Send feedback to {{email}}"
   },
   "openSource": {
-    "title": "Open source and collaboration",
-    "description": "The OpenFarmPlanner source code is publicly available. Contributions, issues, and pull requests are welcome.",
+    "title": "Open source as a trust signal",
+    "description": "OpenFarmPlanner is developed in the open. Source code is public, progress is transparent, and contributions are welcome.",
+    "items": {
+      "publicCode": "Publicly accessible source code",
+      "issues": "Issues for questions, ideas, and bugs",
+      "contributions": "Contributions via pull requests are welcome"
+    },
     "cta": "Go to the GitHub repository",
     "githubUrl": "https://github.com/stipsitzm/OpenFarmPlanner"
   },
+  "finalCta": {
+    "title": "Try OpenFarmPlanner",
+    "description": "Start planning right away or register to join the ongoing product development.",
+    "openApp": "Open OpenFarmPlanner",
+    "register": "Create account"
+  },
   "footer": {
+    "brandTitle": "OpenFarmPlanner",
+    "brandText": "Calm, transparent, and practical crop planning in active development.",
+    "linksTitle": "Legal and project",
+    "contactTitle": "Contact",
+    "contactText": "For questions, feedback, and reports, reach out via email.",
     "imprint": "Imprint",
     "privacy": "Privacy policy",
     "github": "GitHub",

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -1,3 +1,9 @@
+import AgricultureOutlinedIcon from '@mui/icons-material/AgricultureOutlined';
+import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
+import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
+import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
+import Groups2OutlinedIcon from '@mui/icons-material/Groups2Outlined';
 import {
   Box,
   Button,
@@ -10,28 +16,21 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from '../../i18n';
 
-const heroHighlightItems = [
-  'cultureManagement',
-  'fieldOrganization',
-  'planningPeriods',
-  'projectCollaboration',
+const benefitItems = ['clarity', 'collaboration', 'continuousImprovement'] as const;
+
+const featureItems = [
+  { key: 'cultures', icon: AgricultureOutlinedIcon },
+  { key: 'areas', icon: GridViewOutlinedIcon },
+  { key: 'timelines', icon: CalendarMonthOutlinedIcon },
+  { key: 'teams', icon: Groups2OutlinedIcon },
 ] as const;
 
-const featureCardItems = [
-  'cultureManagement',
-  'fieldPlanning',
-  'timePlanning',
-  'projectCollaboration',
+const trustItems = [
+  { key: 'feedback', icon: ForumOutlinedIcon },
+  { key: 'openSource', icon: CodeOutlinedIcon },
 ] as const;
 
-const audienceItems = [
-  'smallVegetableFarms',
-  'csaOperations',
-  'digitalPlanningProjects',
-] as const;
-
-const feedbackItems = ['feedback', 'ideas', 'bugReports'] as const;
-const openSourceItems = ['publicCode', 'issues', 'contributions'] as const;
+const audienceItems = ['smallVegetableFarms', 'csaOperations', 'digitalPlanningProjects'] as const;
 
 export default function HomePage(): React.ReactElement {
   const { t } = useTranslation('home');
@@ -41,110 +40,150 @@ export default function HomePage(): React.ReactElement {
       <Box
         component="section"
         sx={{
-          background: (theme) => `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
+          position: 'relative',
+          overflow: 'hidden',
+          background: (theme) => `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 80%)`,
           borderBottom: 1,
           borderColor: 'divider',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            background: 'radial-gradient(circle at 82% 20%, rgba(25, 118, 210, 0.12), transparent 44%)',
+            pointerEvents: 'none',
+          },
         }}
       >
-        <Container maxWidth="lg" sx={{ py: { xs: 7, md: 10 } }}>
-          <Stack spacing={{ xs: 4, md: 6 }}>
-            <Box
-              sx={{
-                border: 1,
-                borderColor: 'divider',
-                borderRadius: 4,
-                p: { xs: 3, md: 5 },
-                bgcolor: 'background.paper',
-              }}
-            >
-              <Box
-                sx={{
-                  display: 'grid',
-                  gap: { xs: 4, md: 5 },
-                  gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1.2fr) minmax(0, 0.8fr)' },
-                  alignItems: 'start',
-                }}
-              >
-                <Stack spacing={2.5}>
-                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                    <Chip label={t('landing.betaBadge')} color="warning" size="small" />
-                    <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
-                      {t('landing.statusLine')}
-                    </Typography>
-                  </Stack>
-                  <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '2.2rem', md: '3.2rem' }, lineHeight: 1.15 }}>
-                    {t('landing.headline')}
-                  </Typography>
-                  <Typography variant="h5" color="text.primary" sx={{ fontWeight: 500, fontSize: { xs: '1.1rem', md: '1.35rem' } }}>
-                    {t('landing.subtitle')}
-                  </Typography>
-                  <Typography color="text.secondary" sx={{ maxWidth: 720, fontSize: { xs: '1rem', md: '1.05rem' } }}>
-                    {t('landing.description')}
-                  </Typography>
+        <Container maxWidth="xl" sx={{ position: 'relative', py: { xs: 7, md: 9, lg: 11 } }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gap: { xs: 5, md: 6 },
+              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.1fr) minmax(0, 0.9fr)' },
+              alignItems: 'center',
+            }}
+          >
+            <Stack spacing={3}>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                <Chip label={t('landing.betaBadge')} color="warning" size="small" />
+                <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
+                  {t('landing.statusLine')}
+                </Typography>
+              </Stack>
 
-                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ pt: 1 }}>
-                    <Button component={RouterLink} to="/app" variant="contained" size="large">
-                      {t('landing.actions.openApp')}
-                    </Button>
-                    <Button component={RouterLink} to="/register" variant="outlined" size="large">
-                      {t('landing.actions.register')}
-                    </Button>
-                    <Button
-                      component={Link}
-                      href={t('landing.actions.githubUrl')}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
-                      color="inherit"
-                      variant="text"
-                      size="large"
-                    >
-                      {t('landing.actions.github')}
-                    </Button>
-                  </Stack>
-                </Stack>
+              <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '2.1rem', md: '3rem', lg: '3.4rem' }, lineHeight: 1.08, maxWidth: 760 }}>
+                {t('landing.headline')}
+              </Typography>
 
-                <Stack spacing={1.2}>
-                  <Typography variant="subtitle2" sx={{ textTransform: 'uppercase', letterSpacing: 0.8, color: 'text.secondary' }}>
-                    {t('heroHighlights.title')}
-                  </Typography>
-                  {heroHighlightItems.map((itemKey) => (
-                    <Box
-                      key={itemKey}
-                      sx={{
-                        px: 2,
-                        py: 1.6,
-                        borderRadius: 2,
-                        border: 1,
-                        borderColor: 'divider',
-                        bgcolor: 'background.default',
-                      }}
-                    >
-                      <Typography>{t(`heroHighlights.items.${itemKey}`)}</Typography>
-                    </Box>
-                  ))}
-                </Stack>
-              </Box>
-            </Box>
+              <Typography variant="h5" color="text.primary" sx={{ fontSize: { xs: '1.05rem', md: '1.28rem' }, fontWeight: 500, maxWidth: 720 }}>
+                {t('landing.subtitle')}
+              </Typography>
 
-            <Stack spacing={1.5}>
-              <Typography variant="h6">{t('audiences.title')}</Typography>
-              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+              <Typography color="text.secondary" sx={{ maxWidth: 690 }}>
+                {t('landing.description')}
+              </Typography>
+
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                <Button component={RouterLink} to="/app" variant="contained" size="large">
+                  {t('landing.actions.openApp')}
+                </Button>
+                <Button component={RouterLink} to="/register" variant="outlined" size="large">
+                  {t('landing.actions.register')}
+                </Button>
+                <Button
+                  component={Link}
+                  href={t('landing.actions.githubUrl')}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="none"
+                  variant="text"
+                  color="inherit"
+                  size="large"
+                >
+                  {t('landing.actions.github')}
+                </Button>
+              </Stack>
+
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ pt: 0.5 }}>
                 {audienceItems.map((itemKey) => (
                   <Chip key={itemKey} label={t(`audiences.items.${itemKey}`)} variant="outlined" sx={{ borderRadius: 2 }} />
                 ))}
               </Stack>
             </Stack>
-          </Stack>
+
+            <Box
+              sx={{
+                borderRadius: 4,
+                border: 1,
+                borderColor: 'divider',
+                bgcolor: 'background.paper',
+                p: { xs: 2.5, md: 3 },
+                boxShadow: '0 24px 40px rgba(15, 23, 42, 0.08)',
+              }}
+            >
+              <Stack spacing={2}>
+                <Typography variant="subtitle2" sx={{ letterSpacing: 0.5, textTransform: 'uppercase', color: 'text.secondary' }}>
+                  {t('preview.title')}
+                </Typography>
+                <Typography variant="h6">{t('preview.subtitle')}</Typography>
+
+                <Box sx={{ borderRadius: 2, border: 1, borderColor: 'divider', overflow: 'hidden', bgcolor: 'background.default' }}>
+                  <Box sx={{ px: 2, py: 1.1, borderBottom: 1, borderColor: 'divider', display: 'flex', gap: 1 }}>
+                    <Chip label={t('preview.tabs.cultures')} size="small" color="primary" />
+                    <Chip label={t('preview.tabs.areas')} size="small" variant="outlined" />
+                    <Chip label={t('preview.tabs.timeline')} size="small" variant="outlined" />
+                  </Box>
+                  <Stack spacing={1} sx={{ p: 2 }}>
+                    {[1, 2, 3, 4].map((row) => (
+                      <Box key={row} sx={{ border: 1, borderColor: 'divider', borderRadius: 1.5, px: 1.5, py: 1, bgcolor: 'background.paper' }}>
+                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                          <Typography variant="body2">{t(`preview.rows.row${row}`)}</Typography>
+                          <Chip label={t(`preview.status.row${row}`)} size="small" variant="outlined" />
+                        </Stack>
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+
+                <Typography variant="body2" color="text.secondary">
+                  {t('preview.note')}
+                </Typography>
+              </Stack>
+            </Box>
+          </Box>
+
+          <Box
+            sx={{
+              mt: { xs: 5, md: 6 },
+              display: 'grid',
+              gap: 2,
+              gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+            }}
+          >
+            {benefitItems.map((itemKey) => (
+              <Box key={itemKey} sx={{ p: { xs: 2, md: 2.5 }, borderRadius: 2.5, bgcolor: 'background.paper', border: 1, borderColor: 'divider' }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+                  {t(`benefits.items.${itemKey}.title`)}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t(`benefits.items.${itemKey}.description`)}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
         </Container>
       </Box>
 
       <Box component="section" sx={{ py: { xs: 7, md: 9 } }}>
-        <Container maxWidth="lg">
+        <Container maxWidth="xl">
           <Stack spacing={3.5}>
             <Stack spacing={1}>
-              <Typography variant="h3" sx={{ fontSize: { xs: '1.75rem', md: '2.15rem' } }}>{t('featureOverview.title')}</Typography>
-              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>{t('featureOverview.subtitle')}</Typography>
+              <Typography variant="h3" sx={{ fontSize: { xs: '1.7rem', md: '2.2rem' } }}>
+                {t('features.title')}
+              </Typography>
+              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>
+                {t('features.subtitle')}
+              </Typography>
             </Stack>
 
             <Box
@@ -154,20 +193,27 @@ export default function HomePage(): React.ReactElement {
                 gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
               }}
             >
-              {featureCardItems.map((itemKey) => (
+              {featureItems.map(({ key, icon: Icon }) => (
                 <Box
-                  key={itemKey}
+                  key={key}
                   sx={{
+                    p: { xs: 2.5, md: 3 },
+                    borderRadius: 3,
+                    bgcolor: 'background.paper',
                     border: 1,
                     borderColor: 'divider',
-                    borderRadius: 3,
-                    p: { xs: 2.5, md: 3 },
-                    bgcolor: 'background.paper',
+                    display: 'grid',
+                    gridTemplateColumns: 'auto 1fr',
+                    gap: 1.5,
+                    alignItems: 'start',
                   }}
                 >
-                  <Stack spacing={1}>
-                    <Typography variant="h6">{t(`featureOverview.cards.${itemKey}.title`)}</Typography>
-                    <Typography color="text.secondary">{t(`featureOverview.cards.${itemKey}.description`)}</Typography>
+                  <Box sx={{ width: 36, height: 36, borderRadius: 1.5, bgcolor: 'primary.light', color: 'primary.contrastText', display: 'grid', placeItems: 'center' }}>
+                    <Icon fontSize="small" />
+                  </Box>
+                  <Stack spacing={0.8}>
+                    <Typography variant="h6">{t(`features.items.${key}.title`)}</Typography>
+                    <Typography color="text.secondary">{t(`features.items.${key}.description`)}</Typography>
                   </Stack>
                 </Box>
               ))}
@@ -176,71 +222,82 @@ export default function HomePage(): React.ReactElement {
         </Container>
       </Box>
 
-      <Box component="section" sx={{ py: { xs: 7, md: 9 }, bgcolor: 'background.paper', borderTop: 1, borderBottom: 1, borderColor: 'divider' }}>
-        <Container maxWidth="lg">
-          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' } }}>
-            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 } }}>
-              <Stack spacing={1.5}>
-                <Typography variant="h5">{t('feedback.title')}</Typography>
-                <Typography color="text.secondary">{t('feedback.description')}</Typography>
-                <Stack component="ul" spacing={1} sx={{ pl: 2, m: 0 }}>
-                  {feedbackItems.map((itemKey) => (
-                    <Typography component="li" key={itemKey} color="text.secondary">
-                      {t(`feedback.items.${itemKey}`)}
-                    </Typography>
-                  ))}
+      <Box component="section" sx={{ py: { xs: 6, md: 8 }, bgcolor: 'grey.100', borderTop: 1, borderBottom: 1, borderColor: 'divider' }}>
+        <Container maxWidth="xl">
+          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' } }}>
+            {trustItems.map(({ key, icon: Icon }, index) => (
+              <Box
+                key={key}
+                sx={{
+                  p: { xs: 2.5, md: 3.2 },
+                  borderRadius: 3,
+                  bgcolor: index === 1 ? 'background.paper' : 'rgba(25, 118, 210, 0.06)',
+                  border: 1,
+                  borderColor: index === 1 ? 'divider' : 'rgba(25, 118, 210, 0.28)',
+                }}
+              >
+                <Stack spacing={1.3}>
+                  <Stack direction="row" spacing={1.2} alignItems="center">
+                    <Box sx={{ width: 34, height: 34, borderRadius: 1.5, bgcolor: 'background.paper', border: 1, borderColor: 'divider', display: 'grid', placeItems: 'center' }}>
+                      <Icon fontSize="small" />
+                    </Box>
+                    <Typography variant="h5">{t(`${key}.title`)}</Typography>
+                  </Stack>
+                  <Typography color="text.secondary">{t(`${key}.description`)}</Typography>
+                  <Stack component="ul" spacing={0.8} sx={{ m: 0, pl: 2 }}>
+                    {(['item1', 'item2', 'item3'] as const).map((itemKey) => (
+                      <Typography component="li" key={itemKey} color="text.secondary">
+                        {t(`${key}.items.${itemKey}`)}
+                      </Typography>
+                    ))}
+                  </Stack>
+                  {key === 'feedback' ? (
+                    <Button component={Link} href={`mailto:${t('footer.contactEmail')}`} underline="none" variant="outlined" sx={{ width: 'fit-content' }}>
+                      {t('feedback.cta', { email: t('footer.contactEmail') })}
+                    </Button>
+                  ) : (
+                    <Button
+                      component={Link}
+                      href={t('openSource.githubUrl')}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      underline="none"
+                      variant="contained"
+                      sx={{ width: 'fit-content' }}
+                    >
+                      {t('openSource.cta')}
+                    </Button>
+                  )}
                 </Stack>
-                <Button
-                  component={Link}
-                  href={`mailto:${t('footer.contactEmail')}`}
-                  underline="none"
-                  variant="outlined"
-                  sx={{ width: 'fit-content' }}
-                >
-                  {t('feedback.cta', { email: t('footer.contactEmail') })}
-                </Button>
-              </Stack>
-            </Box>
-
-            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 } }}>
-              <Stack spacing={1.5}>
-                <Typography variant="h5">{t('openSource.title')}</Typography>
-                <Typography color="text.secondary">{t('openSource.description')}</Typography>
-                <Stack component="ul" spacing={1} sx={{ pl: 2, m: 0 }}>
-                  {openSourceItems.map((itemKey) => (
-                    <Typography component="li" key={itemKey} color="text.secondary">
-                      {t(`openSource.items.${itemKey}`)}
-                    </Typography>
-                  ))}
-                </Stack>
-                <Button
-                  component={Link}
-                  href={t('openSource.githubUrl')}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  underline="none"
-                  variant="contained"
-                  sx={{ width: 'fit-content' }}
-                >
-                  {t('openSource.cta')}
-                </Button>
-              </Stack>
-            </Box>
+              </Box>
+            ))}
           </Box>
         </Container>
       </Box>
 
-      <Box component="section" sx={{ py: { xs: 6, md: 8 } }}>
-        <Container maxWidth="lg">
-          <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 }, bgcolor: 'background.paper' }}>
-            <Stack spacing={1.5}>
-              <Typography variant="h5">{t('finalCta.title')}</Typography>
-              <Typography color="text.secondary">{t('finalCta.description')}</Typography>
-              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.25}>
-                <Button component={RouterLink} to="/app" variant="contained">
+      <Box component="section" sx={{ py: { xs: 7, md: 9 } }}>
+        <Container maxWidth="xl">
+          <Box
+            sx={{
+              p: { xs: 3, md: 4 },
+              borderRadius: 4,
+              background: 'linear-gradient(135deg, rgba(25, 118, 210, 0.12), rgba(25, 118, 210, 0.04))',
+              border: 1,
+              borderColor: 'rgba(25, 118, 210, 0.25)',
+            }}
+          >
+            <Stack spacing={2}>
+              <Typography variant="h4" sx={{ fontSize: { xs: '1.6rem', md: '2rem' } }}>
+                {t('finalCta.title')}
+              </Typography>
+              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>
+                {t('finalCta.description')}
+              </Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                <Button component={RouterLink} to="/app" variant="contained" size="large">
                   {t('finalCta.openApp')}
                 </Button>
-                <Button component={RouterLink} to="/register" variant="outlined">
+                <Button component={RouterLink} to="/register" variant="outlined" size="large">
                   {t('finalCta.register')}
                 </Button>
               </Stack>
@@ -249,12 +306,14 @@ export default function HomePage(): React.ReactElement {
         </Container>
       </Box>
 
-      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', py: { xs: 4, md: 5 }, bgcolor: 'background.paper' }}>
-        <Container maxWidth="lg">
-          <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, minmax(0, 1fr))' } }}>
-            <Stack spacing={1}>
+      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+        <Container maxWidth="xl" sx={{ py: { xs: 4, md: 5 } }}>
+          <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: { xs: '1fr', md: '1.2fr 1fr 1fr' } }}>
+            <Stack spacing={1.2}>
               <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>{t('footer.brandTitle')}</Typography>
-              <Typography variant="body2" color="text.secondary">{t('footer.brandText')}</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 420 }}>
+                {t('footer.brandText')}
+              </Typography>
             </Stack>
 
             <Stack spacing={1}>

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -1,7 +1,7 @@
 import {
-  Alert,
   Box,
   Button,
+  Chip,
   Container,
   Link,
   Stack,
@@ -10,11 +10,17 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from '../../i18n';
 
-const featureItems = [
+const heroHighlightItems = [
   'cultureManagement',
   'fieldOrganization',
   'planningPeriods',
-  'structuredDocumentation',
+  'projectCollaboration',
+] as const;
+
+const featureCardItems = [
+  'cultureManagement',
+  'fieldPlanning',
+  'timePlanning',
   'projectCollaboration',
 ] as const;
 
@@ -24,150 +30,248 @@ const audienceItems = [
   'digitalPlanningProjects',
 ] as const;
 
+const feedbackItems = ['feedback', 'ideas', 'bugReports'] as const;
+const openSourceItems = ['publicCode', 'issues', 'contributions'] as const;
+
 export default function HomePage(): React.ReactElement {
   const { t } = useTranslation('home');
 
   return (
     <Box sx={{ bgcolor: 'background.default' }}>
-      <Container maxWidth="md" sx={{ py: { xs: 7, md: 10 } }}>
-        <Stack spacing={{ xs: 6, md: 8 }}>
-          <Stack spacing={3} alignItems={{ xs: 'flex-start', sm: 'center' }} textAlign={{ xs: 'left', sm: 'center' }}>
+      <Box
+        component="section"
+        sx={{
+          background: (theme) => `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Container maxWidth="lg" sx={{ py: { xs: 7, md: 10 } }}>
+          <Stack spacing={{ xs: 4, md: 6 }}>
+            <Box
+              sx={{
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 4,
+                p: { xs: 3, md: 5 },
+                bgcolor: 'background.paper',
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'grid',
+                  gap: { xs: 4, md: 5 },
+                  gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1.2fr) minmax(0, 0.8fr)' },
+                  alignItems: 'start',
+                }}
+              >
+                <Stack spacing={2.5}>
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    <Chip label={t('landing.betaBadge')} color="warning" size="small" />
+                    <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
+                      {t('landing.statusLine')}
+                    </Typography>
+                  </Stack>
+                  <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '2.2rem', md: '3.2rem' }, lineHeight: 1.15 }}>
+                    {t('landing.headline')}
+                  </Typography>
+                  <Typography variant="h5" color="text.primary" sx={{ fontWeight: 500, fontSize: { xs: '1.1rem', md: '1.35rem' } }}>
+                    {t('landing.subtitle')}
+                  </Typography>
+                  <Typography color="text.secondary" sx={{ maxWidth: 720, fontSize: { xs: '1rem', md: '1.05rem' } }}>
+                    {t('landing.description')}
+                  </Typography>
+
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ pt: 1 }}>
+                    <Button component={RouterLink} to="/app" variant="contained" size="large">
+                      {t('landing.actions.openApp')}
+                    </Button>
+                    <Button component={RouterLink} to="/register" variant="outlined" size="large">
+                      {t('landing.actions.register')}
+                    </Button>
+                    <Button
+                      component={Link}
+                      href={t('landing.actions.githubUrl')}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      underline="none"
+                      color="inherit"
+                      variant="text"
+                      size="large"
+                    >
+                      {t('landing.actions.github')}
+                    </Button>
+                  </Stack>
+                </Stack>
+
+                <Stack spacing={1.2}>
+                  <Typography variant="subtitle2" sx={{ textTransform: 'uppercase', letterSpacing: 0.8, color: 'text.secondary' }}>
+                    {t('heroHighlights.title')}
+                  </Typography>
+                  {heroHighlightItems.map((itemKey) => (
+                    <Box
+                      key={itemKey}
+                      sx={{
+                        px: 2,
+                        py: 1.6,
+                        borderRadius: 2,
+                        border: 1,
+                        borderColor: 'divider',
+                        bgcolor: 'background.default',
+                      }}
+                    >
+                      <Typography>{t(`heroHighlights.items.${itemKey}`)}</Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </Box>
+            </Box>
+
             <Stack spacing={1.5}>
-              <Typography variant="h2" component="h1" sx={{ fontSize: { xs: '2rem', md: '2.75rem' } }}>
-                {t('landing.title')}
-              </Typography>
-              <Stack direction="row" spacing={1} justifyContent={{ xs: 'flex-start', sm: 'center' }}>
-                <Typography
-                  component="span"
+              <Typography variant="h6">{t('audiences.title')}</Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {audienceItems.map((itemKey) => (
+                  <Chip key={itemKey} label={t(`audiences.items.${itemKey}`)} variant="outlined" sx={{ borderRadius: 2 }} />
+                ))}
+              </Stack>
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box component="section" sx={{ py: { xs: 7, md: 9 } }}>
+        <Container maxWidth="lg">
+          <Stack spacing={3.5}>
+            <Stack spacing={1}>
+              <Typography variant="h3" sx={{ fontSize: { xs: '1.75rem', md: '2.15rem' } }}>{t('featureOverview.title')}</Typography>
+              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>{t('featureOverview.subtitle')}</Typography>
+            </Stack>
+
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 2,
+                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+              }}
+            >
+              {featureCardItems.map((itemKey) => (
+                <Box
+                  key={itemKey}
                   sx={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    px: 1.25,
-                    py: 0.5,
-                    borderRadius: 10,
-                    bgcolor: 'warning.light',
-                    color: 'warning.contrastText',
-                    fontWeight: 700,
-                    fontSize: '0.75rem',
-                    letterSpacing: 0.4,
-                    textTransform: 'uppercase',
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: 3,
+                    p: { xs: 2.5, md: 3 },
+                    bgcolor: 'background.paper',
                   }}
                 >
-                  {t('landing.betaBadge')}
-                </Typography>
+                  <Stack spacing={1}>
+                    <Typography variant="h6">{t(`featureOverview.cards.${itemKey}.title`)}</Typography>
+                    <Typography color="text.secondary">{t(`featureOverview.cards.${itemKey}.description`)}</Typography>
+                  </Stack>
+                </Box>
+              ))}
+            </Box>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box component="section" sx={{ py: { xs: 7, md: 9 }, bgcolor: 'background.paper', borderTop: 1, borderBottom: 1, borderColor: 'divider' }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' } }}>
+            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 } }}>
+              <Stack spacing={1.5}>
+                <Typography variant="h5">{t('feedback.title')}</Typography>
+                <Typography color="text.secondary">{t('feedback.description')}</Typography>
+                <Stack component="ul" spacing={1} sx={{ pl: 2, m: 0 }}>
+                  {feedbackItems.map((itemKey) => (
+                    <Typography component="li" key={itemKey} color="text.secondary">
+                      {t(`feedback.items.${itemKey}`)}
+                    </Typography>
+                  ))}
+                </Stack>
+                <Button
+                  component={Link}
+                  href={`mailto:${t('footer.contactEmail')}`}
+                  underline="none"
+                  variant="outlined"
+                  sx={{ width: 'fit-content' }}
+                >
+                  {t('feedback.cta', { email: t('footer.contactEmail') })}
+                </Button>
               </Stack>
-              <Typography variant="h6" color="text.secondary" sx={{ fontWeight: 500 }}>
-                {t('landing.subtitle')}
-              </Typography>
-            </Stack>
-            <Typography color="text.secondary" sx={{ maxWidth: 720 }}>
-              {t('landing.description')}
-            </Typography>
-            <Alert severity="info" variant="outlined" sx={{ width: '100%', maxWidth: 720, textAlign: 'left' }}>
-              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-                {t('betaNote.title')}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {t('betaNote.description')}
-              </Typography>
-            </Alert>
-            <Stack spacing={1.5} sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 260 } }}>
-              <Button component={RouterLink} to="/app" variant="contained" size="large" sx={{ minWidth: 220 }}>
-                {t('landing.actions.openApp')}
-              </Button>
-              <Button component={RouterLink} to="/register" variant="outlined" size="large" sx={{ minWidth: 220 }}>
-                {t('landing.actions.register')}
-              </Button>
-              <Button
-                component={Link}
-                href={t('landing.actions.githubUrl')}
-                target="_blank"
-                rel="noopener noreferrer"
-                underline="none"
-                color="inherit"
-                variant="text"
-                size="large"
-                sx={{ minWidth: 220 }}
-              >
-                {t('landing.actions.github')}
-              </Button>
-            </Stack>
-          </Stack>
-
-          <Stack spacing={2}>
-            <Typography variant="h5">{t('featureOverview.title')}</Typography>
-            <Box component="ul" sx={{ m: 0, pl: 3, display: 'grid', gap: 1.2 }}>
-              {featureItems.map((itemKey) => (
-                <Typography component="li" key={itemKey} color="text.secondary">
-                  {t(`featureOverview.items.${itemKey}`)}
-                </Typography>
-              ))}
             </Box>
-          </Stack>
 
-          <Stack spacing={2}>
-            <Typography variant="h5">{t('audiences.title')}</Typography>
-            <Box component="ul" sx={{ m: 0, pl: 3, display: 'grid', gap: 1.2 }}>
-              {audienceItems.map((itemKey) => (
-                <Typography component="li" key={itemKey} color="text.secondary">
-                  {t(`audiences.items.${itemKey}`)}
-                </Typography>
-              ))}
+            <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 } }}>
+              <Stack spacing={1.5}>
+                <Typography variant="h5">{t('openSource.title')}</Typography>
+                <Typography color="text.secondary">{t('openSource.description')}</Typography>
+                <Stack component="ul" spacing={1} sx={{ pl: 2, m: 0 }}>
+                  {openSourceItems.map((itemKey) => (
+                    <Typography component="li" key={itemKey} color="text.secondary">
+                      {t(`openSource.items.${itemKey}`)}
+                    </Typography>
+                  ))}
+                </Stack>
+                <Button
+                  component={Link}
+                  href={t('openSource.githubUrl')}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="none"
+                  variant="contained"
+                  sx={{ width: 'fit-content' }}
+                >
+                  {t('openSource.cta')}
+                </Button>
+              </Stack>
             </Box>
-          </Stack>
+          </Box>
+        </Container>
+      </Box>
 
-          <Stack spacing={1.5}>
-            <Typography variant="h5">{t('feedback.title')}</Typography>
-            <Typography color="text.secondary">{t('feedback.description')}</Typography>
-            <Typography color="text.secondary">{t('feedback.contactHint')}</Typography>
-            <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover" sx={{ width: 'fit-content' }}>
-              {t('feedback.contactCta', { email: t('footer.contactEmail') })}
-            </Link>
-          </Stack>
+      <Box component="section" sx={{ py: { xs: 6, md: 8 } }}>
+        <Container maxWidth="lg">
+          <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 3, p: { xs: 2.5, md: 3.5 }, bgcolor: 'background.paper' }}>
+            <Stack spacing={1.5}>
+              <Typography variant="h5">{t('finalCta.title')}</Typography>
+              <Typography color="text.secondary">{t('finalCta.description')}</Typography>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.25}>
+                <Button component={RouterLink} to="/app" variant="contained">
+                  {t('finalCta.openApp')}
+                </Button>
+                <Button component={RouterLink} to="/register" variant="outlined">
+                  {t('finalCta.register')}
+                </Button>
+              </Stack>
+            </Stack>
+          </Box>
+        </Container>
+      </Box>
 
-          <Stack spacing={1.5}>
-            <Typography variant="h5">{t('openSource.title')}</Typography>
-            <Typography color="text.secondary">{t('openSource.description')}</Typography>
-            <Button
-              component={Link}
-              href={t('openSource.githubUrl')}
-              target="_blank"
-              rel="noopener noreferrer"
-              underline="none"
-              variant="outlined"
-              sx={{ width: 'fit-content' }}
-            >
-              {t('openSource.cta')}
-            </Button>
-          </Stack>
+      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', py: { xs: 4, md: 5 }, bgcolor: 'background.paper' }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, minmax(0, 1fr))' } }}>
+            <Stack spacing={1}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>{t('footer.brandTitle')}</Typography>
+              <Typography variant="body2" color="text.secondary">{t('footer.brandText')}</Typography>
+            </Stack>
 
-          <Typography color="text.secondary">{t('statusNote')}</Typography>
-        </Stack>
-      </Container>
+            <Stack spacing={1}>
+              <Typography variant="subtitle2" color="text.secondary">{t('footer.linksTitle')}</Typography>
+              <Link component={RouterLink} to="/impressum" underline="hover">{t('footer.imprint')}</Link>
+              <Link component={RouterLink} to="/datenschutz" underline="hover">{t('footer.privacy')}</Link>
+              <Link href={t('footer.githubUrl')} target="_blank" rel="noopener noreferrer" underline="hover">{t('footer.github')}</Link>
+            </Stack>
 
-      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', py: 3 }}>
-        <Container maxWidth="md">
-          <Stack
-            direction={{ xs: 'column', sm: 'row' }}
-            spacing={{ xs: 1, sm: 3 }}
-            alignItems={{ xs: 'flex-start', sm: 'center' }}
-            justifyContent="space-between"
-          >
-            <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
-              <Link component={RouterLink} to="/impressum" underline="hover">
-                {t('footer.imprint')}
-              </Link>
-              <Link component={RouterLink} to="/datenschutz" underline="hover">
-                {t('footer.privacy')}
-              </Link>
-              <Link href={t('footer.githubUrl')} target="_blank" rel="noopener noreferrer" underline="hover">
-                {t('footer.github')}
+            <Stack spacing={1}>
+              <Typography variant="subtitle2" color="text.secondary">{t('footer.contactTitle')}</Typography>
+              <Typography variant="body2" color="text.secondary">{t('footer.contactText')}</Typography>
+              <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover">
+                {t('footer.contactLabel', { email: t('footer.contactEmail') })}
               </Link>
             </Stack>
-            <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover">
-              {t('footer.contactLabel', { email: t('footer.contactEmail') })}
-            </Link>
-          </Stack>
+          </Box>
         </Container>
       </Box>
     </Box>

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -1,9 +1,4 @@
-import AgricultureOutlinedIcon from '@mui/icons-material/AgricultureOutlined';
-import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
-import CodeOutlinedIcon from '@mui/icons-material/CodeOutlined';
-import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
-import GridViewOutlinedIcon from '@mui/icons-material/GridViewOutlined';
-import Groups2OutlinedIcon from '@mui/icons-material/Groups2Outlined';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import {
   Box,
   Button,
@@ -16,21 +11,7 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from '../../i18n';
 
-const benefitItems = ['clarity', 'collaboration', 'continuousImprovement'] as const;
-
-const featureItems = [
-  { key: 'cultures', icon: AgricultureOutlinedIcon },
-  { key: 'areas', icon: GridViewOutlinedIcon },
-  { key: 'timelines', icon: CalendarMonthOutlinedIcon },
-  { key: 'teams', icon: Groups2OutlinedIcon },
-] as const;
-
-const trustItems = [
-  { key: 'feedback', icon: ForumOutlinedIcon },
-  { key: 'openSource', icon: CodeOutlinedIcon },
-] as const;
-
-const audienceItems = ['smallVegetableFarms', 'csaOperations', 'digitalPlanningProjects'] as const;
+const featureItems = ['cultures', 'areas', 'timelines', 'teams'] as const;
 
 export default function HomePage(): React.ReactElement {
   const { t } = useTranslation('home');
@@ -40,297 +21,130 @@ export default function HomePage(): React.ReactElement {
       <Box
         component="section"
         sx={{
-          position: 'relative',
-          overflow: 'hidden',
-          background: (theme) => `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 80%)`,
           borderBottom: 1,
           borderColor: 'divider',
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            inset: 0,
-            background: 'radial-gradient(circle at 82% 20%, rgba(25, 118, 210, 0.12), transparent 44%)',
-            pointerEvents: 'none',
-          },
+          background: (theme) => `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
         }}
       >
-        <Container maxWidth="xl" sx={{ position: 'relative', py: { xs: 7, md: 9, lg: 11 } }}>
-          <Box
-            sx={{
-              display: 'grid',
-              gap: { xs: 5, md: 6 },
-              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.1fr) minmax(0, 0.9fr)' },
-              alignItems: 'center',
-            }}
-          >
-            <Stack spacing={3}>
-              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                <Chip label={t('landing.betaBadge')} color="warning" size="small" />
-                <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
-                  {t('landing.statusLine')}
-                </Typography>
-              </Stack>
-
-              <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '2.1rem', md: '3rem', lg: '3.4rem' }, lineHeight: 1.08, maxWidth: 760 }}>
-                {t('landing.headline')}
+        <Container maxWidth="lg" sx={{ py: { xs: 8, md: 11 } }}>
+          <Stack spacing={3.5} sx={{ maxWidth: 860 }}>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Chip label={t('landing.betaBadge')} size="small" color="warning" />
+              <Typography variant="body2" color="text.secondary">
+                {t('landing.statusLine')}
               </Typography>
-
-              <Typography variant="h5" color="text.primary" sx={{ fontSize: { xs: '1.05rem', md: '1.28rem' }, fontWeight: 500, maxWidth: 720 }}>
-                {t('landing.subtitle')}
-              </Typography>
-
-              <Typography color="text.secondary" sx={{ maxWidth: 690 }}>
-                {t('landing.description')}
-              </Typography>
-
-              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
-                <Button component={RouterLink} to="/app" variant="contained" size="large">
-                  {t('landing.actions.openApp')}
-                </Button>
-                <Button component={RouterLink} to="/register" variant="outlined" size="large">
-                  {t('landing.actions.register')}
-                </Button>
-                <Button
-                  component={Link}
-                  href={t('landing.actions.githubUrl')}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  underline="none"
-                  variant="text"
-                  color="inherit"
-                  size="large"
-                >
-                  {t('landing.actions.github')}
-                </Button>
-              </Stack>
-
-              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ pt: 0.5 }}>
-                {audienceItems.map((itemKey) => (
-                  <Chip key={itemKey} label={t(`audiences.items.${itemKey}`)} variant="outlined" sx={{ borderRadius: 2 }} />
-                ))}
-              </Stack>
             </Stack>
 
-            <Box
-              sx={{
-                borderRadius: 4,
-                border: 1,
-                borderColor: 'divider',
-                bgcolor: 'background.paper',
-                p: { xs: 2.5, md: 3 },
-                boxShadow: '0 24px 40px rgba(15, 23, 42, 0.08)',
-              }}
-            >
-              <Stack spacing={2}>
-                <Typography variant="subtitle2" sx={{ letterSpacing: 0.5, textTransform: 'uppercase', color: 'text.secondary' }}>
-                  {t('preview.title')}
-                </Typography>
-                <Typography variant="h6">{t('preview.subtitle')}</Typography>
+            <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '2.1rem', md: '3.1rem' }, lineHeight: 1.1 }}>
+              {t('landing.headline')}
+            </Typography>
 
-                <Box sx={{ borderRadius: 2, border: 1, borderColor: 'divider', overflow: 'hidden', bgcolor: 'background.default' }}>
-                  <Box sx={{ px: 2, py: 1.1, borderBottom: 1, borderColor: 'divider', display: 'flex', gap: 1 }}>
-                    <Chip label={t('preview.tabs.cultures')} size="small" color="primary" />
-                    <Chip label={t('preview.tabs.areas')} size="small" variant="outlined" />
-                    <Chip label={t('preview.tabs.timeline')} size="small" variant="outlined" />
-                  </Box>
-                  <Stack spacing={1} sx={{ p: 2 }}>
-                    {[1, 2, 3, 4].map((row) => (
-                      <Box key={row} sx={{ border: 1, borderColor: 'divider', borderRadius: 1.5, px: 1.5, py: 1, bgcolor: 'background.paper' }}>
-                        <Stack direction="row" justifyContent="space-between" alignItems="center">
-                          <Typography variant="body2">{t(`preview.rows.row${row}`)}</Typography>
-                          <Chip label={t(`preview.status.row${row}`)} size="small" variant="outlined" />
-                        </Stack>
-                      </Box>
-                    ))}
-                  </Stack>
-                </Box>
+            <Typography variant="h5" color="text.primary" sx={{ fontSize: { xs: '1.05rem', md: '1.25rem' }, fontWeight: 500 }}>
+              {t('landing.subtitle')}
+            </Typography>
 
-                <Typography variant="body2" color="text.secondary">
-                  {t('preview.note')}
-                </Typography>
-              </Stack>
-            </Box>
-          </Box>
-
-          <Box
-            sx={{
-              mt: { xs: 5, md: 6 },
-              display: 'grid',
-              gap: 2,
-              gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
-            }}
-          >
-            {benefitItems.map((itemKey) => (
-              <Box key={itemKey} sx={{ p: { xs: 2, md: 2.5 }, borderRadius: 2.5, bgcolor: 'background.paper', border: 1, borderColor: 'divider' }}>
-                <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
-                  {t(`benefits.items.${itemKey}.title`)}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {t(`benefits.items.${itemKey}.description`)}
-                </Typography>
-              </Box>
-            ))}
-          </Box>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+              <Button component={RouterLink} to="/app" variant="contained" size="large">
+                {t('landing.actions.openApp')}
+              </Button>
+              <Button component={RouterLink} to="/register" variant="outlined" size="large">
+                {t('landing.actions.register')}
+              </Button>
+              <Button
+                component={Link}
+                href={t('landing.actions.githubUrl')}
+                target="_blank"
+                rel="noopener noreferrer"
+                underline="none"
+                color="inherit"
+                variant="text"
+                size="large"
+              >
+                {t('landing.actions.github')}
+              </Button>
+            </Stack>
+          </Stack>
         </Container>
       </Box>
 
-      <Box component="section" sx={{ py: { xs: 7, md: 9 } }}>
-        <Container maxWidth="xl">
-          <Stack spacing={3.5}>
-            <Stack spacing={1}>
-              <Typography variant="h3" sx={{ fontSize: { xs: '1.7rem', md: '2.2rem' } }}>
-                {t('features.title')}
-              </Typography>
-              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>
-                {t('features.subtitle')}
-              </Typography>
-            </Stack>
-
+      <Box component="section" sx={{ py: { xs: 6, md: 7 } }}>
+        <Container maxWidth="lg">
+          <Stack spacing={2.5}>
+            <Typography variant="h3" sx={{ fontSize: { xs: '1.5rem', md: '1.95rem' } }}>
+              {t('features.title')}
+            </Typography>
             <Box
               sx={{
                 display: 'grid',
-                gap: 2,
+                gap: 1.25,
                 gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
               }}
             >
-              {featureItems.map(({ key, icon: Icon }) => (
-                <Box
-                  key={key}
-                  sx={{
-                    p: { xs: 2.5, md: 3 },
-                    borderRadius: 3,
-                    bgcolor: 'background.paper',
-                    border: 1,
-                    borderColor: 'divider',
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 1fr',
-                    gap: 1.5,
-                    alignItems: 'start',
-                  }}
-                >
-                  <Box sx={{ width: 36, height: 36, borderRadius: 1.5, bgcolor: 'primary.light', color: 'primary.contrastText', display: 'grid', placeItems: 'center' }}>
-                    <Icon fontSize="small" />
-                  </Box>
-                  <Stack spacing={0.8}>
-                    <Typography variant="h6">{t(`features.items.${key}.title`)}</Typography>
-                    <Typography color="text.secondary">{t(`features.items.${key}.description`)}</Typography>
-                  </Stack>
-                </Box>
+              {featureItems.map((itemKey) => (
+                <Stack key={itemKey} direction="row" spacing={1.1} alignItems="center">
+                  <CheckCircleOutlineIcon color="primary" fontSize="small" />
+                  <Typography>{t(`features.items.${itemKey}`)}</Typography>
+                </Stack>
               ))}
             </Box>
           </Stack>
         </Container>
       </Box>
 
-      <Box component="section" sx={{ py: { xs: 6, md: 8 }, bgcolor: 'grey.100', borderTop: 1, borderBottom: 1, borderColor: 'divider' }}>
-        <Container maxWidth="xl">
-          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' } }}>
-            {trustItems.map(({ key, icon: Icon }, index) => (
-              <Box
-                key={key}
-                sx={{
-                  p: { xs: 2.5, md: 3.2 },
-                  borderRadius: 3,
-                  bgcolor: index === 1 ? 'background.paper' : 'rgba(25, 118, 210, 0.06)',
-                  border: 1,
-                  borderColor: index === 1 ? 'divider' : 'rgba(25, 118, 210, 0.28)',
-                }}
-              >
-                <Stack spacing={1.3}>
-                  <Stack direction="row" spacing={1.2} alignItems="center">
-                    <Box sx={{ width: 34, height: 34, borderRadius: 1.5, bgcolor: 'background.paper', border: 1, borderColor: 'divider', display: 'grid', placeItems: 'center' }}>
-                      <Icon fontSize="small" />
-                    </Box>
-                    <Typography variant="h5">{t(`${key}.title`)}</Typography>
-                  </Stack>
-                  <Typography color="text.secondary">{t(`${key}.description`)}</Typography>
-                  <Stack component="ul" spacing={0.8} sx={{ m: 0, pl: 2 }}>
-                    {(['item1', 'item2', 'item3'] as const).map((itemKey) => (
-                      <Typography component="li" key={itemKey} color="text.secondary">
-                        {t(`${key}.items.${itemKey}`)}
-                      </Typography>
-                    ))}
-                  </Stack>
-                  {key === 'feedback' ? (
-                    <Button component={Link} href={`mailto:${t('footer.contactEmail')}`} underline="none" variant="outlined" sx={{ width: 'fit-content' }}>
-                      {t('feedback.cta', { email: t('footer.contactEmail') })}
-                    </Button>
-                  ) : (
-                    <Button
-                      component={Link}
-                      href={t('openSource.githubUrl')}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
-                      variant="contained"
-                      sx={{ width: 'fit-content' }}
-                    >
-                      {t('openSource.cta')}
-                    </Button>
-                  )}
-                </Stack>
-              </Box>
-            ))}
-          </Box>
+      <Box component="section" sx={{ py: { xs: 5, md: 6 }, borderTop: 1, borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+        <Container maxWidth="lg">
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} justifyContent="space-between" alignItems={{ xs: 'flex-start', md: 'center' }}>
+            <Stack spacing={0.7}>
+              <Typography variant="h5">{t('openSource.title')}</Typography>
+              <Typography color="text.secondary">{t('openSource.description')}</Typography>
+            </Stack>
+            <Button
+              component={Link}
+              href={t('openSource.githubUrl')}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="none"
+              variant="outlined"
+            >
+              {t('openSource.cta')}
+            </Button>
+          </Stack>
         </Container>
       </Box>
 
-      <Box component="section" sx={{ py: { xs: 7, md: 9 } }}>
-        <Container maxWidth="xl">
-          <Box
-            sx={{
-              p: { xs: 3, md: 4 },
-              borderRadius: 4,
-              background: 'linear-gradient(135deg, rgba(25, 118, 210, 0.12), rgba(25, 118, 210, 0.04))',
-              border: 1,
-              borderColor: 'rgba(25, 118, 210, 0.25)',
-            }}
+      <Box component="section" sx={{ py: { xs: 6, md: 7 } }}>
+        <Container maxWidth="lg">
+          <Stack spacing={1.5}>
+            <Typography variant="h5">{t('finalCta.title')}</Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.25}>
+              <Button component={RouterLink} to="/app" variant="contained">
+                {t('finalCta.openApp')}
+              </Button>
+              <Button component={RouterLink} to="/register" variant="outlined">
+                {t('finalCta.register')}
+              </Button>
+            </Stack>
+          </Stack>
+        </Container>
+      </Box>
+
+      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', py: 3.5, bgcolor: 'background.paper' }}>
+        <Container maxWidth="lg">
+          <Stack
+            direction={{ xs: 'column', md: 'row' }}
+            spacing={{ xs: 1.2, md: 3 }}
+            justifyContent="space-between"
+            alignItems={{ xs: 'flex-start', md: 'center' }}
           >
-            <Stack spacing={2}>
-              <Typography variant="h4" sx={{ fontSize: { xs: '1.6rem', md: '2rem' } }}>
-                {t('finalCta.title')}
-              </Typography>
-              <Typography color="text.secondary" sx={{ maxWidth: 760 }}>
-                {t('finalCta.description')}
-              </Typography>
-              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
-                <Button component={RouterLink} to="/app" variant="contained" size="large">
-                  {t('finalCta.openApp')}
-                </Button>
-                <Button component={RouterLink} to="/register" variant="outlined" size="large">
-                  {t('finalCta.register')}
-                </Button>
-              </Stack>
-            </Stack>
-          </Box>
-        </Container>
-      </Box>
-
-      <Box component="footer" sx={{ borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
-        <Container maxWidth="xl" sx={{ py: { xs: 4, md: 5 } }}>
-          <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: { xs: '1fr', md: '1.2fr 1fr 1fr' } }}>
-            <Stack spacing={1.2}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>{t('footer.brandTitle')}</Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 420 }}>
-                {t('footer.brandText')}
-              </Typography>
-            </Stack>
-
-            <Stack spacing={1}>
-              <Typography variant="subtitle2" color="text.secondary">{t('footer.linksTitle')}</Typography>
+            <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
               <Link component={RouterLink} to="/impressum" underline="hover">{t('footer.imprint')}</Link>
               <Link component={RouterLink} to="/datenschutz" underline="hover">{t('footer.privacy')}</Link>
               <Link href={t('footer.githubUrl')} target="_blank" rel="noopener noreferrer" underline="hover">{t('footer.github')}</Link>
             </Stack>
-
-            <Stack spacing={1}>
-              <Typography variant="subtitle2" color="text.secondary">{t('footer.contactTitle')}</Typography>
-              <Typography variant="body2" color="text.secondary">{t('footer.contactText')}</Typography>
-              <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover">
-                {t('footer.contactLabel', { email: t('footer.contactEmail') })}
-              </Link>
-            </Stack>
-          </Box>
+            <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover">
+              {t('footer.contactLabel', { email: t('footer.contactEmail') })}
+            </Link>
+          </Stack>
         </Container>
       </Box>
     </Box>

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   Container,
@@ -35,6 +36,26 @@ export default function HomePage(): React.ReactElement {
               <Typography variant="h2" component="h1" sx={{ fontSize: { xs: '2rem', md: '2.75rem' } }}>
                 {t('landing.title')}
               </Typography>
+              <Stack direction="row" spacing={1} justifyContent={{ xs: 'flex-start', sm: 'center' }}>
+                <Typography
+                  component="span"
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    px: 1.25,
+                    py: 0.5,
+                    borderRadius: 10,
+                    bgcolor: 'warning.light',
+                    color: 'warning.contrastText',
+                    fontWeight: 700,
+                    fontSize: '0.75rem',
+                    letterSpacing: 0.4,
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  {t('landing.betaBadge')}
+                </Typography>
+              </Stack>
               <Typography variant="h6" color="text.secondary" sx={{ fontWeight: 500 }}>
                 {t('landing.subtitle')}
               </Typography>
@@ -42,12 +63,33 @@ export default function HomePage(): React.ReactElement {
             <Typography color="text.secondary" sx={{ maxWidth: 720 }}>
               {t('landing.description')}
             </Typography>
+            <Alert severity="info" variant="outlined" sx={{ width: '100%', maxWidth: 720, textAlign: 'left' }}>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {t('betaNote.title')}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('betaNote.description')}
+              </Typography>
+            </Alert>
             <Stack spacing={1.5} sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 260 } }}>
               <Button component={RouterLink} to="/app" variant="contained" size="large" sx={{ minWidth: 220 }}>
                 {t('landing.actions.openApp')}
               </Button>
               <Button component={RouterLink} to="/register" variant="outlined" size="large" sx={{ minWidth: 220 }}>
                 {t('landing.actions.register')}
+              </Button>
+              <Button
+                component={Link}
+                href={t('landing.actions.githubUrl')}
+                target="_blank"
+                rel="noopener noreferrer"
+                underline="none"
+                color="inherit"
+                variant="text"
+                size="large"
+                sx={{ minWidth: 220 }}
+              >
+                {t('landing.actions.github')}
               </Button>
             </Stack>
           </Stack>
@@ -74,6 +116,31 @@ export default function HomePage(): React.ReactElement {
             </Box>
           </Stack>
 
+          <Stack spacing={1.5}>
+            <Typography variant="h5">{t('feedback.title')}</Typography>
+            <Typography color="text.secondary">{t('feedback.description')}</Typography>
+            <Typography color="text.secondary">{t('feedback.contactHint')}</Typography>
+            <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover" sx={{ width: 'fit-content' }}>
+              {t('feedback.contactCta', { email: t('footer.contactEmail') })}
+            </Link>
+          </Stack>
+
+          <Stack spacing={1.5}>
+            <Typography variant="h5">{t('openSource.title')}</Typography>
+            <Typography color="text.secondary">{t('openSource.description')}</Typography>
+            <Button
+              component={Link}
+              href={t('openSource.githubUrl')}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="none"
+              variant="outlined"
+              sx={{ width: 'fit-content' }}
+            >
+              {t('openSource.cta')}
+            </Button>
+          </Stack>
+
           <Typography color="text.secondary">{t('statusNote')}</Typography>
         </Stack>
       </Container>
@@ -92,6 +159,9 @@ export default function HomePage(): React.ReactElement {
               </Link>
               <Link component={RouterLink} to="/datenschutz" underline="hover">
                 {t('footer.privacy')}
+              </Link>
+              <Link href={t('footer.githubUrl')} target="_blank" rel="noopener noreferrer" underline="hover">
+                {t('footer.github')}
               </Link>
             </Stack>
             <Link href={`mailto:${t('footer.contactEmail')}`} underline="hover">


### PR DESCRIPTION
### Motivation
- Make the public landing page clearly communicate that OpenFarmPlanner is in an active beta and being continuously improved while keeping a professional, trust-building tone.
- Encourage user feedback and participation and make the project’s GitHub repository and contribution path visibly accessible without adding any donation or fundraising prompts.
- Preserve primary CTAs for opening the app and registration while adding a lightweight, non-intrusive GitHub action.

### Description
- Updated the public HomePage to add a beta badge, an informational beta Alert, a GitHub CTA in the hero, and new sections for Feedback and Open Source/Contributing; changes are in `frontend/src/pages/public/HomePage.tsx`.
- Added German and English i18n strings for the new hero copy, beta note, feedback text, open-source messaging, and footer GitHub link in `frontend/src/i18n/locales/de/home.json` and `frontend/src/i18n/locales/en/home.json`.
- Extended the public landing assertions in `frontend/src/__tests__/App.test.tsx` to cover the new beta, feedback and GitHub elements.
- Kept existing visual style and CTA hierarchy and explicitly avoided adding any donation/funding section.

### Testing
- Ran the targeted frontend tests with `npm --prefix frontend run test -- App.test.tsx` and the test suite passed (11 tests, 11 passed).
- No additional automated UI/e2e tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e95e56b083229a83b3f986c7ce91)