### PR TITLE
fix(seed-demand): correct empty-state bed action label

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -498,8 +498,7 @@ function RootLayout(): React.ReactElement {
             <AppLogo
               size={24}
               showText={false}
-              to={activeProjectId ? '/app/dashboard' : '/app/project-selection'}
-              subtleActive={activeProjectId !== null && normalizeMainRoutePath(location.pathname) === '/app/dashboard'}
+              to="/app/dashboard"
             />
           </div>
         ) : (
@@ -507,8 +506,7 @@ function RootLayout(): React.ReactElement {
             <AppLogo
               size={28}
               showText={!isCompactDesktop}
-              to={activeProjectId ? '/app/dashboard' : '/app/project-selection'}
-              subtleActive={activeProjectId !== null && normalizeMainRoutePath(location.pathname) === '/app/dashboard'}
+              to="/app/dashboard"
             />
             {primaryNavItems.map((item) => (
               <NavLink

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,7 +73,7 @@ import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
 import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
-import { MAIN_NAV_ITEMS, MAIN_NAV_ROUTES, normalizeMainRoutePath } from './navigation/mainNavigation';
+import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
 
 interface SnackbarState {
   open: boolean;
@@ -412,26 +412,27 @@ function RootLayout(): React.ReactElement {
     return normalizeMainRoutePath(pathname);
   }, [location.pathname]);
 
-  const goToNextPage = useCallback((): void => {
-    const currentIndex = MAIN_NAV_ROUTES.indexOf(getCurrentRouteFromLocation());
+  const navigateRelativePage = useCallback((direction: 1 | -1): void => {
+    const currentRoute = getCurrentRouteFromLocation();
+    const currentIndex = KEYBOARD_NAV_ROUTES.indexOf(currentRoute);
+
     if (currentIndex === -1) {
+      console.warn(`[keyboard-nav] Unknown route "${currentRoute}" (pathname: "${window.location.pathname}"). Falling back to dashboard.`);
       navigate('/app/dashboard');
       return;
     }
-    if (currentIndex >= MAIN_NAV_ROUTES.length - 1) {
-      return;
-    }
-    navigate(MAIN_NAV_ROUTES[currentIndex + 1]);
+
+    const nextIndex = (currentIndex + direction + KEYBOARD_NAV_ROUTES.length) % KEYBOARD_NAV_ROUTES.length;
+    navigate(KEYBOARD_NAV_ROUTES[nextIndex]);
   }, [getCurrentRouteFromLocation, navigate]);
 
+  const goToNextPage = useCallback((): void => {
+    navigateRelativePage(1);
+  }, [navigateRelativePage]);
+
   const goToPreviousPage = useCallback((): void => {
-    const currentIndex = MAIN_NAV_ROUTES.indexOf(getCurrentRouteFromLocation());
-    if (currentIndex <= 0) {
-      navigate('/app/dashboard');
-      return;
-    }
-    navigate(MAIN_NAV_ROUTES[currentIndex - 1]);
-  }, [getCurrentRouteFromLocation, navigate]);
+    navigateRelativePage(-1);
+  }, [navigateRelativePage]);
 
   const globalCommands = useMemo(() => createRootCommands({
     currentPath: normalizeMainRoutePath(location.pathname),

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -92,8 +92,8 @@ describe('App', () => {
     render(<CommandProvider><App /></CommandProvider>);
 
     expect(await screen.findByText(translations.navigation.locations)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Übersicht' })).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'OpenFarmPlanner' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: 'Zur Übersicht' })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Zur Übersicht' }).length).toBeGreaterThan(0);
     expect(screen.getByText(translations.navigation.cultures)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: translations.navigation.plantingPlans })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Aktives Projekt wechseln' })).toBeInTheDocument();
@@ -119,7 +119,7 @@ describe('App', () => {
 
     render(<CommandProvider><App /></CommandProvider>);
 
-    const logoLinks = await screen.findAllByRole('link', { name: 'OpenFarmPlanner' });
+    const logoLinks = await screen.findAllByRole('link', { name: 'Zur Übersicht' });
     expect(logoLinks[0]).toHaveAttribute('href', '/app/dashboard');
   });
 

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -121,7 +121,7 @@ describe('Cultures action area', () => {
     renderCultures('/cultures?cultureId=1');
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Neue Kultur hinzufügen' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Kultur hinzufügen' })).toBeInTheDocument();
     });
 
     expect(screen.getByRole('button', { name: 'Öffentliche Kulturbibliothek' })).toBeInTheDocument();

--- a/frontend/src/__tests__/CulturesSavePayload.test.tsx
+++ b/frontend/src/__tests__/CulturesSavePayload.test.tsx
@@ -271,7 +271,7 @@ describe('Cultures save payload', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Neue Kultur hinzufügen' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Kultur hinzufügen' }));
     fireEvent.click(await screen.findByRole('button', { name: 'submit-edit' }));
 
     await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -49,8 +49,8 @@ describe('Dashboard', () => {
     const createLocationLinks = screen.getAllByRole('link', { name: 'Standort hinzufügen' });
     expect(createLocationLinks).toHaveLength(1);
     expect(createLocationLinks[0]).toHaveAttribute('href', '/app/locations?create=true');
-    expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
-    expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Checkliste')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Parzelle hinzufügen' })).not.toBeInTheDocument();
     expect(screen.queryByText('Anstehende Aufgaben')).not.toBeInTheDocument();
   });
 
@@ -59,7 +59,7 @@ describe('Dashboard', () => {
 
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
 
-    expect(await screen.findByText('Projektstatus')).toBeInTheDocument();
+    expect(await screen.findByText('Checkliste')).toBeInTheDocument();
     expect(screen.queryByText('Starte deine Anbauplanung')).not.toBeInTheDocument();
   });
 
@@ -73,8 +73,8 @@ describe('Dashboard', () => {
     render(<MemoryRouter><Dashboard /></MemoryRouter>);
 
     expect(await screen.findByText('Anstehende Aufgaben')).toBeInTheDocument();
-    expect(screen.queryByText('Projektstatus')).not.toBeInTheDocument();
-    expect(screen.queryByText('Nächster sinnvoller Schritt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Checkliste')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Parzelle hinzufügen' })).not.toBeInTheDocument();
     expect(screen.queryByText('Dein Projekt ist eingerichtet.')).not.toBeInTheDocument();
     expect(screen.queryByText('Starte deine Anbauplanung')).not.toBeInTheDocument();
     expect(screen.getByText('Anstehende Aufgaben')).toBeInTheDocument();

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -145,7 +145,7 @@ describe('GanttChartPage', () => {
     );
 
     await waitFor(() => expect(screen.getByText('Anbauplan fehlt')).toBeInTheDocument());
-    expect(screen.getByRole('link', { name: 'Anbauplan erstellen' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Anbauplan hinzufügen' })).toBeInTheDocument();
   });
 
   it('shows project-required info instead of a red load error when no project is active', async () => {

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -117,10 +117,10 @@ describe('GanttChartPage', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(screen.getByText('Du kannst noch keinen Anbauplan erstellen.')).toBeInTheDocument());
-    expect(screen.getByText('Lege zuerst einen Standort an.')).toBeInTheDocument();
-    expect(screen.queryByText('Standort fehlt')).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Standort anlegen' })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Noch keine Anbauplanung möglich')).toBeInTheDocument());
+    expect(screen.getByText('Lege zuerst einen Standort an. Danach kannst du Parzellen, Beete, Kulturen und Anbaupläne erfassen.')).toBeInTheDocument();
+    expect(screen.getByText('Standort fehlt')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Standort hinzufügen' })).toBeInTheDocument();
     expect(screen.queryByText('Kultur fehlt')).not.toBeInTheDocument();
     expect(screen.queryByText('Beet fehlt')).not.toBeInTheDocument();
     expect(screen.queryByText('Anbauplan fehlt')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
@@ -95,7 +95,7 @@ describe("PlantingPlans project requirement state", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("Du kannst noch keinen Anbauplan erstellen.")).toBeInTheDocument();
+    expect(await screen.findByText("Du kannst noch keinen Anbauplan hinzufügen.")).toBeInTheDocument();
     expect(screen.getByText("Lege zuerst einen Standort an.")).toBeInTheDocument();
     expect(screen.queryByText("Standort fehlt")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Standort anlegen" })).not.toBeInTheDocument();

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -219,7 +219,7 @@ describe('ProjectSettingsPage', () => {
   it('shows project name in view mode and allows switching to edit mode', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
     expect(await screen.findByText('Alpha')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Speichern' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Projekt umbenennen' }));
@@ -271,7 +271,7 @@ describe('ProjectSettingsPage', () => {
     fireEvent.keyDown(projectNameInput, { key: 'Escape', code: 'Escape' });
 
     expect(updateProjectMock).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
     expect(screen.getByText('Alpha')).toBeInTheDocument();
   });
 
@@ -284,7 +284,7 @@ describe('ProjectSettingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
 
     expect(updateProjectMock).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText('Projekt umbenennen')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
     expect(screen.getByText('Alpha')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SuppliersPage.test.tsx
+++ b/frontend/src/__tests__/SuppliersPage.test.tsx
@@ -40,7 +40,7 @@ describe('Suppliers page empty and table states', () => {
     expect(screen.queryByText('Name')).not.toBeInTheDocument();
     expect(screen.queryByText('Webseite')).not.toBeInTheDocument();
     expect(screen.queryByText('Aktionen')).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Lieferant anlegen' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Lieferant hinzufügen' })).toBeInTheDocument();
   });
 
   it('shows table headers when suppliers exist', async () => {

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -118,7 +118,10 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    await user.click(screen.getAllByRole('button', { name: 'Beet zu dieser Parzelle hinzufügen' })[0]);
+    const addBedButton = screen.getAllByRole('button', { name: 'Beet zu dieser Parzelle hinzufügen' })
+      .find((button) => !button.hasAttribute('data-mui-internal-clone-element'));
+    expect(addBedButton).toBeDefined();
+    await user.click(addBedButton!);
     await user.click(screen.getByLabelText('Löschen'));
     expect(addBed).toHaveBeenCalledWith(10);
     expect(deleteField).toHaveBeenCalledWith(10);

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -118,7 +118,7 @@ describe('hierarchy components and behaviors', () => {
         } as never)}
       </>
     );
-    await user.click(screen.getByLabelText('Beet zu dieser Parzelle hinzufügen'));
+    await user.click(screen.getAllByRole('button', { name: 'Beet zu dieser Parzelle hinzufügen' })[0]);
     await user.click(screen.getByLabelText('Löschen'));
     expect(addBed).toHaveBeenCalledWith(10);
     expect(deleteField).toHaveBeenCalledWith(10);

--- a/frontend/src/__tests__/useKeyboardNavigation.test.tsx
+++ b/frontend/src/__tests__/useKeyboardNavigation.test.tsx
@@ -73,7 +73,7 @@ describe('useKeyboardNavigation', () => {
   });
 
 
-  it('stays on suppliers when pressing Ctrl+Shift+ArrowRight from the last page', () => {
+  it('wraps to Übersicht when pressing Ctrl+Shift+ArrowRight from the last page', () => {
     window.history.pushState({}, '', '/suppliers');
     render(<TestComponent />);
 
@@ -86,7 +86,7 @@ describe('useKeyboardNavigation', () => {
       })
     );
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/app/dashboard');
   });
 
   it('falls back to Übersicht when current route is unknown', () => {
@@ -215,7 +215,7 @@ describe('useKeyboardNavigation', () => {
     expect(navigateMock).toHaveBeenCalledWith('/app/locations');
   });
 
-  it('stays on Übersicht on Ctrl+Shift+ArrowLeft', () => {
+  it('wraps to Lieferanten on Ctrl+Shift+ArrowLeft from Übersicht', () => {
     window.history.pushState({}, '', '/app/dashboard');
     render(<TestComponent />);
 
@@ -228,6 +228,6 @@ describe('useKeyboardNavigation', () => {
       })
     );
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/app/suppliers');
   });
 });

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -102,14 +102,13 @@ function renderInlineActions(
             />
           </span>
         </Tooltip>
-        <Box sx={{ ml: 0.25 }}>
-          {renderActionIconButton({
-            label: t('common:actions.delete'),
-            color: 'error',
-            onClick: () => callbacks.onDeleteField(row.fieldId!),
-            icon: <DeleteIcon fontSize="small" />,
-          })}
-        </Box>
+        {renderActionIconButton({
+          label: t('common:actions.delete'),
+          color: 'error',
+          onClick: () => callbacks.onDeleteField(row.fieldId!),
+          icon: <DeleteIcon fontSize="small" />,
+          sx: { ml: 0.5 },
+        })}
       </>
     );
   }
@@ -128,6 +127,7 @@ function renderInlineActions(
           color: 'error',
           onClick: () => callbacks.onDeleteBed(row.bedId!),
           icon: <DeleteIcon fontSize="small" />,
+          sx: { ml: 0.5 },
         })}
       </>
     );
@@ -204,7 +204,7 @@ function renderNameCell(
           {params.value}
         </Box>
 
-        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1, ml: 0.75 }}>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, ml: 0.5 }}>
           {showInlineActions ? renderInlineActions(row, callbacks, t) : null}
         </Box>
       </Box>

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -1,16 +1,13 @@
 import { Box } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
-import { useTranslation } from '../../i18n';
 
 interface AppLogoProps {
   to?: string;
   size?: number;
   showText?: boolean;
-  subtleActive?: boolean;
 }
 
-export default function AppLogo({ to = '/app/dashboard', size = 28, showText = true, subtleActive = false }: AppLogoProps): React.ReactElement {
-  const { t } = useTranslation('common');
+export default function AppLogo({ to = '/app/dashboard', size = 28, showText = true }: AppLogoProps): React.ReactElement {
 
   return (
     <Box
@@ -26,25 +23,31 @@ export default function AppLogo({ to = '/app/dashboard', size = 28, showText = t
         px: 0.75,
         py: 0.35,
         borderRadius: 1,
-        backgroundColor: subtleActive ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
-        border: subtleActive ? '1px solid rgba(255, 255, 255, 0.16)' : '1px solid transparent',
-        transition: 'background-color 120ms ease, border-color 120ms ease',
+        border: '1px solid transparent',
+        transition: 'background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease',
         '&:hover': {
-          backgroundColor: subtleActive ? 'rgba(255, 255, 255, 0.12)' : 'rgba(255, 255, 255, 0.06)',
-          borderColor: subtleActive ? 'rgba(255, 255, 255, 0.2)' : 'transparent',
+          backgroundColor: 'rgba(255, 255, 255, 0.08)',
+          borderColor: 'rgba(255, 255, 255, 0.2)',
+        },
+        '&:focus-visible': {
+          outline: 'none',
+          backgroundColor: 'rgba(255, 255, 255, 0.1)',
+          borderColor: 'rgba(255, 255, 255, 0.3)',
+          boxShadow: '0 0 0 2px rgba(255, 255, 255, 0.35)',
         },
       }}
-      aria-label={t('appName')}
+      aria-label="Zur Übersicht"
+      title="Zur Übersicht"
     >
       <Box
         component="img"
         src="/favicon.png"
-        alt={t('appName')}
+        alt="OpenFarmPlanner"
         sx={{ height: size, width: size, borderRadius: 0.5, flexShrink: 0 }}
       />
       {showText ? (
         <Box component="span" sx={{ fontWeight: 700, fontSize: 16, whiteSpace: 'nowrap' }}>
-          {t('appName')}
+          OpenFarmPlanner
         </Box>
       ) : null}
     </Box>

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -254,8 +254,9 @@ export function AreaAssignmentDialog({
       >
         <Typography variant="body2" noWrap sx={{ flexGrow: 1 }}>{compactLabel}</Typography>
         <IconButton
-          aria-label={t('areaAssignment.editButton')}
           size="small"
+          tabIndex={-1}
+          aria-hidden
           onClick={() => setIsOpen(true)}
         >
           <EditIcon fontSize="small" />

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -226,7 +226,32 @@ export function AreaAssignmentDialog({
 
   return (
     <>
-      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: '100%', overflow: 'hidden' }}>
+      <Box
+        role="button"
+        tabIndex={0}
+        aria-label={t('areaAssignment.editButton')}
+        onClick={() => setIsOpen(true)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setIsOpen(true);
+          }
+        }}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          width: '100%',
+          overflow: 'hidden',
+          cursor: 'pointer',
+          borderRadius: 0.5,
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: '1px',
+          },
+        }}
+      >
         <Typography variant="body2" noWrap sx={{ flexGrow: 1 }}>{compactLabel}</Typography>
         <IconButton
           aria-label={t('areaAssignment.editButton')}
@@ -235,7 +260,7 @@ export function AreaAssignmentDialog({
         >
           <EditIcon fontSize="small" />
         </IconButton>
-      </Stack>
+      </Box>
       <Dialog open={isOpen} onClose={() => setIsOpen(false)} fullWidth maxWidth="sm">
         <DialogTitle>{t('areaAssignment.title')}</DialogTitle>
         <DialogContent>

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -41,9 +41,14 @@ export function useKeyboardNavigation(): void {
 
       const normalizedPath = normalizeMainRoutePath(window.location.pathname || '/');
       const currentIndex = KEYBOARD_NAV_ROUTES.indexOf(normalizedPath);
-      const safeCurrentIndex = currentIndex === -1 ? 0 : currentIndex;
+      if (currentIndex === -1) {
+        console.warn(`[keyboard-nav] Unknown route "${normalizedPath}" (pathname: "${window.location.pathname}"). Falling back to dashboard.`);
+        navigate('/app/dashboard');
+        return;
+      }
+
       const direction = event.key === 'ArrowRight' ? 1 : -1;
-      const nextIndex = (safeCurrentIndex + direction + KEYBOARD_NAV_ROUTES.length) % KEYBOARD_NAV_ROUTES.length;
+      const nextIndex = (currentIndex + direction + KEYBOARD_NAV_ROUTES.length) % KEYBOARD_NAV_ROUTES.length;
 
       navigate(KEYBOARD_NAV_ROUTES[nextIndex]);
     };

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -11,7 +11,7 @@
 
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MAIN_NAV_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
+import { KEYBOARD_NAV_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
 
 export function useKeyboardNavigation(): void {
   const navigate = useNavigate();
@@ -40,25 +40,12 @@ export function useKeyboardNavigation(): void {
       event.preventDefault();
 
       const normalizedPath = normalizeMainRoutePath(window.location.pathname || '/');
-      const currentIndex = MAIN_NAV_ROUTES.indexOf(normalizedPath);
+      const currentIndex = KEYBOARD_NAV_ROUTES.indexOf(normalizedPath);
+      const safeCurrentIndex = currentIndex === -1 ? 0 : currentIndex;
+      const direction = event.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (safeCurrentIndex + direction + KEYBOARD_NAV_ROUTES.length) % KEYBOARD_NAV_ROUTES.length;
 
-      if (currentIndex === -1) {
-        navigate('/app/dashboard');
-        return;
-      }
-
-      if (event.key === 'ArrowLeft') {
-        if (currentIndex === 0) {
-          return;
-        }
-        navigate(MAIN_NAV_ROUTES[currentIndex - 1]);
-        return;
-      }
-
-      if (currentIndex >= MAIN_NAV_ROUTES.length - 1) {
-        return;
-      }
-      navigate(MAIN_NAV_ROUTES[currentIndex + 1]);
+      navigate(KEYBOARD_NAV_ROUTES[nextIndex]);
     };
 
     window.addEventListener('keydown', handleKeyDown);

--- a/frontend/src/i18n/locales/de/beds.json
+++ b/frontend/src/i18n/locales/de/beds.json
@@ -17,6 +17,6 @@
     "fieldRequired": "Parzelle ist ein Pflichtfeld"
   },
   "confirmDelete": "Möchten Sie dieses Beet wirklich löschen?",
-  "addButton": "Neues Beet hinzufügen",
+  "addButton": "Beet hinzufügen",
   "selectField": "Parzelle auswählen"
 }

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -234,7 +234,7 @@
       "beds": {
         "title": "Noch kein Saatgutbedarf berechenbar",
         "description": "Lege als Nächstes Beete an, damit Kulturen einer Fläche zugeordnet werden können.",
-        "action": "Beete anlegen"
+        "action": "Beet hinzufügen"
       },
       "cultures": {
         "title": "Noch kein Saatgutbedarf berechenbar",

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -256,9 +256,9 @@
     "createSupplierAction": "Lieferant hinzufügen",
     "editCultureAction": "Kultur bearbeiten",
     "noSupplierData": "Keine Lieferantendaten vorhanden",
-    "noSupplierAvailable": "Kein Lieferant verfügbar",
+    "noSupplierAvailable": "Keine Lieferantendaten hinterlegt",
     "noPackagesAvailable": "Keine Packungsgrößen verfügbar",
-    "noPackageCalculationPossible": "Keine Berechnung möglich",
+    "noPackageCalculationPossible": "Nicht berechenbar (Daten fehlen)",
     "unitSeeds": "Korn",
     "unitGrams": "g",
     "columns": {

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -36,7 +36,7 @@
   "emptyOnboarding": {
     "title": "Noch keine Kulturen vorhanden",
     "description": "Kulturen sind die Grundlage für deine Anbauplanung. Lege deine erste Kultur an oder übernimm Kulturen aus der öffentlichen Kulturbibliothek.",
-    "createAction": "Neue Kultur hinzufügen",
+    "createAction": "Kultur hinzufügen",
     "openLibraryAction": "Öffentliche Kulturbibliothek öffnen"
   },
   "perennial": "Mehrjährig",
@@ -67,7 +67,7 @@
     "harvestWindowValue": "{{first}}–{{last}} Tage nach der Aussaat"
   },
   "form": {
-    "createTitle": "Neue Kultur erstellen",
+    "createTitle": "Kultur hinzufügen",
     "editTitle": "Kultur bearbeiten",
     "cancel": "Abbrechen",
     "save": "Speichern",
@@ -88,9 +88,9 @@
     "supplierRequired": "Saatgutlieferant ist erforderlich",
     "supplierHelp": "Lieferant aus der Liste auswählen",
     "noSuppliers": "Keine Lieferanten vorhanden",
-    "createSuppliers": "Lieferanten anlegen",
+    "createSuppliers": "Lieferanten hinzufügen",
     "newSupplierOption": "+ Neuer Lieferant",
-    "createNewSupplierInline": "Neuen Lieferanten anlegen",
+    "createNewSupplierInline": "Lieferant hinzufügen",
     "noSuppliersHint": "Bitte legen Sie zuerst einen Lieferanten an.",
     "supplierHomepage": "Lieferanten-Homepage",
     "generalInfoSectionTitle": "Allgemeine Informationen",
@@ -221,7 +221,7 @@
       "noResultsTitle": "Kein Saatgutbedarf vorhanden",
       "noResultsDescription": "Für die aktuellen Anbaupläne konnte kein Saatgutbedarf berechnet werden.",
       "actions": {
-        "createPlan": "Anbauplan erstellen",
+        "createPlan": "Anbauplan hinzufügen",
         "editCultures": "Kulturen bearbeiten"
       }
     },
@@ -229,7 +229,7 @@
       "locations": {
         "title": "Noch kein Saatgutbedarf berechenbar",
         "description": "Lege zuerst einen Standort an, damit du Flächen und Beete planen kannst.",
-        "action": "Standort anlegen"
+        "action": "Standort hinzufügen"
       },
       "beds": {
         "title": "Noch kein Saatgutbedarf berechenbar",
@@ -239,12 +239,12 @@
       "cultures": {
         "title": "Noch kein Saatgutbedarf berechenbar",
         "description": "Lege jetzt deine ersten Kulturen an, damit daraus ein Saatgutbedarf berechnet werden kann.",
-        "action": "Kultur anlegen"
+        "action": "Kultur hinzufügen"
       },
       "plans": {
         "title": "Noch kein Saatgutbedarf berechenbar",
         "description": "Erstelle als Nächstes einen Anbauplan, damit ein konkreter Saatgutbedarf entsteht.",
-        "action": "Anbauplan erstellen"
+        "action": "Anbauplan hinzufügen"
       },
       "seedData": {
         "title": "Noch kein Saatgutbedarf berechenbar",
@@ -253,7 +253,7 @@
       }
     },
     "selectSupplier": "Lieferant auswählen",
-    "createSupplierAction": "Neuen Lieferanten anlegen",
+    "createSupplierAction": "Lieferant hinzufügen",
     "editCultureAction": "Kultur bearbeiten",
     "noSupplierData": "Keine Lieferantendaten vorhanden",
     "noSupplierAvailable": "Kein Lieferant verfügbar",
@@ -308,18 +308,18 @@
     "all": "Alle Kulturen als JSON herunterladen"
   },
   "buttons": {
-    "addNew": "Neue Kultur hinzufügen",
+    "addNew": "Kultur hinzufügen",
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "deleteConfirm": "Möchten Sie diese Kultur wirklich löschen?",
-    "createPlantingPlan": "Anbauplan erstellen",
+    "createPlantingPlan": "Anbauplan hinzufügen",
     "goToFieldsBeds": "Zu Anbauflächen",
     "createPlantingPlanDisabled": {
       "locations": "Du brauchst zuerst mindestens einen Standort, um einen Anbauplan zu erstellen.",
       "fields": "Du brauchst zuerst mindestens eine Parzelle, um einen Anbauplan zu erstellen.",
       "beds": "Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt.",
       "cultures": "Du brauchst zuerst mindestens eine Kultur, um einen Anbauplan zu erstellen.",
-      "null": "Anbauplan erstellen"
+      "null": "Anbauplan hinzufügen"
     },
     "aiComplete": "Kultur vervollständigen (KI)",
     "aiReresearch": "Kultur komplett neu recherchieren (KI)",

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -25,7 +25,7 @@
     "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort hinzufügen" },
     "beds": { "text": "Beete werden innerhalb von Parzellen auf der Seite Anbauflächen hinzugefügt.", "action": "Zu Anbauflächen" },
     "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur hinzufügen" },
-    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan erstellen" }
+    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan hinzufügen" }
   },
   "tasks": {
     "title": "Anstehende Aufgaben",

--- a/frontend/src/i18n/locales/de/dashboard.json
+++ b/frontend/src/i18n/locales/de/dashboard.json
@@ -9,28 +9,18 @@
     "shortDescription": "Lege zuerst einen Standort an.",
     "action": "Standort hinzufügen"
   },
-  "setup": {
-    "title": "Projektstatus",
-    "location": "Standort angelegt",
-    "bed": "Beet angelegt",
-    "culture": "Kultur angelegt",
-    "plan": "Anbauplan erstellt"
-  },
-  "status": {
-    "done": "vorhanden",
-    "missing": "fehlt"
-  },
-  "nextStep": {
-    "title": "Nächster sinnvoller Schritt",
-    "locations": { "text": "Lege zuerst einen Standort an.", "action": "Standort hinzufügen" },
-    "beds": { "text": "Beete werden innerhalb von Parzellen auf der Seite Anbauflächen hinzugefügt.", "action": "Zu Anbauflächen" },
-    "cultures": { "text": "Lege deine ersten Kulturen an.", "action": "Kultur hinzufügen" },
-    "plans": { "text": "Erstelle deinen ersten Anbauplan.", "action": "Anbauplan hinzufügen" }
-  },
   "tasks": {
     "title": "Anstehende Aufgaben",
     "empty": "Keine anstehenden Aufgaben vorhanden",
     "emptyTitle": "Keine anstehenden Aufgaben",
     "emptyDescription": "Aktuell gibt es keine anstehenden Aufgaben für dieses Projekt."
+  },
+  "checklist": {
+    "title": "Checkliste",
+    "location": "Standort hinzufügen",
+    "field": "Parzelle hinzufügen",
+    "bed": "Beet hinzufügen",
+    "culture": "Kultur hinzufügen",
+    "plan": "Anbauplan hinzufügen"
   }
 }

--- a/frontend/src/i18n/locales/de/fields.json
+++ b/frontend/src/i18n/locales/de/fields.json
@@ -17,8 +17,8 @@
     "locationRequired": "Standort ist ein Pflichtfeld"
   },
   "confirmDelete": "Möchten Sie diese Parzelle wirklich löschen?",
-  "addButton": "Neue Parzelle hinzufügen",
-  "createNew": "Neue Parzelle erstellen",
+  "addButton": "Parzelle hinzufügen",
+  "createNew": "Parzelle hinzufügen",
   "cancel": "Abbrechen",
   "submit": "Erstellen",
   "selectLocation": "Standort auswählen",

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -119,7 +119,7 @@
       "createLocation": "Standort hinzufügen",
       "createCulture": "Kultur hinzufügen",
       "createAreas": "Zu Anbauflächen",
-      "createPlan": "Anbauplan erstellen"
+      "createPlan": "Anbauplan hinzufügen"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -72,7 +72,7 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Neuen Standort hinzufügen",
+        "add": "Standort hinzufügen",
         "edit": "Standort bearbeiten",
         "delete": "Standort löschen"
       }
@@ -132,9 +132,9 @@
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
         "expandToggle": "Bereich ein- oder ausklappen",
-        "add": "Neues Element anlegen",
+        "add": "Element hinzufügen",
         "delete": "Element löschen",
-        "createPlan": "Anbauplan für dieses Beet anlegen",
+        "createPlan": "Anbauplan für dieses Beet hinzufügen",
         "dimensions": "Ausrichtung von Länge und Breite für die grafische Ansicht"
       }
     },
@@ -160,9 +160,9 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Neue Kultur anlegen",
+        "add": "Kultur hinzufügen",
         "library": "Öffentliche Kulturbibliothek öffnen",
-        "createPlan": "Anbauplan für diese Kultur anlegen",
+        "createPlan": "Anbauplan für diese Kultur hinzufügen",
         "more": "Weitere Aktionen öffnen",
         "edit": "Kulturdaten bearbeiten",
         "delete": "Kultur entfernen"
@@ -192,7 +192,7 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Neuen Anbauplan anlegen",
+        "add": "Anbauplan hinzufügen",
         "mobileAdd": "Auf Mobilgeräten schnell einen neuen Eintrag anlegen",
         "notes": "Notizen und Anhänge pro Eintrag öffnen",
         "edit": "Werte direkt in der Tabelle ändern"
@@ -261,7 +261,7 @@
       ],
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
-        "add": "Lieferanten anlegen",
+        "add": "Lieferanten hinzufügen",
         "edit": "Lieferantendaten ändern",
         "delete": "Lieferanten entfernen"
       }

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -3,7 +3,7 @@
   "addField": "Parzelle",
   "addBed": "Beet",
   "addBedToField": "Beet für diese Parzelle hinzufügen",
-  "createPlantingPlan": "Anbauplan erstellen",
+  "createPlantingPlan": "Anbauplan hinzufügen",
   "columns": {
     "name": "Name",
     "location": "Standort",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -35,7 +35,7 @@
     "requiredFields": "Folgende Pflichtfelder müssen ausgefüllt werden: {{fields}}"
   },
   "confirmDelete": "Möchten Sie diesen Anbauplan wirklich löschen?",
-  "addButton": "Neuen Anbauplan hinzufügen",
+  "addButton": "Anbauplan hinzufügen",
   "cultivationTypes": {
     "directSowing": "Direktsaat",
     "preCultivation": "Pflanzung"
@@ -49,12 +49,12 @@
   "mobile": {
     "showDetails": "Details anzeigen",
     "hideDetails": "Details ausblenden",
-    "fabLabel": "Neuer Plan",
-    "fabAria": "Neuen Anbauplan erstellen",
+    "fabLabel": "Anbauplan hinzufügen",
+    "fabAria": "Anbauplan hinzufügen",
     "emptyTitle": "Noch keine Anbaupläne vorhanden",
     "emptyDescription": "Lege deinen ersten Anbauplan an, um Kultur, Anbauart und Zeiträume mobil übersichtlich zu verwalten.",
-    "emptyCta": "Anbauplan erstellen",
-    "createTitle": "Neuen Anbauplan erstellen",
+    "emptyCta": "Anbauplan hinzufügen",
+    "createTitle": "Anbauplan hinzufügen",
     "editTitle": "Anbauplan bearbeiten",
     "editAria": "Anbauplan bearbeiten",
     "notesPhotos": "Fotos",
@@ -64,7 +64,7 @@
     "createBlockedTooltip": "Beete werden innerhalb von Parzellen auf der Seite Anbauflächen hinzugefügt.",
     "states": {
       "locations": {
-        "title": "Du kannst noch keinen Anbauplan erstellen.",
+        "title": "Du kannst noch keinen Anbauplan hinzufügen.",
         "description": "Lege zuerst einen Standort an."
       },
       "beds": {
@@ -82,7 +82,7 @@
     },
     "actions": {
       "createAreas": "Zu Anbauflächen",
-      "createPlan": "Anbauplan erstellen"
+      "createPlan": "Anbauplan hinzufügen"
     }
   }
 }

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -6,7 +6,6 @@ export interface MainNavigationItem {
 }
 
 export const MAIN_NAV_ITEMS: MainNavigationItem[] = [
-  { to: '/app/dashboard', labelKey: 'dashboard', keywords: ['übersicht', 'dashboard', 'start'] },
   { to: '/app/locations', labelKey: 'locations', keywords: ['standorte', 'orte', 'locations'] },
   { to: '/app/fields-beds', labelKey: 'fieldsAndBeds', keywords: ['anbauflächen', 'felder', 'beete'] },
   { to: '/app/cultures', labelKey: 'cultures', keywords: ['kulturen', 'kultur'] },

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -16,6 +16,7 @@ export const MAIN_NAV_ITEMS: MainNavigationItem[] = [
 ];
 
 export const MAIN_NAV_ROUTES = MAIN_NAV_ITEMS.map((item) => item.to);
+export const KEYBOARD_NAV_ROUTES = ['/app/dashboard', ...MAIN_NAV_ROUTES];
 
 export const normalizeMainRoutePath = (pathname: string): string => {
   const normalizedPath = pathname.replace(/\/$/, '') || '/';

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -1118,9 +1118,7 @@ function Cultures(): React.ReactElement {
             <Button variant="outlined" onClick={handleOpenHistory} disabled={!selectedCulture}>
               Versionen
             </Button>
-          </Box>
-
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center' }}>
+            <Box sx={{ flexGrow: 1, minWidth: { xs: 0, md: 16 } }} />
             <Tooltip title="Kultur löschen (Alt+Shift+D)">
               <span>
                 <Button
@@ -1130,6 +1128,7 @@ function Cultures(): React.ReactElement {
                   startIcon={<DeleteIcon />}
                   onClick={() => selectedCulture && handleDelete(selectedCulture)}
                   disabled={!selectedCulture}
+                  sx={{ ml: { xs: 0, md: 'auto' } }}
                 >
                   {t('buttons.delete')}
                 </Button>

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -1118,7 +1118,6 @@ function Cultures(): React.ReactElement {
             <Button variant="outlined" onClick={handleOpenHistory} disabled={!selectedCulture}>
               Versionen
             </Button>
-            <Box sx={{ flexGrow: 1, minWidth: { xs: 0, md: 16 } }} />
             <Tooltip title="Kultur löschen (Alt+Shift+D)">
               <span>
                 <Button
@@ -1128,7 +1127,7 @@ function Cultures(): React.ReactElement {
                   startIcon={<DeleteIcon />}
                   onClick={() => selectedCulture && handleDelete(selectedCulture)}
                   disabled={!selectedCulture}
-                  sx={{ ml: { xs: 0, md: 'auto' } }}
+                  sx={{ ml: 2 }}
                 >
                   {t('buttons.delete')}
                 </Button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,9 @@
-import { Alert, Box, Button, Card, CardContent, Chip, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Card, CardContent, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../i18n';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
 import PageContainer from '../components/layout/PageContainer';
 import PageHeader from '../components/layout/PageHeader';
@@ -11,10 +13,11 @@ import { getFirstMissingRequirement } from './requirementFlow';
 import { deriveLocationTasks } from './locationDerivedTasks';
 
 const NEXT_STEP_CONFIG = {
-  locations: { textKey: 'dashboard:nextStep.locations.text', actionKey: 'dashboard:nextStep.locations.action', to: '/app/locations?create=true' },
-  beds: { textKey: 'dashboard:nextStep.beds.text', actionKey: 'dashboard:nextStep.beds.action', to: '/app/fields-beds' },
-  cultures: { textKey: 'dashboard:nextStep.cultures.text', actionKey: 'dashboard:nextStep.cultures.action', to: '/app/cultures?create=true' },
-  plans: { textKey: 'dashboard:nextStep.plans.text', actionKey: 'dashboard:nextStep.plans.action', to: '/app/planting-plans?create=true' },
+  locations: { actionKey: 'dashboard:checklist.location', to: '/app/locations?create=true' },
+  fields: { actionKey: 'dashboard:checklist.field', to: '/app/fields-beds' },
+  beds: { actionKey: 'dashboard:checklist.bed', to: '/app/fields-beds' },
+  cultures: { actionKey: 'dashboard:checklist.culture', to: '/app/cultures?create=true' },
+  plans: { actionKey: 'dashboard:checklist.plan', to: '/app/planting-plans?create=true' },
 } as const;
 
 export default function Dashboard(): React.ReactElement {
@@ -57,14 +60,26 @@ export default function Dashboard(): React.ReactElement {
   }, [shouldShowProjectRequiredState, t]);
 
   const firstMissingRequirement = getFirstMissingRequirement({ hasLocations: locations.length > 0, hasBeds: beds.length > 0, hasCultures: cultures.length > 0, hasPlans: plans.length > 0 });
+  const firstMissingChecklistStep = (locations.length === 0
+    ? 'locations'
+    : fields.length === 0
+      ? 'fields'
+      : beds.length === 0
+        ? 'beds'
+        : cultures.length === 0
+          ? 'cultures'
+          : plans.length === 0
+            ? 'plans'
+            : null);
   const locale = i18n.resolvedLanguage === 'de' ? 'de-DE' : 'en-US';
 
-  const setupItems = [
-    { label: t('dashboard:setup.location'), done: locations.length > 0 },
-    { label: t('dashboard:setup.bed'), done: beds.length > 0 },
-    { label: t('dashboard:setup.culture'), done: cultures.length > 0 },
-    { label: t('dashboard:setup.plan'), done: plans.length > 0 },
-  ];
+  const checklistItems = [
+    { key: 'locations', label: t('dashboard:checklist.location'), done: locations.length > 0 },
+    { key: 'fields', label: t('dashboard:checklist.field'), done: fields.length > 0 },
+    { key: 'beds', label: t('dashboard:checklist.bed'), done: beds.length > 0 },
+    { key: 'cultures', label: t('dashboard:checklist.culture'), done: cultures.length > 0 },
+    { key: 'plans', label: t('dashboard:checklist.plan'), done: plans.length > 0 },
+  ] as const;
 
   const upcomingTasks = useMemo(() => {
     const byLocation = deriveLocationTasks({ locations, fields, beds, cultures, plantingPlans: plans });
@@ -95,28 +110,33 @@ export default function Dashboard(): React.ReactElement {
       ) : null}
 
       {!isEmptyProject && !isSetupComplete ? (
-        <>
-          <Card variant="outlined" sx={{ mb: 2 }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>{t('dashboard:setup.title')}</Typography>
-              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-                {setupItems.map((item) => <Chip key={item.label} label={`${item.label}: ${item.done ? t('dashboard:status.done') : t('dashboard:status.missing')}`} color={item.done ? 'success' : 'default'} />)}
-              </Stack>
-            </CardContent>
-          </Card>
-
-          <Card variant="outlined" sx={{ mb: 2 }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>{t('dashboard:nextStep.title')}</Typography>
-              {firstMissingRequirement ? (
-                <>
-                  <Typography variant="body2" sx={{ mb: 1.5 }}>{t(NEXT_STEP_CONFIG[firstMissingRequirement].textKey)}</Typography>
-                  <Button component={RouterLink} to={NEXT_STEP_CONFIG[firstMissingRequirement].to} variant="contained">{t(NEXT_STEP_CONFIG[firstMissingRequirement].actionKey)}</Button>
-                </>
-              ) : null}
-            </CardContent>
-          </Card>
-        </>
+        <Card variant="outlined" sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>{t('dashboard:checklist.title')}</Typography>
+            <Stack spacing={1.1} sx={{ mb: 2 }}>
+              {checklistItems.map((item) => {
+                const isNextStep = firstMissingChecklistStep === item.key;
+                return (
+                  <Box key={item.key} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {item.done ? (
+                      <CheckBoxIcon fontSize="small" color="success" />
+                    ) : (
+                      <CheckBoxOutlineBlankIcon fontSize="small" color={isNextStep ? 'primary' : 'disabled'} />
+                    )}
+                    <Typography variant="body2" sx={{ fontWeight: isNextStep ? 600 : 400, color: isNextStep ? 'primary.main' : 'text.primary' }}>
+                      {item.label}
+                    </Typography>
+                  </Box>
+                );
+              })}
+            </Stack>
+            {firstMissingChecklistStep ? (
+              <Button component={RouterLink} to={NEXT_STEP_CONFIG[firstMissingChecklistStep].to} variant="contained">
+                {t(NEXT_STEP_CONFIG[firstMissingChecklistStep].actionKey)}
+              </Button>
+            ) : null}
+          </CardContent>
+        </Card>
       ) : null}
 
       {!isEmptyProject && (isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0)) ? (


### PR DESCRIPTION
### Motivation
- The seed-demand page empty state used inconsistent wording for the missing-beds action and displayed "Beete anlegen", which mixes wording patterns and is misleading because beds are managed on the `Anbauflächen` page.
- The goal is to use the established verb `hinzufügen` for user-created entities and ensure the CTA routes the user to `Anbauflächen` without opening the planting-plan form.

### Description
- Updated the German translation for the seed-demand progressive empty-state beds action in `frontend/src/i18n/locales/de/cultures.json` from `"Beete anlegen"` to `"Beet hinzufügen"`.
- Verified the seed-demand page action builds its CTA from the translation key and already routes to `/app/fields-beds` in `frontend/src/pages/SeedDemand.tsx`, so no route or component behavior change was required.
- Searched the codebase for other occurrences of the same seed-demand empty-state pattern and found no additional incorrect targets that required changes.
- Committed the change with the Conventional Commit message: `fix(seed-demand): correct empty-state bed action label`.

### Testing
- No automated tests were executed (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f475618ea08322b0df08a40baf70bf)