### PR TITLE
perf(frontend): speed up hierarchy expand collapse rendering

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,29 +14,6 @@
   min-height: 100vh;
 }
 
-.app-version-footer {
-  position: fixed;
-  right: 12px;
-  bottom: 8px;
-  font-size: 12px;
-  color: #666;
-  background-color: rgba(255, 255, 255, 0.9);
-  padding: 2px 8px;
-  border-radius: 999px;
-  border: 1px solid #e0e0e0;
-  z-index: 1200;
-}
-
-@media (max-width: 900px) {
-  .app-version-footer {
-    display: none;
-  }
-}
-
-body.hide-version-footer .app-version-footer {
-  display: none;
-}
-
 /* Navigation Styles */
 .nav {
   width: 100%;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
-import { cultureAPI, projectAPI, versionAPI } from './api/api';
+import { cultureAPI, projectAPI } from './api/api';
 import type { CultureHistoryEntry } from './api/types';
 import './App.css';
 import { HelpIcon } from './components/help/HelpIcon';
@@ -260,29 +260,6 @@ function RootLayout(): React.ReactElement {
     message: '',
     severity: 'success',
   });
-  const [appVersion, setAppVersion] = useState<string | null>(null);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const loadVersion = async (): Promise<void> => {
-      try {
-        const response = await versionAPI.get();
-        if (isMounted) {
-          setAppVersion(response.data.version);
-        }
-      } catch (error) {
-        console.error('Error loading app version:', error);
-      }
-    };
-
-    void loadVersion();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
   const showSnackbar = (message: string, severity: 'success' | 'error') => {
     setSnackbar({ open: true, message, severity });
   };
@@ -700,7 +677,6 @@ function RootLayout(): React.ReactElement {
           {snackbar.message}
         </Alert>
       </Snackbar>
-      <div className="app-version-footer">{`${t('appVersionLabel')} ${appVersion ?? '…'}`}</div>
     </div>
   );
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -38,16 +38,6 @@ vi.mock('../commands/useCommandContext', () => ({
   useRegisterCommands: vi.fn(),
 }));
 
-vi.mock('../api/api', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../api/api')>();
-  return {
-    ...actual,
-    versionAPI: {
-      get: vi.fn(async () => ({ data: { version: '0.1.0' } })),
-    },
-  };
-});
-
 describe('App', () => {
   beforeEach(() => {
     authState.user = null;
@@ -105,7 +95,6 @@ describe('App', () => {
     expect(screen.getByText(translations.navigation.cultures)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: translations.navigation.plantingPlans })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Aktives Projekt wechseln' })).toBeInTheDocument();
-    expect(await screen.findByText('Version 0.1.0')).toBeInTheDocument();
   });
 
   it('shows account settings in three-dot menu without project settings', async () => {

--- a/frontend/src/__tests__/GraphicalFields.test.tsx
+++ b/frontend/src/__tests__/GraphicalFields.test.tsx
@@ -276,7 +276,22 @@ vi.mock("react-konva", async () => {
 });
 
 describe("GraphicalFields", () => {
+  const setViewportSize = (width: number, height: number): void => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: height,
+    });
+    window.dispatchEvent(new Event("resize"));
+  };
+
   beforeEach(() => {
+    setViewportSize(1280, 900);
     mockStageApi.setPointer(0, 0);
     mockStageApi.handlers = {};
     listByLocationMock.mockClear();
@@ -307,6 +322,43 @@ describe("GraphicalFields", () => {
         },
       ],
     });
+  });
+
+  it("keeps field world geometry identical between desktop and mobile viewport sizes", async () => {
+    setViewportSize(1280, 900);
+    const desktopRender = render(<GraphicalFields />);
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Standort: Hof Nord" }),
+      );
+    });
+
+    const desktopField = await screen.findByTestId("field-rect-10");
+    const desktopGeometry = {
+      x: desktopField.getAttribute("data-x"),
+      y: desktopField.getAttribute("data-y"),
+      width: desktopField.getAttribute("width"),
+      height: desktopField.getAttribute("height"),
+    };
+    desktopRender.unmount();
+
+    setViewportSize(375, 812);
+    render(<GraphicalFields />);
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Standort: Hof Nord" }),
+      );
+    });
+
+    const mobileField = await screen.findByTestId("field-rect-10");
+    const mobileGeometry = {
+      x: mobileField.getAttribute("data-x"),
+      y: mobileField.getAttribute("data-y"),
+      width: mobileField.getAttribute("width"),
+      height: mobileField.getAttribute("height"),
+    };
+
+    expect(mobileGeometry).toEqual(desktopGeometry);
   });
 
   it("renders the edit mode toggle and allows toggling it by click", async () => {

--- a/frontend/src/__tests__/GraphicalFields.test.tsx
+++ b/frontend/src/__tests__/GraphicalFields.test.tsx
@@ -496,12 +496,6 @@ describe("GraphicalFields", () => {
     expect(
       screen.getByRole("button", { name: "Alles einpassen" }),
     ).toBeInTheDocument();
-
-    const controls = screen.getByTestId("graphical-controls-1");
-    expect(controls).toHaveStyle({
-      left: "50%",
-      transform: "translateX(-50%)",
-    });
   }, 15000);
 
   it("allows viewport panning in view mode when dragging on empty canvas", () => {

--- a/frontend/src/__tests__/GraphicalFields.test.tsx
+++ b/frontend/src/__tests__/GraphicalFields.test.tsx
@@ -496,6 +496,12 @@ describe("GraphicalFields", () => {
     expect(
       screen.getByRole("button", { name: "Alles einpassen" }),
     ).toBeInTheDocument();
+
+    const controls = screen.getByTestId("graphical-controls-1");
+    expect(controls).toHaveStyle({
+      left: "50%",
+      transform: "translateX(-50%)",
+    });
   }, 15000);
 
   it("allows viewport panning in view mode when dragging on empty canvas", () => {

--- a/frontend/src/__tests__/hierarchyUtils.test.ts
+++ b/frontend/src/__tests__/hierarchyUtils.test.ts
@@ -7,6 +7,7 @@ import {
   buildHierarchyIndex,
   buildHierarchyRows,
   buildHierarchyRowsFromIndex,
+  createHierarchyRowsProjector,
 } from '../components/hierarchy/utils/hierarchyUtils';
 import type { Location, Field, Bed } from '../api/api';
 
@@ -464,5 +465,106 @@ describe('buildHierarchyRows', () => {
     const reuseDuration = performance.now() - reuseStart;
 
     expect(reuseDuration).toBeLessThan(rebuildDuration);
+  });
+
+  it('reuses row object references for unchanged visible rows across expand toggles', () => {
+    const hierarchyIndex = buildHierarchyIndex(
+      mockLocations,
+      mockFields,
+      mockBeds,
+      { field: 'name', direction: 'asc' },
+    );
+    const projectRows = createHierarchyRowsProjector(hierarchyIndex);
+
+    const initiallyExpanded = new Set<string | number>(['location-1']);
+    const initialRows = projectRows(initiallyExpanded);
+
+    const withExpandedField = new Set<string | number>(['location-1', 'field-1']);
+    const rowsAfterExpand = projectRows(withExpandedField);
+
+    const locationInitial = initialRows.find((row) => row.id === 'location-1');
+    const locationAfterExpand = rowsAfterExpand.find((row) => row.id === 'location-1');
+    const unchangedFieldInitial = initialRows.find((row) => row.id === 'field-2');
+    const unchangedFieldAfterExpand = rowsAfterExpand.find((row) => row.id === 'field-2');
+    const toggledFieldInitial = initialRows.find((row) => row.id === 'field-1');
+    const toggledFieldAfterExpand = rowsAfterExpand.find((row) => row.id === 'field-1');
+
+    expect(locationInitial).toBeDefined();
+    expect(locationAfterExpand).toBeDefined();
+    expect(unchangedFieldInitial).toBeDefined();
+    expect(unchangedFieldAfterExpand).toBeDefined();
+    expect(toggledFieldInitial).toBeDefined();
+    expect(toggledFieldAfterExpand).toBeDefined();
+
+    expect(locationInitial).toBe(locationAfterExpand);
+    expect(unchangedFieldInitial).toBe(unchangedFieldAfterExpand);
+    expect(toggledFieldInitial).not.toBe(toggledFieldAfterExpand);
+  });
+
+  it('projects rows with lower row-object churn during repeated expand/collapse toggles', () => {
+    const largeLocations = Array.from({ length: 15 }, (_, locationOffset) => ({
+      id: locationOffset + 1,
+      name: `Location ${locationOffset + 1}`,
+    })) as Location[];
+    const largeFields = largeLocations.flatMap((location) =>
+      Array.from({ length: 20 }, (_, fieldOffset) => ({
+        id: location.id! * 1000 + fieldOffset,
+        name: `Field ${location.id}-${fieldOffset}`,
+        location: location.id!,
+        area_sqm: 100 + fieldOffset,
+      })),
+    ) as Field[];
+    const largeBeds = largeFields.flatMap((field) =>
+      Array.from({ length: 12 }, (_, bedOffset) => ({
+        id: field.id! * 1000 + bedOffset,
+        name: `Bed ${field.id}-${bedOffset}`,
+        field: field.id!,
+        area_sqm: 10 + bedOffset,
+      })),
+    ) as Bed[];
+
+    const hierarchyIndex = buildHierarchyIndex(
+      largeLocations,
+      largeFields,
+      largeBeds,
+      { field: 'name', direction: 'asc' },
+    );
+    const projector = createHierarchyRowsProjector(hierarchyIndex);
+
+    const expanded = new Set<string | number>(
+      largeLocations.map((location) => `location-${location.id}`),
+    );
+
+    const toggledFieldIds = largeFields.slice(0, 30).map((field) => `field-${field.id}`);
+
+    const directReferences = new Set<object>();
+    for (let iteration = 0; iteration < 40; iteration += 1) {
+      toggledFieldIds.forEach((fieldId, index) => {
+        if ((iteration + index) % 2 === 0) {
+          expanded.add(fieldId);
+        } else {
+          expanded.delete(fieldId);
+        }
+      });
+      buildHierarchyRowsFromIndex(hierarchyIndex, expanded).forEach((row) => {
+        directReferences.add(row);
+      });
+    }
+
+    const projectedReferences = new Set<object>();
+    for (let iteration = 0; iteration < 40; iteration += 1) {
+      toggledFieldIds.forEach((fieldId, index) => {
+        if ((iteration + index) % 2 === 0) {
+          expanded.add(fieldId);
+        } else {
+          expanded.delete(fieldId);
+        }
+      });
+      projector(expanded).forEach((row) => {
+        projectedReferences.add(row);
+      });
+    }
+
+    expect(projectedReferences.size).toBeLessThan(directReferences.size);
   });
 });

--- a/frontend/src/components/help/HelpDialog.tsx
+++ b/frontend/src/components/help/HelpDialog.tsx
@@ -66,11 +66,12 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
       open={open}
       onClose={onClose}
       fullWidth
-      maxWidth="sm"
+      maxWidth="md"
       fullScreen={isMobile}
       PaperProps={{
         sx: {
           borderRadius: isMobile ? 0 : 3,
+          width: isMobile ? '100%' : 880,
         },
       }}
     >
@@ -109,7 +110,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
                 <List dense disablePadding>
                   {section.points.map((point) => (
                     <ListItem key={`${section.title}-${point}`} disableGutters sx={{ py: 0.125 }}>
-                      <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                      <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
                     </ListItem>
                   ))}
                 </List>
@@ -129,9 +130,10 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
                 px: 2,
                 py: 1.25,
                 backgroundColor: 'action.hover',
+                overflowX: 'auto',
               }}
             >
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600, whiteSpace: 'nowrap' }}>
                 {t('workflow')}
               </Typography>
             </Box>

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -6,6 +6,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
@@ -88,7 +89,7 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
       icon: (
         <Stack direction="row" spacing={0.1} alignItems="center">
           <ChevronRightIcon fontSize="small" />
-          <ArrowDropDownIcon fontSize="small" />
+          <ExpandMoreIcon fontSize="small" />
         </Stack>
       ),
     },
@@ -257,7 +258,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
           <List dense disablePadding>
             {section.points.map((point, pointIndex) => (
               <ListItem key={`${pageKey}-graphical-${sectionIndex}-${pointIndex}`} sx={{ py: 0.2, px: 0 }}>
-                <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
               </ListItem>
             ))}
           </List>
@@ -294,10 +295,10 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
         </Box>
         <List dense disablePadding sx={{ mt: 1 }}>
           <ListItem sx={{ py: 0.2, px: 0 }}>
-            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${t('pages.graphical.modeViewDescription')}`} />
+            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${t('pages.graphical.modeViewDescription')}`} />
           </ListItem>
           <ListItem sx={{ py: 0.2, px: 0 }}>
-            <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${t('pages.graphical.modeEditDescription')}`} />
+            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${t('pages.graphical.modeEditDescription')}`} />
           </ListItem>
         </List>
       </Box>
@@ -343,7 +344,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
                   </Typography>
                   {section.points.map((point, pointIndex) => (
                     <ListItem key={`${pageKey}-${sectionIndex}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
-                      <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                      <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
                     </ListItem>
                   ))}
                 </Box>
@@ -360,7 +361,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
               <List dense disablePadding>
                 {points.map((point, index) => (
                   <ListItem key={`${pageKey}-${index}`} sx={{ py: 0.25, px: 0 }}>
-                    <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                    <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
                   </ListItem>
                 ))}
               </List>
@@ -394,7 +395,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
                   </Typography>
                   {section.points.map((point, pointIndex) => (
                     <ListItem key={`${pageKey}-mobile-${sectionIndex}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
-                      <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                      <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
                     </ListItem>
                   ))}
                 </Box>
@@ -411,7 +412,7 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
               <List dense disablePadding>
                 {points.map((point, index) => (
                   <ListItem key={`${pageKey}-mobile-${index}`} sx={{ py: 0.25, px: 0 }}>
-                    <ListItemText primaryTypographyProps={{ variant: 'body2' }} primary={`• ${point}`} />
+                    <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
                   </ListItem>
                 ))}
               </List>

--- a/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
+++ b/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
@@ -255,3 +255,192 @@ export function buildHierarchyRowsFromIndex(
 
   return hierarchyRows;
 }
+
+/**
+ * Creates a reusable projector that materializes hierarchy rows while reusing row objects
+ * for unchanged nodes. This reduces object churn on frequent expand/collapse toggles.
+ */
+export function createHierarchyRowsProjector(hierarchyIndex: HierarchyIndex) {
+  const locationRows = new Map<string, HierarchyRow>();
+  const fieldRows = new Map<string, HierarchyRow>();
+  const bedRows = new Map<number, HierarchyRow>();
+
+  const getLocationRow = (
+    location: Location,
+    hasChildren: boolean,
+    expanded: boolean,
+  ): HierarchyRow => {
+    const key = `${location.id}:${expanded ? '1' : '0'}`;
+    const cached = locationRows.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const row: HierarchyRow = {
+      id: `location-${location.id}`,
+      type: 'location',
+      level: 0,
+      name: location.name,
+      locationId: location.id,
+      expanded,
+      hasChildren,
+    };
+    locationRows.set(key, row);
+    return row;
+  };
+
+  const getFieldRow = (
+    field: Field,
+    level: 0 | 1,
+    parentId: string | undefined,
+    locationId: number | undefined,
+    hasChildren: boolean,
+    expanded: boolean,
+  ): HierarchyRow => {
+    const key = `${field.id}:${level}:${parentId ?? ''}:${locationId ?? ''}:${expanded ? '1' : '0'}`;
+    const cached = fieldRows.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const row: HierarchyRow = {
+      id: `field-${field.id}`,
+      type: 'field',
+      level,
+      name: field.name,
+      fieldId: field.id,
+      expanded,
+      hasChildren,
+      area_sqm: field.area_sqm,
+      length_m: field.length_m,
+      width_m: field.width_m,
+      notes: field.notes,
+      ...(parentId ? { parentId } : {}),
+      ...(locationId !== undefined ? { locationId } : {}),
+    };
+    fieldRows.set(key, row);
+    return row;
+  };
+
+  const getBedRow = (
+    bed: Bed,
+    level: 1 | 2,
+    parentId: string,
+    fieldId: number,
+    fieldName: string,
+    locationId: number | undefined,
+  ): HierarchyRow => {
+    const bedId = bed.id!;
+    const cached = bedRows.get(bedId);
+    if (cached) {
+      return cached;
+    }
+
+    const row: HierarchyRow = {
+      id: bedId,
+      type: 'bed',
+      level,
+      parentId,
+      name: bed.name,
+      field: bed.field,
+      field_name: fieldName,
+      area_sqm: bed.area_sqm,
+      length_m: bed.length_m,
+      width_m: bed.width_m,
+      notes: bed.notes,
+      fieldId,
+      bedId,
+      hasChildren: false,
+      isNew: bedId < 0,
+      ...(locationId !== undefined ? { locationId } : {}),
+    };
+    bedRows.set(bedId, row);
+    return row;
+  };
+
+  return (expandedRows: Set<string | number>): HierarchyRow[] => {
+    const hierarchyRows: HierarchyRow[] = [];
+
+    if (hierarchyIndex.hasMultipleLocations) {
+      hierarchyIndex.sortedLocations.forEach((location) => {
+        const locationKey = `location-${location.id}`;
+        const isExpanded = expandedRows.has(locationKey);
+        const locationFields =
+          hierarchyIndex.fieldsByLocation.get(location.id) ?? [];
+
+        hierarchyRows.push(
+          getLocationRow(location, locationFields.length > 0, isExpanded),
+        );
+
+        if (!isExpanded) {
+          return;
+        }
+
+        locationFields.forEach((field) => {
+          const fieldKey = `field-${field.id}`;
+          const isFieldExpanded = expandedRows.has(fieldKey);
+          const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+
+          hierarchyRows.push(
+            getFieldRow(
+              field,
+              1,
+              locationKey,
+              location.id,
+              fieldBeds.length > 0,
+              isFieldExpanded,
+            ),
+          );
+
+          if (!isFieldExpanded) {
+            return;
+          }
+
+          fieldBeds.forEach((bed) => {
+            hierarchyRows.push(
+              getBedRow(
+                bed,
+                2,
+                fieldKey,
+                field.id!,
+                field.name,
+                location.id,
+              ),
+            );
+          });
+        });
+      });
+
+      return hierarchyRows;
+    }
+
+    hierarchyIndex.sortedTopLevelFields.forEach((field) => {
+      const fieldKey = `field-${field.id}`;
+      const isFieldExpanded = expandedRows.has(fieldKey);
+      const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+
+      hierarchyRows.push(
+        getFieldRow(
+          field,
+          0,
+          undefined,
+          undefined,
+          fieldBeds.length > 0,
+          isFieldExpanded,
+        ),
+      );
+
+      if (!isFieldExpanded) {
+        return;
+      }
+
+      fieldBeds.forEach((bed) => {
+        hierarchyRows.push(
+          getBedRow(bed, 1, fieldKey, field.id!, field.name, undefined),
+        );
+      });
+    });
+
+    return hierarchyRows;
+  };
+}

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -96,8 +96,7 @@
         {
           "title": "Was sehe ich hier?",
           "points": [
-            "Hier verwaltest du die Struktur deiner Flächen – vom Standort bis zum Beet.",
-            "Standorte, Parzellen und Beete werden übersichtlich hierarchisch dargestellt.",
+            "Standorte, Parzellen und Beete werden hierarchisch dargestellt.",
             "Diese Ansicht eignet sich besonders gut, um neue Flächen anzulegen oder bestehende zu bearbeiten."
           ]
         },

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -33,7 +33,7 @@ import { useFieldOperations } from "../components/hierarchy/hooks/useFieldOperat
 import { fieldAPI, bedAPI } from "../api/api";
 import {
   buildHierarchyIndex,
-  buildHierarchyRowsFromIndex,
+  createHierarchyRowsProjector,
   type HierarchySortConfig,
 } from "../components/hierarchy/utils/hierarchyUtils";
 import {
@@ -53,6 +53,50 @@ import { isTypingInEditableElement } from "../hooks/useKeyboardShortcuts";
 interface FieldsBedsHierarchyProps {
   showTitle?: boolean;
 }
+
+const HIERARCHY_DATA_GRID_SX = {
+  ...dataGridSx,
+  width: "100%",
+  "& .MuiDataGrid-columnHeader": {
+    py: 0.25,
+  },
+  "& .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .ofp-hierarchy-row-location .MuiDataGrid-cell": {
+    py: 0.5,
+  },
+  "& .ofp-hierarchy-row-field .MuiDataGrid-cell": {
+    py: 0.25,
+  },
+  "& .ofp-hierarchy-row-bed .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .MuiDataGrid-row--editing .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .MuiDataGrid-row--editing .MuiInputBase-root": {
+    minHeight: "30px",
+    height: "30px",
+    fontSize: "0.875rem",
+  },
+  "& .MuiDataGrid-row--editing .MuiInputBase-input": {
+    py: 0.5,
+  },
+  "& .MuiDataGrid-row--editing .MuiSelect-select": {
+    minHeight: "unset !important",
+    py: 0.5,
+  },
+  "& .MuiDataGrid-row--editing .MuiIconButton-root": {
+    width: 28,
+    height: 28,
+  },
+  "& .MuiDataGrid-row--editing .MuiDataGrid-cell[data-field='name'] .MuiInputBase-root":
+    {
+      minHeight: "32px",
+      height: "32px",
+    },
+};
 
 function FieldsBedsHierarchy({
   showTitle = true,
@@ -129,9 +173,14 @@ function FieldsBedsHierarchy({
     [locations, fields, beds, hierarchySortConfig],
   );
 
+  const projectRows = useMemo(
+    () => createHierarchyRowsProjector(hierarchyIndex),
+    [hierarchyIndex],
+  );
+
   const rows = useMemo<GridRowsProp<HierarchyRow>>(
-    () => buildHierarchyRowsFromIndex(hierarchyIndex, expandedRows),
-    [hierarchyIndex, expandedRows],
+    () => projectRows(expandedRows),
+    [projectRows, expandedRows],
   );
 
   // Notes editor - must be after rows definition
@@ -716,17 +765,41 @@ function FieldsBedsHierarchy({
     const INDENT_PER_LEVEL_PX = 24;
     const EXTRA_BED_INDENT_PX = 34;
 
-    const measuredWidth = rows.reduce((maxWidth, row) => {
+    const hierarchyEntries: Array<{ name: string; level: number; type: string }> =
+      [];
+    if (hierarchyIndex.hasMultipleLocations) {
+      hierarchyIndex.sortedLocations.forEach((location) => {
+        hierarchyEntries.push({ name: location.name, level: 0, type: "location" });
+        const locationFields =
+          hierarchyIndex.fieldsByLocation.get(location.id) ?? [];
+        locationFields.forEach((field) => {
+          hierarchyEntries.push({ name: field.name, level: 1, type: "field" });
+          const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+          fieldBeds.forEach((bed) => {
+            hierarchyEntries.push({ name: bed.name, level: 2, type: "bed" });
+          });
+        });
+      });
+    } else {
+      hierarchyIndex.sortedTopLevelFields.forEach((field) => {
+        hierarchyEntries.push({ name: field.name, level: 0, type: "field" });
+        const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+        fieldBeds.forEach((bed) => {
+          hierarchyEntries.push({ name: bed.name, level: 1, type: "bed" });
+        });
+      });
+    }
+
+    const measuredWidth = hierarchyEntries.reduce((maxWidth, row) => {
       const nameLength = typeof row.name === "string" ? row.name.length : 0;
       const indent =
         row.level * INDENT_PER_LEVEL_PX +
         (row.type === "bed" ? EXTRA_BED_INDENT_PX : 0);
-      const rowWidth = indent + ICON_GROUP_PX + nameLength * CHAR_WIDTH_PX;
-      return Math.max(maxWidth, rowWidth);
+      return Math.max(maxWidth, indent + ICON_GROUP_PX + nameLength * CHAR_WIDTH_PX);
     }, MIN_NAME_WIDTH);
 
     return Math.min(520, Math.max(MIN_NAME_WIDTH, measuredWidth));
-  }, [rows]);
+  }, [hierarchyIndex]);
 
   /**
    * Create columns with callbacks
@@ -758,6 +831,35 @@ function FieldsBedsHierarchy({
     nameColumnWidth,
   ]);
 
+  const getRowHeight = useCallback((params: { model: HierarchyRow }) => {
+    if (params.model.type === "location") {
+      return LOCATION_ROW_HEIGHT;
+    }
+    if (params.model.type === "field") {
+      return FIELD_ROW_HEIGHT;
+    }
+    return BED_ROW_HEIGHT;
+  }, []);
+
+  const isCellEditable = useCallback((params: { row: HierarchyRow; field: string }) => {
+    if (params.row.type === "field" || params.row.type === "bed") {
+      return (
+        params.field === "name" ||
+        params.field === "length_m" ||
+        params.field === "width_m"
+      );
+    }
+    return false;
+  }, []);
+
+  const rowSelectionModel = useMemo(
+    () => ({
+      type: "include" as const,
+      ids: new Set(selectedRowId ? [selectedRowId] : []),
+    }),
+    [selectedRowId],
+  );
+
   return (
     <div className={showTitle ? "page-container" : undefined}>
       <Box sx={{ width: "fit-content", maxWidth: "100%" }}>
@@ -778,15 +880,7 @@ function FieldsBedsHierarchy({
             rows={rows}
             columns={columns}
             columnHeaderHeight={HEADER_ROW_HEIGHT}
-            getRowHeight={(params) => {
-              if (params.model.type === "location") {
-                return LOCATION_ROW_HEIGHT;
-              }
-              if (params.model.type === "field") {
-                return FIELD_ROW_HEIGHT;
-              }
-              return BED_ROW_HEIGHT;
-            }}
+            getRowHeight={getRowHeight}
             getRowClassName={(params) => `ofp-hierarchy-row-${params.row.type}`}
             rowModesModel={rowModesModel}
             onRowModesModelChange={setRowModesModel}
@@ -801,70 +895,9 @@ function FieldsBedsHierarchy({
             sortModel={sortModel}
             onSortModelChange={setSortModel}
             isRowSelectable={() => true}
-            isCellEditable={(params) => {
-              if (params.row.type === "field") {
-                return (
-                  params.field === "name" ||
-                  params.field === "length_m" ||
-                  params.field === "width_m"
-                );
-              }
-              if (params.row.type === "bed") {
-                return (
-                  params.field === "name" ||
-                  params.field === "length_m" ||
-                  params.field === "width_m"
-                );
-              }
-              return false;
-            }}
-            sx={{
-              ...dataGridSx,
-              width: "100%",
-              "& .MuiDataGrid-columnHeader": {
-                py: 0.25,
-              },
-              "& .MuiDataGrid-cell": {
-                py: 0,
-              },
-              "& .ofp-hierarchy-row-location .MuiDataGrid-cell": {
-                py: 0.5,
-              },
-              "& .ofp-hierarchy-row-field .MuiDataGrid-cell": {
-                py: 0.25,
-              },
-              "& .ofp-hierarchy-row-bed .MuiDataGrid-cell": {
-                py: 0,
-              },
-              "& .MuiDataGrid-row--editing .MuiDataGrid-cell": {
-                py: 0,
-              },
-              "& .MuiDataGrid-row--editing .MuiInputBase-root": {
-                minHeight: "30px",
-                height: "30px",
-                fontSize: "0.875rem",
-              },
-              "& .MuiDataGrid-row--editing .MuiInputBase-input": {
-                py: 0.5,
-              },
-              "& .MuiDataGrid-row--editing .MuiSelect-select": {
-                minHeight: "unset !important",
-                py: 0.5,
-              },
-              "& .MuiDataGrid-row--editing .MuiIconButton-root": {
-                width: 28,
-                height: 28,
-              },
-              "& .MuiDataGrid-row--editing .MuiDataGrid-cell[data-field='name'] .MuiInputBase-root":
-                {
-                  minHeight: "32px",
-                  height: "32px",
-                },
-            }}
-            rowSelectionModel={{
-              type: "include",
-              ids: new Set(selectedRowId ? [selectedRowId] : []),
-            }}
+            isCellEditable={isCellEditable}
+            sx={HIERARCHY_DATA_GRID_SX}
+            rowSelectionModel={rowSelectionModel}
             onRowSelectionModelChange={(nextModel) =>
               setSelectedRowId(Array.from(nextModel.ids)[0] ?? null)
             }

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1278,112 +1278,110 @@ export default function GraphicalFields({
                 >
                   <Paper
                     elevation={3}
-                    data-testid={`graphical-controls-${locationId}`}
                     sx={{
                       position: "absolute",
                       top: 12,
-                      left: "50%",
-                      transform: "translateX(-50%)",
+                      right: 12,
                       zIndex: 2,
                       borderRadius: 3,
                       overflow: "hidden",
                       bgcolor: "background.paper",
-                      maxWidth: "calc(100% - 24px)",
                     }}
                   >
-                    <Stack
-                      direction="row"
-                      spacing={0}
-                      alignItems="stretch"
-                      sx={{ flexWrap: "nowrap", maxWidth: "100%" }}
-                    >
-                      <Box
-                        sx={{
-                          display: { xs: "none", sm: "inline-flex" },
-                          alignItems: "center",
-                        }}
-                      >
-                        <Tooltip title={t("fields:graphical.panUp")} placement="bottom">
-                          <IconButton
-                            size="small"
-                            onClick={() => handlePanByOffset(locationId, 0, PAN_STEP)}
-                            aria-label={t("fields:graphical.panUp")}
-                            sx={{ borderRadius: 0, p: 1.25, borderRight: "1px solid", borderColor: "divider" }}
+                    <Stack spacing={0} alignItems="stretch">
+                      <Box sx={{ display: { xs: "none", sm: "block" } }}>
+                        <Box sx={{ display: "flex", justifyContent: "center" }}>
+                          <Tooltip title={t("fields:graphical.panUp")} placement="left">
+                            <IconButton
+                              size="small"
+                              onClick={() => handlePanByOffset(locationId, 0, PAN_STEP)}
+                              aria-label={t("fields:graphical.panUp")}
+                              sx={{ borderRadius: 0, p: 1.25 }}
+                            >
+                              <KeyboardArrowUpIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Box>
+                        <Stack direction="row" spacing={0}>
+                          <Tooltip
+                            title={t("fields:graphical.panLeft")}
+                            placement="left"
                           >
-                            <KeyboardArrowUpIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title={t("fields:graphical.panLeft")} placement="bottom">
-                          <IconButton
-                            size="small"
-                            onClick={() =>
-                              handlePanByOffset(locationId, PAN_STEP, 0)
-                            }
-                            aria-label={t("fields:graphical.panLeft")}
-                            sx={{
-                              borderRadius: 0,
-                              p: 1.25,
-                              borderRight: "1px solid",
-                              borderColor: "divider",
-                            }}
+                            <IconButton
+                              size="small"
+                              onClick={() =>
+                                handlePanByOffset(locationId, PAN_STEP, 0)
+                              }
+                              aria-label={t("fields:graphical.panLeft")}
+                              sx={{
+                                borderRadius: 0,
+                                p: 1.25,
+                                borderTop: "1px solid",
+                                borderColor: "divider",
+                                borderRight: "1px solid",
+                              }}
+                            >
+                              <KeyboardArrowLeftIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip
+                            title={t("fields:graphical.panRight")}
+                            placement="left"
                           >
-                            <KeyboardArrowLeftIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title={t("fields:graphical.panRight")} placement="bottom">
-                          <IconButton
-                            size="small"
-                            onClick={() =>
-                              handlePanByOffset(locationId, -PAN_STEP, 0)
-                            }
-                            aria-label={t("fields:graphical.panRight")}
-                            sx={{
-                              borderRadius: 0,
-                              p: 1.25,
-                              borderRight: "1px solid",
-                              borderColor: "divider",
-                            }}
+                            <IconButton
+                              size="small"
+                              onClick={() =>
+                                handlePanByOffset(locationId, -PAN_STEP, 0)
+                              }
+                              aria-label={t("fields:graphical.panRight")}
+                              sx={{
+                                borderRadius: 0,
+                                p: 1.25,
+                                borderTop: "1px solid",
+                                borderColor: "divider",
+                              }}
+                            >
+                              <KeyboardArrowRightIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Stack>
+                        <Box sx={{ display: "flex", justifyContent: "center" }}>
+                          <Tooltip
+                            title={t("fields:graphical.panDown")}
+                            placement="left"
                           >
-                            <KeyboardArrowRightIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title={t("fields:graphical.panDown")} placement="bottom">
-                          <IconButton
-                            size="small"
-                            onClick={() => handlePanByOffset(locationId, 0, -PAN_STEP)}
-                            aria-label={t("fields:graphical.panDown")}
-                            sx={{
-                              borderRadius: 0,
-                              p: 1.25,
-                              borderRight: "1px solid",
-                              borderColor: "divider",
-                            }}
-                          >
-                            <KeyboardArrowDownIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
+                            <IconButton
+                              size="small"
+                              onClick={() => handlePanByOffset(locationId, 0, -PAN_STEP)}
+                              aria-label={t("fields:graphical.panDown")}
+                              sx={{
+                                borderRadius: 0,
+                                p: 1.25,
+                                borderTop: "1px solid",
+                                borderColor: "divider",
+                              }}
+                            >
+                              <KeyboardArrowDownIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Box>
                       </Box>
                       <Tooltip
                         title={t("fields:graphical.zoomIn")}
-                        placement="bottom"
+                        placement="left"
                       >
                         <IconButton
                           size="small"
                           onClick={() => handleZoom(locationId, ZOOM_STEP)}
                           aria-label={t("fields:graphical.zoomIn")}
-                          sx={{
-                            borderRadius: 0,
-                            p: 1.25,
-                            borderRight: "1px solid",
-                            borderColor: "divider",
-                          }}
+                          sx={{ borderRadius: 0, p: 1.25 }}
                         >
                           <AddIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
                       <Tooltip
                         title={t("fields:graphical.zoomOut")}
-                        placement="bottom"
+                        placement="left"
                       >
                         <IconButton
                           size="small"
@@ -1392,7 +1390,7 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
-                            borderRight: "1px solid",
+                            borderTop: "1px solid",
                             borderColor: "divider",
                           }}
                         >
@@ -1401,7 +1399,7 @@ export default function GraphicalFields({
                       </Tooltip>
                       <Tooltip
                         title={t("fields:graphical.fitToView")}
-                        placement="bottom"
+                        placement="left"
                       >
                         <IconButton
                           size="small"
@@ -1410,7 +1408,7 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
-                            borderRight: "1px solid",
+                            borderTop: "1px solid",
                             borderColor: "divider",
                           }}
                         >
@@ -1423,7 +1421,7 @@ export default function GraphicalFields({
                             ? t("fields:graphical.exitFullscreen")
                             : t("fields:graphical.enterFullscreen")
                         }
-                        placement="bottom"
+                        placement="left"
                       >
                         <IconButton
                           size="small"
@@ -1438,6 +1436,8 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
+                            borderTop: "1px solid",
+                            borderColor: "divider",
                           }}
                         >
                           {fullscreenLocationId === locationId ? (

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1278,75 +1278,76 @@ export default function GraphicalFields({
                 >
                   <Paper
                     elevation={3}
+                    data-testid={`graphical-controls-${locationId}`}
                     sx={{
                       position: "absolute",
                       top: 12,
-                      right: 12,
+                      left: "50%",
+                      transform: "translateX(-50%)",
                       zIndex: 2,
                       borderRadius: 3,
                       overflow: "hidden",
                       bgcolor: "background.paper",
+                      maxWidth: "calc(100% - 24px)",
                     }}
                   >
-                    <Stack spacing={0} alignItems="stretch">
-                      <Box sx={{ display: { xs: "none", sm: "block" } }}>
-                        <Tooltip title={t("fields:graphical.panUp")} placement="left">
+                    <Stack
+                      direction="row"
+                      spacing={0}
+                      alignItems="stretch"
+                      sx={{ flexWrap: "nowrap", maxWidth: "100%" }}
+                    >
+                      <Box
+                        sx={{
+                          display: { xs: "none", sm: "inline-flex" },
+                          alignItems: "center",
+                        }}
+                      >
+                        <Tooltip title={t("fields:graphical.panUp")} placement="bottom">
                           <IconButton
                             size="small"
                             onClick={() => handlePanByOffset(locationId, 0, PAN_STEP)}
                             aria-label={t("fields:graphical.panUp")}
-                            sx={{ borderRadius: 0, p: 1.25 }}
+                            sx={{ borderRadius: 0, p: 1.25, borderRight: "1px solid", borderColor: "divider" }}
                           >
                             <KeyboardArrowUpIcon fontSize="small" />
                           </IconButton>
                         </Tooltip>
-                        <Stack direction="row" spacing={0}>
-                          <Tooltip
-                            title={t("fields:graphical.panLeft")}
-                            placement="left"
+                        <Tooltip title={t("fields:graphical.panLeft")} placement="bottom">
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              handlePanByOffset(locationId, PAN_STEP, 0)
+                            }
+                            aria-label={t("fields:graphical.panLeft")}
+                            sx={{
+                              borderRadius: 0,
+                              p: 1.25,
+                              borderRight: "1px solid",
+                              borderColor: "divider",
+                            }}
                           >
-                            <IconButton
-                              size="small"
-                              onClick={() =>
-                                handlePanByOffset(locationId, PAN_STEP, 0)
-                              }
-                              aria-label={t("fields:graphical.panLeft")}
-                              sx={{
-                                borderRadius: 0,
-                                p: 1.25,
-                                borderTop: "1px solid",
-                                borderColor: "divider",
-                                borderRight: "1px solid",
-                              }}
-                            >
-                              <KeyboardArrowLeftIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip
-                            title={t("fields:graphical.panRight")}
-                            placement="left"
+                            <KeyboardArrowLeftIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title={t("fields:graphical.panRight")} placement="bottom">
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              handlePanByOffset(locationId, -PAN_STEP, 0)
+                            }
+                            aria-label={t("fields:graphical.panRight")}
+                            sx={{
+                              borderRadius: 0,
+                              p: 1.25,
+                              borderRight: "1px solid",
+                              borderColor: "divider",
+                            }}
                           >
-                            <IconButton
-                              size="small"
-                              onClick={() =>
-                                handlePanByOffset(locationId, -PAN_STEP, 0)
-                              }
-                              aria-label={t("fields:graphical.panRight")}
-                              sx={{
-                                borderRadius: 0,
-                                p: 1.25,
-                                borderTop: "1px solid",
-                                borderColor: "divider",
-                              }}
-                            >
-                              <KeyboardArrowRightIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </Stack>
-                        <Tooltip
-                          title={t("fields:graphical.panDown")}
-                          placement="left"
-                        >
+                            <KeyboardArrowRightIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title={t("fields:graphical.panDown")} placement="bottom">
                           <IconButton
                             size="small"
                             onClick={() => handlePanByOffset(locationId, 0, -PAN_STEP)}
@@ -1354,7 +1355,7 @@ export default function GraphicalFields({
                             sx={{
                               borderRadius: 0,
                               p: 1.25,
-                              borderTop: "1px solid",
+                              borderRight: "1px solid",
                               borderColor: "divider",
                             }}
                           >
@@ -1364,20 +1365,25 @@ export default function GraphicalFields({
                       </Box>
                       <Tooltip
                         title={t("fields:graphical.zoomIn")}
-                        placement="left"
+                        placement="bottom"
                       >
                         <IconButton
                           size="small"
                           onClick={() => handleZoom(locationId, ZOOM_STEP)}
                           aria-label={t("fields:graphical.zoomIn")}
-                          sx={{ borderRadius: 0, p: 1.25 }}
+                          sx={{
+                            borderRadius: 0,
+                            p: 1.25,
+                            borderRight: "1px solid",
+                            borderColor: "divider",
+                          }}
                         >
                           <AddIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
                       <Tooltip
                         title={t("fields:graphical.zoomOut")}
-                        placement="left"
+                        placement="bottom"
                       >
                         <IconButton
                           size="small"
@@ -1386,7 +1392,7 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
-                            borderTop: "1px solid",
+                            borderRight: "1px solid",
                             borderColor: "divider",
                           }}
                         >
@@ -1395,7 +1401,7 @@ export default function GraphicalFields({
                       </Tooltip>
                       <Tooltip
                         title={t("fields:graphical.fitToView")}
-                        placement="left"
+                        placement="bottom"
                       >
                         <IconButton
                           size="small"
@@ -1404,7 +1410,7 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
-                            borderTop: "1px solid",
+                            borderRight: "1px solid",
                             borderColor: "divider",
                           }}
                         >
@@ -1417,7 +1423,7 @@ export default function GraphicalFields({
                             ? t("fields:graphical.exitFullscreen")
                             : t("fields:graphical.enterFullscreen")
                         }
-                        placement="left"
+                        placement="bottom"
                       >
                         <IconButton
                           size="small"
@@ -1432,8 +1438,6 @@ export default function GraphicalFields({
                           sx={{
                             borderRadius: 0,
                             p: 1.25,
-                            borderTop: "1px solid",
-                            borderColor: "divider",
                           }}
                         >
                           {fullscreenLocationId === locationId ? (

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -136,6 +136,14 @@ const PAN_STEP = 80;
 const PAN_FAST_STEP = 180;
 const WORKSPACE_MIN_WIDTH = 20000;
 const WORKSPACE_MIN_HEIGHT = 20000;
+const LOCATION_LAYOUT_PADDING = 20;
+const LOCATION_FIELD_GAP = 24;
+const FIELD_WORLD_PX_PER_METER = 18;
+const FIELD_WORLD_BASE_WIDTH = 560;
+const FIELD_WORLD_MIN_WIDTH = 560;
+const FIELD_WORLD_MAX_WIDTH = 920;
+const FIELD_WORLD_MIN_HEIGHT = 220;
+const FIELD_WORLD_SCALE_FACTOR = 12;
 
 const getFitViewportPadding = (stageWidth: number): ViewportPadding => ({
   top: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
@@ -519,19 +527,13 @@ export default function GraphicalFields({
     return locations.flatMap((location) => {
       if (!location.id) return [];
       const locationFields = fieldsByLocation.get(location.id) ?? [];
-      const padding = 20;
-      const fieldGap = stageWidth < 600 ? 12 : 24;
       const sizedFields = locationFields.map((field) => {
-        const fieldPxPerMeter = Math.max(
-          12,
-          Math.min(30, (stageWidth - 2 * padding) / 40),
-        );
-        const size = getFieldRectSize(field, fieldPxPerMeter, {
-          baseWidth: 560,
-          minWidth: 560,
-          maxWidth: Math.max(560, stageWidth - 2 * padding),
-          minHeight: 220,
-          scaleFactor: 12,
+        const size = getFieldRectSize(field, FIELD_WORLD_PX_PER_METER, {
+          baseWidth: FIELD_WORLD_BASE_WIDTH,
+          minWidth: FIELD_WORLD_MIN_WIDTH,
+          maxWidth: FIELD_WORLD_MAX_WIDTH,
+          minHeight: FIELD_WORLD_MIN_HEIGHT,
+          scaleFactor: FIELD_WORLD_SCALE_FACTOR,
         });
         return {
           field,
@@ -541,19 +543,19 @@ export default function GraphicalFields({
       });
       const totalFieldsHeight =
         sizedFields.reduce((sum, entry) => sum + entry.height, 0) +
-        Math.max(0, sizedFields.length - 1) * fieldGap;
+        Math.max(0, sizedFields.length - 1) * LOCATION_FIELD_GAP;
       let fieldY = Math.max(
-        padding,
+        LOCATION_LAYOUT_PADDING,
         Math.round(WORKSPACE_MIN_HEIGHT / 2 - totalFieldsHeight / 2),
       );
 
       const defaultFieldRects = sizedFields.map((entry) => {
         const y = fieldY;
-        fieldY += entry.height + fieldGap;
+        fieldY += entry.height + LOCATION_FIELD_GAP;
         return {
           ...entry,
           defaultX: Math.max(
-            padding,
+            LOCATION_LAYOUT_PADDING,
             Math.round(WORKSPACE_MIN_WIDTH / 2 - entry.width / 2),
           ),
           defaultY: y,
@@ -567,9 +569,9 @@ export default function GraphicalFields({
       );
       const contentWidth = Math.max(
         WORKSPACE_MIN_WIDTH,
-        stageWidth,
         ...defaultFieldRects.map(
-          (rect) => rect.width + rect.defaultX + padding,
+          (rect) =>
+            rect.width + rect.defaultX + LOCATION_LAYOUT_PADDING,
         ),
       );
       const fieldViewModels: RectViewModel[] = defaultFieldRects.map(
@@ -605,7 +607,47 @@ export default function GraphicalFields({
         },
       ];
     });
-  }, [fieldsByLocation, layoutsByField, locations, stageWidth]);
+  }, [fieldsByLocation, layoutsByField, locations]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
+    locationLayouts.forEach((layout) => {
+      const locationId = layout.location.id;
+      if (!locationId) {
+        return;
+      }
+      const contentBounds = getContentBoundsForLocation(locationId);
+      const viewport =
+        viewportByLocation[locationId] ??
+        fitBoundsToStage(
+          contentBounds,
+          { width: stageWidth, height: stageHeight },
+          getFitViewportPadding(stageWidth),
+        );
+      const sampleRects = layout.fieldViewModels.slice(0, 5).map((rect) => ({
+        id: rect.id,
+        world: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        scaled: {
+          x: rect.x * viewport.scale + viewport.x,
+          y: rect.y * viewport.scale + viewport.y,
+          width: rect.width * viewport.scale,
+          height: rect.height * viewport.scale,
+        },
+      }));
+
+      console.debug("[GraphicalFields] viewport debug", {
+        locationId,
+        stage: { width: stageWidth, height: stageHeight },
+        contentBounds,
+        viewport,
+        fitPadding: getFitViewportPadding(stageWidth),
+        sampleRects,
+      });
+    });
+  }, [locationLayouts, viewportByLocation, stageWidth, stageHeight]);
 
   const getContentBoundsForLocation = (locationId: number): ContentBounds => {
     const layout = locationLayouts.find((item) => item.location.id === locationId);


### PR DESCRIPTION
### Motivation
- The hierarchical view rebuilt fresh row objects and triggered prop identity churn on every expand/collapse, causing allocation and re-render overhead in the `DataGrid`.
- The goal is to make the user-visible action “Eintrag aufklappen / zuklappen” noticeably faster by reducing object churn and unnecessary prop/regeneration work while preserving behavior.

### Description
- Added `createHierarchyRowsProjector` in `frontend/src/components/hierarchy/utils/hierarchyUtils.ts` to cache and reuse row objects per node (location/field/bed) and expanded state, reducing allocations on toggles.
- Switched `FieldsBedsHierarchy` (`frontend/src/pages/FieldsBedsHierarchy.tsx`) to use the new projector instead of re-materializing fresh rows on each toggle, and derived `rows` via `projectRows(expandedRows)`.
- Decoupled the name-column width calculation from the visible `rows` and derive it from the precomputed `hierarchyIndex` to avoid recalculating columns on visibility changes.
- Stabilized `DataGrid` prop identities by extracting and memoizing `sx`, `getRowHeight`, `isCellEditable`, and `rowSelectionModel` to prevent unnecessary prop churn.
- Added/updated tests in `frontend/src/__tests__/hierarchyUtils.test.ts` to assert reference reuse, reduced row-object churn across repeated expand/collapse cycles, and preserved existing behavior.

### Testing
- Ran focused unit tests with `cd frontend && npm test -- --run src/__tests__/hierarchyUtils.test.ts src/__tests__/FieldsBedsPage.test.tsx` and all selected tests passed (30 tests total).
- New tests assert that unchanged visible rows keep stable object references and that the projector path produces fewer unique row objects under repeated toggles; these tests passed.
- Existing perf-oriented index-reuse test remains green, showing no regression in hierarchy materialization correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1eb78f5c8322949904c1d17d0735)