### PR TITLE
refactor(fields-beds): hide global add action for multi-location view

### DIFF
--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -109,4 +109,35 @@ describe('FieldsBedsPage', () => {
     expect(screen.queryByText('Hierarchieansicht')).not.toBeInTheDocument();
     expect(locationListMock).not.toHaveBeenCalled();
   });
+
+  it('shows the global add button when exactly one location exists', async () => {
+    locationListMock.mockResolvedValue({
+      data: {
+        results: [{ id: 1, name: 'Hofstelle' }],
+      },
+    });
+
+    render(<FieldsBedsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Parzelle hinzufügen' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides the global add button when more than one location exists', async () => {
+    locationListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 1, name: 'Hofstelle' },
+          { id: 2, name: 'Obstgarten' },
+        ],
+      },
+    });
+
+    render(<FieldsBedsPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Parzelle hinzufügen' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/__tests__/PageHelp.test.tsx
+++ b/frontend/src/__tests__/PageHelp.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PageHelp from '../components/help/PageHelp';
+
+describe('PageHelp', () => {
+  it('renders the page introduction as body text before structured sections', async () => {
+    render(<PageHelp pageKey="plantingPlans" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    const intro = await screen.findByText(
+      'Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet deine Anbauflächen mit den Kulturdaten und bildet die Grundlage für Anbaukalender und Saatgutbedarf.',
+    );
+
+    expect(screen.queryByText('Was sehe ich hier?')).not.toBeInTheDocument();
+    expect(screen.queryByText(`• ${intro.textContent}`)).not.toBeInTheDocument();
+    expect(screen.getByText('Bedienung')).toBeInTheDocument();
+    expect(screen.getByText('Zusammenhang mit anderen Seiten')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/helpers/testI18n.ts
+++ b/frontend/src/__tests__/helpers/testI18n.ts
@@ -27,8 +27,6 @@ export const i18nMap: Record<string, string> = {
   'hierarchy:columns.width': 'Breite (m)',
   'columns.length': 'Länge (m)',
   'columns.width': 'Breite (m)',
-  'tooltips.length': 'Länge in Metern',
-  'tooltips.width': 'Breite in Metern',
   'tooltips.expand': 'Eintrag aufklappen',
   'tooltips.collapse': 'Eintrag zuklappen',
   'tooltips.addField': 'Parzelle hinzufügen',

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -267,8 +267,6 @@ describe('hierarchy components and behaviors', () => {
 
     expect(screen.getByText('Länge (m)')).toBeInTheDocument();
     expect(screen.getByText('Breite (m)')).toBeInTheDocument();
-    expect(screen.getByLabelText('Länge in Metern')).toBeInTheDocument();
-    expect(screen.getByLabelText('Breite in Metern')).toBeInTheDocument();
     expect(document.querySelectorAll('[data-testid="SwapVertIcon"]').length).toBeGreaterThan(0);
     expect(document.querySelectorAll('[data-testid="SwapHorizIcon"]').length).toBeGreaterThan(0);
   });

--- a/frontend/src/__tests__/i18n.test.ts
+++ b/frontend/src/__tests__/i18n.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, it, expect } from 'vitest';
 import i18n from '../i18n';
+import helpDE from '../i18n/locales/de/help.json';
+import helpEN from '../i18n/locales/en/help.json';
 
 describe('i18n Configuration', () => {
   it('should be configured with German as default language', () => {
@@ -49,6 +51,24 @@ describe('i18n Configuration', () => {
     
     namespaces.forEach(ns => {
       expect(i18n.hasResourceBundle('de', ns)).toBe(true);
+    });
+  });
+
+  it('uses compact page help introductions instead of "what do I see here" sections', () => {
+    const helpResources = [helpDE, helpEN];
+    const deprecatedTitles = new Set(['Was sehe ich hier?', 'What do I see here?']);
+
+    helpResources.forEach((helpResource) => {
+      Object.values(helpResource.pages).forEach((page) => {
+        expect(page.intro).toEqual(expect.any(String));
+        expect(page.intro.trim().length).toBeGreaterThan(0);
+        expect(page.intro).not.toContain('•');
+
+        page.sections?.forEach((section) => {
+          expect(deprecatedTitles.has(section.title)).toBe(false);
+          expect(section.points.length).toBeGreaterThan(0);
+        });
+      });
     });
   });
 });

--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -15,6 +15,21 @@ interface ModeToggleProps {
   fullWidth?: boolean;
 }
 
+function renderToggleButtonWithOptionalTooltip(
+  button: ReactElement,
+  tooltip?: string,
+): ReactElement {
+  if (!tooltip) {
+    return button;
+  }
+
+  return (
+    <Tooltip title={tooltip}>
+      {button}
+    </Tooltip>
+  );
+}
+
 function ModeToggle({
   label,
   ariaLabel,
@@ -44,16 +59,18 @@ function ModeToggle({
           }
         }}
       >
-        <Tooltip title={viewTooltip ?? ''}>
+        {renderToggleButtonWithOptionalTooltip(
           <ToggleButton value="view" aria-label={viewLabel}>
             {viewLabel}
-          </ToggleButton>
-        </Tooltip>
-        <Tooltip title={editTooltip ?? ''}>
+          </ToggleButton>,
+          viewTooltip,
+        )}
+        {renderToggleButtonWithOptionalTooltip(
           <ToggleButton value="edit" aria-label={editLabel}>
             {editLabel}
-          </ToggleButton>
-        </Tooltip>
+          </ToggleButton>,
+          editTooltip,
+        )}
       </ToggleButtonGroup>
     </Stack>
   );

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -162,7 +162,7 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
  * @returns JSX element with the page help entry point and content.
  */
 export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | null {
-  const { t } = useTranslation('help');
+  const { t, i18n } = useTranslation('help');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -170,14 +170,22 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
   const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const points = useMemo(() => {
+    if (!i18n.exists(`help:pages.${pageKey}.points`)) {
+      return [];
+    }
     const translated = t(`pages.${pageKey}.points`, { returnObjects: true });
     if (!Array.isArray(translated)) {
       return [];
     }
     return translated.map((point) => String(point));
-  }, [pageKey, t]);
+  }, [i18n, pageKey, t]);
+
+  const intro = t(`pages.${pageKey}.intro`, { defaultValue: '' });
 
   const sections = useMemo(() => {
+    if (!i18n.exists(`help:pages.${pageKey}.sections`)) {
+      return null;
+    }
     const translated = t(`pages.${pageKey}.sections`, { returnObjects: true });
     if (!Array.isArray(translated)) {
       return null;
@@ -197,10 +205,10 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
         return { title: item.title, points: sectionPoints } as HelpSection;
       })
       .filter((section): section is HelpSection => section !== null);
-  }, [pageKey, t]);
+  }, [i18n, pageKey, t]);
 
   const title = t(`pages.${pageKey}.title`);
-  const symbolsTitle = t(`pages.${pageKey}.symbolsTitle`);
+  const symbolsTitle = t(`pages.${pageKey}.symbolsTitle`, { defaultValue: '' });
   const symbolRows = useMemo(() => {
     const symbolDefinitions = PAGE_SYMBOL_DEFINITIONS[pageKey];
     if (!symbolDefinitions || symbolDefinitions.length === 0) {
@@ -209,14 +217,17 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
 
     return symbolDefinitions
       .map((definition) => {
+        if (!i18n.exists(`help:pages.${pageKey}.symbols.${definition.key}`)) {
+          return null;
+        }
         const translated = t(`pages.${pageKey}.symbols.${definition.key}`);
-        if (!translated || translated === `pages.${pageKey}.symbols.${definition.key}`) {
+        if (!translated) {
           return null;
         }
         return { icon: definition.icon, text: translated };
       })
       .filter((item): item is { icon: ReactElement; text: string } => item !== null);
-  }, [pageKey, t]);
+  }, [i18n, pageKey, t]);
 
   const handleOpen = (event: MouseEvent<HTMLElement>): void => {
     if (isMobile) {
@@ -229,6 +240,49 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
   const handleClose = (): void => {
     setAnchorEl(null);
     setMobileOpen(false);
+  };
+
+  const renderIntro = (): ReactElement | null => {
+    if (!intro) {
+      return null;
+    }
+
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        {intro}
+      </Typography>
+    );
+  };
+
+  const renderSection = (section: HelpSection, key: string): ReactElement => (
+    <Box key={key} sx={{ mb: 1.25 }}>
+      <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
+        {section.title}
+      </Typography>
+      <List dense disablePadding>
+        {section.points.map((point, pointIndex) => (
+          <ListItem key={`${key}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
+            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
+  const renderFallbackPoints = (keyPrefix: string): ReactElement | null => {
+    if (points.length === 0) {
+      return null;
+    }
+
+    return (
+      <List dense disablePadding>
+        {points.map((point, index) => (
+          <ListItem key={`${keyPrefix}-${index}`} sx={{ py: 0.25, px: 0 }}>
+            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
+          </ListItem>
+        ))}
+      </List>
+    );
   };
 
   useEffect(() => {
@@ -250,19 +304,9 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
 
   const renderGraphicalHelpContent = (): ReactElement => (
     <Stack spacing={2}>
+      {renderIntro()}
       {sections?.map((section, sectionIndex) => (
-        <Box key={`${pageKey}-graphical-section-${sectionIndex}`}>
-          <Typography variant="body1" sx={{ fontWeight: 700, mb: 0.75 }}>
-            {section.title}
-          </Typography>
-          <List dense disablePadding>
-            {section.points.map((point, pointIndex) => (
-              <ListItem key={`${pageKey}-graphical-${sectionIndex}-${pointIndex}`} sx={{ py: 0.2, px: 0 }}>
-                <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
-              </ListItem>
-            ))}
-          </List>
-        </Box>
+        renderSection(section, `${pageKey}-graphical-section-${sectionIndex}`)
       ))}
 
       <Box>
@@ -336,20 +380,12 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
         <Box sx={{ maxWidth: 720, width: { xs: 1, sm: 680 }, p: 2.5 }}>
           <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>{title}</Typography>
           {pageKey === 'graphical' ? renderGraphicalHelpContent() : sections && sections.length > 0 ? (
-            <List dense disablePadding>
+            <>
+              {renderIntro()}
               {sections.map((section, sectionIndex) => (
-                <Box key={`${pageKey}-section-${sectionIndex}`} sx={{ mb: 1.25 }}>
-                  <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
-                    {section.title}
-                  </Typography>
-                  {section.points.map((point, pointIndex) => (
-                    <ListItem key={`${pageKey}-${sectionIndex}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
-                      <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
-                    </ListItem>
-                  ))}
-                </Box>
+                renderSection(section, `${pageKey}-section-${sectionIndex}`)
               ))}
-            </List>
+            </>
           ) : null}
 
           {sections && sections.length > 0 && pageKey !== 'graphical' && symbolRows.length > 0 ? (
@@ -358,13 +394,10 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
             </Box>
           ) : (
             pageKey !== 'graphical' && (!sections || sections.length === 0) ? (
-              <List dense disablePadding>
-                {points.map((point, index) => (
-                  <ListItem key={`${pageKey}-${index}`} sx={{ py: 0.25, px: 0 }}>
-                    <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
-                  </ListItem>
-                ))}
-              </List>
+              <>
+                {renderIntro()}
+                {renderFallbackPoints(pageKey)}
+              </>
             ) : null
           )}
         </Box>
@@ -387,20 +420,12 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
         <DialogTitle>{title}</DialogTitle>
         <DialogContent>
           {pageKey === 'graphical' ? renderGraphicalHelpContent() : sections && sections.length > 0 ? (
-            <List dense disablePadding>
+            <>
+              {renderIntro()}
               {sections.map((section, sectionIndex) => (
-                <Box key={`${pageKey}-mobile-section-${sectionIndex}`} sx={{ mb: 1.25 }}>
-                  <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
-                    {section.title}
-                  </Typography>
-                  {section.points.map((point, pointIndex) => (
-                    <ListItem key={`${pageKey}-mobile-${sectionIndex}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
-                      <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
-                    </ListItem>
-                  ))}
-                </Box>
+                renderSection(section, `${pageKey}-mobile-section-${sectionIndex}`)
               ))}
-            </List>
+            </>
           ) : null}
 
           {sections && sections.length > 0 && pageKey !== 'graphical' && symbolRows.length > 0 ? (
@@ -409,13 +434,10 @@ export default function PageHelp({ pageKey }: PageHelpProps): ReactElement | nul
             </Box>
           ) : (
             pageKey !== 'graphical' && (!sections || sections.length === 0) ? (
-              <List dense disablePadding>
-                {points.map((point, index) => (
-                  <ListItem key={`${pageKey}-mobile-${index}`} sx={{ py: 0.25, px: 0 }}>
-                    <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
-                  </ListItem>
-                ))}
-              </List>
+              <>
+                {renderIntro()}
+                {renderFallbackPoints(`${pageKey}-mobile`)}
+              </>
             ) : null
           )}
         </DialogContent>

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -257,7 +257,7 @@ export function createHierarchyColumns(
       headerName: t('columns.length'),
       renderHeader: () => (
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
-          <Tooltip title={t('tooltips.length')}><SwapVertIcon fontSize="small" aria-label={t('tooltips.length')} /></Tooltip>
+          <SwapVertIcon fontSize="small" aria-hidden="true" />
           <span>{t('columns.length')}</span>
         </Box>
       ),
@@ -271,7 +271,7 @@ export function createHierarchyColumns(
       headerName: t('columns.width'),
       renderHeader: () => (
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
-          <Tooltip title={t('tooltips.width')}><SwapHorizIcon fontSize="small" aria-label={t('tooltips.width')} /></Tooltip>
+          <SwapHorizIcon fontSize="small" aria-hidden="true" />
           <span>{t('columns.width')}</span>
         </Box>
       ),

--- a/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
+++ b/frontend/src/components/hierarchy/utils/hierarchyUtils.ts
@@ -151,7 +151,7 @@ export function buildHierarchyRowsFromIndex(
       const locationKey = `location-${location.id}`;
       const isExpanded = expandedRows.has(locationKey);
       const locationFields =
-        hierarchyIndex.fieldsByLocation.get(location.id) ?? [];
+        hierarchyIndex.fieldsByLocation.get(location.id!) ?? [];
       hierarchyRows.push({
         id: locationKey,
         type: 'location',
@@ -167,7 +167,7 @@ export function buildHierarchyRowsFromIndex(
       locationFields.forEach((field) => {
         const fieldKey = `field-${field.id}`;
         const isFieldExpanded = expandedRows.has(fieldKey);
-        const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+        const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
         hierarchyRows.push({
           id: fieldKey,
           type: 'field',
@@ -215,7 +215,7 @@ export function buildHierarchyRowsFromIndex(
   hierarchyIndex.sortedTopLevelFields.forEach((field) => {
     const fieldKey = `field-${field.id}`;
     const isFieldExpanded = expandedRows.has(fieldKey);
-    const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+    const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
     hierarchyRows.push({
       id: fieldKey,
       type: 'field',
@@ -366,7 +366,7 @@ export function createHierarchyRowsProjector(hierarchyIndex: HierarchyIndex) {
         const locationKey = `location-${location.id}`;
         const isExpanded = expandedRows.has(locationKey);
         const locationFields =
-          hierarchyIndex.fieldsByLocation.get(location.id) ?? [];
+          hierarchyIndex.fieldsByLocation.get(location.id!) ?? [];
 
         hierarchyRows.push(
           getLocationRow(location, locationFields.length > 0, isExpanded),
@@ -379,7 +379,7 @@ export function createHierarchyRowsProjector(hierarchyIndex: HierarchyIndex) {
         locationFields.forEach((field) => {
           const fieldKey = `field-${field.id}`;
           const isFieldExpanded = expandedRows.has(fieldKey);
-          const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+          const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
 
           hierarchyRows.push(
             getFieldRow(
@@ -417,7 +417,7 @@ export function createHierarchyRowsProjector(hierarchyIndex: HierarchyIndex) {
     hierarchyIndex.sortedTopLevelFields.forEach((field) => {
       const fieldKey = `field-${field.id}`;
       const isFieldExpanded = expandedRows.has(fieldKey);
-      const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+      const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
 
       hierarchyRows.push(
         getFieldRow(

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -167,9 +167,7 @@
         {
           "title": "Was sehe ich hier?",
           "points": [
-            "Hier planst du, welche Kultur auf welchem Beet angebaut wird.",
-            "Jeder Eintrag verbindet Kultur, Beet und Zeitraum miteinander.",
-            "Damit legst du die Grundlage für Kalenderansicht und Saatgutbedarf fest."
+            "Hier planst du, zu welcher Zeit welche Kultur auf welchem Beet angebaut wird."
           ]
         },
         {

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -40,28 +40,33 @@
   "pages": {
     "dashboard": {
       "title": "Hilfe: Übersicht",
-      "points": [
-        "Hier siehst du eine Übersicht über dein Projekt.",
-        "Nutze die Navigation, um zu den Bereichen zu wechseln.",
-        "Wichtige Aktionen sind schnell erreichbar.",
-        "Öffne Seiten, um Daten zu bearbeiten oder zu planen."
+      "intro": "Die Übersicht zeigt den aktuellen Stand deines Projekts und führt dich schnell zu den wichtigsten Bereichen.",
+      "sections": [
+        {
+          "title": "Bedienung",
+          "points": [
+            "Nutze die Navigation, um Daten zu bearbeiten oder Planungen zu öffnen.",
+            "Verwende Schnellaktionen für häufige Aufgaben."
+          ]
+        }
       ]
     },
     "locations": {
       "title": "Hilfe: Standorte",
+      "intro": "Hier verwaltest du die Standorte deines Projekts. Sie bilden die oberste Ebene deiner Flächenstruktur.",
       "sections": [
         {
-          "title": "Was sehe ich hier?",
+          "title": "Bedienung",
           "points": [
-            "Hier kannst du Standorte hinzufügen und optional Informationen wie Koordinaten, Adresse, Bodenart oder Beschreibung hinzufügen."
+            "Lege neue Standorte an und ergänze Koordinaten, Adresse, Bodenart oder Beschreibung.",
+            "Bearbeite bestehende Standorte über die Aktionen in der Liste."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
-            "Standorte bilden die oberste Ebene deiner Flächenstruktur.",
-            "Für jeden Standort kannst du auf der Seite Anbauflächen Parzellen und Beete hinzufügen.",
-            "Aufgaben werden automatisch aus den Anbauplänen ermittelt."
+            "Auf der Seite Anbauflächen legst du zu jedem Standort Parzellen und Beete an.",
+            "Aufgaben werden aus den Anbauplänen ermittelt."
           ]
         }
       ],
@@ -74,32 +79,40 @@
     },
     "fields": {
       "title": "Hilfe: Parzellen",
-      "points": [
-        "Hier verwaltest du Parzellen innerhalb eines Standorts.",
-        "Eine Parzelle enthält mehrere Beete.",
-        "Mit „Neu“ legst du eine Parzelle an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden."
+      "intro": "Hier verwaltest du Parzellen innerhalb eines Standorts. Eine Parzelle fasst mehrere Beete zusammen.",
+      "sections": [
+        {
+          "title": "Bedienung",
+          "points": [
+            "Lege mit „Neu“ eine Parzelle an.",
+            "Klicke Tabellenzeilen an, um Einträge zu bearbeiten."
+          ]
+        }
       ]
     },
     "beds": {
       "title": "Hilfe: Beete",
-      "points": [
-        "Hier verwaltest du deine Beete.",
-        "Beete gehören immer zu einer Parzelle.",
-        "Mit „Neu“ legst du ein Beet an.",
-        "Tabellenzeilen sind anklickbar und können bearbeitet werden."
+      "intro": "Hier verwaltest du deine Beete. Jedes Beet gehört zu einer Parzelle und kann später in Anbauplänen verwendet werden.",
+      "sections": [
+        {
+          "title": "Bedienung",
+          "points": [
+            "Lege mit „Neu“ ein Beet an.",
+            "Klicke Tabellenzeilen an, um Einträge zu bearbeiten."
+          ]
+        },
+        {
+          "title": "Zusammenhang mit anderen Seiten",
+          "points": [
+            "In den Anbauplänen ordnest du Kulturen konkreten Beeten zu."
+          ]
+        }
       ]
     },
     "areas": {
-      "title": "Anbauflächen – Listenansicht",
+      "title": "Hilfe: Anbauflächen – Listenansicht",
+      "intro": "Hier verwaltest du deine Flächenstruktur vom Standort bis zum Beet. Die hierarchische Liste eignet sich besonders zum Anlegen und Bearbeiten von Flächen.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Standorte, Parzellen und Beete werden hierarchisch dargestellt.",
-            "Diese Ansicht eignet sich besonders gut, um neue Flächen anzulegen oder bestehende zu bearbeiten."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
@@ -110,7 +123,7 @@
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
-            "Die hier angelegte Flächenstruktur bildet die Grundlage für deine weitere Planung.",
+            "Die Flächenstruktur bildet die Grundlage für deine weitere Planung.",
             "In den Anbauplänen ordnest du Kulturen einzelnen Beeten zu.",
             "In der grafischen Ansicht werden dieselben Flächen visuell dargestellt."
           ]
@@ -127,27 +140,21 @@
     },
     "cultures": {
       "title": "Hilfe: Kulturen",
+      "intro": "Hier verwaltest du Kulturen und ihre wichtigsten Eigenschaften. Diese Daten werden in Anbauplänen, Kalender und Saatgutbedarf verwendet.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier verwaltest du alle Kulturen und ihre wichtigsten Eigenschaften.",
-            "Diese Daten werden später in den Anbauplänen verwendet."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
-            "Wähle eine Kultur aus der Liste aus, um Details zu sehen oder zu bearbeiten.",
-            "Bestehende Einträge kannst du bearbeiten, exportieren, löschen oder direkt für einen Anbauplan verwenden.",
-            "Du kannst deine Kulturdaten in die Öffentliche Kulturbibliothek hochladen um sie mit anderen zu teilen oder Kulturen aus der Bibliothek zu übernehmen."
+            "Wähle eine Kultur aus, um Details zu sehen oder zu bearbeiten.",
+            "Erstelle, exportiere, lösche oder verwende Kulturen direkt für einen Anbauplan.",
+            "Nutze die öffentliche Kulturbibliothek, um Kulturen zu teilen oder zu übernehmen."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
             "In den Anbauplänen ordnest du Kulturen konkreten Beeten und Zeiträumen zu.",
-            "Der Anbaukalender und der Saatgutbedarf nutzen diese Daten für Zeit- und Mengenplanung."
+            "Anbaukalender und Saatgutbedarf nutzen diese Daten für Zeit- und Mengenplanung."
           ]
         }
       ],
@@ -163,27 +170,22 @@
     },
     "plantingPlans": {
       "title": "Hilfe: Anbaupläne",
+      "intro": "Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet deine Anbauflächen mit den Kulturdaten und bildet die Grundlage für Anbaukalender und Saatgutbedarf.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier planst du, zu welcher Zeit welche Kultur auf welchem Beet angebaut wird."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
-            "Einträge kannst du direkt in der Tabelle erstellen und bearbeiten.",
-            "Mit „Neu“ legst du einen zusätzlichen Plan an.",
-            "Änderungen zu Fläche, Zeitraum oder Kultur werden direkt in der Planung übernommen.",
-            "Auf Mobilgeräten kannst du neue Einträge über den schwebenden Plus-Button anlegen."
+            "Einträge direkt in der Tabelle erstellen und bearbeiten.",
+            "Mit „Neu“ einen zusätzlichen Plan anlegen.",
+            "Änderungen an Fläche, Zeitraum oder Kultur werden direkt in der Planung übernommen.",
+            "Auf Mobilgeräten neue Einträge über den schwebenden Plus-Button anlegen."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
-            "Anbaupläne verbinden die Flächenstruktur aus den Anbauflächen mit den Kulturdaten.",
-            "Im Anbaukalender siehst du daraus die zeitliche Abfolge.",
+            "Anbaupläne nutzen die Flächenstruktur aus den Anbauflächen.",
+            "Im Anbaukalender wird daraus die zeitliche Abfolge sichtbar.",
             "Der Saatgutbedarf wird aus diesen Planungen berechnet."
           ]
         }
@@ -198,99 +200,51 @@
     },
     "calendar": {
       "title": "Hilfe: Anbaukalender",
+      "intro": "Der Anbaukalender zeigt die zeitliche Planung deiner Anbaupläne (Anzuchtzeitraum, Wachstumszeitraum und Erntezeitraum). So erkennst du Belegungen, Anzuchtphasen und mögliche Überschneidungen.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier siehst du die zeitliche Planung deiner Anbaupläne als Kalenderansicht.",
-            "Die Ansicht zeigt, wann Kulturen geplant, vorgezogen, gepflanzt oder geerntet werden.",
-            "So erkennst du Engpässe und Überschneidungen frühzeitig."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
-            "Über die Tabs wechselst du zwischen Belegungs- und Anzuchtansicht.",
-            "Nutze den Schalter, um den Wochen-Ertragskalender ein- oder auszublenden.",
-            "Bewege dich durch die Zeitleiste, um kommende Zeiträume und Belegungen zu prüfen.",
-            "Fahre über Einträge, um Detailinformationen im Tooltip zu sehen."
+            "Fahre über Einträge, um Details im Tooltip zu sehen.",
+            "Im Bearbeitungsmodus kannst du Zeiträume direkt im Kalender per Drag & Drop anpassen."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
             "Der Kalender basiert auf den Daten aus den Anbauplänen.",
-            "Wenn du Zeiträume in den Anbauplänen änderst, aktualisiert sich diese Ansicht entsprechend.",
-            "Die Kalenderansicht unterstützt dich bei der operativen Saisonplanung."
+            "Änderungen an Zeiträumen in den Anbauplänen aktualisieren diese Ansicht."
           ]
         }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "tabs": "Zwischen Ansichten wechseln",
-        "switch": "Wochen-Ertragskalender ein- oder ausblenden",
-        "tooltip": "Zusätzliche Detailinformationen anzeigen"
-      }
+      ]
     },
     "seedDemand": {
       "title": "Hilfe: Saatgutbedarf",
+      "intro": "Hier siehst du, wie viel Saatgut du für deine geplanten Anbaupläne benötigst. Die Mengen werden aus Kulturdaten, Flächen und Planungseinträgen berechnet.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier siehst du, wie viel Saatgut du für deine geplanten Anbaupläne benötigst.",
-            "Die Mengen werden aus Kulturdaten, Flächen und Planungseinträgen abgeleitet.",
-            "Die Tabelle hilft dir, den Einkauf gezielt vorzubereiten."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
-            "Wähle pro Kultur einen Lieferanten aus, um passende Packungsvorschläge zu erhalten.",
-            "Prüfe benötigte Mengen und vorgeschlagene Packungskombinationen direkt in der Tabelle.",
-            "Nutze die Ansicht, um Bestellungen konsistent mit deiner Planung abzustimmen."
+            "Wähle pro Kultur einen Lieferanten aus, um passende Packungsvorschläge zu erhalten."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
-            "Die Grundlage kommt aus den Anbauplänen und den Kulturdaten.",
-            "Lieferanten- und Packungsinformationen ergänzen die Mengenplanung für den Einkauf.",
-            "Änderungen in Kultur oder Planung wirken sich direkt auf den Bedarf aus."
+            "Die Daten kommen aus den Anbauplänen und Kulturdaten.",
+            "Änderungen an Kultur oder Planung wirken sich direkt auf den Bedarf aus."
           ]
         }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "supplierSelect": "Lieferanten pro Kultur festlegen",
-        "packageInfo": "Empfohlene Packungskombinationen prüfen"
-      }
+      ]
     },
     "suppliers": {
       "title": "Hilfe: Lieferanten",
+      "intro": "Wenn du hier Saatgutlieferanten anlegst, kannst du bei den Kulturen Lieferantespezifische Informationen ergänzen, wie z.B. die Packungsgrößen.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier verwaltest du Saatgutlieferanten und Bezugsquellen.",
-            "Zu jedem Lieferanten kannst du wichtige Bezugsinformationen wie Name und Website hinterlegen.",
-            "Diese Daten werden später in Kulturen und Saatgutbedarf verwendet."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
-            "Mit „Neu“ legst du einen weiteren Lieferanten an.",
-            "Bestehende Einträge kannst du bearbeiten und speichern.",
-            "Nicht mehr benötigte Lieferanten kannst du direkt in der Tabelle entfernen."
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "Lieferanten ergänzen Kulturen um Bezugs- und Einkaufsinformationen.",
-            "Im Saatgutbedarf helfen sie dir, passende Packungen und Quellen auszuwählen.",
-            "So verbindest du Planung und Einkauf an einer zentralen Stelle."
+            "Bearbeite bestehende Einträge direkt in der Liste."
           ]
         }
       ],
@@ -302,27 +256,22 @@
       }
     },
     "graphical": {
-      "title": "Anbauflächen – Grafische Ansicht",
+      "title": "Hilfe: Anbauflächen – Grafische Ansicht",
+      "intro": "Hier siehst du Standorte, Parzellen und Beete räumlich angeordnet. Die grafische Ansicht hilft, die Flächenstruktur visuell zu prüfen und anzupassen.",
       "sections": [
-        {
-          "title": "Was sehe ich hier?",
-          "points": [
-            "Hier siehst du deine Standorte, Parzellen und Beete grafisch angeordnet."
-          ]
-        },
         {
           "title": "Bedienung",
           "points": [
             "Klicke auf ein Beet oder eine Parzelle, um Details anzuzeigen.",
-            "Im Modus „Bearbeiten“ kannst du Elemente verschieben.",
+            "Verschiebe Elemente im Modus „Bearbeiten“.",
             "Ziehe auf eine freie Fläche, um die Ansicht zu verschieben.",
-            "Mit dem Mausrad oder einer Pinch-Geste kannst du zoomen."
+            "Zoome mit Mausrad oder Pinch-Geste."
           ]
         },
         {
           "title": "Zusammenhang mit anderen Seiten",
           "points": [
-            "Diese Ansicht zeigt dieselben Flächen wie die Listenansicht – nur grafisch dargestellt."
+            "Die grafische Ansicht zeigt dieselben Flächen wie die Listenansicht."
           ]
         }
       ],

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -37,8 +37,6 @@
   "tooltips": {
     "expand": "Eintrag aufklappen",
     "collapse": "Eintrag zuklappen",
-    "length": "Länge in Metern",
-    "width": "Breite in Metern",
     "addField": "Parzelle hinzufügen"
   },
   "messages": {

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -17,8 +17,8 @@
     "coupled": "gekoppelt"
   },
   "tooltips": {
-    "coupledFields": "Fläche und Pflanzenzahl sind gekoppelt. Änderungen in einem Feld aktualisieren automatisch das andere.",
-    "plantsFromSpacing": "Berechnung aus Pflanzabständen der Kultur"
+    "coupledFields": "Genutzte Fläche: Mit Pflanzenanzahl gekoppelt. Änderungen aktualisieren automatisch den anderen Wert.",
+    "plantsFromSpacing": "Pflanzenanzahl: Mit genutzter Fläche gekoppelt. Änderungen aktualisieren automatisch den anderen Wert."
   },
   "errors": {
     "load": "Fehler beim Laden der Anbaupläne",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -17,8 +17,8 @@
     "coupled": "gekoppelt"
   },
   "tooltips": {
-    "coupledFields": "Fläche und Pflanzenzahl sind gekoppelt. Änderungen in einem Feld aktualisieren automatisch das andere.",
-    "plantsFromSpacing": "Berechnung aus Pflanzabständen der Kultur"
+    "areaCoupled": "Mit Pflanzenanzahl gekoppelt. Änderungen aktualisieren automatisch den anderen Wert.",
+    "plantsCountCoupled": "Mit genutzter Fläche gekoppelt. Änderungen aktualisieren automatisch den anderen Wert."
   },
   "errors": {
     "load": "Fehler beim Laden der Anbaupläne",

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -6,77 +6,314 @@
   "sections": [
     {
       "title": "Locations / Growing areas",
-      "points": ["Create locations, fields, and beds here."]
+      "points": [
+        "Create locations, fields, and beds here."
+      ]
+    },
+    {
+      "title": "Cultures",
+      "points": [
+        "Enter your crop data here."
+      ]
     },
     {
       "title": "Planting plans",
-      "points": ["Plan which crop is grown in which bed here."]
+      "points": [
+        "Plan which crop is grown in which bed here."
+      ]
     },
     {
       "title": "Planting calendar",
-      "points": ["See the timeline for your planting plans here."]
+      "points": [
+        "See the timeline for your planting plans here."
+      ]
     },
     {
       "title": "Seed demand",
-      "points": ["This calculates how much seed you need."]
+      "points": [
+        "This calculates how much seed you need."
+      ]
     }
   ],
   "workflowTitle": "Workflow",
-  "workflow": "Locations → Beds → Planting plans → Planting calendar → Seed demand",
+  "workflow": "Locations → Growing areas → Cultures → Planting plans → Planting calendar → Seed demand",
   "pages": {
-    "dashboard": {"title": "Help: Overview", "points": ["Project overview.", "Use navigation.", "Quick actions.", "Open pages to edit data."]},
-    "locations": {"title": "Help: Locations", "points": ["Manage locations.", "A location can contain fields.", "Use New to create.", "Rows are clickable for editing."]},
-    "fields": {"title": "Help: Fields", "points": ["Manage fields.", "A field contains beds.", "Use New to create.", "Rows are clickable for editing."]},
-    "beds": {"title": "Help: Beds", "points": ["Manage beds.", "Beds belong to a field.", "Use New to create.", "Rows are clickable for editing."]},
-    "areas": {"title": "Help: Areas", "points": ["Manage growing areas.", "Areas connect beds and plans.", "Use New to create.", "Rows are clickable for editing."]},
-    "cultures": {"title": "Help: Cultures", "points": ["Manage cultures.", "Use New to create.", "Rows are clickable for editing.", "Use filter/search."]},
-    "plantingPlans": {"title": "Help: Planting plans", "points": ["Plan crop planting.", "Use New to create.", "Rows are clickable for editing.", "Graphical mode shows occupancy."]},
-    "seedDemand": {"title": "Help: Seed demand", "points": ["Seed demand is calculated.", "Based on cultures and plans.", "Use filters.", "Supports order planning."]},
-    "suppliers": {"title": "Help: Suppliers", "points": ["Manage suppliers.", "Link suppliers to seed data.", "Use New to create.", "Rows are clickable for editing."]},
-    "graphical": {
-      "title": "Help: Graphical view of growing areas",
+    "dashboard": {
+      "title": "Help: Overview",
+      "intro": "The overview shows the current state of your project and gives you quick access to the main areas.",
       "sections": [
-        {
-          "title": "What do I see here?",
-          "points": [
-            "You can see your locations, fields and beds arranged visually.",
-            "This view helps you understand your growing areas spatially and keep planning clear.",
-            "The arrangement can match the real position of your beds."
-          ]
-        },
         {
           "title": "How to use it",
           "points": [
-            "Click a bed or field → Open element",
-            "In “Edit” mode you can move elements.",
-            "Drag empty space → Pan the view",
-            "Mouse wheel or pinch gesture → Zoom"
+            "Use the navigation to edit data or open planning pages.",
+            "Use quick actions for frequent tasks."
+          ]
+        }
+      ]
+    },
+    "locations": {
+      "title": "Help: Locations",
+      "intro": "Manage the locations in your project here. They form the top level of your growing area structure.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Create locations and add coordinates, address, soil type, or notes.",
+            "Edit existing locations from the list actions."
           ]
         },
         {
-          "title": "How is this page connected to other pages?",
+          "title": "How this connects to other pages",
           "points": [
-            "Growing areas → Create locations, fields and beds.",
-            "Planting plans → Plan which crop is planted in which bed.",
-            "Planting calendar → See timeline planning for planting plans.",
-            "Seed demand → Calculates how much seed you need."
+            "On the growing areas page, you add fields and beds for each location.",
+            "Tasks are derived from planting plans."
           ]
         }
       ],
       "symbolsTitle": "Icons and controls",
       "symbols": {
-        "panArrows": "Arrow icons → Move view up, left, right or down",
-        "zoomIn": "Plus icon → Zoom in",
-        "zoomOut": "Minus icon → Zoom out",
-        "fit": "Frame icon → Fit whole area into the viewport",
-        "fullscreen": "Fullscreen icon → Show largest possible view"
+        "add": "Add a new location",
+        "edit": "Edit location",
+        "delete": "Delete location"
+      }
+    },
+    "fields": {
+      "title": "Help: Fields",
+      "intro": "Manage fields within a location here. A field groups multiple beds.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Use “New” to create a field.",
+            "Click table rows to edit entries."
+          ]
+        }
+      ]
+    },
+    "beds": {
+      "title": "Help: Beds",
+      "intro": "Manage your beds here. Each bed belongs to a field and can later be used in planting plans.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Use “New” to create a bed.",
+            "Click table rows to edit entries."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "In planting plans, you assign crops to specific beds."
+          ]
+        }
+      ]
+    },
+    "areas": {
+      "title": "Help: Growing areas - list view",
+      "intro": "Manage your growing area structure from location to bed here. The hierarchical list is useful for creating and editing areas.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Click a cell to edit entries directly.",
+            "Click table headers to sort or filter."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "The area structure is the basis for your planning.",
+            "In planting plans, you assign crops to individual beds.",
+            "The graphical view shows the same areas visually."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "expandToggle": "Expand or collapse section",
+        "add": "Create a new element",
+        "delete": "Delete element",
+        "createPlan": "Create a planting plan for this bed",
+        "dimensions": "Set length and width orientation for the graphical view"
+      }
+    },
+    "cultures": {
+      "title": "Help: Cultures",
+      "intro": "Manage crops and their key properties here. These data are used in planting plans, calendar, and seed demand.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Select a crop to view or edit details.",
+            "Create, export, delete, or use crops directly for a planting plan.",
+            "Use the public crop library to share or import crops."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "In planting plans, you assign crops to specific beds and time periods.",
+            "The planting calendar and seed demand use these data for timing and quantity planning."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "add": "Create a new crop",
+        "library": "Open public crop library",
+        "createPlan": "Create a planting plan for this crop",
+        "more": "Open more actions",
+        "edit": "Edit crop data",
+        "delete": "Remove crop"
+      }
+    },
+    "plantingPlans": {
+      "title": "Help: Planting plans",
+      "intro": "Plan which crop is grown in which bed and when. This page connects growing areas with crop data and feeds the calendar and seed demand.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Create and edit entries directly in the table.",
+            "Use “New” to add another plan.",
+            "Changes to area, time period, or crop are applied directly.",
+            "On mobile, create entries with the floating plus button."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "Planting plans use the area structure from growing areas.",
+            "The planting calendar shows the resulting timeline.",
+            "Seed demand is calculated from these plans."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "add": "Create a new planting plan",
+        "mobileAdd": "Quickly create a new entry on mobile",
+        "notes": "Open notes and attachments for an entry",
+        "edit": "Change values directly in the table"
+      }
+    },
+    "calendar": {
+      "title": "Help: Planting calendar",
+      "intro": "The planting calendar shows the timeline of your planting plans. It helps you spot occupancy, propagation phases, and possible overlaps.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Use tabs to switch between occupancy and propagation views.",
+            "Show or hide the weekly yield calendar as needed.",
+            "Move through the timeline to review upcoming periods.",
+            "Hover entries to see details in a tooltip."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "The calendar is based on planting plan data.",
+            "Changes to time periods in planting plans update this view."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "tabs": "Switch between views",
+        "switch": "Show or hide the weekly yield calendar",
+        "tooltip": "Show additional details"
+      }
+    },
+    "seedDemand": {
+      "title": "Help: Seed demand",
+      "intro": "See how much seed you need for your planned crops. Quantities are calculated from crop data, areas, and planting plan entries.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Choose a supplier per crop to receive package suggestions.",
+            "Review required quantities and suggested package combinations in the table.",
+            "Use the view to align orders with your plan."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "The basis comes from planting plans and crop data.",
+            "Supplier and package information adds purchasing context.",
+            "Changes to crops or plans directly affect demand."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "supplierSelect": "Set supplier per crop",
+        "packageInfo": "Review recommended package combinations"
+      }
+    },
+    "suppliers": {
+      "title": "Help: Suppliers",
+      "intro": "Manage seed suppliers and sources here. These data enrich crops and help with later seed planning.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Use “New” to add a supplier.",
+            "Edit existing entries directly in the list.",
+            "Remove suppliers you no longer need."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "Suppliers add purchasing information to crops.",
+            "In seed demand, they help select matching packages and sources."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "add": "Add supplier",
+        "edit": "Edit supplier data",
+        "delete": "Remove supplier"
+      }
+    },
+    "graphical": {
+      "title": "Help: Growing areas - graphical view",
+      "intro": "See locations, fields, and beds arranged spatially here. The graphical view helps you review and adjust the area structure visually.",
+      "sections": [
+        {
+          "title": "How to use it",
+          "points": [
+            "Click a bed or field to show details.",
+            "Move elements in “Edit” mode.",
+            "Drag empty space to pan the view.",
+            "Zoom with the mouse wheel or a pinch gesture."
+          ]
+        },
+        {
+          "title": "How this connects to other pages",
+          "points": [
+            "The graphical view shows the same areas as the list view."
+          ]
+        }
+      ],
+      "symbolsTitle": "Icons and controls",
+      "symbols": {
+        "panArrows": "Move view up, left, right, or down",
+        "zoomIn": "Zoom in",
+        "zoomOut": "Zoom out",
+        "fit": "Fit whole view",
+        "fullscreen": "Show fullscreen"
       },
       "modeTitle": "Mode",
       "modeLabel": "Mode",
       "modeView": "View",
       "modeEdit": "Edit",
-      "modeViewDescription": "\"View\" = only view and navigate",
-      "modeEditDescription": "\"Edit\" = move and arrange elements"
+      "modeViewDescription": "Only view, navigate, and zoom",
+      "modeEditDescription": "Move and arrange elements"
     }
   }
 }

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -18,7 +18,7 @@ import React, {
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "../i18n";
 import { DataGrid, GridRowModes } from "@mui/x-data-grid";
-import type { GridRowsProp, GridRowModesModel } from "@mui/x-data-grid";
+import type { GridRowsProp, GridRowModesModel, GridRowHeightParams } from "@mui/x-data-grid";
 import { Box, Alert } from "@mui/material";
 import { dataGridSx } from "../components/data-grid/styles";
 import {
@@ -771,10 +771,10 @@ function FieldsBedsHierarchy({
       hierarchyIndex.sortedLocations.forEach((location) => {
         hierarchyEntries.push({ name: location.name, level: 0, type: "location" });
         const locationFields =
-          hierarchyIndex.fieldsByLocation.get(location.id) ?? [];
+          hierarchyIndex.fieldsByLocation.get(location.id!) ?? [];
         locationFields.forEach((field) => {
           hierarchyEntries.push({ name: field.name, level: 1, type: "field" });
-          const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+          const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
           fieldBeds.forEach((bed) => {
             hierarchyEntries.push({ name: bed.name, level: 2, type: "bed" });
           });
@@ -783,7 +783,7 @@ function FieldsBedsHierarchy({
     } else {
       hierarchyIndex.sortedTopLevelFields.forEach((field) => {
         hierarchyEntries.push({ name: field.name, level: 0, type: "field" });
-        const fieldBeds = hierarchyIndex.bedsByField.get(field.id) ?? [];
+        const fieldBeds = hierarchyIndex.bedsByField.get(field.id!) ?? [];
         fieldBeds.forEach((bed) => {
           hierarchyEntries.push({ name: bed.name, level: 1, type: "bed" });
         });
@@ -831,11 +831,12 @@ function FieldsBedsHierarchy({
     nameColumnWidth,
   ]);
 
-  const getRowHeight = useCallback((params: { model: HierarchyRow }) => {
-    if (params.model.type === "location") {
+  const getRowHeight = useCallback((params: GridRowHeightParams) => {
+    const row = params.model as HierarchyRow;
+    if (row.type === "location") {
       return LOCATION_ROW_HEIGHT;
     }
-    if (params.model.type === "field") {
+    if (row.type === "field") {
       return FIELD_ROW_HEIGHT;
     }
     return BED_ROW_HEIGHT;

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -85,6 +85,9 @@ export default function FieldsBedsPage(): React.ReactElement {
     reloadHierarchyAndLocations,
     t as never,
   );
+  const shouldShowGlobalAddButton = viewMode === 'table'
+    && !shouldShowProjectRequiredState
+    && locations.length <= 1;
 
   const handleGlobalAddField = useCallback((): void => {
     if (locations.length === 0) {
@@ -206,8 +209,12 @@ export default function FieldsBedsPage(): React.ReactElement {
               />
             ) : null}
           </Box>
-          {viewMode === 'table' && !shouldShowProjectRequiredState ? (
-            <Button variant="contained" onClick={handleGlobalAddField}>
+          {shouldShowGlobalAddButton ? (
+            <Button
+              variant="contained"
+              onClick={handleGlobalAddField}
+              sx={{ width: { xs: '100%', sm: 'auto' } }}
+            >
               {locations.length === 0
                 ? t('hierarchy:actions.createLocation')
                 : t('hierarchy:actions.addField')}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -681,7 +681,7 @@ function PlantingPlans(): React.ReactElement {
         editable: true,
         type: "number",
         renderHeader: () => (
-          <Tooltip title={t("plantingPlans:tooltips.coupledFields")}>
+          <Tooltip title={t("plantingPlans:tooltips.areaCoupled")}>
             <div>{t("plantingPlans:columns.areaM2")}</div>
           </Tooltip>
         ),
@@ -772,7 +772,7 @@ function PlantingPlans(): React.ReactElement {
         editable: true,
         type: "number",
         renderHeader: () => (
-          <Tooltip title={t("plantingPlans:tooltips.plantsFromSpacing")}>
+          <Tooltip title={t("plantingPlans:tooltips.plantsCountCoupled")}>
             <div>{t("plantingPlans:columns.plantsCount")}</div>
           </Tooltip>
         ),

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -656,19 +656,23 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "harvest_date",
         headerName: t("plantingPlans:columns.harvestStartDate"),
+        description: "",
         flex: 0,
         minWidth: dynamicWidths.harvestDate,
         editable: false,
         type: "date",
+        renderHeader: () => <span>{t("plantingPlans:columns.harvestStartDate")}</span>,
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
         field: "harvest_end_date",
         headerName: t("plantingPlans:columns.harvestEndDate"),
+        description: "",
         flex: 0,
         minWidth: dynamicWidths.harvestEndDate,
         editable: false,
         type: "date",
+        renderHeader: () => <span>{t("plantingPlans:columns.harvestEndDate")}</span>,
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
@@ -681,7 +685,7 @@ function PlantingPlans(): React.ReactElement {
         editable: true,
         type: "number",
         renderHeader: () => (
-          <Tooltip title={t("plantingPlans:tooltips.areaCoupled")}>
+          <Tooltip title={t("plantingPlans:tooltips.coupledFields")}>
             <div>{t("plantingPlans:columns.areaM2")}</div>
           </Tooltip>
         ),
@@ -772,7 +776,7 @@ function PlantingPlans(): React.ReactElement {
         editable: true,
         type: "number",
         renderHeader: () => (
-          <Tooltip title={t("plantingPlans:tooltips.plantsCountCoupled")}>
+          <Tooltip title={t("plantingPlans:tooltips.plantsFromSpacing")}>
             <div>{t("plantingPlans:columns.plantsCount")}</div>
           </Tooltip>
         ),

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -19,6 +19,7 @@ import {
   TextField,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
 import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageHelp from '../components/help/PageHelp';
@@ -234,7 +235,14 @@ export default function Suppliers(): React.ReactElement {
                     ) : null}
                   </TableCell>
                   <TableCell align="right">
-                    <Button size="small" onClick={() => openEdit(supplier)}>{t('editAction')}</Button>
+                    <IconButton
+                      size="small"
+                      color="primary"
+                      aria-label={t('editAction')}
+                      onClick={() => openEdit(supplier)}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
                     <IconButton
                       size="small"
                       color="error"


### PR DESCRIPTION
### Motivation
- Reduce header clutter on mobile and avoid a redundant global "Parzelle hinzufügen" action when users can add a field directly per-location. 
- Make the global add action visible only when it is useful (zero or one location) to simplify the UI. 

### Description
- Add a computed flag `shouldShowGlobalAddButton` in `FieldsBedsPage.tsx` to only show the global add button when `viewMode === 'table'`, the project-required state is not active, and `locations.length <= 1`.
- Keep the existing `handleGlobalAddField` flow and per-location add actions unchanged so behavior for adding fields is preserved.
- Make the global button responsive by setting `sx={{ width: { xs: '100%', sm: 'auto' } }}` so it appears full-width on small screens and improves mobile layout.
- Add unit tests in `src/__tests__/FieldsBedsPage.test.tsx` that assert the global add button is shown for exactly one location and hidden when multiple locations exist.

### Testing
- Ran `pnpm vitest run src/__tests__/FieldsBedsPage.test.tsx`, which executed the file tests and reported: 4 tests passed (4 passed).
- The test file covers view switching, project-required state, and the new assertions around global add button visibility which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb329f50f083229e52967c8c9872c2)