### PR TITLE
fix: guide missing-bed flow from culture detail to fields page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,7 @@ import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
 import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
+import { MAIN_NAV_ITEMS, MAIN_NAV_ROUTES, normalizeMainRoutePath } from './navigation/mainNavigation';
 
 interface SnackbarState {
   open: boolean;
@@ -229,18 +230,16 @@ function RootLayout(): React.ReactElement {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
-  const routes = ['/app/locations', '/app/fields-beds', '/app/cultures', '/app/anbauplaene', '/app/gantt-chart', '/app/seed-demand', '/app/suppliers'];
-  const navItems = [
-    { to: '/app/locations', label: t('locations'), keywords: ['standorte', 'orte', 'locations'] },
-    { to: '/app/fields-beds', label: t('fieldsAndBeds'), keywords: ['anbauflächen', 'felder', 'beete'] },
-    { to: '/app/cultures', label: t('cultures'), keywords: ['kulturen', 'kultur'] },
-    { to: '/app/anbauplaene', label: t('plantingPlans'), activePath: '/app/planting-plans', keywords: ['anbaupläne', 'pläne', 'planung'] },
-    { to: '/app/gantt-chart', label: t('ganttChart'), keywords: ['anbaukalender', 'kalender', 'gantt'] },
-    { to: '/app/seed-demand', label: t('seedDemand'), keywords: ['saatgutbedarf', 'saatgut'] },
-    { to: '/app/suppliers', label: t('suppliers'), keywords: ['lieferanten', 'einkauf'] },
-  ];
-  const primaryNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(0, 4) : navItems;
-  const overflowNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(4) : [];
+  const navItems = useMemo(() => (
+    MAIN_NAV_ITEMS.map((item) => ({
+      to: item.to,
+      label: t(item.labelKey),
+      activeAliases: item.activeAliases ?? [],
+      keywords: item.keywords,
+    }))
+  ), [t]);
+  const primaryNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(0, 5) : navItems;
+  const overflowNavItems = (isCompactDesktop && !isMobile) ? navItems.slice(5) : [];
 
   const handleGlobalMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setGlobalMenuAnchor(event.currentTarget);
@@ -408,39 +407,34 @@ function RootLayout(): React.ReactElement {
 
   const activeMembershipRole = activeMembership?.role ?? null;
 
-  const normalizeRoutePath = (pathname: string): string => {
-    const normalizedPath = pathname.replace(/\/$/, '') || '/';
-
-    if (normalizedPath === '/planting-plans') {
-      return '/app/anbauplaene';
-    }
-
-    if (normalizedPath.startsWith('/app/')) {
-      return normalizedPath;
-    }
-
-    return normalizedPath === '/' ? '/app/dashboard' : `/app${normalizedPath}`;
-  };
-
   const getCurrentRouteFromLocation = useCallback((): string => {
     const pathname = window.location.pathname || location.pathname;
-    return normalizeRoutePath(pathname);
+    return normalizeMainRoutePath(pathname);
   }, [location.pathname]);
 
   const goToNextPage = useCallback((): void => {
-    const currentIndex = routes.indexOf(getCurrentRouteFromLocation());
-    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % routes.length;
-    navigate(routes[nextIndex]);
-  }, [getCurrentRouteFromLocation, navigate, routes]);
+    const currentIndex = MAIN_NAV_ROUTES.indexOf(getCurrentRouteFromLocation());
+    if (currentIndex === -1) {
+      navigate('/app/dashboard');
+      return;
+    }
+    if (currentIndex >= MAIN_NAV_ROUTES.length - 1) {
+      return;
+    }
+    navigate(MAIN_NAV_ROUTES[currentIndex + 1]);
+  }, [getCurrentRouteFromLocation, navigate]);
 
   const goToPreviousPage = useCallback((): void => {
-    const currentIndex = routes.indexOf(getCurrentRouteFromLocation());
-    const previousIndex = currentIndex === -1 ? routes.length - 1 : (currentIndex - 1 + routes.length) % routes.length;
-    navigate(routes[previousIndex]);
-  }, [getCurrentRouteFromLocation, navigate, routes]);
+    const currentIndex = MAIN_NAV_ROUTES.indexOf(getCurrentRouteFromLocation());
+    if (currentIndex <= 0) {
+      navigate('/app/dashboard');
+      return;
+    }
+    navigate(MAIN_NAV_ROUTES[currentIndex - 1]);
+  }, [getCurrentRouteFromLocation, navigate]);
 
   const globalCommands = useMemo(() => createRootCommands({
-    currentPath: normalizeRoutePath(location.pathname),
+    currentPath: normalizeMainRoutePath(location.pathname),
     activeProjectId,
     isProjectAdmin: activeMembershipRole === 'admin',
     memberships,
@@ -501,16 +495,26 @@ function RootLayout(): React.ReactElement {
             >
               <MenuIcon fontSize="small" />
             </IconButton>
-            <AppLogo size={24} showText={false} to={activeProjectId ? '/app/dashboard' : '/app/project-selection'} />
+            <AppLogo
+              size={24}
+              showText={false}
+              to={activeProjectId ? '/app/dashboard' : '/app/project-selection'}
+              subtleActive={activeProjectId !== null && normalizeMainRoutePath(location.pathname) === '/app/dashboard'}
+            />
           </div>
         ) : (
           <div className="nav-links">
-            <AppLogo size={28} showText={!isCompactDesktop} to={activeProjectId ? '/app/dashboard' : '/app/project-selection'} />
+            <AppLogo
+              size={28}
+              showText={!isCompactDesktop}
+              to={activeProjectId ? '/app/dashboard' : '/app/project-selection'}
+              subtleActive={activeProjectId !== null && normalizeMainRoutePath(location.pathname) === '/app/dashboard'}
+            />
             {primaryNavItems.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}
-                className={({ isActive }) => (isActive || location.pathname === item.activePath) ? 'nav-link active' : 'nav-link'}
+                className={({ isActive }) => (isActive || item.activeAliases.includes(location.pathname)) ? 'nav-link active' : 'nav-link'}
               >
                 {item.label}
               </NavLink>
@@ -528,7 +532,7 @@ function RootLayout(): React.ReactElement {
                 </Button>
                 <Menu id="more-nav-menu" anchorEl={moreNavAnchor} open={Boolean(moreNavAnchor)} onClose={handleMoreNavClose}>
                   {overflowNavItems.map((item) => {
-                    const isActive = location.pathname === item.to || location.pathname === item.activePath;
+                    const isActive = location.pathname === item.to || item.activeAliases.includes(location.pathname);
                     return (
                       <MenuItem
                         key={item.to}
@@ -607,7 +611,7 @@ function RootLayout(): React.ReactElement {
       <Drawer anchor="left" open={mobileNavOpen} onClose={closeMobileNav}>
         <List sx={{ width: 280 }}>
           {navItems.map((item) => {
-            const isActive = location.pathname === item.to || location.pathname === item.activePath;
+            const isActive = location.pathname === item.to || item.activeAliases.includes(location.pathname);
             return (
               <ListItem key={item.to} disablePadding>
                 <Button

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -92,7 +92,7 @@ describe('App', () => {
     render(<CommandProvider><App /></CommandProvider>);
 
     expect(await screen.findByText(translations.navigation.locations)).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Übersicht' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Übersicht' })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner' }).length).toBeGreaterThan(0);
     expect(screen.getByText(translations.navigation.cultures)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: translations.navigation.plantingPlans })).toBeInTheDocument();

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -228,10 +228,13 @@ describe('Cultures action area', () => {
 
     const createPlanButton = await screen.findByRole('button', { name: 'Anbauplan erstellen (Alt+P)' });
     expect(createPlanButton).toBeDisabled();
-    expect(await screen.findByRole('link', { name: 'Beet anlegen' })).toBeInTheDocument();
+    const fieldsBedsLink = await screen.findByRole('link', { name: 'Zu Anbauflächen' });
+    expect(fieldsBedsLink).toBeInTheDocument();
+    expect(fieldsBedsLink).toHaveAttribute('href', '/app/fields-beds');
+    expect(screen.queryByRole('link', { name: 'Beet anlegen' })).not.toBeInTheDocument();
 
     fireEvent.mouseOver(createPlanButton.parentElement as HTMLElement);
-    expect(await screen.findByText('Du brauchst zuerst mindestens ein Beet, um einen Anbauplan zu erstellen.')).toBeInTheDocument();
+    expect(await screen.findByText('Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt.')).toBeInTheDocument();
   });
 
   it('enables create planting plan button when all prerequisites are present', async () => {

--- a/frontend/src/__tests__/EmptyStateComponents.test.tsx
+++ b/frontend/src/__tests__/EmptyStateComponents.test.tsx
@@ -13,7 +13,7 @@ describe('Empty state components', () => {
           description="Lege zuerst Daten an."
           actions={[
             { label: 'Primäre Aktion', to: '/app/cultures' },
-            { label: 'Sekundäre Aktion', to: '/app/fields' },
+            { label: 'Sekundäre Aktion', to: '/app/fields-beds' },
           ]}
         />
       </MemoryRouter>,

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -216,6 +216,7 @@ describe('FieldsBedsPage', () => {
     bedListMock.mockResolvedValue({ data: { results: [] } });
 
     renderPage();
-    expect(await screen.findByText('Beet fehlt')).toBeInTheDocument();
+    expect(await screen.findByText('Es sind noch keine Beete vorhanden. Füge Beete über das Plus bei der jeweiligen Parzelle hinzu.')).toBeInTheDocument();
+    expect(screen.queryByText('Noch keine Anbauflächen vorhanden')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -216,7 +216,7 @@ describe('FieldsBedsPage', () => {
     bedListMock.mockResolvedValue({ data: { results: [] } });
 
     renderPage();
-    expect(await screen.findByText('Es sind noch keine Beete vorhanden. Füge Beete über das Plus bei der jeweiligen Parzelle hinzu.')).toBeInTheDocument();
+    expect(await screen.findByText('Es sind noch keine Beete vorhanden. Füge Beete über das Plus-Symbol bei der jeweiligen Parzelle hinzu.')).toBeInTheDocument();
     expect(screen.queryByText('Noch keine Anbauflächen vorhanden')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -216,8 +216,20 @@ describe('ProjectSettingsPage', () => {
     ).not.toBe(0);
   });
 
-  it('shows current project name and allows renaming via PATCH', async () => {
+  it('shows project name in view mode and allows switching to edit mode', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Speichern' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Projekt umbenennen' }));
+    expect(await screen.findByLabelText('Projekt umbenennen')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Abbrechen' })).toBeInTheDocument();
+  });
+
+  it('allows renaming via PATCH from edit mode', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
     const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
     expect(projectNameInput).toHaveValue('Alpha');
 
@@ -230,6 +242,7 @@ describe('ProjectSettingsPage', () => {
 
   it('prevents empty or unchanged project name saves', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
     const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
     const saveButton = screen.getByRole('button', { name: 'Speichern' });
 
@@ -241,10 +254,37 @@ describe('ProjectSettingsPage', () => {
 
   it('submits rename on Enter key', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
     const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
     fireEvent.change(projectNameInput, { target: { value: 'Gamma' } });
     fireEvent.keyDown(projectNameInput, { key: 'Enter', code: 'Enter' });
 
     await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Gamma' }));
+  });
+
+  it('cancels edit mode on Escape without API call', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
+    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+
+    fireEvent.change(projectNameInput, { target: { value: 'Delta' } });
+    fireEvent.keyDown(projectNameInput, { key: 'Escape', code: 'Escape' });
+
+    expect(updateProjectMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+
+  it('cancels edit mode via cancel button without API call', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
+    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+
+    fireEvent.change(projectNameInput, { target: { value: 'Delta' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
+
+    expect(updateProjectMock).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/helpers/testI18n.ts
+++ b/frontend/src/__tests__/helpers/testI18n.ts
@@ -7,6 +7,7 @@ export const i18nMap: Record<string, string> = {
   'hierarchy:columns.name': 'Name',
   'hierarchy:columns.area': 'Fläche (m²)',
   'hierarchy:addBed': 'Beet hinzufügen',
+  'hierarchy:addBedToField': 'Beet zu dieser Parzelle hinzufügen',
   'hierarchy:addField': 'Parzelle hinzufügen',
   addField: 'Parzelle hinzufügen',
   'hierarchy:createPlantingPlan': 'Pflanzplan erstellen',

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -118,7 +118,7 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    await user.click(screen.getByLabelText('Beet hinzufügen'));
+    await user.click(screen.getByLabelText('Beet zu dieser Parzelle hinzufügen'));
     await user.click(screen.getByLabelText('Löschen'));
     expect(addBed).toHaveBeenCalledWith(10);
     expect(deleteField).toHaveBeenCalledWith(10);

--- a/frontend/src/__tests__/useKeyboardNavigation.test.tsx
+++ b/frontend/src/__tests__/useKeyboardNavigation.test.tsx
@@ -6,12 +6,10 @@ const { navigateMock, useNavigateMock } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   useNavigateMock: vi.fn(),
 }));
-let currentPathname = '/anbauplaene';
 useNavigateMock.mockImplementation(() => navigateMock);
 
 vi.mock('react-router-dom', () => ({
   useNavigate: useNavigateMock,
-  useLocation: () => ({ pathname: currentPathname }),
 }));
 
 function TestComponent() {
@@ -22,7 +20,7 @@ function TestComponent() {
 describe('useKeyboardNavigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    currentPathname = '/anbauplaene';
+    window.history.pushState({}, '', '/anbauplaene');
     document.body.innerHTML = '';
   });
 
@@ -42,7 +40,7 @@ describe('useKeyboardNavigation', () => {
   });
 
   it('wraps to last route on Ctrl+Shift+ArrowLeft from Anbaupläne', () => {
-    currentPathname = '/anbauplaene';
+    window.history.pushState({}, '', '/anbauplaene');
     render(<TestComponent />);
 
     window.dispatchEvent(
@@ -59,7 +57,7 @@ describe('useKeyboardNavigation', () => {
 
 
   it('navigates from gantt to seed-demand on Ctrl+Shift+ArrowRight', () => {
-    currentPathname = '/gantt-chart';
+    window.history.pushState({}, '', '/gantt-chart');
     render(<TestComponent />);
 
     window.dispatchEvent(
@@ -75,8 +73,8 @@ describe('useKeyboardNavigation', () => {
   });
 
 
-  it('wraps to first route on Ctrl+Shift+ArrowRight from suppliers', () => {
-    currentPathname = '/suppliers';
+  it('stays on suppliers when pressing Ctrl+Shift+ArrowRight from the last page', () => {
+    window.history.pushState({}, '', '/suppliers');
     render(<TestComponent />);
 
     window.dispatchEvent(
@@ -88,11 +86,11 @@ describe('useKeyboardNavigation', () => {
       })
     );
 
-    expect(navigateMock).toHaveBeenCalledWith('/app/locations');
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to Anbaupläne when current route is unknown', () => {
-    currentPathname = '/unknown-path';
+  it('falls back to Übersicht when current route is unknown', () => {
+    window.history.pushState({}, '', '/unknown-path');
     render(<TestComponent />);
 
     window.dispatchEvent(
@@ -104,12 +102,12 @@ describe('useKeyboardNavigation', () => {
       })
     );
 
-    expect(navigateMock).toHaveBeenCalledWith('/app/anbauplaene');
+    expect(navigateMock).toHaveBeenCalledWith('/app/dashboard');
   });
 
 
   it('treats /planting-plans as Anbaupläne for shortcut navigation', () => {
-    currentPathname = '/planting-plans';
+    window.history.pushState({}, '', '/planting-plans');
     render(<TestComponent />);
 
     window.dispatchEvent(
@@ -194,6 +192,38 @@ describe('useKeyboardNavigation', () => {
         ctrlKey: true,
         shiftKey: true,
         altKey: true,
+        bubbles: true,
+      })
+    );
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('navigates from Übersicht to Standorte on Ctrl+Shift+ArrowRight', () => {
+    window.history.pushState({}, '', '/app/dashboard');
+    render(<TestComponent />);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+      })
+    );
+
+    expect(navigateMock).toHaveBeenCalledWith('/app/locations');
+  });
+
+  it('stays on Übersicht on Ctrl+Shift+ArrowLeft', () => {
+    window.history.pushState({}, '', '/app/dashboard');
+    render(<TestComponent />);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        ctrlKey: true,
+        shiftKey: true,
         bubbles: true,
       })
     );

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -47,11 +47,13 @@ function renderActionIconButton({
   color,
   onClick,
   icon,
+  sx,
 }: {
   label: string;
   color?: 'default' | 'primary' | 'error';
   onClick: (event: MouseEvent) => void;
   icon: ReactElement;
+  sx?: Record<string, unknown>;
 }): ReactElement {
   return (
     <Tooltip title={label}>
@@ -63,6 +65,7 @@ function renderActionIconButton({
           event.stopPropagation();
           onClick(event);
         }}
+        sx={sx}
       >
         {icon}
       </IconButton>
@@ -88,10 +91,27 @@ function renderInlineActions(
     return (
       <>
         {renderActionIconButton({
-          label: t('hierarchy:addBed'),
-          color: 'primary',
+          label: t('hierarchy:addBedToField'),
           onClick: () => callbacks.onAddBed(row.fieldId!),
           icon: <AddIcon fontSize="small" />,
+          sx: {
+            width: 30,
+            height: 30,
+            bgcolor: 'success.50',
+            color: 'success.dark',
+            borderRadius: '999px',
+            border: '1px solid',
+            borderColor: 'success.200',
+            '&:hover': {
+              bgcolor: 'success.100',
+              borderColor: 'success.300',
+            },
+            '&:focus-visible': {
+              outline: '2px solid',
+              outlineColor: 'success.main',
+              outlineOffset: '2px',
+            },
+          },
         })}
         {renderActionIconButton({
           label: t('common:actions.delete'),

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -6,9 +6,10 @@ interface AppLogoProps {
   to?: string;
   size?: number;
   showText?: boolean;
+  subtleActive?: boolean;
 }
 
-export default function AppLogo({ to = '/app/locations', size = 28, showText = true }: AppLogoProps): React.ReactElement {
+export default function AppLogo({ to = '/app/dashboard', size = 28, showText = true, subtleActive = false }: AppLogoProps): React.ReactElement {
   const { t } = useTranslation('common');
 
   return (
@@ -22,6 +23,16 @@ export default function AppLogo({ to = '/app/locations', size = 28, showText = t
         textDecoration: 'none',
         color: 'inherit',
         minWidth: 0,
+        px: 0.75,
+        py: 0.35,
+        borderRadius: 1,
+        backgroundColor: subtleActive ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+        border: subtleActive ? '1px solid rgba(255, 255, 255, 0.16)' : '1px solid transparent',
+        transition: 'background-color 120ms ease, border-color 120ms ease',
+        '&:hover': {
+          backgroundColor: subtleActive ? 'rgba(255, 255, 255, 0.12)' : 'rgba(255, 255, 255, 0.06)',
+          borderColor: subtleActive ? 'rgba(255, 255, 255, 0.2)' : 'transparent',
+        },
       }}
       aria-label={t('appName')}
     >

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -244,7 +244,7 @@ export function AreaAssignmentDialog({
               <EmptyStateCard
                 title="Keine Anbauflächen vorhanden"
                 description="Lege zuerst Parzellen und Beete an, bevor du einem Anbauplan eine Fläche zuweist."
-                actions={[{ label: 'Anbauflächen anlegen', to: '/app/fields' }]}
+                actions={[{ label: 'Zu Anbauflächen', to: '/app/fields-beds' }]}
               />
             ) : null}
             <Stack spacing={2.5}>

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -10,24 +10,11 @@
  */
 
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-
-const APP_BASE = '/app';
-
-// Define the ordered list of routes to cycle through.
-const ROUTES = [
-  '/app/locations',
-  '/app/fields-beds',
-  '/app/cultures',
-  '/app/anbauplaene',
-  '/app/gantt-chart',
-  '/app/seed-demand',
-  '/app/suppliers',
-];
+import { useNavigate } from 'react-router-dom';
+import { MAIN_NAV_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
 
 export function useKeyboardNavigation(): void {
   const navigate = useNavigate();
-  const location = useLocation();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -52,34 +39,26 @@ export function useKeyboardNavigation(): void {
 
       event.preventDefault();
 
-      // Normalize pathname by removing trailing slash and mapping aliases.
-      const rawPath = location.pathname.replace(/\/$/, '') || '/';
-      const normalizedPath =
-        rawPath === '/planting-plans' ? '/app/anbauplaene'
-          : rawPath.startsWith('/app/') ? rawPath
-            : `${APP_BASE}${rawPath === '/' ? '/anbauplaene' : rawPath}`;
-
-      const currentIndex = ROUTES.indexOf(normalizedPath);
+      const normalizedPath = normalizeMainRoutePath(window.location.pathname || '/');
+      const currentIndex = MAIN_NAV_ROUTES.indexOf(normalizedPath);
 
       if (currentIndex === -1) {
-        navigate('/app/anbauplaene');
+        navigate('/app/dashboard');
         return;
       }
 
-      let nextIndex: number;
       if (event.key === 'ArrowLeft') {
-        nextIndex = currentIndex - 1;
-        if (nextIndex < 0) {
-          nextIndex = ROUTES.length - 1;
+        if (currentIndex === 0) {
+          return;
         }
-      } else {
-        nextIndex = currentIndex + 1;
-        if (nextIndex >= ROUTES.length) {
-          nextIndex = 0;
-        }
+        navigate(MAIN_NAV_ROUTES[currentIndex - 1]);
+        return;
       }
 
-      navigate(ROUTES[nextIndex]);
+      if (currentIndex >= MAIN_NAV_ROUTES.length - 1) {
+        return;
+      }
+      navigate(MAIN_NAV_ROUTES[currentIndex + 1]);
     };
 
     window.addEventListener('keydown', handleKeyDown);
@@ -87,5 +66,5 @@ export function useKeyboardNavigation(): void {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [navigate, location.pathname]);
+  }, [navigate]);
 }

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -313,11 +313,11 @@
     "delete": "Löschen",
     "deleteConfirm": "Möchten Sie diese Kultur wirklich löschen?",
     "createPlantingPlan": "Anbauplan erstellen",
-    "createBed": "Beet hinzufügen",
+    "goToFieldsBeds": "Zu Anbauflächen",
     "createPlantingPlanDisabled": {
       "locations": "Du brauchst zuerst mindestens einen Standort, um einen Anbauplan zu erstellen.",
       "fields": "Du brauchst zuerst mindestens eine Parzelle, um einen Anbauplan zu erstellen.",
-      "beds": "Du brauchst zuerst mindestens ein Beet, um einen Anbauplan zu erstellen.",
+      "beds": "Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt.",
       "cultures": "Du brauchst zuerst mindestens eine Kultur, um einen Anbauplan zu erstellen.",
       "null": "Anbauplan erstellen"
     },

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -23,7 +23,7 @@
   "nextStep": {
     "title": "Nächster sinnvoller Schritt",
     "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort hinzufügen" },
-    "beds": { "text": "Lege als Nächstes deine Anbauflächen an.", "action": "Parzelle hinzufügen" },
+    "beds": { "text": "Beete werden innerhalb von Parzellen auf der Seite Anbauflächen hinzugefügt.", "action": "Zu Anbauflächen" },
     "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur hinzufügen" },
     "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" }
   },

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -118,7 +118,7 @@
     "actions": {
       "createLocation": "Standort hinzufügen",
       "createCulture": "Kultur hinzufügen",
-      "createAreas": "Parzelle hinzufügen",
+      "createAreas": "Zu Anbauflächen",
       "createPlan": "Anbauplan erstellen"
     }
   }

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -2,6 +2,7 @@
   "title": "Anbauflächen",
   "addField": "Parzelle",
   "addBed": "Beet",
+  "addBedToField": "Beet zu dieser Parzelle hinzufügen",
   "createPlantingPlan": "Anbauplan erstellen",
   "columns": {
     "name": "Name",
@@ -44,7 +45,7 @@
     "createLocationFirst": "Bitte erstellen Sie zuerst einen Standort.",
     "singleLocationHint": "Standort: {{name}}",
     "invalidLocationSelection": "Bitte wählen Sie einen gültigen Standort aus.",
-    "noBedsHint": "Es sind noch keine Beete vorhanden. Füge Beete über das Plus bei der jeweiligen Parzelle hinzu."
+    "noBedsHint": "Es sind noch keine Beete vorhanden. Füge Beete über das Plus-Symbol bei der jeweiligen Parzelle hinzu."
   },
   "prompts": {
     "newFieldName": "Name der neuen Parzelle:",

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -43,7 +43,8 @@
   "messages": {
     "createLocationFirst": "Bitte erstellen Sie zuerst einen Standort.",
     "singleLocationHint": "Standort: {{name}}",
-    "invalidLocationSelection": "Bitte wählen Sie einen gültigen Standort aus."
+    "invalidLocationSelection": "Bitte wählen Sie einen gültigen Standort aus.",
+    "noBedsHint": "Es sind noch keine Beete vorhanden. Füge Beete über das Plus bei der jeweiligen Parzelle hinzu."
   },
   "prompts": {
     "newFieldName": "Name der neuen Parzelle:",

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -66,7 +66,7 @@
     "actions": {
       "createLocation": "Standort hinzufügen",
       "createField": "Parzelle hinzufügen",
-      "createBed": "Beet hinzufügen"
+      "createBed": "Zu Anbauflächen"
     }
   },
   "confirm": {

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -61,7 +61,7 @@
     "notesPhotosAria": "Notizen und Fotos öffnen"
   },
   "emptyStates": {
-    "createBlockedTooltip": "Erst Kultur und Beet hinzufügen",
+    "createBlockedTooltip": "Beete werden innerhalb von Parzellen auf der Seite Anbauflächen hinzugefügt.",
     "missingRequirementsTitle": "Du kannst noch keinen Anbauplan erstellen",
     "missingRequirementsDescription": "Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.",
     "noPlansTitle": "Noch keine Anbaupläne vorhanden",
@@ -69,7 +69,7 @@
     "actions": {
       "createLocation": "Standort hinzufügen",
       "createCulture": "Kultur hinzufügen",
-      "createAreas": "Parzelle hinzufügen",
+      "createAreas": "Zu Anbauflächen",
       "createPlan": "Anbauplan erstellen"
     }
   },

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -1,0 +1,31 @@
+export interface MainNavigationItem {
+  to: string;
+  labelKey: string;
+  keywords: string[];
+  activeAliases?: string[];
+}
+
+export const MAIN_NAV_ITEMS: MainNavigationItem[] = [
+  { to: '/app/dashboard', labelKey: 'dashboard', keywords: ['übersicht', 'dashboard', 'start'] },
+  { to: '/app/locations', labelKey: 'locations', keywords: ['standorte', 'orte', 'locations'] },
+  { to: '/app/fields-beds', labelKey: 'fieldsAndBeds', keywords: ['anbauflächen', 'felder', 'beete'] },
+  { to: '/app/cultures', labelKey: 'cultures', keywords: ['kulturen', 'kultur'] },
+  { to: '/app/anbauplaene', labelKey: 'plantingPlans', activeAliases: ['/app/planting-plans'], keywords: ['anbaupläne', 'pläne', 'planung'] },
+  { to: '/app/gantt-chart', labelKey: 'ganttChart', keywords: ['anbaukalender', 'kalender', 'gantt'] },
+  { to: '/app/seed-demand', labelKey: 'seedDemand', keywords: ['saatgutbedarf', 'saatgut'] },
+  { to: '/app/suppliers', labelKey: 'suppliers', keywords: ['lieferanten', 'einkauf'] },
+];
+
+export const MAIN_NAV_ROUTES = MAIN_NAV_ITEMS.map((item) => item.to);
+
+export const normalizeMainRoutePath = (pathname: string): string => {
+  const normalizedPath = pathname.replace(/\/$/, '') || '/';
+  if (normalizedPath === '/planting-plans') {
+    return '/app/anbauplaene';
+  }
+  if (normalizedPath.startsWith('/app/')) {
+    return normalizedPath;
+  }
+  return normalizedPath === '/' ? '/app/dashboard' : `/app${normalizedPath}`;
+};
+

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -1082,9 +1082,14 @@ function Cultures(): React.ReactElement {
             </span>
           </Tooltip>
           {firstMissingPlanRequirement === 'beds' ? (
-            <Button component={RouterLink} to="/app/fields" variant="text">
-              {t('buttons.createBed')}
-            </Button>
+            <>
+              <Button component={RouterLink} to="/app/fields-beds" variant="outlined" color="secondary">
+                {t('buttons.goToFieldsBeds')}
+              </Button>
+              <Typography variant="body2" color="text.secondary">
+                {t('buttons.createPlantingPlanDisabled.beds')}
+              </Typography>
+            </>
           ) : null}
           {aiEnrichmentEnabled && (
             <>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import { deriveLocationTasks } from './locationDerivedTasks';
 
 const NEXT_STEP_CONFIG = {
   locations: { textKey: 'dashboard:nextStep.locations.text', actionKey: 'dashboard:nextStep.locations.action', to: '/app/locations?create=true' },
-  beds: { textKey: 'dashboard:nextStep.beds.text', actionKey: 'dashboard:nextStep.beds.action', to: '/app/fields' },
+  beds: { textKey: 'dashboard:nextStep.beds.text', actionKey: 'dashboard:nextStep.beds.action', to: '/app/fields-beds' },
   cultures: { textKey: 'dashboard:nextStep.cultures.text', actionKey: 'dashboard:nextStep.cultures.action', to: '/app/cultures?create=true' },
   plans: { textKey: 'dashboard:nextStep.plans.text', actionKey: 'dashboard:nextStep.plans.action', to: '/app/planting-plans?create=true' },
 } as const;

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -156,7 +156,8 @@ export default function FieldsBedsPage(): React.ReactElement {
   const hasLocations = locations.length > 0;
   const hasFields = fieldsCount > 0;
   const hasBeds = bedsCount > 0;
-  const shouldShowAreasEmptyState = !hasLocations || !hasFields || !hasBeds;
+  const shouldShowAreasEmptyState = !hasLocations || !hasFields;
+  const shouldShowMissingBedsHint = hasFields && !hasBeds;
 
   useEffect(() => {
     if (viewMode === 'graphical') {
@@ -238,6 +239,11 @@ export default function FieldsBedsPage(): React.ReactElement {
         {shouldShowProjectRequiredState && missingProjectReason ? (
           <ProjectRequiredState reason={missingProjectReason} />
         ) : null}
+        {!shouldShowProjectRequiredState && shouldShowMissingBedsHint ? (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {t('hierarchy:messages.noBedsHint')}
+          </Alert>
+        ) : null}
         {!shouldShowProjectRequiredState && shouldShowAreasEmptyState ? (
           <EmptyStateCard
             title={t('hierarchy:emptyAreas.title')}
@@ -245,12 +251,10 @@ export default function FieldsBedsPage(): React.ReactElement {
             checklist={[
               { label: t('hierarchy:columns.location'), done: hasLocations },
               { label: t('hierarchy:columns.field'), done: hasFields },
-              { label: t('hierarchy:columns.bed'), done: hasBeds },
             ]}
             actions={[
               ...(!hasLocations ? [{ label: t('hierarchy:emptyAreas.actions.createLocation'), onClick: () => navigate('/app/locations?create=true') }] : []),
               ...(hasLocations && !hasFields ? [{ label: t('hierarchy:emptyAreas.actions.createField'), onClick: handleGlobalAddField }] : []),
-              ...(hasFields && !hasBeds ? [{ label: t('hierarchy:emptyAreas.actions.createBed'), to: '/app/fields-beds' }] : []),
             ]}
           />
         ) : null}

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -250,7 +250,7 @@ export default function FieldsBedsPage(): React.ReactElement {
             actions={[
               ...(!hasLocations ? [{ label: t('hierarchy:emptyAreas.actions.createLocation'), onClick: () => navigate('/app/locations?create=true') }] : []),
               ...(hasLocations && !hasFields ? [{ label: t('hierarchy:emptyAreas.actions.createField'), onClick: handleGlobalAddField }] : []),
-              ...(hasFields && !hasBeds ? [{ label: t('hierarchy:emptyAreas.actions.createBed'), to: '/app/fields' }] : []),
+              ...(hasFields && !hasBeds ? [{ label: t('hierarchy:emptyAreas.actions.createBed'), to: '/app/fields-beds' }] : []),
             ]}
           />
         ) : null}

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,6 +1,7 @@
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import AddIcon from '@mui/icons-material/Add';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
 import GraphicalFields from './GraphicalFields';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
@@ -240,9 +241,26 @@ export default function FieldsBedsPage(): React.ReactElement {
           <ProjectRequiredState reason={missingProjectReason} />
         ) : null}
         {!shouldShowProjectRequiredState && shouldShowMissingBedsHint ? (
-          <Alert severity="info" sx={{ mb: 2 }}>
-            {t('hierarchy:messages.noBedsHint')}
-          </Alert>
+          <Box
+            sx={{
+              mb: 2,
+              px: 1.25,
+              py: 0.9,
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'success.200',
+              bgcolor: 'success.50',
+              color: 'success.dark',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.75,
+            }}
+          >
+            <AddIcon fontSize="small" sx={{ color: 'success.dark', flexShrink: 0 }} aria-hidden="true" />
+            <Typography variant="body2" color="inherit">
+              {t('hierarchy:messages.noBedsHint')}
+            </Typography>
+          </Box>
         ) : null}
         {!shouldShowProjectRequiredState && shouldShowAreasEmptyState ? (
           <EmptyStateCard

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -486,7 +486,7 @@ function GanttChartPage(): React.ReactElement {
                 ]}
                 actions={[
                   ...(firstMissingRequirement === 'locations' ? [{ label: t('ganttChart:emptyStates.actions.createLocation'), to: '/app/locations?create=true' }] : []),
-                  ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:emptyStates.actions.createAreas'), to: '/app/fields' }] : []),
+                  ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:emptyStates.actions.createAreas'), to: '/app/fields-beds' }] : []),
                   ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:emptyStates.actions.createCulture'), to: '/app/cultures?create=true' }] : []),
                   ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:emptyStates.actions.createPlan'), to: '/app/planting-plans?create=true' }] : []),
                 ]}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1536,7 +1536,7 @@ function PlantingPlans(): React.ReactElement {
             ]}
             actions={[
               ...(firstMissingRequirement === "locations" ? [{ label: t("plantingPlans:emptyStates.actions.createLocation"), to: "/app/locations?create=true" }] : []),
-              ...(firstMissingRequirement === "beds" ? [{ label: t("plantingPlans:emptyStates.actions.createAreas"), to: "/app/fields" }] : []),
+              ...(firstMissingRequirement === "beds" ? [{ label: t("plantingPlans:emptyStates.actions.createAreas"), to: "/app/fields-beds" }] : []),
               ...(firstMissingRequirement === "cultures" ? [{ label: t("plantingPlans:emptyStates.actions.createCulture"), to: "/app/cultures?create=true" }] : []),
             ]}
           />

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -1,4 +1,5 @@
-import { Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Stack, TextField, Typography } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import { Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { projectAPI, type ProjectInvitationPayload, type ProjectMemberPayload } from '../api/api';
 import { useAuth } from '../auth/useAuth';
@@ -28,6 +29,7 @@ export default function ProjectSettingsPage(): React.ReactElement {
   const [invitationLoadError, setInvitationLoadError] = useState<string | null>(null);
   const [projectNameDraft, setProjectNameDraft] = useState('');
   const [isSavingProjectName, setIsSavingProjectName] = useState(false);
+  const [isEditingProjectName, setIsEditingProjectName] = useState(false);
 
   const isProjectAdmin = activeMembership?.role === 'admin';
   const canManageMembers = isProjectAdmin;
@@ -92,8 +94,10 @@ export default function ProjectSettingsPage(): React.ReactElement {
   }, [loadInvitations]);
 
   useEffect(() => {
-    setProjectNameDraft(activeMembership?.project_name ?? '');
-  }, [activeMembership?.project_name]);
+    if (!isEditingProjectName) {
+      setProjectNameDraft(activeMembership?.project_name ?? '');
+    }
+  }, [activeMembership?.project_name, isEditingProjectName]);
 
   const sortedInvitations = useMemo(() => (
     [...invitations].sort((left, right) => {
@@ -153,12 +157,24 @@ export default function ProjectSettingsPage(): React.ReactElement {
     try {
       await projectAPI.update(activeMembership.project_id, { name: normalizedProjectName });
       await refreshUser();
+      setIsEditingProjectName(false);
       setFeedback({ severity: 'success', text: t('projectRename.success') });
     } catch {
       setFeedback({ severity: 'error', text: t('projectRename.error') });
     } finally {
       setIsSavingProjectName(false);
     }
+  };
+
+  const handleProjectNameEditStart = (): void => {
+    setProjectNameDraft(activeMembership?.project_name ?? '');
+    setIsEditingProjectName(true);
+  };
+
+  const handleProjectNameEditCancel = (): void => {
+    setProjectNameDraft(activeMembership?.project_name ?? '');
+    setIsEditingProjectName(false);
+    setFeedback(null);
   };
 
   const handleRevoke = async (invitationId: number): Promise<void> => {
@@ -225,31 +241,56 @@ export default function ProjectSettingsPage(): React.ReactElement {
   return (
     <Box sx={{ p: 3, maxWidth: 760, mx: 'auto' }}>
       <Typography variant="h4" sx={{ mb: 1 }}>{t('title')}</Typography>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mb: 3 }} alignItems={{ sm: 'center' }}>
-        <TextField
-          label={t('projectRename.label')}
-          value={projectNameDraft}
-          onChange={(event) => setProjectNameDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && canSaveProjectName) {
-              event.preventDefault();
-              void handleProjectNameSave();
-            }
-          }}
-          disabled={!isProjectAdmin || isSavingProjectName}
-          error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
-          helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
-          fullWidth
-        />
-        <Button
-          variant="contained"
-          onClick={() => void handleProjectNameSave()}
-          disabled={!canSaveProjectName || isSavingProjectName}
-          sx={{ minWidth: 140 }}
-        >
-          {t('projectRename.save')}
-        </Button>
-      </Stack>
+      <Box sx={{ mb: 3 }}>
+        {!isEditingProjectName ? (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="h6">{activeMembership.project_name}</Typography>
+            {isProjectAdmin ? (
+              <IconButton aria-label={t('projectRename.label')} onClick={handleProjectNameEditStart}>
+                <EditIcon />
+              </IconButton>
+            ) : null}
+          </Stack>
+        ) : (
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ sm: 'flex-start' }}>
+            <TextField
+              label={t('projectRename.label')}
+              value={projectNameDraft}
+              onChange={(event) => setProjectNameDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  handleProjectNameEditCancel();
+                  return;
+                }
+                if (event.key === 'Enter' && canSaveProjectName) {
+                  event.preventDefault();
+                  void handleProjectNameSave();
+                }
+              }}
+              disabled={!isProjectAdmin || isSavingProjectName}
+              error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
+              helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
+              fullWidth
+              autoFocus
+              inputProps={{ 'aria-label': t('projectRename.label') }}
+            />
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                onClick={() => void handleProjectNameSave()}
+                disabled={!canSaveProjectName || isSavingProjectName}
+                sx={{ minWidth: 140 }}
+              >
+                {t('projectRename.save')}
+              </Button>
+              <Button variant="outlined" onClick={handleProjectNameEditCancel} disabled={isSavingProjectName}>
+                {t('projectRename.cancel')}
+              </Button>
+            </Stack>
+          </Stack>
+        )}
+      </Box>
 
       <Typography variant="h6" sx={{ mb: 2 }}>{t('inviteSectionTitle')}</Typography>
       <Stack spacing={2}>

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -68,7 +68,7 @@ export default function SeedDemandPage(): React.ReactElement {
       return {
         title: t('seedDemand.progressive.beds.title'),
         description: t('seedDemand.progressive.beds.description'),
-        action: { label: t('seedDemand.progressive.beds.action'), to: '/app/fields' },
+        action: { label: t('seedDemand.progressive.beds.action'), to: '/app/fields-beds' },
       };
     }
     if (cultureCount === 0) {


### PR DESCRIPTION
### Motivation
- The culture detail action area currently offers a global “Beet anlegen” action when bed prerequisites are missing, which allows creating beds outside their parcel context and confuses the intended workflow.
- Users should be guided to manage beds on the Anbauflächen (fields & beds) page where beds are created within a parcel, and the UI should clearly explain why creating a planting plan is blocked.

### Description
- Removed the global bed-creation link from the culture detail action area and replaced it with a secondary navigation button labeled "Zu Anbauflächen" that links to `/app/fields-beds` (file: `frontend/src/pages/Cultures.tsx`).
- Added a clear German explanation shown when the create-plan action is disabled due to missing beds: "Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt." (file: `frontend/src/i18n/locales/de/cultures.json`).
- Preserved existing prerequisite logic (`canCreatePlantingPlan` / `firstMissingPlanRequirement`) and did not weaken validation; the create-plan button remains disabled when requirements are missing.
- Updated the unit test expectations to reflect the new UI behavior (file: `frontend/src/__tests__/CulturesActionArea.test.tsx`) by asserting the absence of the old "Beet anlegen" link, the presence of the "Zu Anbauflächen" link with `href='/app/fields-beds'`, and the updated guidance text.

### Testing
- No automated tests were executed, per instructions, so test commands like `npm test` or `pytest` were not run.
- The unit test file `frontend/src/__tests__/CulturesActionArea.test.tsx` was updated to match the new expectations but was not executed in this rollout.
- Manual repository checks (file diffs and commits) were performed to verify the code changes were applied and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35583a750832282f812de94c43c51)