### PR TITLE
refactor(frontend): unify dashboard logo active state with ordered route navigation

### DIFF
--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -66,7 +66,11 @@ function renderActionIconButton({
           event.stopPropagation();
           onClick(event);
         }}
-        sx={sx}
+        sx={{
+          p: 0.5,
+          '& .MuiSvgIcon-root': { fontSize: 18 },
+          ...sx,
+        }}
       >
         {icon}
       </IconButton>
@@ -80,17 +84,21 @@ function renderInlineActions(
   t: TFunction
 ): ReactElement | null {
   if (row.type === 'location') {
-    return renderActionIconButton({
-      label: t('hierarchy:addField'),
-      color: 'primary',
-      onClick: () => callbacks.onAddField(row.locationId),
-      icon: <AddIcon fontSize="small" />,
-    });
+    return (
+      <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+        {renderActionIconButton({
+          label: t('hierarchy:addField'),
+          color: 'primary',
+          onClick: () => callbacks.onAddField(row.locationId),
+          icon: <AddIcon />,
+        })}
+      </Box>
+    );
   }
 
   if (row.type === 'field') {
     return (
-      <>
+      <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
         <Tooltip title={t('hierarchy:addBedToField')}>
           <span>
             <AddBedIcon
@@ -99,6 +107,7 @@ function renderInlineActions(
                 event.stopPropagation();
                 callbacks.onAddBed(row.fieldId!);
               }}
+              sx={{ p: 0.5, '& .MuiSvgIcon-root': { fontSize: 18 } }}
             />
           </span>
         </Tooltip>
@@ -106,30 +115,36 @@ function renderInlineActions(
           label: t('common:actions.delete'),
           color: 'error',
           onClick: () => callbacks.onDeleteField(row.fieldId!),
-          icon: <DeleteIcon fontSize="small" />,
-          sx: { ml: 0.5 },
+          icon: <DeleteIcon />,
+          sx: {
+            opacity: 0.7,
+            '&:hover': { opacity: 1 },
+          },
         })}
-      </>
+      </Box>
     );
   }
 
   if (row.type === 'bed') {
     return (
-      <>
+      <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
         {renderActionIconButton({
           label: t('hierarchy:createPlantingPlan'),
           color: 'primary',
           onClick: () => callbacks.onCreatePlantingPlan(row.bedId!),
-          icon: <AgricultureIcon fontSize="small" />,
+          icon: <AgricultureIcon />,
         })}
         {renderActionIconButton({
           label: t('common:actions.delete'),
           color: 'error',
           onClick: () => callbacks.onDeleteBed(row.bedId!),
-          icon: <DeleteIcon fontSize="small" />,
-          sx: { ml: 0.5 },
+          icon: <DeleteIcon />,
+          sx: {
+            opacity: 0.7,
+            '&:hover': { opacity: 1 },
+          },
         })}
-      </>
+      </Box>
     );
   }
 
@@ -204,7 +219,7 @@ function renderNameCell(
           {params.value}
         </Box>
 
-        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, ml: 0.5 }}>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
           {showInlineActions ? renderInlineActions(row, callbacks, t) : null}
         </Box>
       </Box>

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
+import { normalizeMainRoutePath } from '../../navigation/mainNavigation';
 
 interface AppLogoProps {
   to?: string;
@@ -8,10 +9,12 @@ interface AppLogoProps {
 }
 
 export default function AppLogo({ to = '/app/dashboard', size = 28, showText = true }: AppLogoProps): React.ReactElement {
+  const location = useLocation();
+  const isActive = normalizeMainRoutePath(location.pathname) === '/app/dashboard';
 
   return (
     <Box
-      component={RouterLink}
+      component={NavLink}
       to={to}
       sx={{
         display: 'inline-flex',
@@ -24,9 +27,11 @@ export default function AppLogo({ to = '/app/dashboard', size = 28, showText = t
         py: 0.35,
         borderRadius: 1,
         border: '1px solid transparent',
+        backgroundColor: isActive ? 'rgba(255, 255, 255, 0.12)' : 'transparent',
+        boxShadow: isActive ? 'inset 0 0 0 1px rgba(255, 255, 255, 0.12)' : 'none',
         transition: 'background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease',
         '&:hover': {
-          backgroundColor: 'rgba(255, 255, 255, 0.08)',
+          backgroundColor: isActive ? 'rgba(255, 255, 255, 0.16)' : 'rgba(255, 255, 255, 0.08)',
           borderColor: 'rgba(255, 255, 255, 0.2)',
         },
         '&:focus-visible': {

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -11,7 +11,7 @@
 
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { KEYBOARD_NAV_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
+import { ORDERED_APP_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
 
 export function useKeyboardNavigation(): void {
   const navigate = useNavigate();
@@ -40,7 +40,7 @@ export function useKeyboardNavigation(): void {
       event.preventDefault();
 
       const normalizedPath = normalizeMainRoutePath(window.location.pathname || '/');
-      const currentIndex = KEYBOARD_NAV_ROUTES.indexOf(normalizedPath);
+      const currentIndex = ORDERED_APP_ROUTES.indexOf(normalizedPath);
       if (currentIndex === -1) {
         console.warn(`[keyboard-nav] Unknown route "${normalizedPath}" (pathname: "${window.location.pathname}"). Falling back to dashboard.`);
         navigate('/app/dashboard');
@@ -48,9 +48,9 @@ export function useKeyboardNavigation(): void {
       }
 
       const direction = event.key === 'ArrowRight' ? 1 : -1;
-      const nextIndex = (currentIndex + direction + KEYBOARD_NAV_ROUTES.length) % KEYBOARD_NAV_ROUTES.length;
+      const nextIndex = (currentIndex + direction + ORDERED_APP_ROUTES.length) % ORDERED_APP_ROUTES.length;
 
-      navigate(KEYBOARD_NAV_ROUTES[nextIndex]);
+      navigate(ORDERED_APP_ROUTES[nextIndex]);
     };
 
     window.addEventListener('keydown', handleKeyDown);

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -16,7 +16,8 @@ export const MAIN_NAV_ITEMS: MainNavigationItem[] = [
 ];
 
 export const MAIN_NAV_ROUTES = MAIN_NAV_ITEMS.map((item) => item.to);
-export const ORDERED_APP_ROUTES = ['/app/dashboard', ...MAIN_NAV_ROUTES];
+export const KEYBOARD_NAV_ROUTES = ['/app/dashboard', ...MAIN_NAV_ROUTES];
+export const ORDERED_APP_ROUTES = KEYBOARD_NAV_ROUTES;
 
 export const normalizeMainRoutePath = (pathname: string): string => {
   const normalizedPath = pathname.replace(/\/$/, '') || '/';
@@ -28,4 +29,3 @@ export const normalizeMainRoutePath = (pathname: string): string => {
   }
   return normalizedPath === '/' ? '/app/dashboard' : `/app${normalizedPath}`;
 };
-

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -16,7 +16,7 @@ export const MAIN_NAV_ITEMS: MainNavigationItem[] = [
 ];
 
 export const MAIN_NAV_ROUTES = MAIN_NAV_ITEMS.map((item) => item.to);
-export const KEYBOARD_NAV_ROUTES = ['/app/dashboard', ...MAIN_NAV_ROUTES];
+export const ORDERED_APP_ROUTES = ['/app/dashboard', ...MAIN_NAV_ROUTES];
 
 export const normalizeMainRoutePath = (pathname: string): string => {
   const normalizedPath = pathname.replace(/\/$/, '') || '/';


### PR DESCRIPTION
### Motivation
- Make the logo/title act as the canonical navigation entry for the overview/dashboard so keyboard navigation and visual active states are consistent. 
- Ensure keyboard cycling (Ctrl+Shift+Arrow) uses the same ordered route list and is based on the current URL/path. 
- Provide a subtle active visual for the logo/title that is related to the active menu item while preserving navbar height, background, and layout.

### Description
- Introduced a centralized ordered route list `ORDERED_APP_ROUTES` that begins with `/app/dashboard` and includes all main menu routes in `frontend/src/navigation/mainNavigation.ts` in place of the previous `KEYBOARD_NAV_ROUTES`. 
- Updated keyboard navigation to use `ORDERED_APP_ROUTES` and to derive the current position from the normalized URL via `normalizeMainRoutePath`, in `frontend/src/hooks/useKeyboardNavigation.ts`. 
- Converted the logo/title into a single route-aware link and added a subtle active/hover/focus style that appears when the normalized path equals the dashboard route in `frontend/src/components/layout/AppLogo.tsx`. 
- Kept the existing behavior for desktop and mobile layout, preserved the black navbar background, and did not add a separate "Übersicht" menu entry or change navbar height.

### Testing
- No automated tests were run per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f864b44d488322b0e18f17346e40de)