### PR TITLE
fix(frontend): trigger create flows directly from onboarding ctas

### DIFF
--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -8,10 +8,16 @@ import { CommandProvider } from '../commands/CommandProvider';
 
 const {
   listMock,
+  locationListMock,
+  fieldListMock,
+  bedListMock,
   publicCultureListMock,
   publishPublicMock,
 } = vi.hoisted(() => ({
   listMock: vi.fn(),
+  locationListMock: vi.fn(),
+  fieldListMock: vi.fn(),
+  bedListMock: vi.fn(),
   publicCultureListMock: vi.fn(),
   publishPublicMock: vi.fn(),
 }));
@@ -24,6 +30,18 @@ vi.mock('../api/api', async () => {
       ...actual.cultureAPI,
       list: listMock,
       publishPublic: publishPublicMock,
+    },
+    locationAPI: {
+      ...actual.locationAPI,
+      list: locationListMock,
+    },
+    fieldAPI: {
+      ...actual.fieldAPI,
+      list: fieldListMock,
+    },
+    bedAPI: {
+      ...actual.bedAPI,
+      list: bedListMock,
     },
     publicCultureAPI: {
       ...actual.publicCultureAPI,
@@ -87,6 +105,9 @@ describe('Cultures action area', () => {
         results: [],
       },
     });
+    locationListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+    fieldListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Parzelle A', location: 1 }] } });
+    bedListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Beet A', field: 1 }] } });
     publishPublicMock.mockResolvedValue({
       data: {
         operation: 'created',
@@ -199,5 +220,23 @@ describe('Cultures action area', () => {
       expect(screen.getByRole('button', { name: 'Öffentliche Version aktualisieren' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: 'Veröffentlichen' })).not.toBeInTheDocument();
+  });
+
+  it('disables create planting plan button with bed-specific guidance when no beds exist', async () => {
+    bedListMock.mockResolvedValue({ data: { results: [] } });
+    renderCultures('/cultures?cultureId=1');
+
+    const createPlanButton = await screen.findByRole('button', { name: 'Anbauplan erstellen (Alt+P)' });
+    expect(createPlanButton).toBeDisabled();
+    expect(await screen.findByRole('link', { name: 'Beet anlegen' })).toBeInTheDocument();
+
+    fireEvent.mouseOver(createPlanButton.parentElement as HTMLElement);
+    expect(await screen.findByText('Du brauchst zuerst mindestens ein Beet, um einen Anbauplan zu erstellen.')).toBeInTheDocument();
+  });
+
+  it('enables create planting plan button when all prerequisites are present', async () => {
+    renderCultures('/cultures?cultureId=1');
+    const createPlanButton = await screen.findByRole('button', { name: 'Anbauplan erstellen (Alt+P)' });
+    await waitFor(() => expect(createPlanButton).toBeEnabled());
   });
 });

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -46,7 +46,9 @@ describe('Dashboard', () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
     expect(await screen.findByText('Starte deine Anbauplanung')).toBeInTheDocument();
     expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'Standort anlegen' })).toHaveLength(1);
+    const createLocationLinks = screen.getAllByRole('link', { name: 'Standort anlegen' });
+    expect(createLocationLinks).toHaveLength(1);
+    expect(createLocationLinks[0]).toHaveAttribute('href', '/app/locations?create=true');
     expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
     expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
     expect(screen.queryByText('Anstehende Aufgaben')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -46,7 +46,7 @@ describe('Dashboard', () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
     expect(await screen.findByText('Starte deine Anbauplanung')).toBeInTheDocument();
     expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
-    const createLocationLinks = screen.getAllByRole('link', { name: 'Standort anlegen' });
+    const createLocationLinks = screen.getAllByRole('link', { name: 'Standort hinzufügen' });
     expect(createLocationLinks).toHaveLength(1);
     expect(createLocationLinks[0]).toHaveAttribute('href', '/app/locations?create=true');
     expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -205,6 +205,9 @@ describe('FieldsBedsPage', () => {
 
     renderPage();
     expect(await screen.findByText('Parzelle fehlt')).toBeInTheDocument();
+    const matchingButtons = await screen.findAllByRole('button', { name: 'Parzelle hinzufügen' });
+    fireEvent.click(matchingButtons[matchingButtons.length - 1]);
+    expect(await screen.findByRole('heading', { name: 'Parzelle hinzufügen' })).toBeInTheDocument();
   });
 
   it('shows missing bed requirement when fields exist but no beds exist', async () => {

--- a/frontend/src/__tests__/Locations.projectRequired.test.tsx
+++ b/frontend/src/__tests__/Locations.projectRequired.test.tsx
@@ -111,9 +111,9 @@ describe("Locations project requirement state", () => {
       </MemoryRouter>,
     );
 
-    const emptyStateButton = await screen.findByRole("button", { name: "Standort anlegen" });
+    const emptyStateButton = await screen.findByRole("button", { name: "Standort hinzufügen" });
     fireEvent.click(emptyStateButton);
-    expect(await screen.findByRole("heading", { name: "Neuen Standort hinzufügen" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Standort hinzufügen" })).toBeInTheDocument();
     unmount();
 
     render(
@@ -121,9 +121,9 @@ describe("Locations project requirement state", () => {
         <Locations />
       </MemoryRouter>,
     );
-    const headerButton = await screen.findByRole("button", { name: "Neuen Standort hinzufügen" });
+    const headerButton = await screen.findByRole("button", { name: "Standort hinzufügen" });
     fireEvent.click(headerButton);
-    expect(await screen.findByRole("heading", { name: "Neuen Standort hinzufügen" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Standort hinzufügen" })).toBeInTheDocument();
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
@@ -136,7 +136,7 @@ describe("Locations project requirement state", () => {
       </MemoryRouter>,
     );
 
-    const createDialogHeadings = await screen.findAllByRole("heading", { name: "Neuen Standort hinzufügen" });
+    const createDialogHeadings = await screen.findAllByRole("heading", { name: "Standort hinzufügen" });
     expect(createDialogHeadings).toHaveLength(1);
   });
 });

--- a/frontend/src/__tests__/Locations.projectRequired.test.tsx
+++ b/frontend/src/__tests__/Locations.projectRequired.test.tsx
@@ -128,4 +128,15 @@ describe("Locations project requirement state", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
   });
+
+  it("opens the existing create dialog from query intent and clears create parameter", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app/locations?create=true"]}>
+        <Locations />
+      </MemoryRouter>,
+    );
+
+    const createDialogHeadings = await screen.findAllByRole("heading", { name: "Neuen Standort hinzufügen" });
+    expect(createDialogHeadings).toHaveLength(1);
+  });
 });

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -21,12 +21,15 @@ const listMembersMock = vi.fn(async () => ({
 const updateMemberMock = vi.fn(async () => ({ data: { id: 11, role: 'admin' } }));
 const removeMemberMock = vi.fn(async () => ({}));
 const revokeInvitationMock = vi.fn();
+const updateProjectMock = vi.fn(async () => ({ data: { id: 1, name: 'Beta' } }));
+const refreshUserMock = vi.fn(async () => null);
 
 const authState = {
   user: {
     id: 1,
     memberships: [{ project_id: 1, project_name: 'Alpha', role: 'admin' as const }],
   },
+  refreshUser: refreshUserMock,
 };
 
 vi.mock('../auth/useAuth', () => ({
@@ -45,6 +48,7 @@ vi.mock('../api/api', async () => {
       updateMember: (...args: unknown[]) => updateMemberMock(...args),
       removeMember: (...args: unknown[]) => removeMemberMock(...args),
       revokeInvitation: (...args: unknown[]) => revokeInvitationMock(...args),
+      update: (...args: unknown[]) => updateProjectMock(...args),
     },
   };
 });
@@ -62,6 +66,8 @@ describe('ProjectSettingsPage', () => {
     updateMemberMock.mockClear();
     removeMemberMock.mockClear();
     revokeInvitationMock.mockClear();
+    updateProjectMock.mockClear();
+    refreshUserMock.mockClear();
     listMock.mockResolvedValue({ data: [] });
     listMembersMock.mockResolvedValue({
       data: [
@@ -208,5 +214,37 @@ describe('ProjectSettingsPage', () => {
     expect(
       newerInvitation.compareDocumentPosition(olderInvitation) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
+  });
+
+  it('shows current project name and allows renaming via PATCH', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    expect(projectNameInput).toHaveValue('Alpha');
+
+    fireEvent.change(projectNameInput, { target: { value: 'Beta' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+    await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Beta' }));
+    await waitFor(() => expect(refreshUserMock).toHaveBeenCalled());
+  });
+
+  it('prevents empty or unchanged project name saves', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    const saveButton = screen.getByRole('button', { name: 'Speichern' });
+
+    expect(saveButton).toBeDisabled();
+    fireEvent.change(projectNameInput, { target: { value: '   ' } });
+    expect(saveButton).toBeDisabled();
+    expect(updateProjectMock).not.toHaveBeenCalled();
+  });
+
+  it('submits rename on Enter key', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    fireEvent.change(projectNameInput, { target: { value: 'Gamma' } });
+    fireEvent.keyDown(projectNameInput, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Gamma' }));
   });
 });

--- a/frontend/src/__tests__/requirementFlow.test.ts
+++ b/frontend/src/__tests__/requirementFlow.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getFirstMissingCultivationPlanRequirement } from '../pages/requirementFlow';
+
+describe('getFirstMissingCultivationPlanRequirement', () => {
+  it('returns beds when beds are missing but location and field exist', () => {
+    expect(getFirstMissingCultivationPlanRequirement({
+      hasLocations: true,
+      hasFields: true,
+      hasBeds: false,
+      hasCultures: true,
+    })).toBe('beds');
+  });
+
+  it('returns null when all prerequisites are fulfilled', () => {
+    expect(getFirstMissingCultivationPlanRequirement({
+      hasLocations: true,
+      hasFields: true,
+      hasBeds: true,
+      hasCultures: true,
+    })).toBeNull();
+  });
+});

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -258,6 +258,8 @@ export interface VersionResponse {
 export const projectAPI = {
   create: (data: { name: string; description?: string }) =>
     http.post<ProjectPayload>('/projects/', data),
+  update: (projectId: number, data: { name: string }) =>
+    http.patch<ProjectPayload>(`/projects/${projectId}/`, data),
   invite: (projectId: number, data: { email: string; role: 'admin' | 'member' }) =>
     http.post(`/projects/${projectId}/invitations/`, data),
   listMembers: (projectId: number) =>

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -313,7 +313,7 @@
     "delete": "Löschen",
     "deleteConfirm": "Möchten Sie diese Kultur wirklich löschen?",
     "createPlantingPlan": "Anbauplan erstellen",
-    "createBed": "Beet anlegen",
+    "createBed": "Beet hinzufügen",
     "createPlantingPlanDisabled": {
       "locations": "Du brauchst zuerst mindestens einen Standort, um einen Anbauplan zu erstellen.",
       "fields": "Du brauchst zuerst mindestens eine Parzelle, um einen Anbauplan zu erstellen.",

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -313,6 +313,14 @@
     "delete": "Löschen",
     "deleteConfirm": "Möchten Sie diese Kultur wirklich löschen?",
     "createPlantingPlan": "Anbauplan erstellen",
+    "createBed": "Beet anlegen",
+    "createPlantingPlanDisabled": {
+      "locations": "Du brauchst zuerst mindestens einen Standort, um einen Anbauplan zu erstellen.",
+      "fields": "Du brauchst zuerst mindestens eine Parzelle, um einen Anbauplan zu erstellen.",
+      "beds": "Du brauchst zuerst mindestens ein Beet, um einen Anbauplan zu erstellen.",
+      "cultures": "Du brauchst zuerst mindestens eine Kultur, um einen Anbauplan zu erstellen.",
+      "null": "Anbauplan erstellen"
+    },
     "aiComplete": "Kultur vervollständigen (KI)",
     "aiReresearch": "Kultur komplett neu recherchieren (KI)",
     "aiCompleteAll": "Alle Kulturen vervollständigen (KI)",

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -7,7 +7,7 @@
     "title": "Starte deine Anbauplanung",
     "description": "Lege zuerst einen Standort an. Danach kannst du Anbauflächen, Kulturen und Anbaupläne erfassen.",
     "shortDescription": "Lege zuerst einen Standort an.",
-    "action": "Standort anlegen"
+    "action": "Standort hinzufügen"
   },
   "setup": {
     "title": "Projektstatus",
@@ -22,9 +22,9 @@
   },
   "nextStep": {
     "title": "Nächster sinnvoller Schritt",
-    "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort anlegen" },
-    "beds": { "text": "Lege als Nächstes deine Anbauflächen an.", "action": "Anbauflächen anlegen" },
-    "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur anlegen" },
+    "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort hinzufügen" },
+    "beds": { "text": "Lege als Nächstes deine Anbauflächen an.", "action": "Parzelle hinzufügen" },
+    "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur hinzufügen" },
     "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" }
   },
   "tasks": {

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -116,9 +116,9 @@
     "requirementsTitle": "Noch keine Anbauplanung möglich",
     "requirementsDescription": "Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.",
     "actions": {
-      "createLocation": "Standort anlegen",
-      "createCulture": "Kultur anlegen",
-      "createAreas": "Anbauflächen anlegen",
+      "createLocation": "Standort hinzufügen",
+      "createCulture": "Kultur hinzufügen",
+      "createAreas": "Parzelle hinzufügen",
       "createPlan": "Anbauplan erstellen"
     }
   }

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -51,7 +51,7 @@
   },
   "actions": {
     "addField": "Parzelle hinzufügen",
-    "createLocation": "Standort anlegen"
+    "createLocation": "Standort hinzufügen"
   },
   "dialogs": {
     "addField": {
@@ -64,9 +64,9 @@
     "title": "Noch keine Anbauflächen vorhanden",
     "description": "Anbauflächen bestehen aus Standorten, Parzellen und Beeten. Lege zuerst einen Standort an und ergänze danach Parzellen und Beete.",
     "actions": {
-      "createLocation": "Standort anlegen",
-      "createField": "Parzelle anlegen",
-      "createBed": "Beet anlegen"
+      "createLocation": "Standort hinzufügen",
+      "createField": "Parzelle hinzufügen",
+      "createBed": "Beet hinzufügen"
     }
   },
   "confirm": {

--- a/frontend/src/i18n/locales/de/locations.json
+++ b/frontend/src/i18n/locales/de/locations.json
@@ -12,7 +12,7 @@
     "coordinateFormat": "Bitte Koordinaten im Format „Breitengrad, Längengrad“ eingeben."
   },
   "confirmDelete": "Möchten Sie diesen Standort wirklich löschen?",
-  "addButton": "Neuen Standort hinzufügen",
+  "addButton": "Standort hinzufügen",
   "editTitle": "Standort bearbeiten",
   "emptyState": "Noch keine Standorte vorhanden.",
   "openInGoogleMaps": "In Google Maps öffnen",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -61,15 +61,15 @@
     "notesPhotosAria": "Notizen und Fotos öffnen"
   },
   "emptyStates": {
-    "createBlockedTooltip": "Erst Kultur und Beet anlegen",
+    "createBlockedTooltip": "Erst Kultur und Beet hinzufügen",
     "missingRequirementsTitle": "Du kannst noch keinen Anbauplan erstellen",
     "missingRequirementsDescription": "Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.",
     "noPlansTitle": "Noch keine Anbaupläne vorhanden",
     "noPlansDescription": "Anbaupläne verbinden Kulturen mit Beeten und Zeiträumen. Danach erscheinen sie automatisch im Anbaukalender.",
     "actions": {
-      "createLocation": "Standort anlegen",
-      "createCulture": "Kultur anlegen",
-      "createAreas": "Anbauflächen anlegen",
+      "createLocation": "Standort hinzufügen",
+      "createCulture": "Kultur hinzufügen",
+      "createAreas": "Parzelle hinzufügen",
       "createPlan": "Anbauplan erstellen"
     }
   },

--- a/frontend/src/i18n/locales/de/projectInvitations.json
+++ b/frontend/src/i18n/locales/de/projectInvitations.json
@@ -2,6 +2,14 @@
   "title": "Projekteinstellungen",
   "noActiveProject": "Kein aktives Projekt ausgewählt.",
   "projectLabel": "Projekt: {{name}}",
+  "projectRename": {
+    "label": "Projekt umbenennen",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "success": "Projektname aktualisiert.",
+    "error": "Projektname konnte nicht aktualisiert werden.",
+    "minLength": "Mindestens 2 Zeichen."
+  },
   "inviteSectionTitle": "Nutzer einladen",
   "emailLabel": "E-Mail",
   "roleLabel": "Rolle",

--- a/frontend/src/i18n/locales/de/suppliers.json
+++ b/frontend/src/i18n/locales/de/suppliers.json
@@ -1,6 +1,6 @@
 {
   "title": "Lieferanten",
-  "create": "Lieferant anlegen",
+  "create": "Lieferant hinzufügen",
   "edit": "Lieferant bearbeiten",
   "name": "Name",
   "homepage": "Webseite",

--- a/frontend/src/i18n/locales/en/projectInvitations.json
+++ b/frontend/src/i18n/locales/en/projectInvitations.json
@@ -2,6 +2,14 @@
   "title": "Project settings",
   "noActiveProject": "No active project selected.",
   "projectLabel": "Project: {{name}}",
+  "projectRename": {
+    "label": "Rename project",
+    "save": "Save",
+    "cancel": "Cancel",
+    "success": "Project name updated.",
+    "error": "Project name could not be updated.",
+    "minLength": "At least 2 characters."
+  },
   "inviteSectionTitle": "Invite users",
   "emailLabel": "Email",
   "roleLabel": "Role",

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
@@ -105,6 +105,7 @@ import ProjectRequiredState from '../components/project/ProjectRequiredState';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
+  const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
@@ -213,6 +214,27 @@ function Cultures(): React.ReactElement {
     setEditingCulture(undefined);
     setShowForm(true);
   };
+
+  useEffect(() => {
+    if (shouldShowProjectRequiredState || showForm) {
+      return;
+    }
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('create') !== 'true') {
+      return;
+    }
+
+    handleAddNew();
+    searchParams.delete('create');
+    const nextSearch = searchParams.toString();
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      },
+      { replace: true },
+    );
+  }, [location.pathname, location.search, navigate, shouldShowProjectRequiredState, showForm]);
 
   const handleEdit = (culture: Culture) => {
     setEditingCulture(culture);

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -13,7 +13,7 @@ import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
-import { cultureAPI, publicCultureAPI, type Culture, type EnrichmentResult } from '../api/api';
+import { bedAPI, cultureAPI, fieldAPI, locationAPI, publicCultureAPI, type Culture, type EnrichmentResult } from '../api/api';
 import type {
   CultivationType,
   CultureHistoryEntry,
@@ -102,6 +102,7 @@ import { CulturesImportDialog } from './CulturesImportDialog';
 import { EnrichmentLoadingDialog } from './EnrichmentLoadingDialog';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
+import { getFirstMissingCultivationPlanRequirement } from './requirementFlow';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
@@ -152,6 +153,9 @@ function Cultures(): React.ReactElement {
   const [publicCultures, setPublicCultures] = useState<PublicCulture[]>([]);
   const [publicLibraryImportingId, setPublicLibraryImportingId] = useState<number | null>(null);
   const [publishingCultureId, setPublishingCultureId] = useState<number | null>(null);
+  const [hasLocations, setHasLocations] = useState(false);
+  const [hasFields, setHasFields] = useState(false);
+  const [hasBeds, setHasBeds] = useState(false);
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'info') => {
     setSnackbar({ open: true, message, severity });
@@ -189,11 +193,37 @@ function Cultures(): React.ReactElement {
     if (shouldShowProjectRequiredState) {
       setCultures([]);
       setIsCulturesLoading(false);
+      setHasLocations(false);
+      setHasFields(false);
+      setHasBeds(false);
       return;
     }
     // eslint-disable-next-line -- Data fetching on mount is intentional
     fetchCultures();
   }, [fetchCultures, shouldShowProjectRequiredState]);
+
+  useEffect(() => {
+    if (shouldShowProjectRequiredState) {
+      return;
+    }
+    const fetchPlanRequirements = async (): Promise<void> => {
+      try {
+        const [locationsResponse, fieldsResponse, bedsResponse] = await Promise.all([
+          locationAPI.list(),
+          fieldAPI.list(),
+          bedAPI.list(),
+        ]);
+        setHasLocations(locationsResponse.data.results.length > 0);
+        setHasFields(fieldsResponse.data.results.length > 0);
+        setHasBeds(bedsResponse.data.results.length > 0);
+      } catch {
+        setHasLocations(false);
+        setHasFields(false);
+        setHasBeds(false);
+      }
+    };
+    void fetchPlanRequirements();
+  }, [shouldShowProjectRequiredState]);
 
 
   useEffect(() => {
@@ -561,6 +591,13 @@ function Cultures(): React.ReactElement {
   };
 
   const selectedCulture = cultures.find(c => c.id === selectedCultureId);
+  const firstMissingPlanRequirement = getFirstMissingCultivationPlanRequirement({
+    hasLocations,
+    hasFields,
+    hasBeds,
+    hasCultures: cultures.length > 0,
+  });
+  const canCreatePlantingPlan = Boolean(selectedCulture) && firstMissingPlanRequirement === null;
   const isUpdatingOwnPublicCulture = Boolean(selectedCulture?.owned_public_culture_id);
   const dialogCostInfo = getDialogCostInfo(enrichmentResult);
 
@@ -1031,19 +1068,24 @@ function Cultures(): React.ReactElement {
               </Button>
             </span>
           </Tooltip>
-          <Tooltip title="Anbauplan erstellen (Alt+P)">
+          <Tooltip title={canCreatePlantingPlan ? "Anbauplan erstellen (Alt+P)" : t(`buttons.createPlantingPlanDisabled.${firstMissingPlanRequirement}`)}>
             <span>
               <Button
                 aria-label="Anbauplan erstellen (Alt+P)"
                 variant="contained"
                 startIcon={<AgricultureIcon />}
                 onClick={handleCreatePlantingPlan}
-                disabled={!selectedCulture}
+                disabled={!canCreatePlantingPlan}
               >
                 {t('buttons.createPlantingPlan')}
               </Button>
             </span>
           </Tooltip>
+          {firstMissingPlanRequirement === 'beds' ? (
+            <Button component={RouterLink} to="/app/fields" variant="text">
+              {t('buttons.createBed')}
+            </Button>
+          ) : null}
           {aiEnrichmentEnabled && (
             <>
               <Tooltip title={!canRunEnrichmentForCulture(selectedCulture) ? enrichmentDisabledReason : ''}><span><ButtonGroup variant="contained" aria-label={t('ai.menuLabel')} disabled={!selectedCulture || enrichmentLoading || !canRunEnrichmentForCulture(selectedCulture)}>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -11,10 +11,10 @@ import { getFirstMissingRequirement } from './requirementFlow';
 import { deriveLocationTasks } from './locationDerivedTasks';
 
 const NEXT_STEP_CONFIG = {
-  locations: { textKey: 'dashboard:nextStep.locations.text', actionKey: 'dashboard:nextStep.locations.action', to: '/app/locations' },
+  locations: { textKey: 'dashboard:nextStep.locations.text', actionKey: 'dashboard:nextStep.locations.action', to: '/app/locations?create=true' },
   beds: { textKey: 'dashboard:nextStep.beds.text', actionKey: 'dashboard:nextStep.beds.action', to: '/app/fields' },
-  cultures: { textKey: 'dashboard:nextStep.cultures.text', actionKey: 'dashboard:nextStep.cultures.action', to: '/app/cultures' },
-  plans: { textKey: 'dashboard:nextStep.plans.text', actionKey: 'dashboard:nextStep.plans.action', to: '/app/planting-plans' },
+  cultures: { textKey: 'dashboard:nextStep.cultures.text', actionKey: 'dashboard:nextStep.cultures.action', to: '/app/cultures?create=true' },
+  plans: { textKey: 'dashboard:nextStep.plans.text', actionKey: 'dashboard:nextStep.plans.action', to: '/app/planting-plans?create=true' },
 } as const;
 
 export default function Dashboard(): React.ReactElement {
@@ -89,7 +89,7 @@ export default function Dashboard(): React.ReactElement {
           <CardContent>
             <Typography variant="h6" gutterBottom>{t('dashboard:emptyState.title')}</Typography>
             <Typography variant="body2" sx={{ mb: 2 }}>{t('dashboard:emptyState.shortDescription')}</Typography>
-            <Button component={RouterLink} to="/app/locations" variant="contained">{t('dashboard:emptyState.action')}</Button>
+            <Button component={RouterLink} to="/app/locations?create=true" variant="contained">{t('dashboard:emptyState.action')}</Button>
           </CardContent>
         </Card>
       ) : null}

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -103,7 +103,7 @@ export default function FieldsBedsPage(): React.ReactElement {
 
   const handleGlobalAddField = useCallback((): void => {
     if (locations.length === 0) {
-      navigate('/app/locations');
+      navigate('/app/locations?create=true');
       return;
     }
 
@@ -248,8 +248,8 @@ export default function FieldsBedsPage(): React.ReactElement {
               { label: t('hierarchy:columns.bed'), done: hasBeds },
             ]}
             actions={[
-              ...(!hasLocations ? [{ label: t('hierarchy:emptyAreas.actions.createLocation'), to: '/app/locations' }] : []),
-              ...(hasLocations && !hasFields ? [{ label: t('hierarchy:emptyAreas.actions.createField'), to: '/app/fields' }] : []),
+              ...(!hasLocations ? [{ label: t('hierarchy:emptyAreas.actions.createLocation'), onClick: () => navigate('/app/locations?create=true') }] : []),
+              ...(hasLocations && !hasFields ? [{ label: t('hierarchy:emptyAreas.actions.createField'), onClick: handleGlobalAddField }] : []),
               ...(hasFields && !hasBeds ? [{ label: t('hierarchy:emptyAreas.actions.createBed'), to: '/app/fields' }] : []),
             ]}
           />

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -485,10 +485,10 @@ function GanttChartPage(): React.ReactElement {
                   ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:requirements.plan.label'), done: false, missingLabel: t('ganttChart:requirements.plan.missing') }] : []),
                 ]}
                 actions={[
-                  ...(firstMissingRequirement === 'locations' ? [{ label: t('ganttChart:emptyStates.actions.createLocation'), to: '/app/locations' }] : []),
+                  ...(firstMissingRequirement === 'locations' ? [{ label: t('ganttChart:emptyStates.actions.createLocation'), to: '/app/locations?create=true' }] : []),
                   ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:emptyStates.actions.createAreas'), to: '/app/fields' }] : []),
-                  ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:emptyStates.actions.createCulture'), to: '/app/cultures' }] : []),
-                  ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:emptyStates.actions.createPlan'), to: '/app/planting-plans' }] : []),
+                  ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:emptyStates.actions.createCulture'), to: '/app/cultures?create=true' }] : []),
+                  ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:emptyStates.actions.createPlan'), to: '/app/planting-plans?create=true' }] : []),
                 ]}
               />
             </Box>

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -28,6 +28,7 @@ import { resolveLocaleFromLanguage } from '../utils/numberLocalization';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 type SoilType = NonNullable<Location['soil_type']>;
 type Exposure = NonNullable<Location['exposure']>;
@@ -115,6 +116,8 @@ const toFormState = (location: Location | null): LocationFormState => ({
 
 function Locations(): React.ReactElement {
   const { t, i18n } = useTranslation(['locations', 'common']);
+  const location = useLocation();
+  const navigate = useNavigate();
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
   const numberLocale = resolveLocaleFromLanguage(i18n.language);
   const [locations, setLocations] = useState<Location[]>([]);
@@ -155,6 +158,27 @@ function Locations(): React.ReactElement {
     setFormErrorField(null);
     setDialogOpen(true);
   };
+
+  useEffect(() => {
+    if (shouldShowProjectRequiredState || dialogOpen) {
+      return;
+    }
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('create') !== 'true') {
+      return;
+    }
+
+    openCreateDialog();
+    searchParams.delete('create');
+    const nextSearch = searchParams.toString();
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      },
+      { replace: true },
+    );
+  }, [dialogOpen, location.pathname, location.search, navigate, shouldShowProjectRequiredState]);
 
   const openEditDialog = (location: Location): void => {
     setEditingLocation(location);

--- a/frontend/src/pages/Locations.tsx
+++ b/frontend/src/pages/Locations.tsx
@@ -297,7 +297,7 @@ function Locations(): React.ReactElement {
           <EmptyStateCard
             title="Noch keine Standorte vorhanden"
             description="Standorte helfen dir, deine Anbauflächen zu strukturieren, zum Beispiel verschiedene Gärten oder Felder."
-            actions={[{ label: 'Standort anlegen', onClick: openCreateDialog }]}
+            actions={[{ label: t('locations:addButton'), onClick: openCreateDialog }]}
           />
         ) : (
           !shouldShowProjectRequiredState && (

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -451,6 +451,7 @@ function PlantingPlans(): React.ReactElement {
   const [mobileNotesDraft, setMobileNotesDraft] = useState("");
   const [isMobileNotesSaving, setIsMobileNotesSaving] = useState(false);
   const mobilePrefillHandledRef = useRef(false);
+  const createIntentHandledRef = useRef(false);
 
   useEffect(() => {
     if (isMobile) {
@@ -1472,6 +1473,25 @@ function PlantingPlans(): React.ReactElement {
   const shouldShowPrerequisiteState = !canCreatePlan;
   const shouldShowNoPlansState = canCreatePlan && !hasPlans;
 
+  useEffect(() => {
+    if (createIntentHandledRef.current || !canCreatePlan) {
+      return;
+    }
+    if (searchParams.get("create") !== "true") {
+      return;
+    }
+
+    if (isMobile) {
+      openMobileCreateDialog();
+    } else {
+      gridCommandApiRef.current?.addRow();
+    }
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("create");
+    setSearchParams(nextParams, { replace: true });
+    createIntentHandledRef.current = true;
+  }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
+
   return (
     <PageContainer variant="xwide">
       <PageHeader
@@ -1515,16 +1535,16 @@ function PlantingPlans(): React.ReactElement {
               ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:requirements.culture.label"), done: false, missingLabel: t("plantingPlans:requirements.culture.missing") }] : []),
             ]}
             actions={[
-              ...(firstMissingRequirement === "locations" ? [{ label: t("plantingPlans:emptyStates.actions.createLocation"), to: "/app/locations" }] : []),
+              ...(firstMissingRequirement === "locations" ? [{ label: t("plantingPlans:emptyStates.actions.createLocation"), to: "/app/locations?create=true" }] : []),
               ...(firstMissingRequirement === "beds" ? [{ label: t("plantingPlans:emptyStates.actions.createAreas"), to: "/app/fields" }] : []),
-              ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:emptyStates.actions.createCulture"), to: "/app/cultures" }] : []),
+              ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:emptyStates.actions.createCulture"), to: "/app/cultures?create=true" }] : []),
             ]}
           />
         ) : shouldShowNoPlansState ? (
           <EmptyStateCard
             title={t("plantingPlans:emptyStates.noPlansTitle")}
             description={t("plantingPlans:emptyStates.noPlansDescription")}
-            actions={[{ label: t("plantingPlans:emptyStates.actions.createPlan"), to: "/app/planting-plans" }]}
+            actions={[{ label: t("plantingPlans:emptyStates.actions.createPlan"), to: "/app/planting-plans?create=true" }]}
           />
         ) : null}
 

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -11,7 +11,7 @@ interface InviteFeedback {
 
 export default function ProjectSettingsPage(): React.ReactElement {
   const { t } = useTranslation('projectInvitations');
-  const { user } = useAuth();
+  const { user, refreshUser } = useAuth();
   const activeProjectId = Number(window.localStorage.getItem('activeProjectId'));
   const activeMembership = useMemo(
     () => (user?.memberships ?? []).find((membership) => membership.project_id === activeProjectId),
@@ -26,9 +26,15 @@ export default function ProjectSettingsPage(): React.ReactElement {
   const [pendingRemovalMember, setPendingRemovalMember] = useState<ProjectMemberPayload | null>(null);
   const [memberLoadError, setMemberLoadError] = useState<string | null>(null);
   const [invitationLoadError, setInvitationLoadError] = useState<string | null>(null);
+  const [projectNameDraft, setProjectNameDraft] = useState('');
+  const [isSavingProjectName, setIsSavingProjectName] = useState(false);
 
   const isProjectAdmin = activeMembership?.role === 'admin';
   const canManageMembers = isProjectAdmin;
+  const normalizedProjectName = projectNameDraft.trim();
+  const canSaveProjectName = isProjectAdmin
+    && normalizedProjectName.length >= 2
+    && normalizedProjectName !== (activeMembership?.project_name ?? '');
 
   const extractErrorPayload = (error: unknown): { code: string | null; detail: string | null; message: string | null } => {
     const payload = (error as { response?: { data?: { code?: string; detail?: string; message?: string } } })?.response?.data;
@@ -85,6 +91,20 @@ export default function ProjectSettingsPage(): React.ReactElement {
     }, 0);
   }, [loadInvitations]);
 
+  useEffect(() => {
+    setProjectNameDraft(activeMembership?.project_name ?? '');
+  }, [activeMembership?.project_name]);
+
+  const sortedInvitations = useMemo(() => (
+    [...invitations].sort((left, right) => {
+      const expiryDelta = new Date(right.expires_at).getTime() - new Date(left.expires_at).getTime();
+      if (expiryDelta !== 0) {
+        return expiryDelta;
+      }
+      return new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
+    })
+  ), [invitations]);
+
   if (!activeMembership) {
     return (
       <Box sx={{ p: 3 }}>
@@ -121,6 +141,23 @@ export default function ProjectSettingsPage(): React.ReactElement {
         ? t(`error.${payload.code}`, { defaultValue: payload.message ?? payload.detail ?? t('inviteFailed') })
         : (payload.message ?? payload.detail ?? t('inviteFailed'));
       setFeedback({ severity: 'error', text: message });
+    }
+  };
+
+  const handleProjectNameSave = async (): Promise<void> => {
+    if (!activeMembership || !canSaveProjectName) {
+      return;
+    }
+    setIsSavingProjectName(true);
+    setFeedback(null);
+    try {
+      await projectAPI.update(activeMembership.project_id, { name: normalizedProjectName });
+      await refreshUser();
+      setFeedback({ severity: 'success', text: t('projectRename.success') });
+    } catch {
+      setFeedback({ severity: 'error', text: t('projectRename.error') });
+    } finally {
+      setIsSavingProjectName(false);
     }
   };
 
@@ -185,20 +222,34 @@ export default function ProjectSettingsPage(): React.ReactElement {
     return null;
   })();
 
-  const sortedInvitations = useMemo(() => (
-    [...invitations].sort((left, right) => {
-      const expiryDelta = new Date(right.expires_at).getTime() - new Date(left.expires_at).getTime();
-      if (expiryDelta !== 0) {
-        return expiryDelta;
-      }
-      return new Date(right.created_at).getTime() - new Date(left.created_at).getTime();
-    })
-  ), [invitations]);
-
   return (
     <Box sx={{ p: 3, maxWidth: 760, mx: 'auto' }}>
       <Typography variant="h4" sx={{ mb: 1 }}>{t('title')}</Typography>
-      <Typography sx={{ mb: 3 }}>{t('projectLabel', { name: activeMembership.project_name })}</Typography>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mb: 3 }} alignItems={{ sm: 'center' }}>
+        <TextField
+          label={t('projectRename.label')}
+          value={projectNameDraft}
+          onChange={(event) => setProjectNameDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && canSaveProjectName) {
+              event.preventDefault();
+              void handleProjectNameSave();
+            }
+          }}
+          disabled={!isProjectAdmin || isSavingProjectName}
+          error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
+          helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
+          fullWidth
+        />
+        <Button
+          variant="contained"
+          onClick={() => void handleProjectNameSave()}
+          disabled={!canSaveProjectName || isSavingProjectName}
+          sx={{ minWidth: 140 }}
+        >
+          {t('projectRename.save')}
+        </Button>
+      </Stack>
 
       <Typography variant="h6" sx={{ mb: 2 }}>{t('inviteSectionTitle')}</Typography>
       <Stack spacing={2}>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -96,7 +96,8 @@ export default function Suppliers(): React.ReactElement {
       return;
     }
     const searchParams = new URLSearchParams(location.search);
-    if (searchParams.get('create') !== '1') {
+    const createIntent = searchParams.get('create');
+    if (createIntent !== '1' && createIntent !== 'true') {
       return;
     }
 
@@ -220,7 +221,7 @@ export default function Suppliers(): React.ReactElement {
             <EmptyStateCard
               title={t('emptyState.title')}
               description={t('emptyState.description')}
-              actions={[{ label: t('create'), to: '/app/suppliers?create=1' }]}
+              actions={[{ label: t('create'), to: '/app/suppliers?create=true' }]}
             />
           </Box>
         ) : (

--- a/frontend/src/pages/requirementFlow.ts
+++ b/frontend/src/pages/requirementFlow.ts
@@ -1,4 +1,5 @@
 export type RequirementStep = 'locations' | 'beds' | 'cultures' | 'plans' | null;
+export type CultivationPlanRequirementStep = 'locations' | 'fields' | 'beds' | 'cultures' | null;
 
 interface RequirementState {
   hasLocations: boolean;
@@ -12,5 +13,22 @@ export function getFirstMissingRequirement(state: RequirementState): Requirement
   if (!state.hasBeds) return 'beds';
   if (!state.hasCultures) return 'cultures';
   if (!state.hasPlans) return 'plans';
+  return null;
+}
+
+interface CultivationPlanRequirementState {
+  hasLocations: boolean;
+  hasFields: boolean;
+  hasBeds: boolean;
+  hasCultures: boolean;
+}
+
+export function getFirstMissingCultivationPlanRequirement(
+  state: CultivationPlanRequirementState,
+): CultivationPlanRequirementStep {
+  if (!state.hasLocations) return 'locations';
+  if (!state.hasFields) return 'fields';
+  if (!state.hasBeds) return 'beds';
+  if (!state.hasCultures) return 'cultures';
   return null;
 }


### PR DESCRIPTION
### Motivation
- Reduce onboarding friction by making CTA buttons open the existing create flows directly instead of only navigating to the target page.

### Description
- Update Dashboard CTAs to include create intent query params (e.g. `/app/locations?create=true`, `/app/cultures?create=true`, `/app/planting-plans?create=true`).
- Locations page: consume `?create=true`, open the existing create dialog, and remove the query param via a `replace` navigation to avoid repeated auto-open/backstack noise (reuse existing dialog; no new modal introduced).
- Cultures page: consume `?create=true`, open the existing create form dialog and clear the param after opening (reuses existing form dialog).
- Suppliers page: switch empty-state CTA to `?create=true` and accept both legacy `create=1` and `create=true` when parsing the intent, then clear the param.
- Planting Plans page: consume `?create=true` to trigger the existing create flow (`addRow()` on desktop or existing mobile create dialog) and then remove the param; updated related empty-state actions to use create-intent routes.
- Gantt / other empty-state CTAs: updated to use `?create=true` for location/culture/plan creation consistency.
- Tests: updated/added tests to assert the Dashboard CTA target (`href` includes `?create=true`) and that the Locations page opens the existing create dialog when visited with `/app/locations?create=true` (ensures only a single dialog instance opens).

### Testing
- Ran unit test suite with `cd frontend && npm test`, all tests passed (`580 tests, 79 files` in the run) including the modified/added tests for Dashboard and Locations (they passed).
- Ran linter with `cd frontend && npm run lint`; linting failed but the failures are pre-existing, repo-wide `react-hooks/*`, `react-refresh/*` and other rule violations across multiple files outside this change set and are unrelated to this PR's modifications.
- Behavior validated: CTAs now point at `?create=true`; pages with existing create flows open those flows automatically and clean the query param after consumption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3482e5c30832298e6db91417c1fed)