### PR TITLE
Add progressive requirement flow and unified empty-state UI; refine navigation and Gantt behaviors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,7 +20,7 @@
   max-width: 100%;
   box-sizing: border-box;
   padding: 10px 20px;
-  background: linear-gradient(90deg, #2e3b2f 0%, #344c33 100%);
+  background: linear-gradient(90deg, #111315 0%, #1a1d21 100%);
   color: white;
   margin-bottom: 20px;
   display: flex;
@@ -72,8 +72,8 @@
 }
 
 .nav-link.active {
-  background-color: #4f8a52;
-  color: #f7fff7;
+  background-color: #2f353b;
+  color: #ffffff;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,7 +20,7 @@
   max-width: 100%;
   box-sizing: border-box;
   padding: 10px 20px;
-  background-color: #333;
+  background: linear-gradient(90deg, #2e3b2f 0%, #344c33 100%);
   color: white;
   margin-bottom: 20px;
   display: flex;
@@ -68,11 +68,13 @@
 }
 
 .nav-link:hover {
-  background-color: #555;
+  background-color: rgba(255, 255, 255, 0.14);
 }
 
 .nav-link.active {
-  background-color: #1976d2;
+  background-color: #4f8a52;
+  color: #f7fff7;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
 }
 
 .nav-link.home {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -229,9 +229,8 @@ function RootLayout(): React.ReactElement {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
-  const routes = ['/app/dashboard', '/app/locations', '/app/fields-beds', '/app/cultures', '/app/anbauplaene', '/app/gantt-chart', '/app/seed-demand', '/app/suppliers'];
+  const routes = ['/app/locations', '/app/fields-beds', '/app/cultures', '/app/anbauplaene', '/app/gantt-chart', '/app/seed-demand', '/app/suppliers'];
   const navItems = [
-    { to: '/app/dashboard', label: t('dashboard'), keywords: ['übersicht', 'dashboard', 'start'] },
     { to: '/app/locations', label: t('locations'), keywords: ['standorte', 'orte', 'locations'] },
     { to: '/app/fields-beds', label: t('fieldsAndBeds'), keywords: ['anbauflächen', 'felder', 'beete'] },
     { to: '/app/cultures', label: t('cultures'), keywords: ['kulturen', 'kultur'] },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,7 +52,6 @@ import AddIcon from '@mui/icons-material/Add';
 import { cultureAPI, projectAPI } from './api/api';
 import type { CultureHistoryEntry } from './api/types';
 import './App.css';
-import { HelpIcon } from './components/help/HelpIcon';
 import { useAuth } from './auth/useAuth';
 import ProtectedRoute from './auth/ProtectedRoute';
 import HomePage from './pages/public/HomePage';
@@ -68,6 +67,7 @@ import ProjectSelectionPage from './pages/ProjectSelectionPage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import ProjectSettingsPage from './pages/ProjectSettingsPage';
 import InvitationAcceptPage from './pages/InvitationAcceptPage';
+import AppLogo from './components/layout/AppLogo';
 import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
 import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
 import { resolveRouterBasename } from './routerBasename';
@@ -154,6 +154,7 @@ interface GlobalMenuProps {
   onOpenProjectHistory: () => Promise<void>;
   onOpenAccountSettings: () => void;
   onOpenShortcuts: () => void;
+  onOpenHelp: () => void;
   onLogout: () => Promise<void>;
   t: (key: string) => string;
 }
@@ -168,6 +169,7 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
     onOpenProjectHistory,
     onOpenAccountSettings,
     onOpenShortcuts,
+    onOpenHelp,
     onLogout,
     t,
   } = props;
@@ -187,6 +189,9 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
       </MenuItem>
       <MenuItem onClick={onOpenShortcuts}>
         Tastenkürzel
+      </MenuItem>
+      <MenuItem onClick={onOpenHelp}>
+        Hilfe
       </MenuItem>
       <MenuItem onClick={() => void onLogout()}>
         {t('commandPalette.commands.logout')} {userLabel}
@@ -210,11 +215,13 @@ function RootLayout(): React.ReactElement {
   const location = useLocation();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const isCompactDesktop = useMediaQuery('(max-width:1365px)');
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
   const { openPalette } = useCommandContext();
   const [globalMenuAnchor, setGlobalMenuAnchor] = useState<null | HTMLElement>(null);
   const [projectMenuAnchor, setProjectMenuAnchor] = useState<null | HTMLElement>(null);
+  const [moreNavAnchor, setMoreNavAnchor] = useState<null | HTMLElement>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [isSwitchingProject, setIsSwitchingProject] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
@@ -231,6 +238,8 @@ function RootLayout(): React.ReactElement {
     { to: '/app/seed-demand', label: t('seedDemand'), keywords: ['saatgutbedarf', 'saatgut'] },
     { to: '/app/suppliers', label: t('suppliers'), keywords: ['lieferanten', 'einkauf'] },
   ];
+  const primaryNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(0, 4) : navItems;
+  const overflowNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(4) : [];
 
   const handleGlobalMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setGlobalMenuAnchor(event.currentTarget);
@@ -246,6 +255,12 @@ function RootLayout(): React.ReactElement {
 
   const handleProjectMenuClose = () => {
     setProjectMenuAnchor(null);
+  };
+  const handleMoreNavOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setMoreNavAnchor(event.currentTarget);
+  };
+  const handleMoreNavClose = () => {
+    setMoreNavAnchor(null);
   };
 
   const closeMobileNav = () => {
@@ -406,17 +421,22 @@ function RootLayout(): React.ReactElement {
     return normalizedPath === '/' ? '/app/locations' : `/app${normalizedPath}`;
   };
 
-  const goToNextPage = (): void => {
-    const currentIndex = routes.indexOf(normalizeRoutePath(location.pathname));
+  const getCurrentRouteFromLocation = useCallback((): string => {
+    const pathname = window.location.pathname || location.pathname;
+    return normalizeRoutePath(pathname);
+  }, [location.pathname]);
+
+  const goToNextPage = useCallback((): void => {
+    const currentIndex = routes.indexOf(getCurrentRouteFromLocation());
     const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % routes.length;
     navigate(routes[nextIndex]);
-  };
+  }, [getCurrentRouteFromLocation, navigate, routes]);
 
-  const goToPreviousPage = (): void => {
-    const currentIndex = routes.indexOf(normalizeRoutePath(location.pathname));
+  const goToPreviousPage = useCallback((): void => {
+    const currentIndex = routes.indexOf(getCurrentRouteFromLocation());
     const previousIndex = currentIndex === -1 ? routes.length - 1 : (currentIndex - 1 + routes.length) % routes.length;
     navigate(routes[previousIndex]);
-  };
+  }, [getCurrentRouteFromLocation, navigate, routes]);
 
   const globalCommands = useMemo(() => createRootCommands({
     currentPath: normalizeRoutePath(location.pathname),
@@ -447,7 +467,23 @@ function RootLayout(): React.ReactElement {
       openPalette: t('commandPalette.label'),
       openShortcuts: t('commandPalette.commands.openShortcuts'),
     },
-  }), [activeMembershipRole, activeProjectId, location.pathname, memberships, navigate, openCurrentPageHelp, openPalette, t]);
+  }), [
+    activeMembershipRole,
+    activeProjectId,
+    goToNextPage,
+    goToPreviousPage,
+    handleLogout,
+    handleOpenCreateProject,
+    handleOpenProjectHistory,
+    handleOpenProjectSettings,
+    handleSwitchProject,
+    location.pathname,
+    memberships,
+    navigate,
+    openCurrentPageHelp,
+    openPalette,
+    t,
+  ]);
 
   useRegisterCommands('global-app', globalCommands);
   
@@ -464,11 +500,12 @@ function RootLayout(): React.ReactElement {
             >
               <MenuIcon fontSize="small" />
             </IconButton>
-            <span className="mobile-nav-title">OpenFarmPlanner</span>
+            <AppLogo size={24} showText={false} />
           </div>
         ) : (
           <div className="nav-links">
-            {navItems.map((item) => (
+            <AppLogo size={28} showText={!isCompactDesktop} />
+            {primaryNavItems.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}
@@ -477,6 +514,36 @@ function RootLayout(): React.ReactElement {
                 {item.label}
               </NavLink>
             ))}
+            {overflowNavItems.length > 0 ? (
+              <>
+                <Button
+                  size="small"
+                  onClick={handleMoreNavOpen}
+                  aria-controls={moreNavAnchor ? 'more-nav-menu' : undefined}
+                  aria-haspopup="true"
+                  sx={{ color: 'white', textTransform: 'none', px: 1 }}
+                >
+                  Mehr
+                </Button>
+                <Menu id="more-nav-menu" anchorEl={moreNavAnchor} open={Boolean(moreNavAnchor)} onClose={handleMoreNavClose}>
+                  {overflowNavItems.map((item) => {
+                    const isActive = location.pathname === item.to || location.pathname === item.activePath;
+                    return (
+                      <MenuItem
+                        key={item.to}
+                        selected={Boolean(isActive)}
+                        onClick={() => {
+                          navigate(item.to);
+                          handleMoreNavClose();
+                        }}
+                      >
+                        {item.label}
+                      </MenuItem>
+                    );
+                  })}
+                </Menu>
+              </>
+            ) : null}
           </div>
         )}
         <div className="nav-actions">
@@ -520,7 +587,6 @@ function RootLayout(): React.ReactElement {
           >
             <MoreVertIcon fontSize="small" />
           </IconButton>
-          <HelpIcon buttonSx={{ color: 'white' }} size="small" />
           <GlobalMenu
             anchorEl={globalMenuAnchor}
             open={Boolean(globalMenuAnchor)}
@@ -530,6 +596,7 @@ function RootLayout(): React.ReactElement {
             onOpenProjectHistory={handleOpenProjectHistory}
             onOpenAccountSettings={() => navigateFromGlobalMenu('/app/account-settings')}
             onOpenShortcuts={handleOpenShortcuts}
+            onOpenHelp={openCurrentPageHelp}
             onLogout={handleLogout}
             t={t}
           />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import PlantingPlans from './pages/PlantingPlans';
 import GanttChart from './pages/GanttChart';
 import SeedDemandPage from './pages/SeedDemand';
 import Suppliers from './pages/Suppliers';
+import Dashboard from './pages/Dashboard';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import MenuIcon from '@mui/icons-material/Menu';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
@@ -228,8 +229,9 @@ function RootLayout(): React.ReactElement {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
-  const routes = ['/app/locations', '/app/fields-beds', '/app/cultures', '/app/anbauplaene', '/app/gantt-chart', '/app/seed-demand', '/app/suppliers'];
+  const routes = ['/app/dashboard', '/app/locations', '/app/fields-beds', '/app/cultures', '/app/anbauplaene', '/app/gantt-chart', '/app/seed-demand', '/app/suppliers'];
   const navItems = [
+    { to: '/app/dashboard', label: t('dashboard'), keywords: ['übersicht', 'dashboard', 'start'] },
     { to: '/app/locations', label: t('locations'), keywords: ['standorte', 'orte', 'locations'] },
     { to: '/app/fields-beds', label: t('fieldsAndBeds'), keywords: ['anbauflächen', 'felder', 'beete'] },
     { to: '/app/cultures', label: t('cultures'), keywords: ['kulturen', 'kultur'] },
@@ -379,7 +381,7 @@ function RootLayout(): React.ReactElement {
         description: newProjectDescription.trim(),
       });
       closeCreateProjectDialog();
-      navigate('/app/locations');
+      navigate('/app/dashboard');
       await applyProjectContextChange(response.data.id);
     } catch (error) {
       console.error('Error creating project:', error);
@@ -418,7 +420,7 @@ function RootLayout(): React.ReactElement {
       return normalizedPath;
     }
 
-    return normalizedPath === '/' ? '/app/locations' : `/app${normalizedPath}`;
+    return normalizedPath === '/' ? '/app/dashboard' : `/app${normalizedPath}`;
   };
 
   const getCurrentRouteFromLocation = useCallback((): string => {
@@ -500,11 +502,11 @@ function RootLayout(): React.ReactElement {
             >
               <MenuIcon fontSize="small" />
             </IconButton>
-            <AppLogo size={24} showText={false} />
+            <AppLogo size={24} showText={false} to={activeProjectId ? '/app/dashboard' : '/app/project-selection'} />
           </div>
         ) : (
           <div className="nav-links">
-            <AppLogo size={28} showText={!isCompactDesktop} />
+            <AppLogo size={28} showText={!isCompactDesktop} to={activeProjectId ? '/app/dashboard' : '/app/project-selection'} />
             {primaryNavItems.map((item) => (
               <NavLink
                 key={item.to}
@@ -827,8 +829,9 @@ function createAppRouter(basename: string) {
           children: [
             {
               index: true,
-              loader: () => redirect('/app/locations'),
+              loader: () => redirect('/app/dashboard'),
             },
+            { path: 'dashboard', element: <Dashboard /> },
             { path: 'locations', element: <Locations /> },
             { path: 'fields-beds', element: <FieldsBedsPage /> },
             { path: 'cultures', element: <Cultures /> },

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -92,6 +92,7 @@ describe('App', () => {
     render(<CommandProvider><App /></CommandProvider>);
 
     expect(await screen.findByText(translations.navigation.locations)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Übersicht' })).not.toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner' }).length).toBeGreaterThan(0);
     expect(screen.getByText(translations.navigation.cultures)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: translations.navigation.plantingPlans })).toBeInTheDocument();

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -92,6 +92,7 @@ describe('App', () => {
     render(<CommandProvider><App /></CommandProvider>);
 
     expect(await screen.findByText(translations.navigation.locations)).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner' }).length).toBeGreaterThan(0);
     expect(screen.getByText(translations.navigation.cultures)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: translations.navigation.plantingPlans })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Aktives Projekt wechseln' })).toBeInTheDocument();

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -98,6 +98,30 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Aktives Projekt wechseln' })).toBeInTheDocument();
   });
 
+  it('links logo to dashboard when an active project is selected', async () => {
+    authState.user = {
+      id: 1,
+      email: 'demo@example.com',
+      display_name: 'Demo',
+      display_label: 'Demo',
+      is_active: true,
+      default_project_id: 1,
+      last_project_id: 1,
+      resolved_project_id: 1,
+      needs_project_selection: false,
+      memberships: [{ project_id: 1, project_name: 'Alpha', role: 'admin' }],
+      account_pending_deletion: false,
+      scheduled_deletion_at: null,
+    };
+    authState.activeProjectId = 1;
+    window.history.pushState({}, '', '/app/locations');
+
+    render(<CommandProvider><App /></CommandProvider>);
+
+    const logoLinks = await screen.findAllByRole('link', { name: 'OpenFarmPlanner' });
+    expect(logoLinks[0]).toHaveAttribute('href', '/app/dashboard');
+  });
+
   it('shows account settings in three-dot menu without project settings', async () => {
     authState.user = {
       id: 1,

--- a/frontend/src/__tests__/CultureDetail.test.tsx
+++ b/frontend/src/__tests__/CultureDetail.test.tsx
@@ -80,6 +80,8 @@ describe('CultureDetail Component', () => {
     );
 
     expect(screen.getByText('Noch keine Kulturen vorhanden')).toBeInTheDocument();
+    expect(screen.getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
+    expect(screen.queryByLabelText(translations.cultures.searchPlaceholder)).not.toBeInTheDocument();
     expect(screen.queryByText('Keine Kulturen gefunden')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Suche und Filter zurücksetzen' })).not.toBeInTheDocument();
   });

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -42,10 +42,11 @@ describe('Dashboard', () => {
     mocks.planList.mockResolvedValue({ data: { results: [] } });
   });
 
-  it('shows welcome box and first action for a completely empty project', async () => {
+  it('shows only the start box for a completely empty project', async () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
-    expect(await screen.findByText('Willkommen bei OpenFarmPlanner')).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'Standort anlegen' }).length).toBeGreaterThan(0);
+    expect(await screen.findByText('Starte deine Anbauplanung')).toBeInTheDocument();
+    expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Standort anlegen' })).toHaveLength(1);
     expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
     expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
     expect(screen.queryByText('Anstehende Aufgaben')).not.toBeInTheDocument();
@@ -57,7 +58,7 @@ describe('Dashboard', () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
 
     expect(await screen.findByText('Projektstatus')).toBeInTheDocument();
-    expect(screen.queryByText('Willkommen bei OpenFarmPlanner')).not.toBeInTheDocument();
+    expect(screen.queryByText('Starte deine Anbauplanung')).not.toBeInTheDocument();
   });
 
   it('shows aggregated upcoming tasks and ready state when setup is complete', async () => {
@@ -73,7 +74,7 @@ describe('Dashboard', () => {
     expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
     expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
     expect(screen.queryByText('Dein Projekt ist eingerichtet.')).not.toBeInTheDocument();
-    expect(screen.queryByText('Willkommen bei OpenFarmPlanner')).not.toBeInTheDocument();
+    expect(screen.queryByText('Starte deine Anbauplanung')).not.toBeInTheDocument();
     expect(screen.getByText('Anstehende Aufgaben')).toBeInTheDocument();
     expect(screen.queryByText('Keine anstehenden Aufgaben vorhanden')).not.toBeInTheDocument();
   });

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Dashboard from '../pages/Dashboard';
+
+const mocks = vi.hoisted(() => ({
+  locationList: vi.fn(),
+  fieldList: vi.fn(),
+  bedList: vi.fn(),
+  cultureList: vi.fn(),
+  planList: vi.fn(),
+}));
+
+const projectRequirementState = vi.hoisted(() => ({
+  shouldShowProjectRequiredState: false,
+  missingProjectReason: null as null | 'no_projects' | 'no_active_project',
+}));
+
+vi.mock('../api/api', async () => {
+  const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
+  return {
+    ...actual,
+    locationAPI: { ...actual.locationAPI, list: mocks.locationList },
+    fieldAPI: { ...actual.fieldAPI, list: mocks.fieldList },
+    bedAPI: { ...actual.bedAPI, list: mocks.bedList },
+    cultureAPI: { ...actual.cultureAPI, list: mocks.cultureList },
+    plantingPlanAPI: { ...actual.plantingPlanAPI, list: mocks.planList },
+  };
+});
+
+vi.mock('../hooks/useProjectRequirement', () => ({ useProjectRequirement: () => projectRequirementState }));
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectRequirementState.shouldShowProjectRequiredState = false;
+    projectRequirementState.missingProjectReason = null;
+    mocks.locationList.mockResolvedValue({ data: { results: [] } });
+    mocks.fieldList.mockResolvedValue({ data: { results: [] } });
+    mocks.bedList.mockResolvedValue({ data: { results: [] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [] } });
+    mocks.planList.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('shows empty project state and location-first action', async () => {
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+    expect(await screen.findByText('Starte deine Anbauplanung')).toBeInTheDocument();
+    expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Standort anlegen' }).length).toBeGreaterThan(0);
+  });
+
+  it('shows aggregated upcoming tasks and ready state when setup is complete', async () => {
+    mocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+    mocks.fieldList.mockResolvedValue({ data: { results: [{ id: 2, name: 'Nord', location: 1 }] } });
+    mocks.bedList.mockResolvedValue({ data: { results: [{ id: 3, name: 'Beet A', field: 2 }] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 4, name: 'Salat', growth_duration_days: 10 }] } });
+    mocks.planList.mockResolvedValue({ data: { results: [{ id: 5, culture: 4, bed: 3, planting_date: '2099-01-01', culture_name: 'Salat' }] } });
+
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+
+    expect(await screen.findByText('Dein Projekt ist eingerichtet.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Anbaukalender öffnen' })).toBeInTheDocument();
+    expect(screen.getByText('Anstehende Aufgaben')).toBeInTheDocument();
+    expect(screen.queryByText('Keine anstehenden Aufgaben vorhanden')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -58,9 +58,24 @@ describe('Dashboard', () => {
 
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
 
-    expect(await screen.findByText('Dein Projekt ist eingerichtet.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Anbaukalender öffnen' })).toBeInTheDocument();
+    expect(await screen.findByText('Anstehende Aufgaben')).toBeInTheDocument();
+    expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dein Projekt ist eingerichtet.')).not.toBeInTheDocument();
     expect(screen.getByText('Anstehende Aufgaben')).toBeInTheDocument();
     expect(screen.queryByText('Keine anstehenden Aufgaben vorhanden')).not.toBeInTheDocument();
+  });
+
+  it('shows compact tasks empty state when setup is complete but there are no upcoming tasks', async () => {
+    mocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+    mocks.fieldList.mockResolvedValue({ data: { results: [{ id: 2, name: 'Nord', location: 1 }] } });
+    mocks.bedList.mockResolvedValue({ data: { results: [{ id: 3, name: 'Beet A', field: 2 }] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 4, name: 'Salat' }] } });
+    mocks.planList.mockResolvedValue({ data: { results: [{ id: 5, culture: 4, bed: 3, planting_date: '2020-01-01', culture_name: 'Salat' }] } });
+
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+
+    expect(await screen.findByText('Keine anstehenden Aufgaben')).toBeInTheDocument();
+    expect(screen.getByText('Aktuell gibt es keine anstehenden Aufgaben für dieses Projekt.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -42,11 +42,22 @@ describe('Dashboard', () => {
     mocks.planList.mockResolvedValue({ data: { results: [] } });
   });
 
-  it('shows empty project state and location-first action', async () => {
+  it('shows welcome box and first action for a completely empty project', async () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
-    expect(await screen.findByText('Starte deine Anbauplanung')).toBeInTheDocument();
-    expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
+    expect(await screen.findByText('Willkommen bei OpenFarmPlanner')).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'Standort anlegen' }).length).toBeGreaterThan(0);
+    expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Anstehende Aufgaben')).not.toBeInTheDocument();
+  });
+
+  it('does not show welcome box for partially configured projects', async () => {
+    mocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+
+    expect(await screen.findByText('Projektstatus')).toBeInTheDocument();
+    expect(screen.queryByText('Willkommen bei OpenFarmPlanner')).not.toBeInTheDocument();
   });
 
   it('shows aggregated upcoming tasks and ready state when setup is complete', async () => {
@@ -62,6 +73,7 @@ describe('Dashboard', () => {
     expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
     expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
     expect(screen.queryByText('Dein Projekt ist eingerichtet.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Willkommen bei OpenFarmPlanner')).not.toBeInTheDocument();
     expect(screen.getByText('Anstehende Aufgaben')).toBeInTheDocument();
     expect(screen.queryByText('Keine anstehenden Aufgaben vorhanden')).not.toBeInTheDocument();
   });

--- a/frontend/src/__tests__/EmptyStateComponents.test.tsx
+++ b/frontend/src/__tests__/EmptyStateComponents.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import EmptyStateCard from '../components/project/EmptyStateCard';
+import RequirementChecklist from '../components/project/RequirementChecklist';
+
+describe('Empty state components', () => {
+  it('renders a neutral outlined empty-state container with consistent action variants', () => {
+    render(
+      <MemoryRouter>
+        <EmptyStateCard
+          title="Noch keine Daten"
+          description="Lege zuerst Daten an."
+          actions={[
+            { label: 'Primäre Aktion', to: '/app/cultures' },
+            { label: 'Sekundäre Aktion', to: '/app/fields' },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    const primary = screen.getByRole('link', { name: 'Primäre Aktion' });
+    const secondary = screen.getByRole('link', { name: 'Sekundäre Aktion' });
+
+    expect(screen.getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
+    expect(screen.getByText('Noch keine Daten')).toBeInTheDocument();
+    expect(screen.getByText('Lege zuerst Daten an.')).toBeInTheDocument();
+    expect(primary.className).toContain('MuiButton-contained');
+    expect(secondary.className).toContain('MuiButton-outlined');
+  });
+
+  it('shows requirement states without duplicated status text', () => {
+    render(
+      <RequirementChecklist
+        items={[
+          { label: 'Kultur', satisfied: true },
+          { label: 'Beet', satisfied: false },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Kultur vorhanden')).toBeInTheDocument();
+    expect(screen.getByText('Beet fehlt')).toBeInTheDocument();
+    expect(screen.queryByText('Kultur vorhanden vorhanden')).not.toBeInTheDocument();
+    expect(screen.queryByText('Beet fehlt fehlt')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -103,6 +103,50 @@ beforeEach(() => {
 });
 
 describe('GanttChartPage', () => {
+  it('shows only location as first missing requirement when no locations exist', async () => {
+    mocks.planList.mockResolvedValue({ data: { results: [] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [] } });
+    mocks.bedList.mockResolvedValue({ data: { results: [] } });
+    mocks.locationList.mockResolvedValue({ data: { results: [] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <GanttChartPage />
+        </CommandProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Noch keine Anbauplanung möglich')).toBeInTheDocument());
+    expect(screen.getByText('Standort fehlt')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Standort anlegen' })).toBeInTheDocument();
+    expect(screen.queryByText('Kultur fehlt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Beet fehlt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Anbauplan fehlt')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Kultur anlegen' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Anbauflächen anlegen' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Feldbelegung' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ansicht' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Ertragsverteilung')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-gantt')).not.toBeInTheDocument();
+  });
+
+  it('shows "Anbauplan fehlt" when cultures and beds exist but no plan exists', async () => {
+    mocks.planList.mockResolvedValue({ data: { results: [] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <GanttChartPage />
+        </CommandProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Anbauplan fehlt')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Anbauplan erstellen' })).toBeInTheDocument();
+  });
+
   it('shows project-required info instead of a red load error when no project is active', async () => {
     projectRequirementState.shouldShowProjectRequiredState = true;
     projectRequirementState.missingProjectReason = 'no_active_project';
@@ -256,8 +300,8 @@ describe('GanttChartPage', () => {
   });
 
   it('fills empty yield weeks between available week entries', async () => {
-    mocks.planList.mockResolvedValue({ data: { results: [] } });
-    mocks.cultureList.mockResolvedValue({ data: { results: [] } });
+    mocks.planList.mockResolvedValue({ data: { results: [{ id: 10, culture: 1, culture_name: 'Kohl', bed: 3, planting_date: '2026-03-01' }] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Kohl' }] } });
     mocks.yieldList.mockResolvedValue({
       data: [
         {
@@ -285,6 +329,23 @@ describe('GanttChartPage', () => {
     expect(screen.getByText('W13')).toBeInTheDocument();
     expect(screen.getByText('W14')).toBeInTheDocument();
     expect(screen.getByText('W15')).toBeInTheDocument();
+  });
+
+  it('hides yield distribution area when no yield data is available', async () => {
+    mocks.planList.mockResolvedValue({ data: { results: [{ id: 10, culture: 1, culture_name: 'Kohl', bed: 3, planting_date: '2026-03-01' }] } });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Kohl' }] } });
+    mocks.yieldList.mockResolvedValue({ data: [] });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <GanttChartPage />
+        </CommandProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('mock-gantt')).toBeInTheDocument());
+    expect(screen.queryByText('Ertragsverteilung')).not.toBeInTheDocument();
   });
 
   it('still shows a red load error for real API failures', async () => {

--- a/frontend/src/__tests__/Locations.projectRequired.test.tsx
+++ b/frontend/src/__tests__/Locations.projectRequired.test.tsx
@@ -88,4 +88,17 @@ describe("Locations project requirement state", () => {
       expect(screen.getByText("Fehler beim Laden der Standorte")).toBeInTheDocument();
     });
   });
+
+  it("does not render upcoming tasks section in location cards", async () => {
+    apiMocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: "Hof" }] } });
+
+    render(
+      <MemoryRouter>
+        <Locations />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Hof")).toBeInTheDocument();
+    expect(screen.queryByText("Anstehende Aufgaben")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/Locations.projectRequired.test.tsx
+++ b/frontend/src/__tests__/Locations.projectRequired.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Locations from "../pages/Locations";
@@ -100,5 +100,32 @@ describe("Locations project requirement state", () => {
 
     expect(await screen.findByText("Hof")).toBeInTheDocument();
     expect(screen.queryByText("Anstehende Aufgaben")).not.toBeInTheDocument();
+  });
+
+  it("uses the same create dialog flow for header and empty-state add actions", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <Locations />
+      </MemoryRouter>,
+    );
+
+    const emptyStateButton = await screen.findByRole("button", { name: "Standort anlegen" });
+    fireEvent.click(emptyStateButton);
+    expect(await screen.findByRole("heading", { name: "Neuen Standort hinzufügen" })).toBeInTheDocument();
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <Locations />
+      </MemoryRouter>,
+    );
+    const headerButton = await screen.findByRole("button", { name: "Neuen Standort hinzufügen" });
+    fireEvent.click(headerButton);
+    expect(await screen.findByRole("heading", { name: "Neuen Standort hinzufügen" })).toBeInTheDocument();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
@@ -5,7 +5,10 @@ import PlantingPlans from "../pages/PlantingPlans";
 
 const apiMocks = vi.hoisted(() => ({
   cultureList: vi.fn(),
+  locationList: vi.fn(),
+  fieldList: vi.fn(),
   bedList: vi.fn(),
+  planList: vi.fn(),
 }));
 
 const projectRequirementState = vi.hoisted(() => ({
@@ -21,6 +24,14 @@ vi.mock("../commands/useCommandContext", () => ({
   useCommandContextTag: vi.fn(),
   useRegisterCommands: vi.fn(),
 }));
+vi.mock("../hooks/useNavigationBlocker", () => ({
+  useNavigationBlocker: () => ({
+    isBlocked: false,
+    proceed: vi.fn(),
+    reset: vi.fn(),
+    destination: null,
+  }),
+}));
 
 vi.mock("../api/api", async () => {
   const actual = await vi.importActual<typeof import("../api/api")>("../api/api");
@@ -30,9 +41,21 @@ vi.mock("../api/api", async () => {
       ...actual.cultureAPI,
       list: apiMocks.cultureList,
     },
+    locationAPI: {
+      ...actual.locationAPI,
+      list: apiMocks.locationList,
+    },
+    fieldAPI: {
+      ...actual.fieldAPI,
+      list: apiMocks.fieldList,
+    },
     bedAPI: {
       ...actual.bedAPI,
       list: apiMocks.bedList,
+    },
+    plantingPlanAPI: {
+      ...actual.plantingPlanAPI,
+      list: apiMocks.planList,
     },
   };
 });
@@ -43,7 +66,10 @@ describe("PlantingPlans project requirement state", () => {
     projectRequirementState.shouldShowProjectRequiredState = false;
     projectRequirementState.missingProjectReason = null;
     apiMocks.cultureList.mockResolvedValue({ data: { results: [] } });
+    apiMocks.locationList.mockResolvedValue({ data: { results: [] } });
+    apiMocks.fieldList.mockResolvedValue({ data: { results: [] } });
     apiMocks.bedList.mockResolvedValue({ data: { results: [] } });
+    apiMocks.planList.mockResolvedValue({ data: { results: [] } });
   });
 
   it("shows friendly no-project state and skips project-bound loading", async () => {
@@ -60,5 +86,21 @@ describe("PlantingPlans project requirement state", () => {
     expect(screen.getByRole("button", { name: "Erstes Projekt anlegen" })).toBeInTheDocument();
     expect(apiMocks.cultureList).not.toHaveBeenCalled();
     expect(apiMocks.bedList).not.toHaveBeenCalled();
+  });
+
+  it("shows only location as first missing requirement when no locations exist", async () => {
+    render(
+      <MemoryRouter>
+        <PlantingPlans />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Du kannst noch keinen Anbauplan erstellen")).toBeInTheDocument();
+    expect(screen.getByText("Standort fehlt")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Standort anlegen" })).toBeInTheDocument();
+    expect(screen.queryByText("Kultur fehlt")).not.toBeInTheDocument();
+    expect(screen.queryByText("Beet fehlt")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Kultur anlegen" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Anbauflächen anlegen" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SeedDemand.test.tsx
+++ b/frontend/src/__tests__/SeedDemand.test.tsx
@@ -4,11 +4,13 @@ import { MemoryRouter } from 'react-router-dom';
 import SeedDemandPage from '../pages/SeedDemand';
 import { CommandProvider } from '../commands/CommandProvider';
 
-const { listMock, saveSelectionMock, cultureListMock, planListMock } = vi.hoisted(() => ({
+const { listMock, saveSelectionMock, cultureListMock, planListMock, locationListMock, bedListMock } = vi.hoisted(() => ({
   listMock: vi.fn(),
   saveSelectionMock: vi.fn(),
   cultureListMock: vi.fn(),
   planListMock: vi.fn(),
+  locationListMock: vi.fn(),
+  bedListMock: vi.fn(),
 }));
 const projectRequirementState = vi.hoisted(() => ({
   shouldShowProjectRequiredState: false,
@@ -29,6 +31,12 @@ vi.mock('../api/api', async () => {
     plantingPlanAPI: {
       list: planListMock,
     },
+    locationAPI: {
+      list: locationListMock,
+    },
+    bedAPI: {
+      list: bedListMock,
+    },
   };
 });
 
@@ -48,8 +56,95 @@ describe('SeedDemandPage', () => {
     projectRequirementState.shouldShowProjectRequiredState = false;
     projectRequirementState.missingProjectReason = null;
     saveSelectionMock.mockResolvedValue({ data: { culture_id: 1, selected_supplier_id: 10 } });
+    cultureListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Basis', seed_rate_value: 1, seed_rate_direct_value: null, seed_rate_pre_cultivation_value: null }] },
+    });
+    planListMock.mockResolvedValue({ data: { results: [{ id: 1 }] } });
+    locationListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+    bedListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Beet 1' }] } });
+  });
+
+  it('shows location-first progressive requirement and no table header when no locations exist', async () => {
+    listMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+    locationListMock.mockResolvedValue({ data: { results: [] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <SeedDemandPage />
+        </CommandProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('seedDemand.progressive.locations.title')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('seedDemand.columns.culture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Keine Einträge vorhanden')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'seedDemand.progressive.locations.action' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'seedDemand.progressive.beds.action' })).not.toBeInTheDocument();
+  });
+
+  it('shows culture-step requirement when locations and beds exist but cultures are missing', async () => {
+    listMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
     cultureListMock.mockResolvedValue({ data: { results: [] } });
     planListMock.mockResolvedValue({ data: { results: [] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <SeedDemandPage />
+        </CommandProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('seedDemand.progressive.cultures.title')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: 'seedDemand.progressive.cultures.action' })).toBeInTheDocument();
+  });
+
+  it('shows plan-step requirement when cultures exist but plans are missing', async () => {
+    listMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+    cultureListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Karotte', seed_rate_value: 2, seed_rate_direct_value: null, seed_rate_pre_cultivation_value: null }] },
+    });
+    planListMock.mockResolvedValue({ data: { results: [] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <SeedDemandPage />
+        </CommandProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('seedDemand.progressive.plans.title')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: 'seedDemand.progressive.plans.action' })).toBeInTheDocument();
+  });
+
+  it('shows no-results empty state when requirements are fulfilled but no rows are calculated', async () => {
+    listMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+    cultureListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Karotte', seed_rate_value: 2, seed_rate_direct_value: null, seed_rate_pre_cultivation_value: null }] },
+    });
+    planListMock.mockResolvedValue({ data: { results: [{ id: 1 }] } });
+
+    render(
+      <MemoryRouter>
+        <CommandProvider>
+          <SeedDemandPage />
+        </CommandProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('seedDemand.columns.culture')).toBeInTheDocument();
+    });
+    expect(screen.getByText('seedDemand.emptyStates.noResultsTitle')).toBeInTheDocument();
+    expect(screen.getByText('seedDemand.emptyStates.noResultsDescription')).toBeInTheDocument();
   });
 
   it('shows project-required info instead of a technical error when no project exists', async () => {

--- a/frontend/src/__tests__/SuppliersPage.test.tsx
+++ b/frontend/src/__tests__/SuppliersPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Suppliers from '../pages/Suppliers';
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock('../api/api', async () => {
+  const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
+  return {
+    ...actual,
+    supplierAPI: {
+      ...actual.supplierAPI,
+      list: mocks.list,
+    },
+  };
+});
+
+vi.mock('../hooks/useProjectRequirement', () => ({
+  useProjectRequirement: () => ({ shouldShowProjectRequiredState: false, missingProjectReason: null }),
+}));
+
+describe('Suppliers page empty and table states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows only empty-state and no table headers when no suppliers exist', async () => {
+    mocks.list.mockResolvedValue({ data: { results: [] } });
+
+    render(
+      <MemoryRouter>
+        <Suppliers />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Noch keine Lieferanten vorhanden')).toBeInTheDocument());
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+    expect(screen.queryByText('Webseite')).not.toBeInTheDocument();
+    expect(screen.queryByText('Aktionen')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Lieferant anlegen' })).toBeInTheDocument();
+  });
+
+  it('shows table headers when suppliers exist', async () => {
+    mocks.list.mockResolvedValue({
+      data: {
+        results: [{ id: 1, name: 'Reinsaat', homepage_url: 'https://example.com' }],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <Suppliers />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Reinsaat')).toBeInTheDocument());
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Webseite')).toBeInTheDocument();
+    expect(screen.getByText('Aktionen')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -1,0 +1,41 @@
+import { Box } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useTranslation } from '../../i18n';
+
+interface AppLogoProps {
+  to?: string;
+  size?: number;
+  showText?: boolean;
+}
+
+export default function AppLogo({ to = '/app/locations', size = 28, showText = true }: AppLogoProps): React.ReactElement {
+  const { t } = useTranslation('common');
+
+  return (
+    <Box
+      component={RouterLink}
+      to={to}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 1,
+        textDecoration: 'none',
+        color: 'inherit',
+        minWidth: 0,
+      }}
+      aria-label={t('appName')}
+    >
+      <Box
+        component="img"
+        src="/favicon.png"
+        alt={t('appName')}
+        sx={{ height: size, width: size, borderRadius: 0.5, flexShrink: 0 }}
+      />
+      {showText ? (
+        <Box component="span" sx={{ fontWeight: 700, fontSize: 16, whiteSpace: 'nowrap' }}>
+          {t('appName')}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/frontend/src/components/project/EmptyStateCard.tsx
+++ b/frontend/src/components/project/EmptyStateCard.tsx
@@ -1,17 +1,20 @@
 import { Box, Button, Paper, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import RequirementChecklist from './RequirementChecklist';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 export interface EmptyStateAction {
   label: string;
-  to: string;
+  to?: string;
+  onClick?: () => void;
 }
 
 interface EmptyStateCardProps {
   title: string;
   description: string;
   actions?: EmptyStateAction[];
-  checklist?: Array<{ label: string; done: boolean }>;
+  checklist?: Array<{ label: string; done: boolean; doneLabel?: string; missingLabel?: string }>;
+  showInfoIcon?: boolean;
 }
 
 export default function EmptyStateCard({
@@ -19,22 +22,51 @@ export default function EmptyStateCard({
   description,
   actions = [],
   checklist = [],
+  showInfoIcon = true,
 }: EmptyStateCardProps): React.ReactElement {
   return (
-    <Paper variant="outlined" sx={{ mb: 2, p: 2 }}>
-      <Typography variant="subtitle1" sx={{ mb: 0.75, fontWeight: 600 }}>{title}</Typography>
+    <Paper
+      variant="outlined"
+      sx={{
+        mb: 2,
+        p: 2,
+        width: '100%',
+        maxWidth: 880,
+        borderColor: 'divider',
+        backgroundColor: 'grey.50',
+        borderLeft: 4,
+        borderLeftColor: 'primary.main',
+        boxShadow: 'none',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.75 }}>
+        {showInfoIcon ? <InfoOutlinedIcon fontSize="small" color="primary" /> : null}
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>{title}</Typography>
+      </Box>
       <Typography variant="body2" sx={{ mb: actions.length > 0 || checklist.length > 0 ? 1.5 : 0 }}>
         {description}
       </Typography>
-      {checklist.length > 0 ? <Box sx={{ mb: 1.5 }}><RequirementChecklist items={checklist.map((item) => ({ label: item.label, satisfied: item.done }))} /></Box> : null}
+      {checklist.length > 0 ? (
+        <Box sx={{ mb: 1.5 }}>
+          <RequirementChecklist
+            items={checklist.map((item) => ({
+              label: item.label,
+              satisfied: item.done,
+              satisfiedLabel: item.doneLabel,
+              missingLabel: item.missingLabel,
+            }))}
+          />
+        </Box>
+      ) : null}
       {actions.length > 0 ? (
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {actions.map((action) => (
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center', flexDirection: { xs: 'column', sm: 'row' } }}>
+          {actions.map((action, index) => (
             <Button
               key={`${action.label}-${action.to}`}
-              component={RouterLink}
+              component={action.to ? RouterLink : 'button'}
               to={action.to}
-              variant="outlined"
+              onClick={action.onClick}
+              variant={index === 0 ? 'contained' : 'outlined'}
               size="small"
             >
               {action.label}

--- a/frontend/src/components/project/RequirementChecklist.tsx
+++ b/frontend/src/components/project/RequirementChecklist.tsx
@@ -5,6 +5,8 @@ import { Chip, Stack } from '@mui/material';
 interface RequirementChecklistItem {
   label: string;
   satisfied: boolean;
+  satisfiedLabel?: string;
+  missingLabel?: string;
 }
 
 interface RequirementChecklistProps {
@@ -13,14 +15,26 @@ interface RequirementChecklistProps {
 
 export default function RequirementChecklist({ items }: RequirementChecklistProps): React.ReactElement {
   return (
-    <Stack spacing={0.75} sx={{ alignItems: 'flex-start' }}>
+    <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ alignItems: 'flex-start' }}>
       {items.map((item) => (
         <Stack key={item.label} direction="row" spacing={1} alignItems="center">
           <Chip
             size="small"
             color={item.satisfied ? 'success' : 'default'}
+            variant={item.satisfied ? 'filled' : 'outlined'}
             icon={item.satisfied ? <CheckCircleOutlineIcon /> : <ErrorOutlineIcon />}
-            label={item.satisfied ? `${item.label} vorhanden` : `${item.label} fehlt`}
+            label={item.satisfied
+              ? (item.satisfiedLabel ?? `${item.label} vorhanden`)
+              : (item.missingLabel ?? `${item.label} fehlt`)}
+            sx={item.satisfied
+              ? undefined
+              : {
+                color: 'text.secondary',
+                borderColor: 'divider',
+                '& .MuiChip-icon': {
+                  color: 'text.secondary',
+                },
+              }}
           />
         </Stack>
       ))}

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -45,6 +45,7 @@ import type { Culture } from '../api/api';
 import { SearchableSelect } from '../components/inputs/SearchableSelect';
 import type { SearchableSelectOption } from '../components/inputs/SearchableSelect';
 import { UI_LABEL_SEPARATOR } from '../utils/uiLabelSeparator';
+import EmptyStateCard from '../components/project/EmptyStateCard';
 
 interface CultureDetailProps {
   cultures: Culture[];
@@ -457,6 +458,7 @@ export function CultureDetail({
   return (
     <Box sx={{ width: '100%' }}>
       {/* Searchable Dropdown */}
+      {cultures.length > 0 ? (
       <Box sx={{ mb: 3 }}>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
           <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 } }}>
@@ -613,6 +615,7 @@ export function CultureDetail({
           {t('searchHelperText', { count: filteredCultures.length })}
         </Typography>
       </Box>
+      ) : null}
 
       {/* Detail View */}
       {selectedCulture && (
@@ -1051,24 +1054,14 @@ export function CultureDetail({
       )}
 
       {!isLoading && !selectedCulture && cultures.length === 0 && (
-        <Card>
-          <CardContent>
-            <Typography variant="h6" align="center" sx={{ mb: 1 }}>
-              {t('emptyOnboarding.title')}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 2 }}>
-              {t('emptyOnboarding.description')}
-            </Typography>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} justifyContent="center">
-              <Button variant="contained" onClick={onCreateCulture}>
-                {t('emptyOnboarding.createAction')}
-              </Button>
-              <Button variant="outlined" onClick={onOpenPublicLibrary}>
-                {t('emptyOnboarding.openLibraryAction')}
-              </Button>
-            </Stack>
-          </CardContent>
-        </Card>
+        <EmptyStateCard
+          title={t('emptyOnboarding.title')}
+          description={t('emptyOnboarding.description')}
+          actions={[
+            { label: t('emptyOnboarding.createAction'), onClick: onCreateCulture },
+            { label: t('emptyOnboarding.openLibraryAction'), onClick: onOpenPublicLibrary },
+          ]}
+        />
       )}
 
       {!isLoading && !selectedCulture && cultures.length > 0 && filteredCultures.length === 0 && (

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -15,6 +15,7 @@ import navigationDE from './locales/de/navigation.json';
 import navigationEN from './locales/en/navigation.json';
 import homeDE from './locales/de/home.json';
 import homeEN from './locales/en/home.json';
+import dashboardDE from './locales/de/dashboard.json';
 import locationsDE from './locales/de/locations.json';
 import culturesDE from './locales/de/cultures.json';
 import plantingPlansDE from './locales/de/plantingPlans.json';
@@ -43,7 +44,7 @@ i18n
     debug: import.meta.env.DEV && import.meta.env.MODE !== 'test',
     
     // Namespaces for organizing translations
-    ns: ['common', 'navigation', 'home', 'locations', 'cultures', 'plantingPlans', 'fields', 'beds', 'hierarchy', 'ganttChart', 'suppliers', 'help', 'auth', 'account', 'projectInvitations'],
+    ns: ['common', 'navigation', 'home', 'dashboard', 'locations', 'cultures', 'plantingPlans', 'fields', 'beds', 'hierarchy', 'ganttChart', 'suppliers', 'help', 'auth', 'account', 'projectInvitations'],
     defaultNS: 'common',
     
     // Translation resources
@@ -52,6 +53,7 @@ i18n
         common: commonDE,
         navigation: navigationDE,
         home: homeDE,
+        dashboard: dashboardDE,
         locations: locationsDE,
         cultures: culturesDE,
         plantingPlans: plantingPlansDE,

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -203,6 +203,55 @@
     "title": "Saatgutbedarf",
     "loadError": "Saatgutbedarf konnte nicht geladen werden.",
     "saveError": "Lieferantenauswahl konnte nicht gespeichert werden.",
+    "requirements": {
+      "plantingPlans": {
+        "label": "Anbaupläne",
+        "missing": "Anbaupläne fehlen",
+        "done": "Anbaupläne vorhanden"
+      },
+      "seedData": {
+        "label": "Saatgutdaten",
+        "missing": "Saatgutdaten fehlen",
+        "done": "Saatgutdaten vorhanden"
+      }
+    },
+    "emptyStates": {
+      "requirementsTitle": "Noch kein Saatgutbedarf berechenbar",
+      "requirementsDescription": "Für den Saatgutbedarf brauchst du Anbaupläne und Saatgutdaten zu deinen Kulturen.",
+      "noResultsTitle": "Kein Saatgutbedarf vorhanden",
+      "noResultsDescription": "Für die aktuellen Anbaupläne konnte kein Saatgutbedarf berechnet werden.",
+      "actions": {
+        "createPlan": "Anbauplan erstellen",
+        "editCultures": "Kulturen bearbeiten"
+      }
+    },
+    "progressive": {
+      "locations": {
+        "title": "Noch kein Saatgutbedarf berechenbar",
+        "description": "Lege zuerst einen Standort an, damit du Flächen und Beete planen kannst.",
+        "action": "Standort anlegen"
+      },
+      "beds": {
+        "title": "Noch kein Saatgutbedarf berechenbar",
+        "description": "Lege als Nächstes Beete an, damit Kulturen einer Fläche zugeordnet werden können.",
+        "action": "Beete anlegen"
+      },
+      "cultures": {
+        "title": "Noch kein Saatgutbedarf berechenbar",
+        "description": "Lege jetzt deine ersten Kulturen an, damit daraus ein Saatgutbedarf berechnet werden kann.",
+        "action": "Kultur anlegen"
+      },
+      "plans": {
+        "title": "Noch kein Saatgutbedarf berechenbar",
+        "description": "Erstelle als Nächstes einen Anbauplan, damit ein konkreter Saatgutbedarf entsteht.",
+        "action": "Anbauplan erstellen"
+      },
+      "seedData": {
+        "title": "Noch kein Saatgutbedarf berechenbar",
+        "description": "Ergänze Saatgutdaten bei deinen Kulturen, damit der Bedarf berechnet werden kann.",
+        "action": "Saatgutdaten ergänzen"
+      }
+    },
     "selectSupplier": "Lieferant auswählen",
     "createSupplierAction": "Neuen Lieferanten anlegen",
     "editCultureAction": "Kultur bearbeiten",

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -6,11 +6,7 @@
   "emptyState": {
     "title": "Starte deine Anbauplanung",
     "description": "Lege zuerst einen Standort an. Danach kannst du Anbauflächen, Kulturen und Anbaupläne erfassen.",
-    "action": "Standort anlegen"
-  },
-  "welcome": {
-    "title": "Willkommen bei OpenFarmPlanner",
-    "description": "Starte deine Anbauplanung, indem du zuerst einen Standort anlegst.",
+    "shortDescription": "Lege zuerst einen Standort an.",
     "action": "Standort anlegen"
   },
   "setup": {

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -1,0 +1,34 @@
+{
+  "title": "Übersicht",
+  "errors": {
+    "load": "Fehler beim Laden der Dashboard-Daten"
+  },
+  "emptyState": {
+    "title": "Starte deine Anbauplanung",
+    "description": "Lege zuerst einen Standort an. Danach kannst du Anbauflächen, Kulturen und Anbaupläne erfassen.",
+    "action": "Standort anlegen"
+  },
+  "setup": {
+    "title": "Projektstatus",
+    "location": "Standort angelegt",
+    "bed": "Beet angelegt",
+    "culture": "Kultur angelegt",
+    "plan": "Anbauplan erstellt"
+  },
+  "status": {
+    "done": "vorhanden",
+    "missing": "fehlt"
+  },
+  "nextStep": {
+    "title": "Nächster sinnvoller Schritt",
+    "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort anlegen" },
+    "beds": { "text": "Lege als Nächstes deine Anbauflächen an.", "action": "Anbauflächen anlegen" },
+    "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur anlegen" },
+    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" },
+    "ready": { "text": "Dein Projekt ist eingerichtet.", "action": "Anbaukalender öffnen" }
+  },
+  "tasks": {
+    "title": "Anstehende Aufgaben",
+    "empty": "Keine anstehenden Aufgaben vorhanden"
+  }
+}

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -24,11 +24,12 @@
     "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort anlegen" },
     "beds": { "text": "Lege als Nächstes deine Anbauflächen an.", "action": "Anbauflächen anlegen" },
     "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur anlegen" },
-    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" },
-    "ready": { "text": "Dein Projekt ist eingerichtet.", "action": "Anbaukalender öffnen" }
+    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" }
   },
   "tasks": {
     "title": "Anstehende Aufgaben",
-    "empty": "Keine anstehenden Aufgaben vorhanden"
+    "empty": "Keine anstehenden Aufgaben vorhanden",
+    "emptyTitle": "Keine anstehenden Aufgaben",
+    "emptyDescription": "Aktuell gibt es keine anstehenden Aufgaben für dieses Projekt."
   }
 }

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -8,6 +8,11 @@
     "description": "Lege zuerst einen Standort an. Danach kannst du Anbauflächen, Kulturen und Anbaupläne erfassen.",
     "action": "Standort anlegen"
   },
+  "welcome": {
+    "title": "Willkommen bei OpenFarmPlanner",
+    "description": "Starte deine Anbauplanung, indem du zuerst einen Standort anlegst.",
+    "action": "Standort anlegen"
+  },
   "setup": {
     "title": "Projektstatus",
     "location": "Standort angelegt",

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -89,5 +89,37 @@
   },
   "seedlings": {
     "emptyState": "Keine Jungpflanzen-Anzuchtzeiträume für dieses Jahr vorhanden."
+  },
+  "requirements": {
+    "location": {
+      "label": "Standort",
+      "missing": "Standort fehlt",
+      "done": "Standort vorhanden"
+    },
+    "culture": {
+      "label": "Kultur",
+      "missing": "Kultur fehlt",
+      "done": "Kultur vorhanden"
+    },
+    "bed": {
+      "label": "Beet",
+      "missing": "Beet fehlt",
+      "done": "Beet vorhanden"
+    },
+    "plan": {
+      "label": "Anbauplan",
+      "missing": "Anbauplan fehlt",
+      "done": "Anbauplan vorhanden"
+    }
+  },
+  "emptyStates": {
+    "requirementsTitle": "Noch keine Anbauplanung möglich",
+    "requirementsDescription": "Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.",
+    "actions": {
+      "createLocation": "Standort anlegen",
+      "createCulture": "Kultur anlegen",
+      "createAreas": "Anbauflächen anlegen",
+      "createPlan": "Anbauplan erstellen"
+    }
   }
 }

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -1,5 +1,6 @@
 {
   "home": "Start",
+  "dashboard": "Übersicht",
   "locations": "Standorte",
   "fieldsAndBeds": "Anbauflächen",
   "cultures": "Kulturen",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -63,13 +63,28 @@
   "emptyStates": {
     "createBlockedTooltip": "Erst Kultur und Beet anlegen",
     "missingRequirementsTitle": "Du kannst noch keinen Anbauplan erstellen",
-    "missingRequirementsDescription": "Für einen Anbauplan brauchst du mindestens eine Kultur und ein Beet.",
+    "missingRequirementsDescription": "Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.",
     "noPlansTitle": "Noch keine Anbaupläne vorhanden",
     "noPlansDescription": "Anbaupläne verbinden Kulturen mit Beeten und Zeiträumen. Danach erscheinen sie automatisch im Anbaukalender.",
     "actions": {
+      "createLocation": "Standort anlegen",
       "createCulture": "Kultur anlegen",
       "createAreas": "Anbauflächen anlegen",
       "createPlan": "Anbauplan erstellen"
+    }
+  },
+  "requirements": {
+    "location": {
+      "label": "Standort",
+      "missing": "Standort fehlt"
+    },
+    "bed": {
+      "label": "Beet",
+      "missing": "Beet fehlt"
+    },
+    "culture": {
+      "label": "Kultur",
+      "missing": "Kultur fehlt"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/suppliers.json
+++ b/frontend/src/i18n/locales/de/suppliers.json
@@ -20,5 +20,9 @@
   "deleteError": "Lieferant konnte nicht gelöscht werden.",
   "invalidDomain": "Ungültige Domain: {{domain}}. Domains müssen gültige Hostnamen ohne Schema oder Pfad sein (z.B. example.com).",
   "domainValidationError": "Einige Domains sind ungültig. Bitte korrigieren Sie die Eingabe.",
-  "invalidUrl": "Bitte geben Sie eine gültige URL ein (z.B. https://example.com)."
+  "invalidUrl": "Bitte geben Sie eine gültige URL ein (z.B. https://example.com).",
+  "emptyState": {
+    "title": "Noch keine Lieferanten vorhanden",
+    "description": "Lieferanten helfen dir bei der Saatgutplanung und beim Paketvergleich. Du kannst auch ohne Lieferanten starten."
+  }
 }

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -984,6 +984,7 @@ function Cultures(): React.ReactElement {
       </Box>
 
       {/* Action buttons for selected culture */}
+      {cultures.length > 0 && (
       <Box
         sx={{
           display: 'flex',
@@ -1110,6 +1111,7 @@ function Cultures(): React.ReactElement {
           </Tooltip>
           <Box sx={{ flexGrow: 1 }} />
       </Box>
+      )}
 
       <PublicCultureLibraryDialog
         open={publicLibraryOpen}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,139 @@
+import { Alert, Box, Button, Card, CardContent, Chip, Stack, Typography } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from '../i18n';
+import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
+import PageContainer from '../components/layout/PageContainer';
+import PageHeader from '../components/layout/PageHeader';
+import ProjectRequiredState from '../components/project/ProjectRequiredState';
+import { useProjectRequirement } from '../hooks/useProjectRequirement';
+import { getFirstMissingRequirement } from './requirementFlow';
+import { deriveLocationTasks } from './locationDerivedTasks';
+
+const NEXT_STEP_CONFIG = {
+  locations: { textKey: 'dashboard:nextStep.locations.text', actionKey: 'dashboard:nextStep.locations.action', to: '/app/locations' },
+  beds: { textKey: 'dashboard:nextStep.beds.text', actionKey: 'dashboard:nextStep.beds.action', to: '/app/fields' },
+  cultures: { textKey: 'dashboard:nextStep.cultures.text', actionKey: 'dashboard:nextStep.cultures.action', to: '/app/cultures' },
+  plans: { textKey: 'dashboard:nextStep.plans.text', actionKey: 'dashboard:nextStep.plans.action', to: '/app/planting-plans' },
+} as const;
+
+export default function Dashboard(): React.ReactElement {
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
+  const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [fields, setFields] = useState<Field[]>([]);
+  const [beds, setBeds] = useState<Bed[]>([]);
+  const [cultures, setCultures] = useState<Culture[]>([]);
+  const [plans, setPlans] = useState<PlantingPlan[]>([]);
+
+  useEffect(() => {
+    if (shouldShowProjectRequiredState) {
+      setLoading(false);
+      setError(null);
+      setLocations([]); setFields([]); setBeds([]); setCultures([]); setPlans([]);
+      return;
+    }
+    const fetchData = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        const [locationsRes, fieldsRes, bedsRes, culturesRes, plansRes] = await Promise.all([
+          locationAPI.list(), fieldAPI.list(), bedAPI.list(), cultureAPI.list(), plantingPlanAPI.list(),
+        ]);
+        setLocations(locationsRes.data.results);
+        setFields(fieldsRes.data.results);
+        setBeds(bedsRes.data.results);
+        setCultures(culturesRes.data.results);
+        setPlans(plansRes.data.results);
+        setError(null);
+      } catch {
+        setError(t('dashboard:errors.load'));
+      } finally {
+        setLoading(false);
+      }
+    };
+    void fetchData();
+  }, [shouldShowProjectRequiredState, t]);
+
+  const firstMissingRequirement = getFirstMissingRequirement({ hasLocations: locations.length > 0, hasBeds: beds.length > 0, hasCultures: cultures.length > 0, hasPlans: plans.length > 0 });
+  const locale = i18n.resolvedLanguage === 'de' ? 'de-DE' : 'en-US';
+
+  const setupItems = [
+    { label: t('dashboard:setup.location'), done: locations.length > 0 },
+    { label: t('dashboard:setup.bed'), done: beds.length > 0 },
+    { label: t('dashboard:setup.culture'), done: cultures.length > 0 },
+    { label: t('dashboard:setup.plan'), done: plans.length > 0 },
+  ];
+
+  const upcomingTasks = useMemo(() => {
+    const byLocation = deriveLocationTasks({ locations, fields, beds, cultures, plantingPlans: plans });
+    return Object.values(byLocation).flat().sort((a, b) => a.date.localeCompare(b.date)).slice(0, 8);
+  }, [beds, cultures, fields, locations, plans]);
+
+  const locationNameById = useMemo(() => new Map(locations.filter((l) => l.id !== undefined).map((l) => [l.id as number, l.name])), [locations]);
+
+  if (loading) return <PageContainer><Typography>{t('common:messages.loading')}</Typography></PageContainer>;
+  if (shouldShowProjectRequiredState && missingProjectReason) return <PageContainer><ProjectRequiredState reason={missingProjectReason} /></PageContainer>;
+
+  const isEmptyProject = locations.length === 0 && beds.length === 0 && cultures.length === 0 && plans.length === 0;
+
+  return (
+    <PageContainer>
+      <PageHeader title={t('dashboard:title')} />
+      {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
+
+      {isEmptyProject ? (
+        <Card variant="outlined" sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>{t('dashboard:emptyState.title')}</Typography>
+            <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:emptyState.description')}</Typography>
+            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:emptyState.action')}</Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>{t('dashboard:setup.title')}</Typography>
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            {setupItems.map((item) => <Chip key={item.label} label={`${item.label}: ${item.done ? t('dashboard:status.done') : t('dashboard:status.missing')}`} color={item.done ? 'success' : 'default'} />)}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>{t('dashboard:nextStep.title')}</Typography>
+          {firstMissingRequirement ? (
+            <>
+              <Typography variant="body2" sx={{ mb: 1.5 }}>{t(NEXT_STEP_CONFIG[firstMissingRequirement].textKey)}</Typography>
+              <Button component={RouterLink} to={NEXT_STEP_CONFIG[firstMissingRequirement].to} variant="contained">{t(NEXT_STEP_CONFIG[firstMissingRequirement].actionKey)}</Button>
+            </>
+          ) : (
+            <>
+              <Typography variant="body2" sx={{ mb: 1.5 }}>{t('dashboard:nextStep.ready.text')}</Typography>
+              <Button component={RouterLink} to="/app/gantt-chart" variant="contained">{t('dashboard:nextStep.ready.action')}</Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" gutterBottom>{t('dashboard:tasks.title')}</Typography>
+          {upcomingTasks.length === 0 ? <Typography variant="body2">{t('dashboard:tasks.empty')}</Typography> : (
+            <Stack spacing={0.75}>
+              {upcomingTasks.map((task) => (
+                <Box key={`${task.locationId}-${task.type}-${task.date}-${task.planId ?? 'na'}`} sx={{ borderBottom: '1px solid', borderColor: 'divider', pb: 0.5 }}>
+                  <Typography variant="body2">{new Date(`${task.date}T00:00:00`).toLocaleDateString(locale)} – {t(`locations:taskTitles.${task.type}`)}</Typography>
+                  <Typography variant="caption" color="text.secondary">{task.cultureName ?? ''}{task.cultureName && task.locationId ? ' · ' : ''}{locationNameById.get(task.locationId) ?? ''}</Typography>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -77,6 +77,7 @@ export default function Dashboard(): React.ReactElement {
   if (shouldShowProjectRequiredState && missingProjectReason) return <PageContainer><ProjectRequiredState reason={missingProjectReason} /></PageContainer>;
 
   const isEmptyProject = locations.length === 0 && beds.length === 0 && cultures.length === 0 && plans.length === 0;
+  const isSetupComplete = firstMissingRequirement === null;
 
   return (
     <PageContainer>
@@ -93,36 +94,41 @@ export default function Dashboard(): React.ReactElement {
         </Card>
       ) : null}
 
-      <Card variant="outlined" sx={{ mb: 2 }}>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>{t('dashboard:setup.title')}</Typography>
-          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-            {setupItems.map((item) => <Chip key={item.label} label={`${item.label}: ${item.done ? t('dashboard:status.done') : t('dashboard:status.missing')}`} color={item.done ? 'success' : 'default'} />)}
-          </Stack>
-        </CardContent>
-      </Card>
+      {!isSetupComplete ? (
+        <>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>{t('dashboard:setup.title')}</Typography>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {setupItems.map((item) => <Chip key={item.label} label={`${item.label}: ${item.done ? t('dashboard:status.done') : t('dashboard:status.missing')}`} color={item.done ? 'success' : 'default'} />)}
+              </Stack>
+            </CardContent>
+          </Card>
 
-      <Card variant="outlined" sx={{ mb: 2 }}>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>{t('dashboard:nextStep.title')}</Typography>
-          {firstMissingRequirement ? (
-            <>
-              <Typography variant="body2" sx={{ mb: 1.5 }}>{t(NEXT_STEP_CONFIG[firstMissingRequirement].textKey)}</Typography>
-              <Button component={RouterLink} to={NEXT_STEP_CONFIG[firstMissingRequirement].to} variant="contained">{t(NEXT_STEP_CONFIG[firstMissingRequirement].actionKey)}</Button>
-            </>
-          ) : (
-            <>
-              <Typography variant="body2" sx={{ mb: 1.5 }}>{t('dashboard:nextStep.ready.text')}</Typography>
-              <Button component={RouterLink} to="/app/gantt-chart" variant="contained">{t('dashboard:nextStep.ready.action')}</Button>
-            </>
-          )}
-        </CardContent>
-      </Card>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>{t('dashboard:nextStep.title')}</Typography>
+              {firstMissingRequirement ? (
+                <>
+                  <Typography variant="body2" sx={{ mb: 1.5 }}>{t(NEXT_STEP_CONFIG[firstMissingRequirement].textKey)}</Typography>
+                  <Button component={RouterLink} to={NEXT_STEP_CONFIG[firstMissingRequirement].to} variant="contained">{t(NEXT_STEP_CONFIG[firstMissingRequirement].actionKey)}</Button>
+                </>
+              ) : null}
+            </CardContent>
+          </Card>
+        </>
+      ) : null}
 
+      {isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0) ? (
       <Card variant="outlined">
         <CardContent>
           <Typography variant="h6" gutterBottom>{t('dashboard:tasks.title')}</Typography>
-          {upcomingTasks.length === 0 ? <Typography variant="body2">{t('dashboard:tasks.empty')}</Typography> : (
+          {upcomingTasks.length === 0 ? (
+            <>
+              <Typography variant="subtitle2">{t('dashboard:tasks.emptyTitle')}</Typography>
+              <Typography variant="body2">{t('dashboard:tasks.emptyDescription')}</Typography>
+            </>
+          ) : (
             <Stack spacing={0.75}>
               {upcomingTasks.map((task) => (
                 <Box key={`${task.locationId}-${task.type}-${task.date}-${task.planId ?? 'na'}`} sx={{ borderBottom: '1px solid', borderColor: 'divider', pb: 0.5 }}>
@@ -134,6 +140,7 @@ export default function Dashboard(): React.ReactElement {
           )}
         </CardContent>
       </Card>
+      ) : null}
     </PageContainer>
   );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -87,14 +87,14 @@ export default function Dashboard(): React.ReactElement {
       {isEmptyProject ? (
         <Card variant="outlined" sx={{ mb: 2 }}>
           <CardContent>
-            <Typography variant="h6" gutterBottom>{t('dashboard:emptyState.title')}</Typography>
-            <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:emptyState.description')}</Typography>
-            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:emptyState.action')}</Button>
+            <Typography variant="h6" gutterBottom>{t('dashboard:welcome.title')}</Typography>
+            <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:welcome.description')}</Typography>
+            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:welcome.action')}</Button>
           </CardContent>
         </Card>
       ) : null}
 
-      {!isSetupComplete ? (
+      {!isEmptyProject && !isSetupComplete ? (
         <>
           <Card variant="outlined" sx={{ mb: 2 }}>
             <CardContent>
@@ -119,7 +119,7 @@ export default function Dashboard(): React.ReactElement {
         </>
       ) : null}
 
-      {isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0) ? (
+      {!isEmptyProject && (isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0)) ? (
       <Card variant="outlined">
         <CardContent>
           <Typography variant="h6" gutterBottom>{t('dashboard:tasks.title')}</Typography>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -87,9 +87,9 @@ export default function Dashboard(): React.ReactElement {
       {isEmptyProject ? (
         <Card variant="outlined" sx={{ mb: 2 }}>
           <CardContent>
-            <Typography variant="h6" gutterBottom>{t('dashboard:welcome.title')}</Typography>
-            <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:welcome.description')}</Typography>
-            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:welcome.action')}</Button>
+            <Typography variant="h6" gutterBottom>{t('dashboard:emptyState.title')}</Typography>
+            <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:emptyState.shortDescription')}</Typography>
+            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:emptyState.action')}</Button>
           </CardContent>
         </Card>
       ) : null}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -55,6 +55,7 @@ import {
   type GanttTask,
   type GanttTaskGroup,
 } from './ganttChartUtils';
+import { getFirstMissingRequirement } from './requirementFlow';
 
 interface WeeklyYieldCultureMeta {
   id: number;
@@ -313,6 +314,16 @@ function GanttChartPage(): React.ReactElement {
   }), [calendarMode, t]);
 
   const activeTaskGroups = calendarMode === 'occupancy' ? occupancyTaskGroups : seedlingTaskGroups;
+  const hasCultures = cultures.length > 0;
+  const hasBeds = beds.length > 0;
+  const hasPlantingPlans = plantingPlans.length > 0;
+  const firstMissingRequirement = getFirstMissingRequirement({
+    hasLocations: locations.length > 0,
+    hasBeds,
+    hasCultures,
+    hasPlans: hasPlantingPlans,
+  });
+  const hasCalendarRequirements = firstMissingRequirement === null;
 
   const renderOccupancyTooltip = useCallback(({ task }: { task: GanttTask }) => (
     <Box sx={{ p: 0.5 }}>
@@ -396,6 +407,7 @@ function GanttChartPage(): React.ReactElement {
       maxTotalYield: maxYield,
     };
   }, [weeklyYield]);
+  const hasYieldData = chartData.length > 0;
 
   const yAxisTicks = useMemo(() => {
     const tickCount = 5;
@@ -431,18 +443,20 @@ function GanttChartPage(): React.ReactElement {
       <PageHeader title={t('ganttChart:title')} actions={<PageHelp pageKey="calendar" />} marginBottom={1} />
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
-        <Box sx={{ mb: 2 }}>
-          <Tabs
-            value={calendarMode}
-            onChange={(_, value: CalendarMode) => setCalendarMode(value)}
-            aria-label={t('ganttChart:viewSelectorAriaLabel')}
-          >
-            <Tab label={t('ganttChart:modes.occupancy')} value="occupancy" />
-            <Tab label={t('ganttChart:modes.seedlings')} value="seedlings" />
-          </Tabs>
-        </Box>
+        {hasCalendarRequirements ? (
+          <Box sx={{ mb: 2 }}>
+            <Tabs
+              value={calendarMode}
+              onChange={(_, value: CalendarMode) => setCalendarMode(value)}
+              aria-label={t('ganttChart:viewSelectorAriaLabel')}
+            >
+              <Tab label={t('ganttChart:modes.occupancy')} value="occupancy" />
+              <Tab label={t('ganttChart:modes.seedlings')} value="seedlings" />
+            </Tabs>
+          </Box>
+        ) : null}
 
-        {calendarMode === 'occupancy' ? (
+        {hasCalendarRequirements && calendarMode === 'occupancy' ? (
           <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <ModeToggle
               label={t('ganttChart:modeLabel')}
@@ -458,24 +472,29 @@ function GanttChartPage(): React.ReactElement {
           </Box>
         ) : null}
 
-        <Paper className="gantt-container-wrapper">
-          {activeTaskGroups.length === 0 ? (
+        {!hasCalendarRequirements ? (
+          <Paper className="gantt-container-wrapper">
             <Box sx={{ p: 2 }}>
               <EmptyStateCard
-                title="Noch keine Anbaupläne vorhanden"
-                description="Der Anbaukalender zeigt deine geplanten Kulturen über die Zeit. Lege zuerst einen Anbauplan an – danach erscheint er automatisch hier."
+                title={t('ganttChart:emptyStates.requirementsTitle')}
+                description={t('ganttChart:emptyStates.requirementsDescription')}
                 checklist={[
-                  { label: 'Kultur angelegt', done: cultures.length > 0 },
-                  { label: 'Beet angelegt', done: beds.length > 0 },
+                  ...(firstMissingRequirement === 'locations' ? [{ label: t('ganttChart:requirements.location.label'), done: false, missingLabel: t('ganttChart:requirements.location.missing') }] : []),
+                  ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:requirements.bed.label'), done: false, missingLabel: t('ganttChart:requirements.bed.missing') }] : []),
+                  ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:requirements.culture.label'), done: false, missingLabel: t('ganttChart:requirements.culture.missing') }] : []),
+                  ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:requirements.plan.label'), done: false, missingLabel: t('ganttChart:requirements.plan.missing') }] : []),
                 ]}
                 actions={[
-                  ...(cultures.length === 0 ? [{ label: 'Kultur anlegen', to: '/app/cultures' }] : []),
-                  ...(beds.length === 0 ? [{ label: 'Anbauflächen anlegen', to: '/app/fields' }] : []),
-                  ...(cultures.length > 0 && beds.length > 0 ? [{ label: 'Anbauplan erstellen', to: '/app/planting-plans' }] : []),
+                  ...(firstMissingRequirement === 'locations' ? [{ label: t('ganttChart:emptyStates.actions.createLocation'), to: '/app/locations' }] : []),
+                  ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:emptyStates.actions.createAreas'), to: '/app/fields' }] : []),
+                  ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:emptyStates.actions.createCulture'), to: '/app/cultures' }] : []),
+                  ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:emptyStates.actions.createPlan'), to: '/app/planting-plans' }] : []),
                 ]}
               />
             </Box>
-          ) : (
+          </Paper>
+        ) : (
+          <Paper className="gantt-container-wrapper">
             <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
               <GanttChart
                 key={ganttRenderKey}
@@ -525,17 +544,14 @@ function GanttChartPage(): React.ReactElement {
                   : undefined}
               />
             </GanttRenderBoundary>
-          )}
-        </Paper>
+          </Paper>
+        )}
 
-        {calendarMode === 'occupancy' ? (
+        {hasCalendarRequirements && calendarMode === 'occupancy' && hasYieldData ? (
           <Paper className="gantt-container-wrapper" sx={{ mt: 3, p: 2 }}>
             <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
               {t('ganttChart:yieldDistributionTitle')}
             </Typography>
-            {chartData.length === 0 ? (
-              <div className="gantt-no-data">{t('ganttChart:noYieldData')}</div>
-            ) : (
               <Box sx={{ width: '100%' }}>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
                   {chartCultures.map((culture) => (
@@ -593,7 +609,6 @@ function GanttChartPage(): React.ReactElement {
                   </Box>
                 </Box>
               </Box>
-            )}
           </Paper>
         ) : null}
     </PageContainer>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
   Alert,
   Box,
@@ -6,7 +6,6 @@ import {
   Card,
   CardActions,
   CardContent,
-  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -20,13 +19,12 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
+import { locationAPI, type Location } from '../api/api';
 import PageHelp from '../components/help/PageHelp';
 import PageHeader from '../components/layout/PageHeader';
 import PageContainer from '../components/layout/PageContainer';
 import { useTranslation } from '../i18n';
 import { resolveLocaleFromLanguage } from '../utils/numberLocalization';
-import { deriveLocationTasks, type DerivedLocationTask } from './locationDerivedTasks';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
@@ -102,12 +100,6 @@ const validateCoordinateRange = (value: number | null, min: number, max: number)
 const formatCoordinate = (value: number, locale: string): string =>
   new Intl.NumberFormat(locale, { minimumFractionDigits: 4, maximumFractionDigits: 4 }).format(value);
 
-const formatTaskDate = (value: string, locale: string): string => {
-  const parsed = new Date(`${value}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString(locale);
-};
-
 const toFormState = (location: Location | null): LocationFormState => ({
   name: location?.name ?? '',
   coordinates:
@@ -126,10 +118,6 @@ function Locations(): React.ReactElement {
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
   const numberLocale = resolveLocaleFromLanguage(i18n.language);
   const [locations, setLocations] = useState<Location[]>([]);
-  const [fields, setFields] = useState<Field[]>([]);
-  const [beds, setBeds] = useState<Bed[]>([]);
-  const [plantingPlans, setPlantingPlans] = useState<PlantingPlan[]>([]);
-  const [cultures, setCultures] = useState<Culture[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
@@ -142,18 +130,8 @@ function Locations(): React.ReactElement {
     setLoading(true);
     setError('');
     try {
-      const [locationsResponse, fieldsResponse, bedsResponse, plansResponse, culturesResponse] = await Promise.all([
-        locationAPI.list(),
-        fieldAPI.list(),
-        bedAPI.list(),
-        plantingPlanAPI.list(),
-        cultureAPI.list(),
-      ]);
+      const [locationsResponse] = await Promise.all([locationAPI.list()]);
       setLocations(locationsResponse.data.results);
-      setFields(fieldsResponse.data.results);
-      setBeds(bedsResponse.data.results);
-      setPlantingPlans(plansResponse.data.results);
-      setCultures(culturesResponse.data.results);
     } catch {
       setError(t('locations:errors.load'));
     } finally {
@@ -169,18 +147,6 @@ function Locations(): React.ReactElement {
     }
     void loadData();
   }, [loadData, shouldShowProjectRequiredState]);
-
-  const tasksByLocation = useMemo(
-    () =>
-      deriveLocationTasks({
-        locations,
-        fields,
-        beds,
-        plantingPlans,
-        cultures,
-      }),
-    [beds, cultures, fields, locations, plantingPlans],
-  );
 
   const openCreateDialog = (): void => {
     setEditingLocation(null);
@@ -280,12 +246,6 @@ function Locations(): React.ReactElement {
     }
   };
 
-  const renderTaskLine = (task: DerivedLocationTask): string => {
-    const taskTitle = t(`locations:taskTitles.${task.type}`);
-    const culture = task.cultureName ? ` – ${task.cultureName}` : '';
-    return `${formatTaskDate(task.date, numberLocale)} – ${taskTitle}${culture}`;
-  };
-
   return (
     <PageContainer>
       <Box sx={{ width: '100%', mx: 'auto' }}>
@@ -333,7 +293,6 @@ function Locations(): React.ReactElement {
               const mapLink = hasCoordinates
                 ? `https://www.google.com/maps?q=${location.latitude},${location.longitude}`
                 : null;
-              const taskPreview = (location.id ? tasksByLocation[location.id] : []) ?? [];
 
               return (
                 <Box
@@ -375,22 +334,6 @@ function Locations(): React.ReactElement {
                         </Typography>
                       </Stack>
 
-                      <Box mt={2}>
-                        <Typography variant="subtitle2" gutterBottom>
-                          {t('locations:upcomingTasks')}
-                        </Typography>
-                        {taskPreview.length === 0 ? (
-                          <Typography variant="body2" color="text.secondary">
-                            {t('locations:noUpcomingTasks')}
-                          </Typography>
-                        ) : (
-                          <Stack spacing={0.5}>
-                            {taskPreview.slice(0, 3).map((task) => (
-                              <Chip key={`${task.type}-${task.date}-${task.planId ?? 'na'}`} label={renderTaskLine(task)} size="small" />
-                            ))}
-                          </Stack>
-                        )}
-                      </Box>
                     </CardContent>
                     <CardActions sx={{ justifyContent: 'flex-end', mt: 'auto' }}>
                       <Button size="small" startIcon={<EditOutlinedIcon />} onClick={() => openEditDialog(location)}>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -273,7 +273,7 @@ function Locations(): React.ReactElement {
           <EmptyStateCard
             title="Noch keine Standorte vorhanden"
             description="Standorte helfen dir, deine Anbauflächen zu strukturieren, zum Beispiel verschiedene Gärten oder Felder."
-            actions={[{ label: 'Standort anlegen', to: '/app/locations' }]}
+            actions={[{ label: 'Standort anlegen', onClick: openCreateDialog }]}
           />
         ) : (
           !shouldShowProjectRequiredState && (

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -77,6 +77,7 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
+import { getFirstMissingRequirement } from "./requirementFlow";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
 import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 import EmptyStateCard from "../components/project/EmptyStateCard";
@@ -1457,9 +1458,16 @@ function PlantingPlans(): React.ReactElement {
       );
     }
   };
+  const hasLocations = locations.length > 0;
   const hasCultures = cultures.length > 0;
   const hasBeds = beds.length > 0;
-  const canCreatePlan = hasCultures && hasBeds;
+  const firstMissingRequirement = getFirstMissingRequirement({
+    hasLocations,
+    hasBeds,
+    hasCultures,
+    hasPlans: false,
+  });
+  const canCreatePlan = firstMissingRequirement === "plans";
   const hasPlans = mobileRows.length > 0;
   const shouldShowPrerequisiteState = !canCreatePlan;
   const shouldShowNoPlansState = canCreatePlan && !hasPlans;
@@ -1502,12 +1510,14 @@ function PlantingPlans(): React.ReactElement {
             title={t("plantingPlans:emptyStates.missingRequirementsTitle")}
             description={t("plantingPlans:emptyStates.missingRequirementsDescription")}
             checklist={[
-              { label: t("plantingPlans:columns.culture"), done: hasCultures },
-              { label: t("plantingPlans:columns.bed"), done: hasBeds },
+              ...(firstMissingRequirement === "locations" ? [{ label: t("plantingPlans:requirements.location.label"), done: false, missingLabel: t("plantingPlans:requirements.location.missing") }] : []),
+              ...(firstMissingRequirement === "beds" ? [{ label: t("plantingPlans:requirements.bed.label"), done: false, missingLabel: t("plantingPlans:requirements.bed.missing") }] : []),
+              ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:requirements.culture.label"), done: false, missingLabel: t("plantingPlans:requirements.culture.missing") }] : []),
             ]}
             actions={[
-              ...(!hasCultures ? [{ label: t("plantingPlans:emptyStates.actions.createCulture"), to: "/app/cultures" }] : []),
-              ...(!hasBeds ? [{ label: t("plantingPlans:emptyStates.actions.createAreas"), to: "/app/fields" }] : []),
+              ...(firstMissingRequirement === "locations" ? [{ label: t("plantingPlans:emptyStates.actions.createLocation"), to: "/app/locations" }] : []),
+              ...(firstMissingRequirement === "beds" ? [{ label: t("plantingPlans:emptyStates.actions.createAreas"), to: "/app/fields" }] : []),
+              ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:emptyStates.actions.createCulture"), to: "/app/cultures" }] : []),
             ]}
           />
         ) : shouldShowNoPlansState ? (

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
@@ -18,7 +18,7 @@ import {
   Typography,
 } from '@mui/material';
 import { seedDemandAPI, type SeedDemand } from '../api/api';
-import { cultureAPI, plantingPlanAPI } from '../api/api';
+import { bedAPI, cultureAPI, locationAPI, plantingPlanAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import { useCommandContextTag } from '../commands/useCommandContext';
 import PageHelp from '../components/help/PageHelp';
@@ -50,6 +50,50 @@ export default function SeedDemandPage(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [cultureCount, setCultureCount] = useState(0);
   const [planCount, setPlanCount] = useState(0);
+  const [hasCulturesWithSeedData, setHasCulturesWithSeedData] = useState(false);
+  const [locationCount, setLocationCount] = useState(0);
+  const [bedCount, setBedCount] = useState(0);
+  const hasPlans = planCount > 0;
+  const hasSeedData = hasCulturesWithSeedData;
+  const canCalculateSeedDemand = locationCount > 0 && bedCount > 0 && cultureCount > 0 && hasPlans && hasSeedData;
+  const missingRequirement = useMemo(() => {
+    if (locationCount === 0) {
+      return {
+        title: t('seedDemand.progressive.locations.title'),
+        description: t('seedDemand.progressive.locations.description'),
+        action: { label: t('seedDemand.progressive.locations.action'), to: '/app/locations' },
+      };
+    }
+    if (bedCount === 0) {
+      return {
+        title: t('seedDemand.progressive.beds.title'),
+        description: t('seedDemand.progressive.beds.description'),
+        action: { label: t('seedDemand.progressive.beds.action'), to: '/app/fields' },
+      };
+    }
+    if (cultureCount === 0) {
+      return {
+        title: t('seedDemand.progressive.cultures.title'),
+        description: t('seedDemand.progressive.cultures.description'),
+        action: { label: t('seedDemand.progressive.cultures.action'), to: '/app/cultures' },
+      };
+    }
+    if (!hasPlans) {
+      return {
+        title: t('seedDemand.progressive.plans.title'),
+        description: t('seedDemand.progressive.plans.description'),
+        action: { label: t('seedDemand.progressive.plans.action'), to: '/app/planting-plans' },
+      };
+    }
+    if (!hasSeedData) {
+      return {
+        title: t('seedDemand.progressive.seedData.title'),
+        description: t('seedDemand.progressive.seedData.description'),
+        action: { label: t('seedDemand.progressive.seedData.action'), to: '/app/cultures' },
+      };
+    }
+    return null;
+  }, [bedCount, cultureCount, hasPlans, hasSeedData, locationCount, t]);
 
   const loadRows = async () => {
     setIsLoading(true);
@@ -57,9 +101,22 @@ export default function SeedDemandPage(): React.ReactElement {
     try {
       const response = await seedDemandAPI.list();
       setRows(response.data.results ?? []);
-      const [culturesResponse, plansResponse] = await Promise.all([cultureAPI.list(), plantingPlanAPI.list()]);
-      setCultureCount(culturesResponse.data.results.length);
+      const [culturesResponse, plansResponse, locationsResponse, bedsResponse] = await Promise.all([
+        cultureAPI.list(),
+        plantingPlanAPI.list(),
+        locationAPI.list(),
+        bedAPI.list(),
+      ]);
+      const cultures = culturesResponse.data.results;
+      setCultureCount(cultures.length);
       setPlanCount(plansResponse.data.results.length);
+      setLocationCount(locationsResponse.data.results.length);
+      setBedCount(bedsResponse.data.results.length);
+      setHasCulturesWithSeedData(cultures.some((culture) => (
+        culture.seed_rate_value !== null
+        || culture.seed_rate_direct_value !== null
+        || culture.seed_rate_pre_cultivation_value !== null
+      )));
     } catch {
       setError(t('seedDemand.loadError'));
     } finally {
@@ -84,6 +141,7 @@ export default function SeedDemandPage(): React.ReactElement {
       setRows([]);
       setIsLoading(false);
       setError(null);
+      setHasCulturesWithSeedData(false);
       return;
     }
     void loadRows();
@@ -118,19 +176,16 @@ export default function SeedDemandPage(): React.ReactElement {
         {isLoading && <CircularProgress />}
         {error && <Alert severity="error">{error}</Alert>}
 
-        {!isLoading && !error && (
+        {!isLoading && !error && !canCalculateSeedDemand && (
+          <EmptyStateCard
+            title={missingRequirement?.title ?? t('seedDemand.emptyStates.requirementsTitle')}
+            description={missingRequirement?.description ?? t('seedDemand.emptyStates.requirementsDescription')}
+            actions={missingRequirement ? [missingRequirement.action] : []}
+          />
+        )}
+
+        {!isLoading && !error && canCalculateSeedDemand && (
           <TableContainer component={Paper} sx={{ width: 'fit-content', maxWidth: '100%' }}>
-            {rows.length === 0 ? (
-              <EmptyStateCard
-                title="Noch kein Saatgutbedarf berechenbar"
-                description="Der Saatgutbedarf entsteht aus deinen Anbauplänen und den Saatgutdaten der Kulturen."
-                actions={planCount === 0
-                  ? [{ label: 'Anbauplan erstellen', to: '/app/planting-plans' }]
-                  : cultureCount === 0
-                    ? [{ label: 'Kultur anlegen', to: '/app/cultures' }]
-                    : [{ label: 'Kulturen bearbeiten', to: '/app/cultures' }]}
-              />
-            ) : null}
             <Table
               sx={{
                 '& .MuiTableCell-root': { py: 1 },
@@ -230,6 +285,14 @@ export default function SeedDemandPage(): React.ReactElement {
               })}
             </TableBody>
             </Table>
+            {rows.length === 0 ? (
+              <Box sx={{ p: 2 }}>
+                <EmptyStateCard
+                  title={t('seedDemand.emptyStates.noResultsTitle')}
+                  description={t('seedDemand.emptyStates.noResultsDescription')}
+                />
+              </Box>
+            ) : null}
           </TableContainer>
         )}
       </Box>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -215,56 +215,59 @@ export default function Suppliers(): React.ReactElement {
             </Box>
           )}
         />
-        <TableContainer sx={{ width: 'fit-content', maxWidth: '100%', overflowX: 'auto' }}>
-          {suppliers.length === 0 ? (
+        {suppliers.length === 0 ? (
+          <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard
-              title="Noch keine Lieferanten vorhanden"
-              description="Lieferanten helfen dir bei der Saatgutplanung und beim Paketvergleich. Du kannst auch ohne Lieferanten starten."
-              actions={[{ label: 'Lieferant anlegen', to: '/app/suppliers?create=1' }]}
+              title={t('emptyState.title')}
+              description={t('emptyState.description')}
+              actions={[{ label: t('create'), to: '/app/suppliers?create=1' }]}
             />
-          ) : null}
-          <Table size="small" sx={{ width: 'auto' }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>{t('name')}</TableCell>
-                <TableCell>{t('homepage')}</TableCell>
-                <TableCell align="right">{t('actions')}</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {suppliers.map((supplier) => (
-                <TableRow key={supplier.id} hover>
-                  <TableCell>{supplier.name}</TableCell>
-                  <TableCell>
-                    {supplier.homepage_url ? (
-                      <Link href={supplier.homepage_url} target="_blank" rel="noopener noreferrer" underline="hover">
-                        {supplier.homepage_url}
-                      </Link>
-                    ) : null}
-                  </TableCell>
-                  <TableCell align="right">
-                    <IconButton
-                      size="small"
-                      color="primary"
-                      aria-label={t('editAction')}
-                      onClick={() => openEdit(supplier)}
-                    >
-                      <EditIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      color="error"
-                      aria-label={t('deleteAction')}
-                      onClick={() => void deleteSupplier(supplier)}
-                    >
-                      <CloseIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
+          </Box>
+        ) : (
+          <TableContainer sx={{ width: 'fit-content', maxWidth: '100%', overflowX: 'auto' }}>
+            <Table size="small" sx={{ width: 'auto' }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('name')}</TableCell>
+                  <TableCell>{t('homepage')}</TableCell>
+                  <TableCell align="right">{t('actions')}</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+              </TableHead>
+              <TableBody>
+                {suppliers.map((supplier) => (
+                  <TableRow key={supplier.id} hover>
+                    <TableCell>{supplier.name}</TableCell>
+                    <TableCell>
+                      {supplier.homepage_url ? (
+                        <Link href={supplier.homepage_url} target="_blank" rel="noopener noreferrer" underline="hover">
+                          {supplier.homepage_url}
+                        </Link>
+                      ) : null}
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        size="small"
+                        color="primary"
+                        aria-label={t('editAction')}
+                        onClick={() => openEdit(supplier)}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        aria-label={t('deleteAction')}
+                        onClick={() => void deleteSupplier(supplier)}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Box>
 
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} fullWidth maxWidth="sm">

--- a/frontend/src/pages/requirementFlow.ts
+++ b/frontend/src/pages/requirementFlow.ts
@@ -1,0 +1,16 @@
+export type RequirementStep = 'locations' | 'beds' | 'cultures' | 'plans' | null;
+
+interface RequirementState {
+  hasLocations: boolean;
+  hasBeds: boolean;
+  hasCultures: boolean;
+  hasPlans: boolean;
+}
+
+export function getFirstMissingRequirement(state: RequirementState): RequirementStep {
+  if (!state.hasLocations) return 'locations';
+  if (!state.hasBeds) return 'beds';
+  if (!state.hasCultures) return 'cultures';
+  if (!state.hasPlans) return 'plans';
+  return null;
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -6,7 +6,9 @@ const theme = createTheme({
   palette: {
     // Primary color used by contained buttons and primary components
     primary: {
-      main: '#1976d2',
+      main: '#2e7d32',
+      dark: '#1b5e20',
+      light: '#60ad5e',
     },
     secondary: {
       main: '#9c27b0',


### PR DESCRIPTION
### Motivation
- Guide users step-by-step when core resources are missing (locations, beds, cultures, planting plans) so pages surface the next actionable requirement instead of technical errors.
- Provide a consistent, more informative empty-state presentation with actionable buttons and clearer checklist labels across multiple pages.
- Improve top navigation for compact desktop layouts, add the app logo, overflow menu and surface page help in the global menu for easier access.

### Description
- Add `pages/requirementFlow.ts` with `getFirstMissingRequirement` and use it in `GanttChart`, `PlantingPlans` and other pages to determine the first missing requirement and gate UI rendering accordingly.
- Rework empty-state components: `components/project/EmptyStateCard.tsx` now supports optional `to`/`onClick` actions, configurable info icon, and new styling, and `components/project/RequirementChecklist.tsx` supports custom satisfied/missing labels and improved chip styling.
- Introduce `components/layout/AppLogo.tsx` and update `App.tsx` to show the logo, support a compact-desktop primary/overflow nav split, add a `Mehr` overflow menu, move page help into the global menu and robustify route navigation with `getCurrentRouteFromLocation`.
- Update pages and styles to use the new components and flow: `GanttChart`, `PlantingPlans`, `SeedDemand`, `Cultures`, and `Suppliers` receive UI and logic updates; `App.css` nav styling adjusted and multiple i18n JSON files augmented with new strings; tests updated and new tests added.

### Testing
- Ran the component/unit test suite (`vitest`) under `frontend/src/__tests__`, including added tests `EmptyStateComponents.test.tsx` and `SuppliersPage.test.tsx` and updated tests for `GanttChart`, `SeedDemand`, `PlantingPlans`, `CultureDetail`, and `App`, and all tests passed.
- No end-to-end or manual QA steps were included in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e58bd54883228e4c4d41f8a0bcdf)