### PR TITLE
refactor(planting-plans): split location field and bed selectors

### DIFF
--- a/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
+++ b/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Bed, Field } from "../api/types";
 import {
   collectHierarchyAvailability,
+  filterBedOptionsBySelection,
+  filterFieldOptionsByLocation,
   normalizeSelectionAfterBedChange,
   normalizeSelectionAfterFieldChange,
   normalizeSelectionAfterLocationChange,
@@ -29,6 +31,24 @@ describe("PlantingPlans hierarchy normalization", () => {
     expect(Array.from(availability.locationIdsWithBeds).sort()).toEqual([1, 2]);
     expect(availability.locationIdsWithBeds.has(3)).toBe(false);
     expect(availability.fieldIdsWithBeds.has(30)).toBe(false);
+  });
+
+  it("filters field options immediately from the locally selected location", () => {
+    const allFields: Field[] = [
+      ...fields,
+      { id: 30, name: "Parzelle Ost", location: 1 },
+    ];
+    const availability = collectHierarchyAvailability(allFields, beds);
+    const filtered = filterFieldOptionsByLocation(2, allFields, availability.fieldIdsWithBeds);
+
+    expect(filtered.map((field) => field.id)).toEqual([20]);
+  });
+
+  it("filters bed options immediately from local field selection", () => {
+    const availability = collectHierarchyAvailability(fields, beds);
+    const filtered = filterBedOptionsBySelection(1, 10, fields, beds, availability.fieldIdsWithBeds);
+
+    expect(filtered.map((bed) => bed.id)).toEqual([100]);
   });
 
   it("resets field and bed when location no longer matches", () => {

--- a/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
+++ b/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Bed, Field } from "../api/types";
 import {
+  collectHierarchyAvailability,
   normalizeSelectionAfterBedChange,
   normalizeSelectionAfterFieldChange,
   normalizeSelectionAfterLocationChange,
@@ -17,6 +18,19 @@ const beds: Bed[] = [
 ];
 
 describe("PlantingPlans hierarchy normalization", () => {
+  it("excludes locations and fields without beds from availability", () => {
+    const allFields: Field[] = [
+      ...fields,
+      { id: 30, name: "Parzelle Ost", location: 3 },
+    ];
+    const availability = collectHierarchyAvailability(allFields, beds);
+
+    expect(Array.from(availability.fieldIdsWithBeds).sort()).toEqual([10, 20]);
+    expect(Array.from(availability.locationIdsWithBeds).sort()).toEqual([1, 2]);
+    expect(availability.locationIdsWithBeds.has(3)).toBe(false);
+    expect(availability.fieldIdsWithBeds.has(30)).toBe(false);
+  });
+
   it("resets field and bed when location no longer matches", () => {
     const row = { location_id: 1, field_id: 10, bed: 100 };
 

--- a/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
+++ b/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { Bed, Field } from "../api/types";
+import {
+  normalizeSelectionAfterBedChange,
+  normalizeSelectionAfterFieldChange,
+  normalizeSelectionAfterLocationChange,
+} from "../pages/PlantingPlans";
+
+const fields: Field[] = [
+  { id: 10, name: "Parzelle Nord", location: 1 },
+  { id: 20, name: "Parzelle Süd", location: 2 },
+];
+
+const beds: Bed[] = [
+  { id: 100, name: "Beet 1", field: 10, area_sqm: 7 },
+  { id: 200, name: "Beet 1", field: 20, area_sqm: 5 },
+];
+
+describe("PlantingPlans hierarchy normalization", () => {
+  it("resets field and bed when location no longer matches", () => {
+    const row = { location_id: 1, field_id: 10, bed: 100 };
+
+    const next = normalizeSelectionAfterLocationChange(row, 2, fields, beds);
+
+    expect(next.location_id).toBe(2);
+    expect(next.field_id).toBeUndefined();
+    expect(next.bed).toBe(0);
+  });
+
+  it("keeps location/field/bed aligned when field changes", () => {
+    const row = { location_id: 1, field_id: 10, bed: 100 };
+
+    const next = normalizeSelectionAfterFieldChange(row, 20, fields, beds);
+
+    expect(next.location_id).toBe(2);
+    expect(next.field_id).toBe(20);
+    expect(next.bed).toBe(0);
+  });
+
+  it("fills location and field from selected bed", () => {
+    const row = { location_id: 1, field_id: 10, bed: 100 };
+
+    const next = normalizeSelectionAfterBedChange(row, 200, fields, beds);
+
+    expect(next.location_id).toBe(2);
+    expect(next.field_id).toBe(20);
+    expect(next.bed).toBe(200);
+  });
+});

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -697,7 +697,7 @@ export function EditableDataGrid<T extends EditableRow>({
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
       <Box sx={{ width: '100%', overflowX: 'auto', overflowY: 'visible' }}>
-        <Box sx={{ display: 'inline-block', width: 'fit-content', minWidth: 0 }}>
+        <Box sx={{ display: 'block', width: '100%', minWidth: 0 }}>
           <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -718,7 +718,7 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: 'auto' }}
+          sx={{ ...dataGridSx, width: '100%' }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {

--- a/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
@@ -17,6 +17,7 @@ import type { SearchableSelectOption } from '../inputs/SearchableSelect';
 
 export interface SearchableSelectEditCellProps extends GridRenderEditCellParams {
   options: SearchableSelectOption[];
+  onValueChange?: (nextValue: number | null) => Promise<void> | void;
 }
 
 export function SearchableSelectEditCell({
@@ -24,6 +25,7 @@ export function SearchableSelectEditCell({
   value,
   field,
   options,
+  onValueChange,
 }: SearchableSelectEditCellProps): React.ReactElement {
   const apiRef = useGridApiContext();
   const initialValueRef = useRef(value);
@@ -42,16 +44,17 @@ export function SearchableSelectEditCell({
     setCurrentOption(selectedOption);
   }, [selectedOption]);
 
-  const handleChange = (_: unknown, newValue: SearchableSelectOption | null) => {
+  const handleChange = async (_: unknown, newValue: SearchableSelectOption | null) => {
     setCurrentOption(newValue);
     const nextValue = newValue?.value ?? null;
 
     if (nextValue !== initialValueRef.current) {
-      apiRef.current.setEditCellValue({
+      await apiRef.current.setEditCellValue({
         id,
         field,
         value: nextValue,
       });
+      await onValueChange?.(nextValue);
     }
   };
 
@@ -61,7 +64,9 @@ export function SearchableSelectEditCell({
       value={currentOption}
       inputValue={inputValue}
       onInputChange={setInputValue}
-      onChange={(newValue) => handleChange(undefined, newValue)}
+      onChange={(newValue) => {
+        void handleChange(undefined, newValue);
+      }}
       size="small"
       textFieldSx={{ '& .MuiInputBase-root': { height: '100%' } }}
     />

--- a/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
@@ -9,7 +9,7 @@
  * @returns Autocomplete-based edit cell.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useGridApiContext } from '@mui/x-data-grid';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { SearchableSelect } from '../inputs/SearchableSelect';
@@ -28,7 +28,6 @@ export function SearchableSelectEditCell({
   onValueChange,
 }: SearchableSelectEditCellProps): React.ReactElement {
   const apiRef = useGridApiContext();
-  const initialValueRef = useRef(value);
   const [inputValue, setInputValue] = useState('');
 
   const selectedOption = useMemo(
@@ -48,7 +47,7 @@ export function SearchableSelectEditCell({
     setCurrentOption(newValue);
     const nextValue = newValue?.value ?? null;
 
-    if (nextValue !== initialValueRef.current) {
+    if (nextValue !== value) {
       await apiRef.current.setEditCellValue({
         id,
         field,

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -2,6 +2,8 @@
   "title": "Anbaupläne",
   "columns": {
     "culture": "Kultur",
+    "location": "Standort",
+    "field": "Parzelle",
     "bed": "Beet",
     "fieldBed": "Parzelle{{separator}}Beet",
     "plantingDate": "Pflanzdatum",

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -106,6 +106,12 @@ interface MobileCreateFormState {
   notes: string;
 }
 
+interface HierarchyDraftState {
+  location_id: number | null;
+  field_id: number | null;
+  bed: number;
+}
+
 const CULTIVATION_TYPE_OPTIONS = [
   {
     value: "direct_sowing",
@@ -397,11 +403,17 @@ function PlantingPlans(): React.ReactElement {
   const [mobileLastEditedField, setMobileLastEditedField] = useState<
     "area_m2" | "plants_count" | null
   >(null);
+  const [hierarchyDraftByRowId, setHierarchyDraftByRowId] = useState<Record<string, HierarchyDraftState>>({});
+  const hierarchyDraftByRowIdRef = useRef<Record<string, HierarchyDraftState>>({});
   const [isMobileNotesOpen, setIsMobileNotesOpen] = useState(false);
   const [mobileNotesTarget, setMobileNotesTarget] = useState<PlantingPlanRow | null>(null);
   const [mobileNotesDraft, setMobileNotesDraft] = useState("");
   const [isMobileNotesSaving, setIsMobileNotesSaving] = useState(false);
   const mobilePrefillHandledRef = useRef(false);
+
+  useEffect(() => {
+    hierarchyDraftByRowIdRef.current = hierarchyDraftByRowId;
+  }, [hierarchyDraftByRowId]);
 
   useEffect(() => {
     if (isMobile) {
@@ -572,22 +584,30 @@ function PlantingPlans(): React.ReactElement {
     return bedOptions.filter((option) => allowedBedIds.has(option.value));
   };
 
-  const getDraftRowForEditCell = (
-    params: GridRenderEditCellParams<PlantingPlanRow>,
+  const buildDraftRow = (
+    rowId: number | string,
+    fallbackRow: PlantingPlanRow,
   ): PlantingPlanRow => {
-    const apiWithDraft = params.api as unknown as {
-      getRowWithUpdatedValues?: (id: number | string, field: string) => PlantingPlanRow;
-      getRow?: (id: number | string) => PlantingPlanRow;
-    };
-    const draftRow = apiWithDraft.getRowWithUpdatedValues?.(
-      params.id,
-      String(params.field),
-    );
-    if (draftRow) {
-      return draftRow;
+    const draft = hierarchyDraftByRowIdRef.current[String(rowId)];
+    if (!draft) {
+      return fallbackRow;
     }
-    const persistedRow = apiWithDraft.getRow?.(params.id);
-    return persistedRow ?? (params.row as PlantingPlanRow);
+    return {
+      ...fallbackRow,
+      location_id: draft.location_id ?? undefined,
+      field_id: draft.field_id ?? undefined,
+      bed: draft.bed,
+    };
+  };
+
+  const setDraftForRow = (
+    rowId: number | string,
+    nextDraft: HierarchyDraftState,
+  ): void => {
+    setHierarchyDraftByRowId((previous) => ({
+      ...previous,
+      [String(rowId)]: nextDraft,
+    }));
   };
 
   const getCultivationTypeOptionsForRow = useMemo(
@@ -917,7 +937,6 @@ function PlantingPlans(): React.ReactElement {
               return row ? locationOptions : [];
             },
             renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
-              const draftRow = getDraftRowForEditCell(params);
               return (
                 <SearchableSelectEditCell
                   {...params}
@@ -925,11 +944,16 @@ function PlantingPlans(): React.ReactElement {
                   onValueChange={async (nextValue) => {
                     const nextLocationId = typeof nextValue === "number" ? nextValue : 0;
                     const normalized = normalizeSelectionAfterLocationChange(
-                      draftRow,
+                      buildDraftRow(params.id, params.row as PlantingPlanRow),
                       nextLocationId,
                       fields,
                       beds,
                     );
+                    setDraftForRow(params.id, {
+                      location_id: normalized.location_id ?? null,
+                      field_id: normalized.field_id ?? null,
+                      bed: normalized.bed ?? 0,
+                    });
                     await params.api.setEditCellValue({
                       id: params.id,
                       field: "field_id",
@@ -973,9 +997,9 @@ function PlantingPlans(): React.ReactElement {
         valueOptions: (params: GridValueOptionsParams<PlantingPlanRow>) => {
           const row = params.row as PlantingPlanRow | undefined;
           return row ? getFieldOptionsForRow(row) : fieldOptions;
-        },
-        renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
-          const draftRow = getDraftRowForEditCell(params);
+            },
+            renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
+          const draftRow = buildDraftRow(params.id, params.row as PlantingPlanRow);
           const options = getFieldOptionsForRow(draftRow);
           return (
             <SearchableSelectEditCell
@@ -984,11 +1008,16 @@ function PlantingPlans(): React.ReactElement {
               onValueChange={async (nextValue) => {
                 const nextFieldId = typeof nextValue === "number" ? nextValue : 0;
                 const normalized = normalizeSelectionAfterFieldChange(
-                  draftRow,
+                  buildDraftRow(params.id, params.row as PlantingPlanRow),
                   nextFieldId,
                   fields,
                   beds,
                 );
+                setDraftForRow(params.id, {
+                  location_id: normalized.location_id ?? null,
+                  field_id: normalized.field_id ?? null,
+                  bed: normalized.bed ?? 0,
+                });
                 await params.api.setEditCellValue({
                   id: params.id,
                   field: "location_id",
@@ -1029,7 +1058,7 @@ function PlantingPlans(): React.ReactElement {
           return row ? getBedOptionsForRow(row) : bedOptions;
         },
         renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
-          const draftRow = getDraftRowForEditCell(params);
+          const draftRow = buildDraftRow(params.id, params.row as PlantingPlanRow);
           const options = getBedOptionsForRow(draftRow);
           return (
             <SearchableSelectEditCell
@@ -1038,11 +1067,16 @@ function PlantingPlans(): React.ReactElement {
               onValueChange={async (nextValue) => {
                 const nextBedId = typeof nextValue === "number" ? nextValue : 0;
                 const normalized = normalizeSelectionAfterBedChange(
-                  draftRow,
+                  buildDraftRow(params.id, params.row as PlantingPlanRow),
                   nextBedId,
                   fields,
                   beds,
                 );
+                setDraftForRow(params.id, {
+                  location_id: normalized.location_id ?? null,
+                  field_id: normalized.field_id ?? null,
+                  bed: normalized.bed ?? 0,
+                });
                 await params.api.setEditCellValue({
                   id: params.id,
                   field: "location_id",
@@ -1723,7 +1757,16 @@ function PlantingPlans(): React.ReactElement {
             api={plantingPlanAPI as unknown as DataGridAPI<PlantingPlanRow>}
             commandApiRef={gridCommandApiRef}
             onSelectedRowChange={setSelectedPlan}
-            onRowsStateChange={(rows) => setMobileRows(rows)}
+            onRowsStateChange={(rows) => {
+              setMobileRows(rows);
+              setHierarchyDraftByRowId((previous) => {
+                const rowIds = new Set(rows.map((row) => String(row.id)));
+                const prunedEntries = Object.entries(previous).filter(([key]) =>
+                  rowIds.has(key),
+                );
+                return Object.fromEntries(prunedEntries);
+              });
+            }}
             createNewRow={() => ({
             id: -Date.now(),
             culture: 0,

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -13,6 +13,7 @@ import type {
   GridCellParams,
   GridColDef,
   GridRenderCellParams,
+  GridRenderEditCellParams,
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
@@ -64,6 +65,7 @@ import { AreaM2EditCell } from "../components/data-grid/AreaM2EditCell";
 import {
   EditableDataGrid,
   createSingleSelectColumn,
+  SearchableSelectEditCell,
   type EditableRow,
   type DataGridAPI,
   type SearchableSelectOption,
@@ -271,6 +273,39 @@ export const collectHierarchyAvailability = (
 
   return { fieldIdsWithBeds, locationIdsWithBeds };
 };
+
+export const filterFieldOptionsByLocation = (
+  rowLocationId: number | null,
+  fields: Field[],
+  fieldIdsWithBeds: Set<number>,
+): Field[] =>
+  fields.filter((field) => {
+    if (field.id === undefined || !fieldIdsWithBeds.has(field.id)) {
+      return false;
+    }
+    return rowLocationId ? field.location === rowLocationId : true;
+  });
+
+export const filterBedOptionsBySelection = (
+  rowLocationId: number | null,
+  rowFieldId: number | null,
+  fields: Field[],
+  beds: Bed[],
+  fieldIdsWithBeds: Set<number>,
+): Bed[] =>
+  beds.filter((bed) => {
+    if (bed.id === undefined || !fieldIdsWithBeds.has(bed.field)) {
+      return false;
+    }
+    if (rowFieldId) {
+      return bed.field === rowFieldId;
+    }
+    if (rowLocationId) {
+      const linkedField = fields.find((field) => field.id === bed.field);
+      return linkedField?.location === rowLocationId;
+    }
+    return true;
+  });
 
 const buildBedDisplayLabel = (
   bedName: string | null | undefined,
@@ -506,32 +541,53 @@ function PlantingPlans(): React.ReactElement {
 
   const getFieldOptionsForRow = (row: PlantingPlanRow): SearchableSelectOption[] => {
     const rowLocationId = resolveLocationIdForRow(row);
-    return fieldOptions.filter((option) => {
-      const linkedField = fieldById.get(option.value);
-      if (!linkedField) {
-        return false;
-      }
-      return rowLocationId ? linkedField.location === rowLocationId : true;
-    });
+    const filteredFields = filterFieldOptionsByLocation(
+      rowLocationId,
+      fields,
+      hierarchyAvailability.fieldIdsWithBeds,
+    );
+    const allowedFieldIds = new Set(
+      filteredFields
+        .filter((field) => field.id !== undefined)
+        .map((field) => field.id!),
+    );
+    return fieldOptions.filter((option) => allowedFieldIds.has(option.value));
   };
 
   const getBedOptionsForRow = (row: PlantingPlanRow): SearchableSelectOption[] => {
     const rowLocationId = resolveLocationIdForRow(row);
     const rowFieldId = resolveFieldIdForRow(row);
-    return bedOptions.filter((option) => {
-      const linkedBed = bedById.get(option.value);
-      if (!linkedBed) {
-        return false;
-      }
-      if (rowFieldId) {
-        return linkedBed.field === rowFieldId;
-      }
-      if (rowLocationId) {
-        const linkedField = fieldById.get(linkedBed.field);
-        return linkedField?.location === rowLocationId;
-      }
-      return true;
-    });
+    const filteredBeds = filterBedOptionsBySelection(
+      rowLocationId,
+      rowFieldId,
+      fields,
+      beds,
+      hierarchyAvailability.fieldIdsWithBeds,
+    );
+    const allowedBedIds = new Set(
+      filteredBeds
+        .filter((bed) => bed.id !== undefined)
+        .map((bed) => bed.id!),
+    );
+    return bedOptions.filter((option) => allowedBedIds.has(option.value));
+  };
+
+  const getDraftRowForEditCell = (
+    params: GridRenderEditCellParams<PlantingPlanRow>,
+  ): PlantingPlanRow => {
+    const apiWithDraft = params.api as unknown as {
+      getRowWithUpdatedValues?: (id: number | string, field: string) => PlantingPlanRow;
+      getRow?: (id: number | string) => PlantingPlanRow;
+    };
+    const draftRow = apiWithDraft.getRowWithUpdatedValues?.(
+      params.id,
+      String(params.field),
+    );
+    if (draftRow) {
+      return draftRow;
+    }
+    const persistedRow = apiWithDraft.getRow?.(params.id);
+    return persistedRow ?? (params.row as PlantingPlanRow);
   };
 
   const getCultivationTypeOptionsForRow = useMemo(
@@ -860,6 +916,34 @@ function PlantingPlans(): React.ReactElement {
               const row = params.row as PlantingPlanRow | undefined;
               return row ? locationOptions : [];
             },
+            renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
+              const draftRow = getDraftRowForEditCell(params);
+              return (
+                <SearchableSelectEditCell
+                  {...params}
+                  options={locationOptions}
+                  onValueChange={async (nextValue) => {
+                    const nextLocationId = typeof nextValue === "number" ? nextValue : 0;
+                    const normalized = normalizeSelectionAfterLocationChange(
+                      draftRow,
+                      nextLocationId,
+                      fields,
+                      beds,
+                    );
+                    await params.api.setEditCellValue({
+                      id: params.id,
+                      field: "field_id",
+                      value: normalized.field_id ?? null,
+                    });
+                    await params.api.setEditCellValue({
+                      id: params.id,
+                      field: "bed",
+                      value: normalized.bed ?? 0,
+                    });
+                  }}
+                />
+              );
+            },
             valueGetter: (_value: unknown, row: PlantingPlanRow) => resolveLocationIdForRow(row),
             valueSetter: (value: unknown, row: PlantingPlanRow) => {
               const nextRow = row as PlantingPlanRow;
@@ -890,6 +974,35 @@ function PlantingPlans(): React.ReactElement {
           const row = params.row as PlantingPlanRow | undefined;
           return row ? getFieldOptionsForRow(row) : fieldOptions;
         },
+        renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
+          const draftRow = getDraftRowForEditCell(params);
+          const options = getFieldOptionsForRow(draftRow);
+          return (
+            <SearchableSelectEditCell
+              {...params}
+              options={options}
+              onValueChange={async (nextValue) => {
+                const nextFieldId = typeof nextValue === "number" ? nextValue : 0;
+                const normalized = normalizeSelectionAfterFieldChange(
+                  draftRow,
+                  nextFieldId,
+                  fields,
+                  beds,
+                );
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: "location_id",
+                  value: normalized.location_id ?? null,
+                });
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: "bed",
+                  value: normalized.bed ?? 0,
+                });
+              }}
+            />
+          );
+        },
         valueGetter: (_value: unknown, row: PlantingPlanRow) => resolveFieldIdForRow(row),
         valueSetter: (value: unknown, row: PlantingPlanRow) => {
           const nextRow = row as PlantingPlanRow;
@@ -914,6 +1027,35 @@ function PlantingPlans(): React.ReactElement {
         valueOptions: (params: GridValueOptionsParams<PlantingPlanRow>) => {
           const row = params.row as PlantingPlanRow | undefined;
           return row ? getBedOptionsForRow(row) : bedOptions;
+        },
+        renderEditCell: (params: GridRenderEditCellParams<PlantingPlanRow>) => {
+          const draftRow = getDraftRowForEditCell(params);
+          const options = getBedOptionsForRow(draftRow);
+          return (
+            <SearchableSelectEditCell
+              {...params}
+              options={options}
+              onValueChange={async (nextValue) => {
+                const nextBedId = typeof nextValue === "number" ? nextValue : 0;
+                const normalized = normalizeSelectionAfterBedChange(
+                  draftRow,
+                  nextBedId,
+                  fields,
+                  beds,
+                );
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: "location_id",
+                  value: normalized.location_id ?? null,
+                });
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: "field_id",
+                  value: normalized.field_id ?? null,
+                });
+              }}
+            />
+          );
         },
         renderCell: (params: GridRenderCellParams<PlantingPlanRow>) => {
           const row = params.row as PlantingPlanRow;
@@ -1484,7 +1626,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="xwide">
+    <PageContainer variant="full">
       <PageHeader
         title={t("plantingPlans:title")}
         actions={(

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -12,6 +12,7 @@ import { useSearchParams } from "react-router-dom";
 import type {
   GridCellParams,
   GridColDef,
+  GridRenderCellParams,
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
@@ -44,9 +45,13 @@ import {
   plantingPlanAPI,
   cultureAPI,
   bedAPI,
+  fieldAPI,
+  locationAPI,
   type PlantingPlan,
   type Culture,
   type Bed,
+  type Field,
+  type Location,
 } from "../api/api";
 import type { CultivationType } from "../api/types";
 import { extractApiErrorMessage } from "../api/errors";
@@ -55,7 +60,6 @@ import {
   parseLocalizedNumber,
   resolveLocaleFromLanguage,
 } from "../utils/numberLocalization";
-import { UI_LABEL_SEPARATOR } from "../utils/uiLabelSeparator";
 import { AreaM2EditCell } from "../components/data-grid/AreaM2EditCell";
 import {
   EditableDataGrid,
@@ -83,6 +87,8 @@ import { useProjectRequirement } from "../hooks/useProjectRequirement";
 interface PlantingPlanRow extends PlantingPlan, EditableRow {
   id: number;
   isNew?: boolean;
+  location_id?: number;
+  field_id?: number;
   area_m2?: number;
   plants_count?: number | null; // UI-only derived field
   note_attachment_count?: number;
@@ -110,7 +116,7 @@ const CULTIVATION_TYPE_OPTIONS = [
 ] as const;
 
 const CULTURE_COLUMN_MAX_WIDTH = 280;
-const BED_COLUMN_MAX_WIDTH = 320;
+const BED_COLUMN_MAX_WIDTH = 220;
 
 const estimateColumnWidth = (
   values: string[],
@@ -155,27 +161,106 @@ const toNumericValue = (value: unknown): number | null => {
   return null;
 };
 
+interface HierarchySelectionRow {
+  location_id?: number;
+  field_id?: number;
+  bed?: number;
+}
+
+export const normalizeSelectionAfterLocationChange = (
+  row: HierarchySelectionRow,
+  nextLocationId: number,
+  fields: Field[],
+  beds: Bed[],
+): HierarchySelectionRow => {
+  const selectedField =
+    typeof row.field_id === "number"
+      ? fields.find((field) => field.id === row.field_id)
+      : undefined;
+  const nextFieldId =
+    selectedField && selectedField.location === nextLocationId
+      ? selectedField.id
+      : undefined;
+
+  const selectedBed =
+    typeof row.bed === "number"
+      ? beds.find((bed) => bed.id === row.bed)
+      : undefined;
+  const selectedBedField =
+    selectedBed && typeof selectedBed.field === "number"
+      ? fields.find((field) => field.id === selectedBed.field)
+      : undefined;
+  const nextBedId =
+    selectedBed &&
+    selectedBedField &&
+    selectedBedField.location === nextLocationId &&
+    (!nextFieldId || selectedBed.field === nextFieldId)
+      ? selectedBed.id
+      : 0;
+
+  return {
+    ...row,
+    location_id: nextLocationId,
+    field_id: nextFieldId,
+    bed: nextBedId,
+  };
+};
+
+export const normalizeSelectionAfterFieldChange = (
+  row: HierarchySelectionRow,
+  nextFieldId: number,
+  fields: Field[],
+  beds: Bed[],
+): HierarchySelectionRow => {
+  const selectedField = fields.find((field) => field.id === nextFieldId);
+  const selectedBed =
+    typeof row.bed === "number"
+      ? beds.find((bed) => bed.id === row.bed)
+      : undefined;
+  const nextBedId =
+    selectedBed && selectedBed.field === nextFieldId ? selectedBed.id : 0;
+
+  return {
+    ...row,
+    location_id: selectedField?.location ?? row.location_id,
+    field_id: nextFieldId,
+    bed: nextBedId,
+  };
+};
+
+export const normalizeSelectionAfterBedChange = (
+  row: HierarchySelectionRow,
+  nextBedId: number,
+  fields: Field[],
+  beds: Bed[],
+): HierarchySelectionRow => {
+  const selectedBed = beds.find((bed) => bed.id === nextBedId);
+  const selectedField = selectedBed
+    ? fields.find((field) => field.id === selectedBed.field)
+    : undefined;
+  return {
+    ...row,
+    location_id: selectedField?.location ?? row.location_id,
+    field_id: selectedBed?.field ?? row.field_id,
+    bed: nextBedId,
+  };
+};
+
 const buildBedDisplayLabel = (
   bedName: string | null | undefined,
-  fieldName: string | null | undefined,
   areaSqm: number | null,
   locale: string,
 ): string => {
   const normalizedBedName = (bedName ?? "").trim();
-  const normalizedFieldName = (fieldName ?? "").trim();
-  const combinedName = [normalizedFieldName, normalizedBedName]
-    .filter((part) => part.length > 0)
-    .join(UI_LABEL_SEPARATOR);
-
-  if (!combinedName) {
+  if (!normalizedBedName) {
     return "—";
   }
 
   if (areaSqm === null) {
-    return combinedName;
+    return normalizedBedName;
   }
 
-  return `${combinedName} (${formatAreaM2(areaSqm, locale)})`;
+  return `${normalizedBedName} (${formatAreaM2(areaSqm, locale)})`;
 };
 
 const createEmptyMobileCreateForm = (): MobileCreateFormState => ({
@@ -229,6 +314,8 @@ function PlantingPlans(): React.ReactElement {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [searchParams, setSearchParams] = useSearchParams();
   const [cultures, setCultures] = useState<Culture[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [fields, setFields] = useState<Field[]>([]);
   const [beds, setBeds] = useState<Bed[]>([]);
   const [areaWarning, setAreaWarning] = useState<string>("");
   const urlParamProcessedRef = useRef<boolean>(false);
@@ -282,6 +369,45 @@ function PlantingPlans(): React.ReactElement {
     [cultures],
   );
 
+  const hasMultipleLocations = locations.length > 1;
+
+  const locationById = useMemo(
+    () => new Map(locations.filter((location) => location.id !== undefined).map((location) => [location.id!, location])),
+    [locations],
+  );
+
+  const fieldById = useMemo(
+    () => new Map(fields.filter((field) => field.id !== undefined).map((field) => [field.id!, field])),
+    [fields],
+  );
+
+  const bedById = useMemo(
+    () => new Map(beds.filter((bed) => bed.id !== undefined).map((bed) => [bed.id!, bed])),
+    [beds],
+  );
+
+  const locationOptions: SearchableSelectOption[] = useMemo(
+    () =>
+      locations
+        .filter((location) => location.id !== undefined)
+        .map((location) => ({
+          value: location.id!,
+          label: location.name,
+        })),
+    [locations],
+  );
+
+  const fieldOptions: SearchableSelectOption[] = useMemo(
+    () =>
+      fields
+        .filter((field) => field.id !== undefined)
+        .map((field) => ({
+          value: field.id!,
+          label: field.name,
+        })),
+    [fields],
+  );
+
   const bedOptions: SearchableSelectOption[] = useMemo(
     () =>
       beds
@@ -292,7 +418,6 @@ function PlantingPlans(): React.ReactElement {
             value: b.id!,
             label: buildBedDisplayLabel(
               b.name,
-              b.field_name,
               normalizedAreaSqm,
               numberLocale,
             ),
@@ -300,6 +425,15 @@ function PlantingPlans(): React.ReactElement {
         }),
     [beds, numberLocale],
   );
+
+  const bedNameUsageCount = useMemo(() => {
+    const counts = new Map<string, number>();
+    beds.forEach((bed) => {
+      const key = bed.name.trim().toLocaleLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    });
+    return counts;
+  }, [beds]);
 
   const cultivationTypeOptions = useMemo(
     () =>
@@ -310,10 +444,70 @@ function PlantingPlans(): React.ReactElement {
     [t],
   );
 
-  const fieldBedColumnLabel = useMemo(
-    () => t("plantingPlans:columns.fieldBed", { separator: UI_LABEL_SEPARATOR }),
-    [t],
-  );
+  const resolveLocationIdForRow = (row: PlantingPlanRow): number | null => {
+    if (typeof row.location_id === "number" && locationById.has(row.location_id)) {
+      return row.location_id;
+    }
+    if (typeof row.field_id === "number") {
+      const linkedField = fieldById.get(row.field_id);
+      if (linkedField?.location) {
+        return linkedField.location;
+      }
+    }
+    if (typeof row.bed === "number") {
+      const linkedBed = bedById.get(row.bed);
+      if (linkedBed) {
+        const linkedField = fieldById.get(linkedBed.field);
+        if (linkedField?.location) {
+          return linkedField.location;
+        }
+      }
+    }
+    return locations[0]?.id ?? null;
+  };
+
+  const resolveFieldIdForRow = (row: PlantingPlanRow): number | null => {
+    if (typeof row.field_id === "number" && fieldById.has(row.field_id)) {
+      return row.field_id;
+    }
+    if (typeof row.bed === "number") {
+      const linkedBed = bedById.get(row.bed);
+      if (linkedBed && fieldById.has(linkedBed.field)) {
+        return linkedBed.field;
+      }
+    }
+    return null;
+  };
+
+  const getFieldOptionsForRow = (row: PlantingPlanRow): SearchableSelectOption[] => {
+    const rowLocationId = resolveLocationIdForRow(row);
+    return fieldOptions.filter((option) => {
+      const linkedField = fieldById.get(option.value);
+      if (!linkedField) {
+        return false;
+      }
+      return rowLocationId ? linkedField.location === rowLocationId : true;
+    });
+  };
+
+  const getBedOptionsForRow = (row: PlantingPlanRow): SearchableSelectOption[] => {
+    const rowLocationId = resolveLocationIdForRow(row);
+    const rowFieldId = resolveFieldIdForRow(row);
+    return bedOptions.filter((option) => {
+      const linkedBed = bedById.get(option.value);
+      if (!linkedBed) {
+        return false;
+      }
+      if (rowFieldId) {
+        return linkedBed.field === rowFieldId;
+      }
+      if (rowLocationId) {
+        const linkedField = fieldById.get(linkedBed.field);
+        return linkedField?.location === rowLocationId;
+      }
+      return true;
+    });
+  };
 
   const getCultivationTypeOptionsForRow = useMemo(
     () => (row: PlantingPlanRow) => {
@@ -338,15 +532,25 @@ function PlantingPlans(): React.ReactElement {
     );
     const bedWidth = estimateColumnWidth(
       [
-        fieldBedColumnLabel,
+        t("plantingPlans:columns.bed"),
         ...bedOptions.map((option) => option.label),
       ],
-      260,
+      180,
       BED_COLUMN_MAX_WIDTH,
     );
 
     return {
       culture: cultureWidth,
+      location: estimateColumnWidth(
+        [t("plantingPlans:columns.location"), ...locationOptions.map((option) => option.label)],
+        140,
+        210,
+      ),
+      field: estimateColumnWidth(
+        [t("plantingPlans:columns.field"), ...fieldOptions.map((option) => option.label)],
+        140,
+        210,
+      ),
       bed: bedWidth,
       cultivationType: estimateColumnWidth(
         [
@@ -388,7 +592,7 @@ function PlantingPlans(): React.ReactElement {
       ),
       notes: 260,
     };
-  }, [bedOptions, beds, cultivationTypeOptions, cultureOptions, fieldBedColumnLabel, numberLocale, t]);
+  }, [bedOptions, beds, cultivationTypeOptions, cultureOptions, fieldOptions, locationOptions, numberLocale, t]);
 
   /**
    * Check for cultureId or bedId parameter in URL and set as initial values
@@ -447,16 +651,22 @@ function PlantingPlans(): React.ReactElement {
   useEffect(() => {
     if (shouldShowProjectRequiredState) {
       setCultures([]);
+      setLocations([]);
+      setFields([]);
       setBeds([]);
       return;
     }
     const fetchData = async (): Promise<void> => {
       try {
-        const [culturesResponse, bedsResponse] = await Promise.all([
+        const [culturesResponse, locationsResponse, fieldsResponse, bedsResponse] = await Promise.all([
           cultureAPI.list(),
+          locationAPI.list(),
+          fieldAPI.list(),
           bedAPI.list(),
         ]);
         setCultures(culturesResponse.data.results);
+        setLocations(locationsResponse.data.results);
+        setFields(fieldsResponse.data.results);
         setBeds(
           bedsResponse.data.results.map((bed) => ({
             ...bed,
@@ -464,7 +674,7 @@ function PlantingPlans(): React.ReactElement {
           })),
         );
       } catch (err) {
-        console.error("Error fetching cultures and beds:", err);
+        console.error("Error fetching hierarchy data:", err);
       }
     };
     fetchData();
@@ -610,29 +820,123 @@ function PlantingPlans(): React.ReactElement {
           error: !params.props.value,
         }),
       },
+      ...(hasMultipleLocations
+        ? [{
+            ...createSingleSelectColumn<PlantingPlanRow>({
+              field: "location_id",
+              headerName: t("plantingPlans:columns.location"),
+              flex: 0,
+              minWidth: dynamicWidths.location,
+              maxWidth: dynamicWidths.location,
+              truncateCellText: true,
+              options: locationOptions,
+            }),
+            valueOptions: (params: GridValueOptionsParams<PlantingPlanRow>) => {
+              const row = params.row as PlantingPlanRow | undefined;
+              return row ? locationOptions : [];
+            },
+            valueGetter: (_value: unknown, row: PlantingPlanRow) => resolveLocationIdForRow(row),
+            valueSetter: (value: unknown, row: PlantingPlanRow) => {
+              const nextRow = row as PlantingPlanRow;
+              const nextLocationId = typeof value === "number" ? value : Number(value);
+              return {
+                ...nextRow,
+                ...normalizeSelectionAfterLocationChange(
+                  nextRow,
+                  nextLocationId,
+                  fields,
+                  beds,
+                ),
+              } as PlantingPlanRow;
+            },
+          }]
+        : []),
+      {
+        ...createSingleSelectColumn<PlantingPlanRow>({
+          field: "field_id",
+          headerName: t("plantingPlans:columns.field"),
+          flex: 0,
+          minWidth: dynamicWidths.field,
+          maxWidth: dynamicWidths.field,
+          truncateCellText: true,
+          options: fieldOptions,
+        }),
+        valueOptions: (params: GridValueOptionsParams<PlantingPlanRow>) => {
+          const row = params.row as PlantingPlanRow | undefined;
+          return row ? getFieldOptionsForRow(row) : fieldOptions;
+        },
+        valueGetter: (_value: unknown, row: PlantingPlanRow) => resolveFieldIdForRow(row),
+        valueSetter: (value: unknown, row: PlantingPlanRow) => {
+          const nextRow = row as PlantingPlanRow;
+          const nextFieldId = typeof value === "number" ? value : Number(value);
+
+          return {
+            ...nextRow,
+            ...normalizeSelectionAfterFieldChange(nextRow, nextFieldId, fields, beds),
+          } as PlantingPlanRow;
+        },
+      },
       {
         ...createSingleSelectColumn<PlantingPlanRow>({
           field: "bed",
-          headerName: fieldBedColumnLabel,
+          headerName: t("plantingPlans:columns.bed"),
           flex: 0,
           minWidth: dynamicWidths.bed,
           maxWidth: BED_COLUMN_MAX_WIDTH,
           truncateCellText: true,
           options: bedOptions,
         }),
+        valueOptions: (params: GridValueOptionsParams<PlantingPlanRow>) => {
+          const row = params.row as PlantingPlanRow | undefined;
+          return row ? getBedOptionsForRow(row) : bedOptions;
+        },
+        renderCell: (params: GridRenderCellParams<PlantingPlanRow>) => {
+          const row = params.row as PlantingPlanRow;
+          const bedId = typeof row.bed === "number" ? row.bed : Number(row.bed);
+          const selectedBed = bedById.get(bedId);
+          const text = String(params.formattedValue ?? "");
+          const hasNameConflict = selectedBed
+            ? (bedNameUsageCount.get(selectedBed.name.trim().toLocaleLowerCase()) ?? 0) > 1
+            : false;
+
+          if (!hasNameConflict || !selectedBed) {
+            return text;
+          }
+
+          const selectedField = fieldById.get(selectedBed.field);
+          const selectedLocation = selectedField ? locationById.get(selectedField.location) : undefined;
+          const tooltipText = [selectedLocation?.name, selectedField?.name, selectedBed.name]
+            .filter((part): part is string => Boolean(part))
+            .join(" / ");
+
+          return (
+            <Tooltip title={tooltipText}>
+              <Box
+                component="span"
+                sx={{
+                  display: "block",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  width: "100%",
+                }}
+              >
+                {text}
+              </Box>
+            </Tooltip>
+          );
+        },
         valueSetter: (value, row) => {
           const nextRow = row as PlantingPlanRow;
-          const numericValue =
-            typeof value === "number" ? value : Number(value);
-          const selectedBed = beds.find((bed) => bed.id === numericValue);
+          const numericValue = typeof value === "number" ? value : Number(value);
+          const selectedBed = bedById.get(numericValue);
           const isNewRow = Boolean(nextRow.isNew);
           const currentArea = nextRow.area_m2;
-          const shouldAutofill =
-            isNewRow && (currentArea === undefined || currentArea === null);
+          const shouldAutofill = isNewRow && (currentArea === undefined || currentArea === null);
 
           return {
             ...nextRow,
-            bed: numericValue,
+            ...normalizeSelectionAfterBedChange(nextRow, numericValue, fields, beds),
             area_m2:
               shouldAutofill && selectedBed?.area_sqm !== undefined
                 ? selectedBed.area_sqm
@@ -812,6 +1116,8 @@ function PlantingPlans(): React.ReactElement {
       },
     ],
     [
+      bedById,
+      bedNameUsageCount,
       bedOptions,
       beds,
       cultivationTypeOptions,
@@ -819,7 +1125,15 @@ function PlantingPlans(): React.ReactElement {
       cultureOptions,
       cultures,
       dynamicWidths,
-      fieldBedColumnLabel,
+      fieldById,
+      fieldOptions,
+      getBedOptionsForRow,
+      getFieldOptionsForRow,
+      hasMultipleLocations,
+      locationById,
+      locationOptions,
+      resolveFieldIdForRow,
+      resolveLocationIdForRow,
       areaWarning,
       t,
     ],
@@ -853,13 +1167,12 @@ function PlantingPlans(): React.ReactElement {
     if (linkedBed) {
       return buildBedDisplayLabel(
         linkedBed.name,
-        linkedBed.field_name,
         toNumericValue(linkedBed.area_sqm),
         numberLocale,
       );
     }
     if (row.bed_name) {
-      return buildBedDisplayLabel(row.bed_name, null, null, numberLocale);
+      return buildBedDisplayLabel(row.bed_name, null, numberLocale);
     }
     const fallback = bedOptions.find((option) => option.value === row.bed);
     return fallback?.label ?? "—";
@@ -1238,6 +1551,8 @@ function PlantingPlans(): React.ReactElement {
             id: -Date.now(),
             culture: 0,
             cultivation_type: "pre_cultivation",
+            location_id: locations[0]?.id,
+            field_id: undefined,
             bed: 0,
             planting_date: "",
             quantity: undefined,
@@ -1262,6 +1577,8 @@ function PlantingPlans(): React.ReactElement {
           }
           mapToRow={(plan) => {
             const areaFromApi = toNumericValue(plan.area_usage_sqm);
+            const linkedBed = plan.bed ? bedById.get(plan.bed) : undefined;
+            const linkedField = linkedBed ? fieldById.get(linkedBed.field) : undefined;
             return {
               ...plan,
               id: plan.id!,
@@ -1270,6 +1587,8 @@ function PlantingPlans(): React.ReactElement {
               culture_name: plan.culture_name || "",
               bed: plan.bed,
               bed_name: plan.bed_name || "",
+              field_id: linkedBed?.field,
+              location_id: linkedField?.location,
               planting_date: plan.planting_date,
               harvest_date: plan.harvest_date,
               harvest_end_date: plan.harvest_end_date,

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1322,8 +1322,9 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "notes",
         headerName: t("common:fields.notes"),
-        flex: 1,
+        width: 220,
         minWidth: dynamicWidths.notes,
+        maxWidth: 260,
         // Notes field will be overridden by NotesCell in EditableDataGrid
       },
     ],
@@ -1660,7 +1661,7 @@ function PlantingPlans(): React.ReactElement {
   };
 
   return (
-    <PageContainer variant="full">
+    <PageContainer variant="xwide">
       <PageHeader
         title={t("plantingPlans:title")}
         actions={(
@@ -1751,7 +1752,13 @@ function PlantingPlans(): React.ReactElement {
           </Box>
         ) : null}
 
-        <Box sx={{ display: isMobile ? "none" : "block" }}>
+        <Box
+          sx={{
+            display: isMobile ? "none" : "block",
+            width: "100%",
+            maxWidth: "1520px",
+          }}
+        >
           <EditableDataGrid<PlantingPlanRow>
             columns={columns}
             api={plantingPlanAPI as unknown as DataGridAPI<PlantingPlanRow>}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -246,6 +246,32 @@ export const normalizeSelectionAfterBedChange = (
   };
 };
 
+interface HierarchyAvailability {
+  fieldIdsWithBeds: Set<number>;
+  locationIdsWithBeds: Set<number>;
+}
+
+export const collectHierarchyAvailability = (
+  fields: Field[],
+  beds: Bed[],
+): HierarchyAvailability => {
+  const fieldIdsWithBeds = new Set<number>();
+  beds.forEach((bed) => {
+    if (typeof bed.field === "number") {
+      fieldIdsWithBeds.add(bed.field);
+    }
+  });
+
+  const locationIdsWithBeds = new Set<number>();
+  fields.forEach((field) => {
+    if (field.id !== undefined && fieldIdsWithBeds.has(field.id)) {
+      locationIdsWithBeds.add(field.location);
+    }
+  });
+
+  return { fieldIdsWithBeds, locationIdsWithBeds };
+};
+
 const buildBedDisplayLabel = (
   bedName: string | null | undefined,
   areaSqm: number | null,
@@ -386,32 +412,40 @@ function PlantingPlans(): React.ReactElement {
     [beds],
   );
 
+  const hierarchyAvailability = useMemo(
+    () => collectHierarchyAvailability(fields, beds),
+    [fields, beds],
+  );
+
   const locationOptions: SearchableSelectOption[] = useMemo(
     () =>
       locations
         .filter((location) => location.id !== undefined)
+        .filter((location) => hierarchyAvailability.locationIdsWithBeds.has(location.id!))
         .map((location) => ({
           value: location.id!,
           label: location.name,
         })),
-    [locations],
+    [hierarchyAvailability.locationIdsWithBeds, locations],
   );
 
   const fieldOptions: SearchableSelectOption[] = useMemo(
     () =>
       fields
         .filter((field) => field.id !== undefined)
+        .filter((field) => hierarchyAvailability.fieldIdsWithBeds.has(field.id!))
         .map((field) => ({
           value: field.id!,
           label: field.name,
         })),
-    [fields],
+    [fields, hierarchyAvailability.fieldIdsWithBeds],
   );
 
   const bedOptions: SearchableSelectOption[] = useMemo(
     () =>
       beds
         .filter((b) => b.id !== undefined)
+        .filter((bed) => hierarchyAvailability.fieldIdsWithBeds.has(bed.field))
         .map((b) => {
           const normalizedAreaSqm = toNumericValue(b.area_sqm);
           return {
@@ -423,17 +457,8 @@ function PlantingPlans(): React.ReactElement {
             ),
           };
         }),
-    [beds, numberLocale],
+    [beds, hierarchyAvailability.fieldIdsWithBeds, numberLocale],
   );
-
-  const bedNameUsageCount = useMemo(() => {
-    const counts = new Map<string, number>();
-    beds.forEach((bed) => {
-      const key = bed.name.trim().toLocaleLowerCase();
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    });
-    return counts;
-  }, [beds]);
 
   const cultivationTypeOptions = useMemo(
     () =>
@@ -463,7 +488,7 @@ function PlantingPlans(): React.ReactElement {
         }
       }
     }
-    return locations[0]?.id ?? null;
+    return locationOptions[0]?.value ?? null;
   };
 
   const resolveFieldIdForRow = (row: PlantingPlanRow): number | null => {
@@ -527,29 +552,29 @@ function PlantingPlans(): React.ReactElement {
         t("plantingPlans:columns.culture"),
         ...cultureOptions.map((option) => option.label),
       ],
-      200,
-      CULTURE_COLUMN_MAX_WIDTH,
+      170,
+      240,
     );
     const bedWidth = estimateColumnWidth(
       [
         t("plantingPlans:columns.bed"),
         ...bedOptions.map((option) => option.label),
       ],
-      180,
-      BED_COLUMN_MAX_WIDTH,
+      145,
+      210,
     );
 
     return {
       culture: cultureWidth,
       location: estimateColumnWidth(
         [t("plantingPlans:columns.location"), ...locationOptions.map((option) => option.label)],
-        140,
-        210,
+        110,
+        165,
       ),
       field: estimateColumnWidth(
         [t("plantingPlans:columns.field"), ...fieldOptions.map((option) => option.label)],
-        140,
-        210,
+        115,
+        175,
       ),
       bed: bedWidth,
       cultivationType: estimateColumnWidth(
@@ -557,23 +582,23 @@ function PlantingPlans(): React.ReactElement {
           t("plantingPlans:columns.cultivationType"),
           ...cultivationTypeOptions.map((option) => option.label),
         ],
-        140,
-        190,
+        110,
+        150,
       ),
       plantingDate: estimateColumnWidth(
         [t("plantingPlans:columns.plantingDate"), "2026-12-31"],
-        140,
-        180,
+        110,
+        130,
       ),
       harvestDate: estimateColumnWidth(
         [t("plantingPlans:columns.harvestStartDate"), "2026-12-31"],
-        145,
-        190,
+        112,
+        135,
       ),
       harvestEndDate: estimateColumnWidth(
         [t("plantingPlans:columns.harvestEndDate"), "2026-12-31"],
-        145,
-        190,
+        112,
+        135,
       ),
       area: estimateColumnWidth(
         [
@@ -582,15 +607,15 @@ function PlantingPlans(): React.ReactElement {
             .filter((bed) => typeof bed.area_sqm === "number")
             .map((bed) => formatAreaM2(bed.area_sqm as number, numberLocale)),
         ],
-        112,
-        150,
+        95,
+        120,
       ),
       plants: estimateColumnWidth(
         [t("plantingPlans:columns.plantsCount"), "≈ 9999"],
-        120,
-        150,
+        96,
+        122,
       ),
-      notes: 260,
+      notes: 180,
     };
   }, [bedOptions, beds, cultivationTypeOptions, cultureOptions, fieldOptions, locationOptions, numberLocale, t]);
 
@@ -895,8 +920,18 @@ function PlantingPlans(): React.ReactElement {
           const bedId = typeof row.bed === "number" ? row.bed : Number(row.bed);
           const selectedBed = bedById.get(bedId);
           const text = String(params.formattedValue ?? "");
+          const scopedOptions = getBedOptionsForRow(row);
+          const scopedNameCount = scopedOptions.reduce((accumulator, option) => {
+            const scopedBed = bedById.get(option.value);
+            if (!scopedBed) {
+              return accumulator;
+            }
+            const normalizedName = scopedBed.name.trim().toLocaleLowerCase();
+            accumulator.set(normalizedName, (accumulator.get(normalizedName) ?? 0) + 1);
+            return accumulator;
+          }, new Map<string, number>());
           const hasNameConflict = selectedBed
-            ? (bedNameUsageCount.get(selectedBed.name.trim().toLocaleLowerCase()) ?? 0) > 1
+            ? (scopedNameCount.get(selectedBed.name.trim().toLocaleLowerCase()) ?? 0) > 1
             : false;
 
           if (!hasNameConflict || !selectedBed) {
@@ -1111,13 +1146,13 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "notes",
         headerName: t("common:fields.notes"),
-        width: dynamicWidths.notes,
+        flex: 1,
+        minWidth: dynamicWidths.notes,
         // Notes field will be overridden by NotesCell in EditableDataGrid
       },
     ],
     [
       bedById,
-      bedNameUsageCount,
       bedOptions,
       beds,
       cultivationTypeOptions,
@@ -1551,7 +1586,7 @@ function PlantingPlans(): React.ReactElement {
             id: -Date.now(),
             culture: 0,
             cultivation_type: "pre_cultivation",
-            location_id: locations[0]?.id,
+            location_id: locationOptions[0]?.value,
             field_id: undefined,
             bed: 0,
             planting_date: "",


### PR DESCRIPTION
### Motivation
- Replace the previous combined “Parzelle → Beet” column with separate selectors for `Standort` (location), `Parzelle` (field) and `Beet` to improve selection clarity and enable cascading filtering by hierarchical IDs. 
- Keep table width compact and show bed area only next to the bed (e.g. `Beetname (x,xx m²)`), while preserving existing data loading and API contracts that rely on bed IDs.

### Description
- Added fetching of `locations` and `fields` alongside `beds` and indexed them (`locationById`, `fieldById`, `bedById`) to drive filtered options and lookups. 
- Introduced new row properties `location_id` and `field_id`, and added three DataGrid columns: `location_id` (shown only when project has multiple locations), `field_id`, and `bed` (keeps sending bed ID to API). 
- Implemented canonical normalization helpers `normalizeSelectionAfterLocationChange`, `normalizeSelectionAfterFieldChange`, and `normalizeSelectionAfterBedChange` which ensure cascading behavior and reset invalid selections; these are used in column `valueSetter`s so selections stay aligned and internal state always uses IDs. 
- Kept bed labels compact using `Beetname (x,xx m²)` and added conditional tooltip disambiguation only when duplicate bed names exist (tooltip shows `Standort / Parzelle / Beet`). 
- Mapped existing planting plans to derived `field_id`/`location_id` in `mapToRow` so older plans still load correctly; `mapToApiData` still uses `bed` and area input fields so persistence/validation unchanged. 
- Added German i18n keys for new column headers (`plantingPlans.columns.location` and `.field`). 
- Added unit tests `src/__tests__/plantingPlans.hierarchy.test.ts` covering normalization rules (location/field/bed sync and resets).

### Testing
- Ran unit tests with `npm run test -- src/__tests__/plantingPlans.hierarchy.test.ts src/__tests__/plantingPlans.mobile.test.ts` and observed all tests passed (hierarchy tests + existing mobile helpers passed). 
- Ran `npm run test -- src/__tests__/plantingPlans.mobile.test.ts src/__tests__/PlantingPlans.projectRequired.test.tsx` earlier and those tests passed. 
- Built the frontend with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed97d37c248322bfb5eed0009ec2f8)