### PR TITLE
fix(frontend): stabilize planting area editing with assignment dialog

### DIFF
--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -210,4 +210,44 @@ describe('AreaAssignmentDialog', () => {
 
     expect(onApply).toHaveBeenCalledWith(101);
   });
+
+  it('supports reverse tab order with Shift+Tab', async () => {
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Übernehmen' })).toHaveFocus();
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('button', { name: 'Abbrechen' })).toHaveFocus();
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveFocus();
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveFocus();
+  });
+
+  it('keeps tab navigation working after confirming a dropdown option with Enter', async () => {
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    const locationSelect = screen.getByRole('combobox', { name: 'Standort' });
+    await user.click(locationSelect);
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+  });
 });

--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -163,4 +163,51 @@ describe('AreaAssignmentDialog', () => {
     expect(screen.queryByRole('combobox', { name: 'Standort' })).not.toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Parzelle' })).toBeInTheDocument();
   });
+
+  it('does not apply the dialog when Enter is used inside an opened dropdown', async () => {
+    const onApply = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={onApply} />,
+    );
+
+    await openDialog();
+    await user.click(screen.getByRole('combobox', { name: 'Standort' }));
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog', { name: 'Anbaufläche ändern' })).toBeInTheDocument();
+  });
+
+  it('follows logical tab order and supports Enter on action buttons', async () => {
+    const onApply = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={onApply} />,
+    );
+
+    await openDialog();
+    await user.tab();
+    expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Abbrechen' })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Anbaufläche ändern' })).not.toBeInTheDocument();
+    });
+
+    await openDialog();
+    const applyButton = screen.getByRole('button', { name: 'Übernehmen' });
+    for (let i = 0; i < 6 && document.activeElement !== applyButton; i += 1) {
+      await user.tab();
+    }
+    expect(applyButton).toHaveFocus();
+    await user.keyboard('{Enter}');
+
+    expect(onApply).toHaveBeenCalledWith(101);
+  });
 });

--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Bed, Field, Location } from '../api/types';
+import { AreaAssignmentDialog } from '../components/planting-plans/AreaAssignmentDialog';
+
+const locations: Location[] = [
+  { id: 1, name: 'Regenbogenland' },
+  { id: 2, name: 'Sonnengarten' },
+  { id: 3, name: 'Leerstandort' },
+];
+
+const fields: Field[] = [
+  { id: 11, name: '8 Karotte + Zwiebel', location: 1 },
+  { id: 12, name: '9 Pastinake', location: 1 },
+  { id: 21, name: '5 Tomate', location: 2 },
+  { id: 31, name: 'Ohne Beete', location: 3 },
+];
+
+const beds: Bed[] = [
+  { id: 101, name: '5', field: 11, field_name: '8 Karotte + Zwiebel', area_sqm: 10 },
+  { id: 102, name: '6', field: 12, field_name: '9 Pastinake', area_sqm: 8 },
+  { id: 201, name: '5', field: 21, field_name: '5 Tomate', area_sqm: 12.5 },
+];
+
+const openDialog = async (): Promise<void> => {
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText('Anbaufläche bearbeiten'));
+  expect(await screen.findByRole('dialog', { name: 'Anbaufläche ändern' })).toBeInTheDocument();
+};
+
+const openSelect = async (label: string): Promise<void> => {
+  const user = userEvent.setup();
+  const trigger = screen.getByRole('combobox', { name: label });
+  await user.click(trigger);
+};
+
+describe('AreaAssignmentDialog', () => {
+  it('opens with current location/field/bed selection', async () => {
+    render(
+      <AreaAssignmentDialog
+        bedId={101}
+        beds={beds}
+        fields={fields}
+        locations={locations}
+        locale="de-DE"
+        compactLabel="Regenbogenland · 8 Karotte + Zwiebel · 5 (10,00 m²)"
+        onApply={vi.fn()}
+      />,
+    );
+
+    await openDialog();
+
+    expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveTextContent('Regenbogenland');
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveTextContent('8 Karotte + Zwiebel');
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent('5 (10,00 m²)');
+  });
+
+  it('filters fields and beds when location changes', async () => {
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    await openSelect('Standort');
+    await userEvent.setup().click(screen.getByRole('option', { name: 'Sonnengarten' }));
+
+    await openSelect('Parzelle');
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByRole('option', { name: '5 Tomate' })).toBeInTheDocument();
+    expect(within(listbox).queryByRole('option', { name: 'Ohne Beete' })).not.toBeInTheDocument();
+  });
+
+  it('filters beds when field changes', async () => {
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    await openSelect('Parzelle');
+    await userEvent.setup().click(screen.getByRole('option', { name: '9 Pastinake' }));
+
+    await openSelect('Beet');
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByRole('option', { name: /9 Pastinake.*6 \(8,00 m²\)/ })).toBeInTheDocument();
+    expect(within(listbox).queryByRole('option', { name: /8 Karotte \+ Zwiebel.*5 \(10,00 m²\)/ })).not.toBeInTheDocument();
+  });
+
+  it('sets location and field automatically when bed changes', async () => {
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    await openSelect('Standort');
+    await userEvent.setup().click(screen.getByRole('option', { name: 'Sonnengarten' }));
+    await openSelect('Parzelle');
+    await userEvent.setup().click(screen.getByRole('option', { name: '5 Tomate' }));
+    await openSelect('Beet');
+    await userEvent.setup().click(screen.getByRole('option', { name: /5 Tomate.*12,50 m²/ }));
+
+    expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveTextContent('Sonnengarten');
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveTextContent('5 Tomate');
+  });
+
+  it('applies the changed bed selection', async () => {
+    const onApply = vi.fn();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={onApply} />,
+    );
+
+    await openDialog();
+    await openSelect('Parzelle');
+    await userEvent.setup().click(screen.getByRole('option', { name: '9 Pastinake' }));
+    await openSelect('Beet');
+    await userEvent.setup().click(screen.getByRole('option', { name: /9 Pastinake.*8,00 m²/ }));
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Übernehmen' }));
+
+    expect(onApply).toHaveBeenCalledWith(102);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Anbaufläche ändern' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('cancels dialog changes without applying', async () => {
+    const onApply = vi.fn();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" onApply={onApply} />,
+    );
+
+    await openDialog();
+    await openSelect('Parzelle');
+    await userEvent.setup().click(screen.getByRole('option', { name: '9 Pastinake' }));
+    await openSelect('Beet');
+    await userEvent.setup().click(screen.getByRole('option', { name: /9 Pastinake.*8,00 m²/ }));
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Abbrechen' }));
+
+    expect(onApply).not.toHaveBeenCalled();
+
+    await openDialog();
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent('5 (10,00 m²)');
+  });
+
+  it('hides location selector when only one selectable location exists', async () => {
+    const singleLocationFields: Field[] = [
+      { id: 11, name: '8 Karotte + Zwiebel', location: 1 },
+      { id: 12, name: '9 Pastinake', location: 1 },
+    ];
+
+    render(
+      <AreaAssignmentDialog
+        bedId={101}
+        beds={beds.filter((item) => item.id !== 201)}
+        fields={singleLocationFields}
+        locations={locations}
+        locale="de-DE"
+        compactLabel="x"
+        onApply={vi.fn()}
+      />,
+    );
+
+    await openDialog();
+    expect(screen.queryByRole('combobox', { name: 'Standort' })).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Parzelle' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/CompactAreaCell.test.tsx
+++ b/frontend/src/__tests__/CompactAreaCell.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CompactAreaCell, shouldShowAreaTooltip } from '../components/planting-plans/CompactAreaCell';
+
+describe('CompactAreaCell', () => {
+  it('shows tooltip with full text on hover for long values', async () => {
+    const user = userEvent.setup();
+    const label = 'Regenbogenland · 8 Karotte + Zwiebel · Beet 5 (10,00 m²)';
+
+    render(<CompactAreaCell label={label} />);
+
+    await user.hover(screen.getByText(label));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(label);
+  });
+
+  it('is keyboard focusable with full accessible text for long values', async () => {
+    const user = userEvent.setup();
+    const label = 'Regenbogenland · 8 Karotte + Zwiebel · Beet 5 (10,00 m²)';
+
+    render(<CompactAreaCell label={label} />);
+
+    await user.tab();
+
+    const focusTarget = screen.getByLabelText(label);
+    expect(focusTarget).toHaveFocus();
+  });
+
+  it('keeps short values compact without tooltip interaction', async () => {
+    const user = userEvent.setup();
+    const label = 'Parzelle · Beet';
+
+    render(<CompactAreaCell label={label} />);
+
+    await user.hover(screen.getByText(label));
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('uses compact ellipsis styles', () => {
+    const label = 'Regenbogenland · 8 Karotte + Zwiebel · Beet 5 (10,00 m²)';
+    const { container } = render(<CompactAreaCell label={label} />);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toHaveStyle({ overflow: 'hidden' });
+  });
+
+  it('decides tooltip visibility only when value is long or overflowing', () => {
+    expect(shouldShowAreaTooltip('kurz', false)).toBe(false);
+    expect(shouldShowAreaTooltip('x'.repeat(45), false)).toBe(true);
+    expect(shouldShowAreaTooltip('kurz', true)).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/plantingPlans.mobile.test.ts
+++ b/frontend/src/__tests__/plantingPlans.mobile.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Bed } from "../api/types";
-import { buildMobileCreateForm, getVisibleMobileRows } from "../pages/PlantingPlans";
+import {
+  buildAreaColumnHeaderLabel,
+  buildMobileCreateForm,
+  getVisibleMobileRows,
+} from "../pages/PlantingPlans";
 
 describe("PlantingPlans mobile create helpers", () => {
   it("prefills selected bed and area in the mobile create form", () => {
@@ -37,5 +41,17 @@ describe("PlantingPlans mobile create helpers", () => {
 
     expect(visibleRows).toHaveLength(1);
     expect(visibleRows[0].id).toBe(1);
+  });
+
+  it("builds area column header with location for multi-location projects", () => {
+    expect(
+      buildAreaColumnHeaderLabel(true, "Standort", "Parzelle", "Beet"),
+    ).toBe("Standort · Parzelle · Beet");
+  });
+
+  it("builds area column header without location for single-location projects", () => {
+    expect(
+      buildAreaColumnHeaderLabel(false, "Standort", "Parzelle", "Beet"),
+    ).toBe("Parzelle · Beet");
   });
 });

--- a/frontend/src/components/data-grid/PlantsCountEditCell.tsx
+++ b/frontend/src/components/data-grid/PlantsCountEditCell.tsx
@@ -21,8 +21,6 @@ export function PlantsCountEditCell(props: PlantsCountEditCellProps): React.Reac
   const { id, value, field, hasFocus, onLastEditedFieldChange } = props;
   const apiRef = useGridApiContext();
   
-  console.log('[DEBUG] PlantsCountEditCell mounted for row', id, 'with value:', value);
-  
   // Track initial value to prevent premature updates that steal focus
   const initialValueRef = useRef(value);
   
@@ -33,7 +31,6 @@ export function PlantsCountEditCell(props: PlantsCountEditCellProps): React.Reac
   
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
-    console.log('[DEBUG] PlantsCountEditCell input changed to:', val);
     setInputValue(val);
     
     // Immediately update DataGrid with the new value
@@ -42,7 +39,6 @@ export function PlantsCountEditCell(props: PlantsCountEditCellProps): React.Reac
     // Only call setEditCellValue if value actually changed from initial
     // This prevents premature grid updates on mount that can steal focus
     if (numValue !== initialValueRef.current) {
-      console.log('[DEBUG] PlantsCountEditCell calling setEditCellValue with:', numValue);
       apiRef.current.setEditCellValue({
         id,
         field,

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import { useTranslation } from '../../i18n';
+import type { Bed, Field, Location } from '../../api/types';
+import { UI_LABEL_SEPARATOR } from '../../utils/uiLabelSeparator';
+
+interface AreaAssignmentDialogProps {
+  bedId: number | null;
+  beds: Bed[];
+  fields: Field[];
+  locations: Location[];
+  locale: string;
+  onApply: (bedId: number) => Promise<void> | void;
+  compactLabel: string;
+}
+
+interface AssignmentState {
+  locationId: number | null;
+  fieldId: number | null;
+  bedId: number | null;
+}
+
+const formatArea = (value: number, locale: string): string =>
+  `${new Intl.NumberFormat(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value)} m²`;
+
+const toNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? null : value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+const normalizeState = (
+  bedId: number | null,
+  bedsWithLocation: Array<Bed & { fieldId: number; locationId: number }>,
+): AssignmentState => {
+  const selectedBed = bedsWithLocation.find((item) => item.id === bedId);
+  if (!selectedBed) {
+    return { locationId: null, fieldId: null, bedId: bedId ?? null };
+  }
+
+  return {
+    locationId: selectedBed.locationId,
+    fieldId: selectedBed.fieldId,
+    bedId: selectedBed.id ?? null,
+  };
+};
+
+export function AreaAssignmentDialog({
+  bedId,
+  beds,
+  fields,
+  locations,
+  locale,
+  onApply,
+  compactLabel,
+}: AreaAssignmentDialogProps): React.ReactElement {
+  const { t } = useTranslation('plantingPlans');
+  const [isOpen, setIsOpen] = useState(false);
+  const [draft, setDraft] = useState<AssignmentState>({ locationId: null, fieldId: null, bedId: bedId ?? null });
+
+  const fieldsById = useMemo(() => new Map(fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item])), [fields]);
+
+  const bedsWithLocation = useMemo(
+    () => beds
+      .filter((item): item is Bed & { id: number } => item.id !== undefined)
+      .map((item) => {
+        const relatedField = fieldsById.get(item.field);
+        if (!relatedField || relatedField.id === undefined) {
+          return null;
+        }
+
+        return {
+          ...item,
+          fieldId: relatedField.id,
+          locationId: relatedField.location,
+        };
+      })
+      .filter((item): item is Bed & { id: number; fieldId: number; locationId: number } => item !== null),
+    [beds, fieldsById],
+  );
+
+  const eligibleFieldIds = useMemo(() => new Set(bedsWithLocation.map((item) => item.fieldId)), [bedsWithLocation]);
+  const eligibleLocationIds = useMemo(
+    () => new Set(fields.filter((item) => item.id !== undefined && eligibleFieldIds.has(item.id)).map((item) => item.location)),
+    [eligibleFieldIds, fields],
+  );
+
+  const selectableLocations = useMemo(
+    () => locations.filter((item) => item.id !== undefined && eligibleLocationIds.has(item.id)),
+    [eligibleLocationIds, locations],
+  );
+  const hasSingleLocation = selectableLocations.length <= 1;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const nextState = normalizeState(bedId, bedsWithLocation);
+    if (hasSingleLocation && selectableLocations[0]?.id !== undefined) {
+      nextState.locationId = selectableLocations[0].id;
+    }
+    setDraft(nextState);
+  }, [bedId, bedsWithLocation, hasSingleLocation, isOpen, selectableLocations]);
+
+  const selectableFields = useMemo(() => {
+    if (!draft.locationId) {
+      return fields.filter((item) => item.id !== undefined && eligibleFieldIds.has(item.id));
+    }
+    return fields.filter((item) => item.id !== undefined && item.location === draft.locationId && eligibleFieldIds.has(item.id));
+  }, [draft.locationId, eligibleFieldIds, fields]);
+
+  const selectableBeds = useMemo(() => {
+    if (draft.fieldId) {
+      return bedsWithLocation.filter((item) => item.fieldId === draft.fieldId);
+    }
+    if (draft.locationId) {
+      return bedsWithLocation.filter((item) => item.locationId === draft.locationId);
+    }
+    return bedsWithLocation;
+  }, [bedsWithLocation, draft.fieldId, draft.locationId]);
+
+  const handleLocationChange = (value: number): void => {
+    const nextFields = fields.filter((item) => item.id !== undefined && item.location === value && eligibleFieldIds.has(item.id));
+    const nextFieldIds = new Set(nextFields.map((item) => item.id as number));
+    const nextBeds = bedsWithLocation.filter((item) => item.locationId === value);
+    const nextBedIds = new Set(nextBeds.map((item) => item.id));
+
+    setDraft((previous) => ({
+      locationId: value,
+      fieldId: previous.fieldId && nextFieldIds.has(previous.fieldId) ? previous.fieldId : null,
+      bedId: previous.bedId && nextBedIds.has(previous.bedId) ? previous.bedId : null,
+    }));
+  };
+
+  const handleFieldChange = (value: number): void => {
+    const selectedField = fieldsById.get(value);
+    const nextBeds = bedsWithLocation.filter((item) => item.fieldId === value);
+    const nextBedIds = new Set(nextBeds.map((item) => item.id));
+
+    setDraft((previous) => ({
+      locationId: selectedField?.location ?? previous.locationId,
+      fieldId: value,
+      bedId: previous.bedId && nextBedIds.has(previous.bedId) ? previous.bedId : null,
+    }));
+  };
+
+  const handleBedChange = (value: number): void => {
+    const selectedBed = bedsWithLocation.find((item) => item.id === value);
+    setDraft((previous) => ({
+      locationId: selectedBed?.locationId ?? previous.locationId,
+      fieldId: selectedBed?.fieldId ?? previous.fieldId,
+      bedId: value,
+    }));
+  };
+
+  const handleApply = async (): Promise<void> => {
+    if (!draft.bedId) {
+      return;
+    }
+    await onApply(draft.bedId);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: '100%', overflow: 'hidden' }}>
+        <Typography variant="body2" noWrap sx={{ flexGrow: 1 }}>{compactLabel}</Typography>
+        <IconButton
+          aria-label={t('areaAssignment.editButton')}
+          size="small"
+          onClick={() => setIsOpen(true)}
+        >
+          <EditIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>{t('areaAssignment.title')}</DialogTitle>
+        <DialogContent>
+          <Box sx={{ pt: 1 }}>
+            <Stack spacing={2.5}>
+              {!hasSingleLocation && (
+                <FormControl fullWidth size="small">
+                  <InputLabel id="assignment-location-label">{t('columns.location')}</InputLabel>
+                  <Select
+                    id="assignment-location"
+                    labelId="assignment-location-label"
+                    value={draft.locationId ?? ''}
+                    label={t('columns.location')}
+                    onChange={(event) => handleLocationChange(Number(event.target.value))}
+                  >
+                    {selectableLocations.map((item) => (
+                      <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              <FormControl fullWidth size="small">
+                <InputLabel id="assignment-field-label">{t('columns.field')}</InputLabel>
+                <Select
+                  id="assignment-field"
+                  labelId="assignment-field-label"
+                  value={draft.fieldId ?? ''}
+                  label={t('columns.field')}
+                  onChange={(event) => handleFieldChange(Number(event.target.value))}
+                >
+                  {selectableFields.map((item) => (
+                    <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl fullWidth size="small">
+                <InputLabel id="assignment-bed-label">{t('columns.bed')}</InputLabel>
+                <Select
+                  id="assignment-bed"
+                  labelId="assignment-bed-label"
+                  value={draft.bedId ?? ''}
+                  label={t('columns.bed')}
+                  onChange={(event) => handleBedChange(Number(event.target.value))}
+                >
+                  {selectableBeds.map((item) => {
+                    const areaSqm = toNumericValue(item.area_sqm);
+                    const prefix = item.field_name ? `${item.field_name}${UI_LABEL_SEPARATOR}` : '';
+                    const label = areaSqm === null
+                      ? `${prefix}${item.name}`
+                      : `${prefix}${item.name} (${formatArea(areaSqm, locale)})`;
+                    return (
+                      <MenuItem key={item.id} value={item.id}>{label}</MenuItem>
+                    );
+                  })}
+                </Select>
+              </FormControl>
+            </Stack>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsOpen(false)}>{t('areaAssignment.cancel')}</Button>
+          <Button variant="contained" onClick={handleApply} disabled={!draft.bedId}>{t('areaAssignment.apply')}</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import {
   Box,
   Button,
@@ -78,6 +78,15 @@ export function AreaAssignmentDialog({
   const { t } = useTranslation('plantingPlans');
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState<AssignmentState>({ locationId: null, fieldId: null, bedId: bedId ?? null });
+  const locationSelectRef = useRef<HTMLDivElement | null>(null);
+  const fieldSelectRef = useRef<HTMLDivElement | null>(null);
+  const bedSelectRef = useRef<HTMLDivElement | null>(null);
+
+  const stopGridEnterPropagation = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === 'Escape') {
+      event.stopPropagation();
+    }
+  };
 
   const fieldsById = useMemo(() => new Map(fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item])), [fields]);
 
@@ -195,22 +204,7 @@ export function AreaAssignmentDialog({
           <EditIcon fontSize="small" />
         </IconButton>
       </Stack>
-      <Dialog
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
-        fullWidth
-        maxWidth="sm"
-        onKeyDown={(event) => {
-          if (event.key !== 'Enter') {
-            return;
-          }
-          const target = event.target as HTMLElement | null;
-          const isDialogAction = Boolean(target?.closest('button[data-dialog-action="cancel"], button[data-dialog-action="apply"]'));
-          if (!isDialogAction) {
-            event.stopPropagation();
-          }
-        }}
-      >
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} fullWidth maxWidth="sm">
         <DialogTitle>{t('areaAssignment.title')}</DialogTitle>
         <DialogContent>
           <Box sx={{ pt: 1 }}>
@@ -219,11 +213,21 @@ export function AreaAssignmentDialog({
                 <FormControl fullWidth size="small">
                   <InputLabel id="assignment-location-label">{t('columns.location')}</InputLabel>
                   <Select
+                    ref={locationSelectRef}
                     id="assignment-location"
                     labelId="assignment-location-label"
                     value={draft.locationId ?? ''}
                     label={t('columns.location')}
-                    onChange={(event) => handleLocationChange(Number(event.target.value))}
+                    onKeyDown={stopGridEnterPropagation}
+                    onChange={(event) => {
+                      handleLocationChange(Number(event.target.value));
+                      requestAnimationFrame(() => locationSelectRef.current?.focus());
+                    }}
+                    MenuProps={{
+                      MenuListProps: {
+                        onKeyDown: stopGridEnterPropagation,
+                      },
+                    }}
                   >
                     {selectableLocations.map((item) => (
                       <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>
@@ -235,11 +239,21 @@ export function AreaAssignmentDialog({
               <FormControl fullWidth size="small">
                 <InputLabel id="assignment-field-label">{t('columns.field')}</InputLabel>
                 <Select
+                  ref={fieldSelectRef}
                   id="assignment-field"
                   labelId="assignment-field-label"
                   value={draft.fieldId ?? ''}
                   label={t('columns.field')}
-                  onChange={(event) => handleFieldChange(Number(event.target.value))}
+                  onKeyDown={stopGridEnterPropagation}
+                  onChange={(event) => {
+                    handleFieldChange(Number(event.target.value));
+                    requestAnimationFrame(() => fieldSelectRef.current?.focus());
+                  }}
+                  MenuProps={{
+                    MenuListProps: {
+                      onKeyDown: stopGridEnterPropagation,
+                    },
+                  }}
                 >
                   {selectableFields.map((item) => (
                     <MenuItem key={item.id} value={item.id}>{item.name}</MenuItem>
@@ -250,11 +264,21 @@ export function AreaAssignmentDialog({
               <FormControl fullWidth size="small">
                 <InputLabel id="assignment-bed-label">{t('columns.bed')}</InputLabel>
                 <Select
+                  ref={bedSelectRef}
                   id="assignment-bed"
                   labelId="assignment-bed-label"
                   value={draft.bedId ?? ''}
                   label={t('columns.bed')}
-                  onChange={(event) => handleBedChange(Number(event.target.value))}
+                  onKeyDown={stopGridEnterPropagation}
+                  onChange={(event) => {
+                    handleBedChange(Number(event.target.value));
+                    requestAnimationFrame(() => bedSelectRef.current?.focus());
+                  }}
+                  MenuProps={{
+                    MenuListProps: {
+                      onKeyDown: stopGridEnterPropagation,
+                    },
+                  }}
                 >
                   {selectableBeds.map((item) => {
                     const areaSqm = toNumericValue(item.area_sqm);

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -17,7 +17,8 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import { useTranslation } from '../../i18n';
 import type { Bed, Field, Location } from '../../api/types';
-import { UI_LABEL_SEPARATOR } from '../../utils/uiLabelSeparator';
+
+const AREA_LABEL_SEPARATOR = ' · ';
 
 interface AreaAssignmentDialogProps {
   bedId: number | null;
@@ -194,7 +195,22 @@ export function AreaAssignmentDialog({
           <EditIcon fontSize="small" />
         </IconButton>
       </Stack>
-      <Dialog open={isOpen} onClose={() => setIsOpen(false)} fullWidth maxWidth="sm">
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        fullWidth
+        maxWidth="sm"
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter') {
+            return;
+          }
+          const target = event.target as HTMLElement | null;
+          const isDialogAction = Boolean(target?.closest('button[data-dialog-action="cancel"], button[data-dialog-action="apply"]'));
+          if (!isDialogAction) {
+            event.stopPropagation();
+          }
+        }}
+      >
         <DialogTitle>{t('areaAssignment.title')}</DialogTitle>
         <DialogContent>
           <Box sx={{ pt: 1 }}>
@@ -242,7 +258,7 @@ export function AreaAssignmentDialog({
                 >
                   {selectableBeds.map((item) => {
                     const areaSqm = toNumericValue(item.area_sqm);
-                    const prefix = item.field_name ? `${item.field_name}${UI_LABEL_SEPARATOR}` : '';
+                    const prefix = item.field_name ? `${item.field_name}${AREA_LABEL_SEPARATOR}` : '';
                     const label = areaSqm === null
                       ? `${prefix}${item.name}`
                       : `${prefix}${item.name} (${formatArea(areaSqm, locale)})`;
@@ -256,8 +272,8 @@ export function AreaAssignmentDialog({
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setIsOpen(false)}>{t('areaAssignment.cancel')}</Button>
-          <Button variant="contained" onClick={handleApply} disabled={!draft.bedId}>{t('areaAssignment.apply')}</Button>
+          <Button type="button" data-dialog-action="cancel" onClick={() => setIsOpen(false)}>{t('areaAssignment.cancel')}</Button>
+          <Button type="button" data-dialog-action="apply" variant="contained" onClick={handleApply} disabled={!draft.bedId}>{t('areaAssignment.apply')}</Button>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/src/components/planting-plans/CompactAreaCell.tsx
+++ b/frontend/src/components/planting-plans/CompactAreaCell.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Tooltip, Typography } from '@mui/material';
+
+interface CompactAreaCellProps {
+  label: string;
+}
+
+const TOOLTIP_TEXT_LENGTH_THRESHOLD = 40;
+
+export function shouldShowAreaTooltip(label: string, isOverflowing: boolean): boolean {
+  return isOverflowing || label.length > TOOLTIP_TEXT_LENGTH_THRESHOLD;
+}
+
+export function CompactAreaCell({ label }: CompactAreaCellProps): React.ReactElement {
+  const textRef = useRef<HTMLParagraphElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const element = textRef.current;
+    if (!element) {
+      return;
+    }
+
+    const updateOverflow = (): void => {
+      setIsOverflowing(element.scrollWidth > element.clientWidth);
+    };
+
+    updateOverflow();
+    window.addEventListener('resize', updateOverflow);
+    return () => {
+      window.removeEventListener('resize', updateOverflow);
+    };
+  }, [label]);
+
+  const showTooltip = useMemo(
+    () => shouldShowAreaTooltip(label, isOverflowing),
+    [isOverflowing, label],
+  );
+
+  return (
+    <Tooltip
+      title={showTooltip ? label : ''}
+      disableHoverListener={!showTooltip}
+      disableFocusListener={!showTooltip}
+      disableTouchListener={!showTooltip}
+      enterTouchDelay={450}
+    >
+      <Box
+        sx={{ width: '100%', minWidth: 0, overflow: 'hidden' }}
+        tabIndex={showTooltip ? 0 : -1}
+        aria-label={showTooltip ? label : undefined}
+      >
+        <Typography
+          ref={textRef}
+          variant="body2"
+          noWrap
+          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {label}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -40,7 +40,7 @@ i18n
     fallbackLng: 'de',
     
     // Enable debug mode in development
-    debug: import.meta.env.DEV,
+    debug: import.meta.env.DEV && import.meta.env.MODE !== 'test',
     
     // Namespaces for organizing translations
     ns: ['common', 'navigation', 'home', 'locations', 'cultures', 'plantingPlans', 'fields', 'beds', 'hierarchy', 'ganttChart', 'suppliers', 'help', 'auth', 'account', 'projectInvitations'],

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -2,6 +2,8 @@
   "title": "Anbaupläne",
   "columns": {
     "culture": "Kultur",
+    "location": "Standort",
+    "field": "Parzelle",
     "bed": "Beet",
     "fieldBed": "Parzelle{{separator}}Beet",
     "plantingDate": "Pflanzdatum",
@@ -37,6 +39,12 @@
   "cultivationTypes": {
     "directSowing": "Direktsaat",
     "preCultivation": "Pflanzung"
+  },
+  "areaAssignment": {
+    "title": "Anbaufläche ändern",
+    "editButton": "Anbaufläche bearbeiten",
+    "apply": "Übernehmen",
+    "cancel": "Abbrechen"
   },
   "mobile": {
     "showDetails": "Details anzeigen",

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -610,7 +610,7 @@ export default function GraphicalFields({
   }, [fieldsByLocation, layoutsByField, locations]);
 
   useEffect(() => {
-    if (!import.meta.env.DEV) {
+    if (!import.meta.env.DEV || import.meta.env.MODE === 'test') {
       return;
     }
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -78,6 +78,7 @@ import {
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
+import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 
 const AREA_LABEL_SEPARATOR = " · ";
 
@@ -707,7 +708,7 @@ function PlantingPlans(): React.ReactElement {
           const row = params.row as PlantingPlanRow;
           const fallback = bedOptions.find((option) => option.value === row.bed);
           const label = fallback?.label ?? "—";
-          return <Typography variant="body2" noWrap>{label}</Typography>;
+          return <CompactAreaCell label={label} />;
         },
         renderEditCell: (params) => {
           const row = params.row as PlantingPlanRow;

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -57,7 +57,6 @@ import {
   parseLocalizedNumber,
   resolveLocaleFromLanguage,
 } from "../utils/numberLocalization";
-import { UI_LABEL_SEPARATOR } from "../utils/uiLabelSeparator";
 import { AreaM2EditCell } from "../components/data-grid/AreaM2EditCell";
 import {
   EditableDataGrid,
@@ -79,6 +78,18 @@ import {
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
+
+const AREA_LABEL_SEPARATOR = " · ";
+
+export const buildAreaColumnHeaderLabel = (
+  includeLocation: boolean,
+  locationLabel: string,
+  fieldLabel: string,
+  bedLabel: string,
+): string =>
+  includeLocation
+    ? `${locationLabel}${AREA_LABEL_SEPARATOR}${fieldLabel}${AREA_LABEL_SEPARATOR}${bedLabel}`
+    : `${fieldLabel}${AREA_LABEL_SEPARATOR}${bedLabel}`;
 
 /**
  * Row data type for Data Grid
@@ -175,7 +186,7 @@ const buildBedDisplayLabel = (
     normalizedBedName,
   ]
     .filter((part) => part.length > 0)
-    .join(UI_LABEL_SEPARATOR);
+    .join(AREA_LABEL_SEPARATOR);
 
   if (!combinedName) {
     return "—";
@@ -349,8 +360,38 @@ function PlantingPlans(): React.ReactElement {
   );
 
   const fieldBedColumnLabel = useMemo(
-    () => t("plantingPlans:columns.fieldBed", { separator: UI_LABEL_SEPARATOR }),
+    () =>
+      t("plantingPlans:columns.fieldBed", {
+        separator: AREA_LABEL_SEPARATOR,
+      }),
     [t],
+  );
+
+  const hasMultipleLocationsWithBeds = useMemo(() => {
+    const fieldById = new Map(
+      fields
+        .filter((item) => item.id !== undefined)
+        .map((item) => [item.id as number, item]),
+    );
+    const locationIdsWithBeds = new Set<number>();
+    beds.forEach((bed) => {
+      const field = fieldById.get(bed.field);
+      if (field) {
+        locationIdsWithBeds.add(field.location);
+      }
+    });
+    return locationIdsWithBeds.size > 1;
+  }, [beds, fields]);
+
+  const areaColumnLabel = useMemo(
+    () =>
+      buildAreaColumnHeaderLabel(
+        hasMultipleLocationsWithBeds,
+        t("plantingPlans:columns.location"),
+        t("plantingPlans:columns.field"),
+        t("plantingPlans:columns.bed"),
+      ),
+    [hasMultipleLocationsWithBeds, t],
   );
 
   const getCultivationTypeOptionsForRow = useMemo(
@@ -656,7 +697,7 @@ function PlantingPlans(): React.ReactElement {
       },
       {
         field: "bed",
-        headerName: fieldBedColumnLabel,
+          headerName: areaColumnLabel,
         flex: 0,
         minWidth: dynamicWidths.bed,
         maxWidth: BED_COLUMN_MAX_WIDTH,
@@ -891,6 +932,7 @@ function PlantingPlans(): React.ReactElement {
       cultureOptions,
       cultures,
       dynamicWidths,
+      areaColumnLabel,
       fieldBedColumnLabel,
       numberLocale,
       areaWarning,

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -44,11 +44,13 @@ import {
   plantingPlanAPI,
   cultureAPI,
   bedAPI,
+  fieldAPI,
+  locationAPI,
   type PlantingPlan,
   type Culture,
   type Bed,
 } from "../api/api";
-import type { CultivationType } from "../api/types";
+import type { CultivationType, Field, Location } from "../api/types";
 import { extractApiErrorMessage } from "../api/errors";
 import {
   formatLocalizedNumber,
@@ -76,6 +78,7 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
+import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
 
 /**
  * Row data type for Data Grid
@@ -156,14 +159,21 @@ const toNumericValue = (value: unknown): number | null => {
 };
 
 const buildBedDisplayLabel = (
+  locationName: string | null | undefined,
   bedName: string | null | undefined,
   fieldName: string | null | undefined,
   areaSqm: number | null,
+  includeLocation: boolean,
   locale: string,
 ): string => {
+  const normalizedLocationName = (locationName ?? "").trim();
   const normalizedBedName = (bedName ?? "").trim();
   const normalizedFieldName = (fieldName ?? "").trim();
-  const combinedName = [normalizedFieldName, normalizedBedName]
+  const combinedName = [
+    includeLocation ? normalizedLocationName : "",
+    normalizedFieldName,
+    normalizedBedName,
+  ]
     .filter((part) => part.length > 0)
     .join(UI_LABEL_SEPARATOR);
 
@@ -230,6 +240,8 @@ function PlantingPlans(): React.ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const [cultures, setCultures] = useState<Culture[]>([]);
   const [beds, setBeds] = useState<Bed[]>([]);
+  const [fields, setFields] = useState<Field[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
   const [areaWarning, setAreaWarning] = useState<string>("");
   const urlParamProcessedRef = useRef<boolean>(false);
   const gridCommandApiRef = useRef<EditableDataGridCommandApi | null>(null);
@@ -283,22 +295,48 @@ function PlantingPlans(): React.ReactElement {
   );
 
   const bedOptions: SearchableSelectOption[] = useMemo(
-    () =>
-      beds
+    () => {
+      const fieldById = new Map(
+        fields
+          .filter((item) => item.id !== undefined)
+          .map((item) => [item.id as number, item]),
+      );
+      const locationById = new Map(
+        locations
+          .filter((item) => item.id !== undefined)
+          .map((item) => [item.id as number, item]),
+      );
+      const locationIdsWithBeds = new Set<number>();
+      beds.forEach((bed) => {
+        const field = fieldById.get(bed.field);
+        if (field) {
+          locationIdsWithBeds.add(field.location);
+        }
+      });
+      const includeLocation = locationIdsWithBeds.size > 1;
+
+      return beds
         .filter((b) => b.id !== undefined)
         .map((b) => {
+          const field = fieldById.get(b.field);
+          const locationName = field
+            ? locationById.get(field.location)?.name
+            : null;
           const normalizedAreaSqm = toNumericValue(b.area_sqm);
           return {
             value: b.id!,
             label: buildBedDisplayLabel(
+              locationName,
               b.name,
-              b.field_name,
+              b.field_name ?? field?.name,
               normalizedAreaSqm,
+              includeLocation,
               numberLocale,
             ),
           };
-        }),
-    [beds, numberLocale],
+        });
+    },
+    [beds, fields, locations, numberLocale],
   );
 
   const cultivationTypeOptions = useMemo(
@@ -386,7 +424,7 @@ function PlantingPlans(): React.ReactElement {
         120,
         150,
       ),
-      notes: 260,
+      notes: 220,
     };
   }, [bedOptions, beds, cultivationTypeOptions, cultureOptions, fieldBedColumnLabel, numberLocale, t]);
 
@@ -448,13 +486,17 @@ function PlantingPlans(): React.ReactElement {
     if (shouldShowProjectRequiredState) {
       setCultures([]);
       setBeds([]);
+      setFields([]);
+      setLocations([]);
       return;
     }
     const fetchData = async (): Promise<void> => {
       try {
-        const [culturesResponse, bedsResponse] = await Promise.all([
+        const [culturesResponse, bedsResponse, fieldsResponse, locationsResponse] = await Promise.all([
           cultureAPI.list(),
           bedAPI.list(),
+          fieldAPI.list(),
+          locationAPI.list(),
         ]);
         setCultures(culturesResponse.data.results);
         setBeds(
@@ -463,6 +505,8 @@ function PlantingPlans(): React.ReactElement {
             area_sqm: toNumericValue(bed.area_sqm) ?? undefined,
           })),
         );
+        setFields(fieldsResponse.data.results);
+        setLocations(locationsResponse.data.results);
       } catch (err) {
         console.error("Error fetching cultures and beds:", err);
       }
@@ -611,15 +655,41 @@ function PlantingPlans(): React.ReactElement {
         }),
       },
       {
-        ...createSingleSelectColumn<PlantingPlanRow>({
-          field: "bed",
-          headerName: fieldBedColumnLabel,
-          flex: 0,
-          minWidth: dynamicWidths.bed,
-          maxWidth: BED_COLUMN_MAX_WIDTH,
-          truncateCellText: true,
-          options: bedOptions,
-        }),
+        field: "bed",
+        headerName: fieldBedColumnLabel,
+        flex: 0,
+        minWidth: dynamicWidths.bed,
+        maxWidth: BED_COLUMN_MAX_WIDTH,
+        editable: true,
+        sortable: false,
+        renderCell: (params) => {
+          const row = params.row as PlantingPlanRow;
+          const fallback = bedOptions.find((option) => option.value === row.bed);
+          const label = fallback?.label ?? "—";
+          return <Typography variant="body2" noWrap>{label}</Typography>;
+        },
+        renderEditCell: (params) => {
+          const row = params.row as PlantingPlanRow;
+          const fallback = bedOptions.find((option) => option.value === row.bed);
+          const label = fallback?.label ?? "—";
+          return (
+            <AreaAssignmentDialog
+              bedId={typeof row.bed === "number" ? row.bed : Number(row.bed)}
+              beds={beds}
+              fields={fields}
+              locations={locations}
+              locale={numberLocale}
+              compactLabel={label}
+              onApply={async (nextBedId) => {
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: "bed",
+                  value: nextBedId,
+                });
+              }}
+            />
+          );
+        },
         valueSetter: (value, row) => {
           const nextRow = row as PlantingPlanRow;
           const numericValue =
@@ -814,12 +884,15 @@ function PlantingPlans(): React.ReactElement {
     [
       bedOptions,
       beds,
+      fields,
+      locations,
       cultivationTypeOptions,
       getCultivationTypeOptionsForRow,
       cultureOptions,
       cultures,
       dynamicWidths,
       fieldBedColumnLabel,
+      numberLocale,
       areaWarning,
       t,
     ],
@@ -849,17 +922,37 @@ function PlantingPlans(): React.ReactElement {
   };
 
   const getBedLabel = (row: PlantingPlanRow): string => {
+    const fieldById = new Map(
+      fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item]),
+    );
+    const locationById = new Map(
+      locations.filter((item) => item.id !== undefined).map((item) => [item.id as number, item]),
+    );
+    const locationIdsWithBeds = new Set<number>();
+    beds.forEach((item) => {
+      const field = fieldById.get(item.field);
+      if (field) {
+        locationIdsWithBeds.add(field.location);
+      }
+    });
+    const includeLocation = locationIdsWithBeds.size > 1;
     const linkedBed = beds.find((bed) => bed.id === row.bed);
     if (linkedBed) {
+      const linkedField = fieldById.get(linkedBed.field);
+      const locationName = linkedField
+        ? locationById.get(linkedField.location)?.name
+        : null;
       return buildBedDisplayLabel(
+        locationName,
         linkedBed.name,
-        linkedBed.field_name,
+        linkedBed.field_name ?? linkedField?.name,
         toNumericValue(linkedBed.area_sqm),
+        includeLocation,
         numberLocale,
       );
     }
     if (row.bed_name) {
-      return buildBedDisplayLabel(row.bed_name, null, null, numberLocale);
+      return buildBedDisplayLabel(null, row.bed_name, null, null, includeLocation, numberLocale);
     }
     const fallback = bedOptions.find((option) => option.value === row.bed);
     return fallback?.label ?? "—";


### PR DESCRIPTION
### Motivation
- The inline, three-cell edit UI for Standort/Parzelle/Beet in the Planting Plans grid was complex, brittle and caused inconsistent dropdowns and display glitches.
- Replace the fragile dependent inline editors with a single, controlled UI that is easier to reason about and maintain.

### Description
- Add a new `AreaAssignmentDialog` component (`frontend/src/components/planting-plans/AreaAssignmentDialog.tsx`) that presents Standort / Parzelle / Beet as controlled selects in a dialog and enforces filtering/auto-sync/clearing rules by ID.
- Replace the inline bed edit column in `PlantingPlans` (`frontend/src/pages/PlantingPlans.tsx`) with a compact single-cell display and open the dialog for editing via the grid edit renderer while preserving the existing row save flow by calling `params.api.setEditCellValue`.
- Load `fields` and `locations` together with `beds` and use their relationships to build compact labels (show Standort only when multiple locations contain beds) and to prevent selecting locations/fields without beds.
- Add German i18n strings for the dialog (`frontend/src/i18n/locales/de/plantingPlans.json`) and tighten table layout by reducing the notes column width.
- Add focused unit tests for dialog behaviour (`frontend/src/__tests__/AreaAssignmentDialog.test.tsx`) that check opening, filtering, auto-propagation, apply/cancel and single-location behavior.

### Testing
- Ran component tests: `cd frontend && npm run test -- AreaAssignmentDialog.test.tsx plantingPlans.mobile.test.ts` and all tests passed.
- Built the frontend: `cd frontend && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edabf157508322825dbcabcdb96381)