### PR TITLE
Topbar context actions for Cultures, compact notes indicator, UI & theme tweaks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,7 +62,6 @@ import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import PublicIcon from '@mui/icons-material/Public';
@@ -640,29 +639,34 @@ function RootLayout(): React.ReactElement {
               })}
             </List>
           </Stack>
-          <IconButton
-            aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
-            onClick={toggleSidebarCollapsed}
-            size="small"
-            sx={{
-              position: 'absolute',
-              top: '50%',
-              right: -16,
-              transform: 'translateY(-50%)',
-              width: 34,
-              height: 34,
-              borderRadius: '50%',
-              border: '1px solid',
-              borderColor: 'divider',
-              bgcolor: 'background.paper',
-              boxShadow: 2,
-              transition: 'transform 0.25s ease, background-color 0.2s ease',
-              '&:hover': { bgcolor: 'action.hover' },
-              zIndex: 5,
-            }}
-          >
-            {sidebarCollapsed ? <ChevronRightIcon fontSize="medium" /> : <ChevronLeftIcon fontSize="medium" />}
-          </IconButton>
+          <Tooltip title={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'} placement="right">
+            <IconButton
+              aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
+              onClick={toggleSidebarCollapsed}
+              size="small"
+              sx={{
+                position: 'absolute',
+                top: 34,
+                right: -16,
+                transform: 'translateY(-50%)',
+                width: 34,
+                height: 34,
+                borderRadius: '50%',
+                border: '1px solid',
+                borderColor: 'rgba(0,0,0,0.2)',
+                bgcolor: 'background.paper',
+                boxShadow: 3,
+                transition: 'background-color 0.2s ease',
+                '&:hover': { bgcolor: 'action.selected' },
+                zIndex: 5,
+              }}
+            >
+              <ChevronLeftIcon
+                fontSize="medium"
+                sx={{ transform: sidebarCollapsed ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.25s ease' }}
+              />
+            </IconButton>
+          </Tooltip>
         </Box>
       ) : null}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,6 @@ import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import PublicIcon from '@mui/icons-material/Public';
@@ -93,6 +92,33 @@ import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
+
+function SidebarToggleGlyph(): React.ReactElement {
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        width: 16,
+        height: 16,
+        border: '1.5px solid',
+        borderColor: '#9ca3af',
+        borderRadius: '5px',
+        position: 'relative',
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          top: 1,
+          bottom: 1,
+          left: '50%',
+          width: '1.5px',
+          transform: 'translateX(-50%)',
+          backgroundColor: '#9ca3af',
+          borderRadius: 999,
+        },
+      }}
+    />
+  );
+}
 
 interface SnackbarState {
   open: boolean;
@@ -649,21 +675,21 @@ function RootLayout(): React.ReactElement {
                 top: 34,
                 right: -15,
                 transform: 'translateY(-50%)',
-                width: 30,
-                height: 30,
+                width: 28,
+                height: 28,
                 borderRadius: '50%',
                 border: '1px solid',
-                borderColor: 'rgba(15, 23, 42, 0.2)',
-                bgcolor: 'background.paper',
-                boxShadow: '0 2px 6px rgba(15, 23, 42, 0.16)',
-                transition: 'background-color 0.2s ease, box-shadow 0.2s ease',
-                '&:hover': { bgcolor: 'action.selected', boxShadow: '0 3px 10px rgba(15, 23, 42, 0.2)' },
+                borderColor: '#E5E7EB',
+                bgcolor: '#FFFFFF',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+                transition: 'background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease',
+                '&:hover': { bgcolor: '#F3F4F6', borderColor: '#D1D5DB' },
+                '&:active': { bgcolor: '#E5E7EB' },
+                '&:focus-visible': { outline: '2px solid #D1D5DB', outlineOffset: 2 },
                 zIndex: 5,
               }}
             >
-              <ChevronLeftIcon
-                sx={{ fontSize: 20, transform: sidebarCollapsed ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.25s ease' }}
-              />
+              <SidebarToggleGlyph />
             </IconButton>
           </Tooltip>
         </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -251,13 +251,14 @@ function RootLayout(): React.ReactElement {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
+  const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
   const { openPalette } = useCommandContext();
   const [globalMenuAnchor, setGlobalMenuAnchor] = useState<null | HTMLElement>(null);
   const [projectMenuAnchor, setProjectMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(!isLargeDesktop);
   const [isSwitchingProject, setIsSwitchingProject] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
@@ -588,6 +589,9 @@ function RootLayout(): React.ReactElement {
     window.addEventListener('keydown', handleSidebarShortcut);
     return () => window.removeEventListener('keydown', handleSidebarShortcut);
   }, [isDesktopUp]);
+  useEffect(() => {
+    setSidebarCollapsed(!isLargeDesktop);
+  }, [isLargeDesktop]);
   
   const sidebarWidth = sidebarCollapsed ? 64 : 240;
   const currentPageTitle = useMemo(() => {
@@ -617,13 +621,12 @@ function RootLayout(): React.ReactElement {
   return (
     <Box className="app" sx={{ display: 'flex', minHeight: '100vh' }}>
       {isDesktopUp ? (
-        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.2s ease' }}>
+        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative' }}>
           <Stack sx={{ height: '100%' }}>
             <Stack direction="row" alignItems="center" justifyContent={sidebarCollapsed ? 'center' : 'space-between'} sx={{ px: sidebarCollapsed ? 1 : 2, py: 1 }}>
               <AppLogo size={26} showText={!sidebarCollapsed} to="/app/dashboard" />
-              {!sidebarCollapsed ? <IconButton aria-label="Sidebar einklappen" size="small" onClick={toggleSidebarCollapsed}><ChevronLeftIcon fontSize="small" /></IconButton> : null}
+              {!sidebarCollapsed ? <Box sx={{ width: 24, height: 24 }} /> : null}
             </Stack>
-            {sidebarCollapsed ? <IconButton aria-label="Sidebar ausklappen" size="small" onClick={toggleSidebarCollapsed} sx={{ mx: 'auto', mb: 1 }}><ChevronRightIcon fontSize="small" /></IconButton> : null}
             <List sx={{ px: 1 }}>
               {navItems.map((item) => {
                 const isActive = location.pathname === item.to || item.activeAliases.includes(location.pathname);
@@ -637,6 +640,29 @@ function RootLayout(): React.ReactElement {
               })}
             </List>
           </Stack>
+          <IconButton
+            aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
+            onClick={toggleSidebarCollapsed}
+            size="small"
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              right: -16,
+              transform: 'translateY(-50%)',
+              width: 34,
+              height: 34,
+              borderRadius: '50%',
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+              boxShadow: 2,
+              transition: 'transform 0.25s ease, background-color 0.2s ease',
+              '&:hover': { bgcolor: 'action.hover' },
+              zIndex: 5,
+            }}
+          >
+            {sidebarCollapsed ? <ChevronRightIcon fontSize="medium" /> : <ChevronLeftIcon fontSize="medium" />}
+          </IconButton>
         </Box>
       ) : null}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -637,22 +637,40 @@ function RootLayout(): React.ReactElement {
       {isDesktopUp ? (
         <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
-            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: sidebarCollapsed ? 1 : 2, py: 1, gap: 1 }}>
-              <AppLogo size={26} showText={!sidebarCollapsed} to="/app/dashboard" />
-              <IconButton
-                aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
-                onClick={toggleSidebarCollapsed}
-                size="small"
-                sx={{
-                  width: 30,
-                  height: 30,
-                  color: '#6B7280',
-                  '&:hover': { bgcolor: '#F3F4F6' },
-                }}
-              >
-                <SidebarToggleGlyph />
-              </IconButton>
-            </Stack>
+            {!sidebarCollapsed ? (
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 2, py: 1, gap: 1 }}>
+                <AppLogo size={26} showText to="/app/dashboard" />
+                <IconButton
+                  aria-label="Sidebar einklappen"
+                  onClick={toggleSidebarCollapsed}
+                  size="small"
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    color: '#6B7280',
+                    '&:hover': { bgcolor: '#F3F4F6' },
+                  }}
+                >
+                  <SidebarToggleGlyph />
+                </IconButton>
+              </Stack>
+            ) : (
+              <Stack direction="row" alignItems="center" justifyContent="center" sx={{ py: 1, mb: 0.5 }}>
+                <IconButton
+                  aria-label="Sidebar ausklappen"
+                  onClick={toggleSidebarCollapsed}
+                  size="small"
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    color: '#6B7280',
+                    '&:hover': { bgcolor: '#F3F4F6' },
+                  }}
+                >
+                  <SidebarToggleGlyph />
+                </IconButton>
+              </Stack>
+            )}
             <List sx={{ px: 1 }}>
               {navItems.map((item) => {
                 const isActive = location.pathname === item.to || item.activeAliases.includes(location.pathname);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,6 +65,7 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import PublicIcon from '@mui/icons-material/Public';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
 import { cultureAPI, projectAPI } from './api/api';
@@ -221,6 +222,19 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
   );
 }
 
+export interface TopbarContextAction {
+  id: string;
+  label: string;
+  ariaLabel?: string;
+  onClick: () => void;
+  disabled?: boolean;
+  shortcutHint?: string;
+}
+
+export interface RootLayoutOutletContext {
+  setTopbarContextActions: (actions: TopbarContextAction[]) => void;
+}
+
 
 /**
  * Root layout component with navigation.
@@ -249,6 +263,8 @@ function RootLayout(): React.ReactElement {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
+  const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
+  const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },
     ...MAIN_NAV_ITEMS.map((item) => ({
@@ -406,6 +422,22 @@ function RootLayout(): React.ReactElement {
     handleGlobalMenuClose();
     navigate(path);
   };
+  const handleCultureActionsMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setCultureActionsMenuAnchor(event.currentTarget);
+  };
+
+  const handleCultureActionsMenuClose = () => {
+    setCultureActionsMenuAnchor(null);
+  };
+  const isCulturesPage = location.pathname.startsWith('/app/cultures');
+  const cultureLibraryAction = useMemo(
+    () => topbarContextActions.find((action) => action.id === 'cultures-open-library'),
+    [topbarContextActions],
+  );
+  const cultureImportExportActions = useMemo(
+    () => topbarContextActions.filter((action) => action.id !== 'cultures-open-library'),
+    [topbarContextActions],
+  );
 
   const handleCreateProject = async (): Promise<void> => {
     if (!newProjectName.trim()) {
@@ -620,6 +652,54 @@ function RootLayout(): React.ReactElement {
           </Typography>
           {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isCulturesPage && !isMobile ? (
+            <>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => cultureLibraryAction?.onClick()}
+                aria-label="Öffentliche Kulturbibliothek öffnen"
+                startIcon={<PublicIcon fontSize="small" />}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+                disabled={!cultureLibraryAction || cultureLibraryAction.disabled}
+              >
+                Bibliothek
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                aria-label="Import/Export öffnen"
+                aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={Boolean(cultureActionsMenuAnchor)}
+                onClick={handleCultureActionsMenuOpen}
+                endIcon={<KeyboardArrowDownIcon fontSize="small" />}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+              >
+                Import/Export
+              </Button>
+              <Menu
+                id="culture-actions-menu"
+                anchorEl={cultureActionsMenuAnchor}
+                open={Boolean(cultureActionsMenuAnchor)}
+                onClose={handleCultureActionsMenuClose}
+              >
+                {cultureImportExportActions.map((action) => (
+                  <MenuItem
+                    key={action.id}
+                    aria-label={action.ariaLabel ?? action.label}
+                    onClick={() => {
+                      action.onClick();
+                      handleCultureActionsMenuClose();
+                    }}
+                    disabled={action.disabled}
+                  >
+                    <ListItemText primary={action.label} secondary={action.shortcutHint} />
+                  </MenuItem>
+                ))}
+              </Menu>
+            </>
+          ) : null}
           {topbarPrimaryAction && !isMobile ? (
             <Button size="small" variant="contained" onClick={() => navigate(topbarPrimaryAction.to)} sx={{ textTransform: 'none' }}>
               + {topbarPrimaryAction.label}
@@ -714,7 +794,7 @@ function RootLayout(): React.ReactElement {
         </List>
       </Drawer>
 
-      <Outlet />
+      <Outlet context={{ setTopbarContextActions } satisfies RootLayoutOutletContext} />
       </Box>
 
       <Dialog open={projectHistoryOpen} onClose={() => setProjectHistoryOpen(false)} fullWidth maxWidth="sm">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -706,6 +706,19 @@ function RootLayout(): React.ReactElement {
             {currentPageTitle}
           </Typography>
           {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
+          {isCulturesPage ? (
+            <Box
+              id="cultures-selector-topbar-slot"
+              sx={{
+                ml: 1,
+                flex: 1,
+                minWidth: 0,
+                maxWidth: { md: 420, lg: 520 },
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            />
+          ) : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.5 }}>
           {isCulturesPage && !isMobile ? (
             <>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -620,7 +620,7 @@ function RootLayout(): React.ReactElement {
   return (
     <Box className="app" sx={{ display: 'flex', minHeight: '100vh' }}>
       {isDesktopUp ? (
-        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative' }}>
+        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
             <Stack direction="row" alignItems="center" justifyContent={sidebarCollapsed ? 'center' : 'space-between'} sx={{ px: sidebarCollapsed ? 1 : 2, py: 1 }}>
               <AppLogo size={26} showText={!sidebarCollapsed} to="/app/dashboard" />
@@ -647,23 +647,22 @@ function RootLayout(): React.ReactElement {
               sx={{
                 position: 'absolute',
                 top: 34,
-                right: -16,
+                right: -15,
                 transform: 'translateY(-50%)',
-                width: 34,
-                height: 34,
+                width: 30,
+                height: 30,
                 borderRadius: '50%',
                 border: '1px solid',
-                borderColor: 'rgba(0,0,0,0.2)',
+                borderColor: 'rgba(15, 23, 42, 0.2)',
                 bgcolor: 'background.paper',
-                boxShadow: 3,
-                transition: 'background-color 0.2s ease',
-                '&:hover': { bgcolor: 'action.selected' },
+                boxShadow: '0 2px 6px rgba(15, 23, 42, 0.16)',
+                transition: 'background-color 0.2s ease, box-shadow 0.2s ease',
+                '&:hover': { bgcolor: 'action.selected', boxShadow: '0 3px 10px rgba(15, 23, 42, 0.2)' },
                 zIndex: 5,
               }}
             >
               <ChevronLeftIcon
-                fontSize="medium"
-                sx={{ transform: sidebarCollapsed ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.25s ease' }}
+                sx={{ fontSize: 20, transform: sidebarCollapsed ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.25s ease' }}
               />
             </IconButton>
           </Tooltip>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,28 +95,17 @@ import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './n
 
 function SidebarToggleGlyph(): React.ReactElement {
   return (
-    <Box
+    <svg
       aria-hidden
-      sx={{
-        width: 16,
-        height: 16,
-        border: '1.5px solid',
-        borderColor: '#9ca3af',
-        borderRadius: '5px',
-        position: 'relative',
-        '&::after': {
-          content: '""',
-          position: 'absolute',
-          top: 1,
-          bottom: 1,
-          left: '50%',
-          width: '1.5px',
-          transform: 'translateX(-50%)',
-          backgroundColor: '#9ca3af',
-          borderRadius: 999,
-        },
-      }}
-    />
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect x="2.25" y="2.25" width="13.5" height="13.5" rx="4.25" stroke="#9CA3AF" strokeWidth="1.5" />
+      <line x1="8.95" y1="3.25" x2="8.95" y2="14.75" stroke="#9CA3AF" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
   );
 }
 
@@ -648,9 +637,21 @@ function RootLayout(): React.ReactElement {
       {isDesktopUp ? (
         <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
-            <Stack direction="row" alignItems="center" justifyContent={sidebarCollapsed ? 'center' : 'space-between'} sx={{ px: sidebarCollapsed ? 1 : 2, py: 1 }}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: sidebarCollapsed ? 1 : 2, py: 1, gap: 1 }}>
               <AppLogo size={26} showText={!sidebarCollapsed} to="/app/dashboard" />
-              {!sidebarCollapsed ? <Box sx={{ width: 24, height: 24 }} /> : null}
+              <IconButton
+                aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
+                onClick={toggleSidebarCollapsed}
+                size="small"
+                sx={{
+                  width: 30,
+                  height: 30,
+                  color: '#6B7280',
+                  '&:hover': { bgcolor: '#F3F4F6' },
+                }}
+              >
+                <SidebarToggleGlyph />
+              </IconButton>
             </Stack>
             <List sx={{ px: 1 }}>
               {navItems.map((item) => {
@@ -665,33 +666,6 @@ function RootLayout(): React.ReactElement {
               })}
             </List>
           </Stack>
-          <Tooltip title={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'} placement="right">
-            <IconButton
-              aria-label={sidebarCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
-              onClick={toggleSidebarCollapsed}
-              size="small"
-              sx={{
-                position: 'absolute',
-                top: 34,
-                right: -15,
-                transform: 'translateY(-50%)',
-                width: 28,
-                height: 28,
-                borderRadius: '50%',
-                border: '1px solid',
-                borderColor: '#E5E7EB',
-                bgcolor: '#FFFFFF',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
-                transition: 'background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease',
-                '&:hover': { bgcolor: '#F3F4F6', borderColor: '#D1D5DB' },
-                '&:active': { bgcolor: '#E5E7EB' },
-                '&:focus-visible': { outline: '2px solid #D1D5DB', outlineOffset: 2 },
-                zIndex: 5,
-              }}
-            >
-              <SidebarToggleGlyph />
-            </IconButton>
-          </Tooltip>
         </Box>
       ) : null}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -64,6 +64,7 @@ export interface NotesFieldConfig {
   titleKey?: string;
   attachmentNoteIdField?: string;
   attachmentCountField?: string;
+  compactIndicator?: boolean;
 }
 
 export interface EditableDataGridProps<T extends EditableRow> {
@@ -563,6 +564,7 @@ export function EditableDataGrid<T extends EditableRow>({
               excerpt={excerpt}
               rawValue={value}
               attachmentCount={attachmentCount}
+              compactIndicator={Boolean(fieldConfig?.compactIndicator)}
               onOpen={() => notesEditor.handleOpen(params.id, col.field)}
               onOpenAttachments={(event) => {
                 event.preventDefault();

--- a/frontend/src/components/data-grid/NotesCell.tsx
+++ b/frontend/src/components/data-grid/NotesCell.tsx
@@ -17,6 +17,7 @@ export interface NotesCellProps {
   rawValue: string;
   onOpen: () => void;
   attachmentCount?: number;
+  compactIndicator?: boolean;
   onOpenAttachments?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -26,6 +27,7 @@ export function NotesCell({
   rawValue,
   onOpen,
   attachmentCount = 0,
+  compactIndicator = false,
   onOpenAttachments,
 }: NotesCellProps): React.ReactElement {
   const { t } = useTranslation('common');
@@ -68,6 +70,59 @@ export function NotesCell({
 
   const notesAria = hasValue ? t('notes.editWithContent') : t('notes.editEmpty');
   const attachmentTooltip = t('notes.attachmentsCount', { count: attachmentCount });
+  const hasAttachments = attachmentCount > 0;
+  const compactAriaLabel = hasValue && hasAttachments
+    ? 'Notiz und Bilder vorhanden'
+    : hasValue
+      ? 'Notiz vorhanden'
+      : hasAttachments
+        ? 'Bilder vorhanden'
+        : 'Keine Notiz oder Bilder vorhanden';
+  const compactTooltip = hasValue && hasAttachments
+    ? `Notiz vorhanden. ${attachmentTooltip}`
+    : hasValue
+      ? 'Notiz vorhanden'
+      : hasAttachments
+        ? attachmentTooltip
+        : 'Keine Notiz oder Bilder vorhanden';
+
+  if (compactIndicator) {
+    return (
+      <Tooltip title={hasValue || hasAttachments ? compactTooltip : '—'} arrow>
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-label={compactAriaLabel}
+          onClick={onOpen}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              onOpen();
+            }
+          }}
+          sx={{
+            width: '100%',
+            height: '100%',
+            minHeight: 32,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.25,
+            whiteSpace: 'nowrap',
+            cursor: 'pointer',
+          }}
+        >
+          {hasValue ? <NotesIcon fontSize="small" color="action" /> : null}
+          {hasAttachments ? <PhotoLibraryIcon fontSize="small" color="action" /> : null}
+          {!hasValue && !hasAttachments ? (
+            <Typography variant="body2" color="text.disabled" aria-hidden>
+              —
+            </Typography>
+          ) : null}
+        </Box>
+      </Tooltip>
+    );
+  }
 
   return (
     <Tooltip
@@ -142,7 +197,7 @@ export function NotesCell({
           {hasValue && hasMore ? ' ...' : ''}
         </Typography>
 
-        {attachmentCount > 0 && onOpenAttachments && (
+        {hasAttachments && onOpenAttachments && (
           <Tooltip title={attachmentTooltip} arrow>
             <IconButton
               size="small"

--- a/frontend/src/components/inputs/SearchableSelect.tsx
+++ b/frontend/src/components/inputs/SearchableSelect.tsx
@@ -21,6 +21,7 @@
 import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
+import type { ReactNode } from 'react';
 
 export interface SearchableSelectOption<T = unknown> {
   value: number;
@@ -41,6 +42,7 @@ export interface SearchableSelectProps<T = unknown> {
   textFieldSx?: SxProps<Theme>;
   inputValue?: string;
   onInputChange?: (value: string) => void;
+  endAdornment?: ReactNode;
 }
 
 export function SearchableSelect<T = unknown>({
@@ -56,6 +58,7 @@ export function SearchableSelect<T = unknown>({
   textFieldSx,
   inputValue,
   onInputChange,
+  endAdornment,
 }: SearchableSelectProps<T>): React.ReactElement {
   const [internalInputValue, setInternalInputValue] = useState('');
   const resolvedInputValue = inputValue ?? internalInputValue;
@@ -95,6 +98,15 @@ export function SearchableSelect<T = unknown>({
           placeholder={placeholder}
           autoFocus={autoFocus}
           sx={textFieldSx}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                {params.InputProps.endAdornment}
+                {endAdornment}
+              </span>
+            ),
+          }}
         />
       )}
     />

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
@@ -148,6 +149,7 @@ export function CultureDetail({
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
   const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
+  const [topbarSlot, setTopbarSlot] = useState<HTMLElement | null>(null);
 
   const activeFilterCount = useMemo(
     () => [
@@ -239,6 +241,10 @@ export function CultureDetail({
     yieldMax,
     yieldMin,
   ]);
+
+  useEffect(() => {
+    setTopbarSlot(document.getElementById('cultures-selector-topbar-slot'));
+  }, []);
 
   const filteredCultures = useMemo(() => {
     const parsedGrowthDaysMin = growthDaysMin ? Number(growthDaysMin) : null;
@@ -455,11 +461,8 @@ export function CultureDetail({
     return [];
   }, [activeCultivationTypes, selectedCulture]);
 
-  return (
-    <Box sx={{ width: '100%' }}>
-      {/* Searchable Dropdown */}
-      {cultures.length > 0 ? (
-      <Box sx={{ mb: 3 }}>
+  const selectorControl = cultures.length > 0 ? (
+      <Box sx={{ width: '100%' }}>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
           <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 } }}>
             <SearchableSelect
@@ -625,7 +628,11 @@ export function CultureDetail({
           {t('searchHelperText', { count: filteredCultures.length })}
         </Typography>
       </Box>
-      ) : null}
+  ) : null;
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      {topbarSlot && selectorControl ? createPortal(selectorControl, topbarSlot) : selectorControl}
 
       {/* Detail View */}
       {selectedCulture && (

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -482,7 +482,7 @@ export function CultureDetail({
                 <FilterListIcon fontSize="small" />
               </Badge>
             }
-            sx={{ alignSelf: { xs: 'flex-end', sm: 'center' }, whiteSpace: 'nowrap' }}
+            sx={{ alignSelf: 'center', whiteSpace: 'nowrap' }}
             aria-expanded={isFilterPopoverOpen}
             aria-haspopup="dialog"
             aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
@@ -612,6 +612,7 @@ export function CultureDetail({
                 setYieldMin('');
                 setYieldMax('');
                 setSelectedSowingMonths([]);
+                setFilterAnchorEl(null);
               }}
               sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
             >

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -146,6 +146,7 @@ export function CultureDetail({
   const [yieldMax, setYieldMax] = useState('');
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
   const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
+  const isFilterPopoverOpen = Boolean(filterAnchorEl);
 
   const activeFilterCount = useMemo(
     () => [
@@ -1098,4 +1099,3 @@ export function CultureDetail({
     </Box>
   );
 }
-  const isFilterPopoverOpen = Boolean(filterAnchorEl);

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -461,7 +461,7 @@ export function CultureDetail({
       {cultures.length > 0 ? (
       <Box sx={{ mb: 3 }}>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
-          <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 }, position: 'relative' }}>
+          <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 } }}>
             <SearchableSelect
               options={cultureOptions}
               value={selectedOption}
@@ -471,32 +471,25 @@ export function CultureDetail({
               noOptionsText={t('noOptionsEnhanced')}
               textFieldSx={{
                 width: '100%',
-                '& .MuiInputBase-root': {
-                  pr: 5.5,
-                },
               }}
               inputValue={searchQuery}
               onInputChange={setSearchQuery}
+              endAdornment={(
+                <IconButton
+                  size="small"
+                  onClick={(event) => setFilterAnchorEl(event.currentTarget)}
+                  aria-expanded={isFilterPopoverOpen}
+                  aria-haspopup="dialog"
+                  aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
+                  aria-label="Erweiterte Filter öffnen"
+                  sx={{ bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent' }}
+                >
+                  <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
+                    <TuneIcon fontSize="small" />
+                  </Badge>
+                </IconButton>
+              )}
             />
-            <IconButton
-              size="small"
-              onClick={(event) => setFilterAnchorEl(event.currentTarget)}
-              aria-expanded={isFilterPopoverOpen}
-              aria-haspopup="dialog"
-              aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
-              aria-label="Erweiterte Filter öffnen"
-              sx={{
-                position: 'absolute',
-                top: '50%',
-                right: 8,
-                transform: 'translateY(-50%)',
-                bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent',
-              }}
-            >
-              <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
-                <TuneIcon fontSize="small" />
-              </Badge>
-            </IconButton>
           </Box>
         </Stack>
 

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -14,7 +14,7 @@ import { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
-import FilterListIcon from '@mui/icons-material/FilterList';
+import TuneIcon from '@mui/icons-material/Tune';
 import {
   Badge,
   Box,
@@ -36,6 +36,7 @@ import {
   MenuItem,
   Stack,
   Button,
+  IconButton,
   Popover,
   TextField,
 } from '@mui/material';
@@ -460,7 +461,7 @@ export function CultureDetail({
       {cultures.length > 0 ? (
       <Box sx={{ mb: 3 }}>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
-          <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 } }}>
+          <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 }, position: 'relative' }}>
             <SearchableSelect
               options={cultureOptions}
               value={selectedOption}
@@ -468,28 +469,35 @@ export function CultureDetail({
               label={t('searchPlaceholder')}
               placeholder={t('searchInputPlaceholderEnhanced')}
               noOptionsText={t('noOptionsEnhanced')}
-              textFieldSx={{ width: '100%' }}
+              textFieldSx={{
+                width: '100%',
+                '& .MuiInputBase-root': {
+                  pr: 5.5,
+                },
+              }}
               inputValue={searchQuery}
               onInputChange={setSearchQuery}
             />
-          </Box>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={(event) => setFilterAnchorEl(event.currentTarget)}
-            startIcon={
+            <IconButton
+              size="small"
+              onClick={(event) => setFilterAnchorEl(event.currentTarget)}
+              aria-expanded={isFilterPopoverOpen}
+              aria-haspopup="dialog"
+              aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
+              aria-label="Erweiterte Filter öffnen"
+              sx={{
+                position: 'absolute',
+                top: '50%',
+                right: 8,
+                transform: 'translateY(-50%)',
+                bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent',
+              }}
+            >
               <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
-                <FilterListIcon fontSize="small" />
+                <TuneIcon fontSize="small" />
               </Badge>
-            }
-            sx={{ alignSelf: 'center', whiteSpace: 'nowrap' }}
-            aria-expanded={isFilterPopoverOpen}
-            aria-haspopup="dialog"
-            aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
-            aria-label={t('filters.toggle')}
-          >
-            {t('filters.toggle')}
-          </Button>
+            </IconButton>
+          </Box>
         </Stack>
 
         <Popover

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -31,6 +31,9 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  List,
+  ListItemButton,
+  ListItemText,
   FormControl,
   InputLabel,
   Select,
@@ -624,9 +627,6 @@ export function CultureDetail({
             </Button>
           </Stack>
         </Popover>
-        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: 'block' }}>
-          {t('searchHelperText', { count: filteredCultures.length })}
-        </Typography>
       </Box>
   ) : null;
 
@@ -1063,9 +1063,20 @@ export function CultureDetail({
       {!isLoading && !selectedCulture && filteredCultures.length > 0 && (
         <Card>
           <CardContent>
-            <Typography variant="body1" color="text.secondary" align="center">
-              {t('selectPrompt')}
-            </Typography>
+            <List dense sx={{ py: 0 }}>
+              {filteredCultures.map((culture) => (
+                <ListItemButton
+                  key={culture.id}
+                  onClick={() => onCultureSelect(culture)}
+                  sx={{ borderRadius: 1, mb: 0.5 }}
+                >
+                  <ListItemText
+                    primary={culture.name}
+                    secondary={culture.variety || culture.crop_family || undefined}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -15,14 +15,11 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import {
   Badge,
   Box,
   Card,
   CardContent,
-  Collapse,
   CircularProgress,
   Typography,
   Chip,
@@ -39,6 +36,7 @@ import {
   MenuItem,
   Stack,
   Button,
+  Popover,
   TextField,
 } from '@mui/material';
 import type { Culture } from '../api/api';
@@ -147,7 +145,7 @@ export function CultureDetail({
   const [yieldMin, setYieldMin] = useState('');
   const [yieldMax, setYieldMax] = useState('');
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
 
   const activeFilterCount = useMemo(
     () => [
@@ -477,28 +475,37 @@ export function CultureDetail({
           <Button
             variant="outlined"
             size="small"
-            onClick={() => setFiltersExpanded((prev) => !prev)}
+            onClick={(event) => setFilterAnchorEl(event.currentTarget)}
             startIcon={
               <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
                 <FilterListIcon fontSize="small" />
               </Badge>
             }
-            endIcon={filtersExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             sx={{ alignSelf: { xs: 'flex-end', sm: 'center' }, whiteSpace: 'nowrap' }}
-            aria-expanded={filtersExpanded}
+            aria-expanded={isFilterPopoverOpen}
+            aria-haspopup="dialog"
+            aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
             aria-label={t('filters.toggle')}
           >
             {t('filters.toggle')}
           </Button>
         </Stack>
 
-        <Collapse in={filtersExpanded}>
+        <Popover
+          id="culture-filters-popover"
+          open={isFilterPopoverOpen}
+          anchorEl={filterAnchorEl}
+          onClose={() => setFilterAnchorEl(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          PaperProps={{ sx: { width: { xs: 'min(92vw, 360px)', sm: 360 }, p: 1.5 } }}
+        >
           <Stack
-            direction={{ xs: 'column', md: 'row' }}
+            direction="column"
             spacing={1}
             sx={{ pt: 0.5, pb: 0.5 }}
           >
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-family-filter-label">{t('filters.cropFamily')}</InputLabel>
               <Select
                 labelId="culture-family-filter-label"
@@ -512,7 +519,7 @@ export function CultureDetail({
                 ))}
               </Select>
             </FormControl>
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-method-filter-label">{t('filters.cultivationType')}</InputLabel>
               <Select
                 labelId="culture-method-filter-label"
@@ -526,7 +533,7 @@ export function CultureDetail({
                 <MenuItem value="both">{t('filters.both')}</MenuItem>
               </Select>
             </FormControl>
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-nutrient-filter-label">{t('filters.nutrientDemand')}</InputLabel>
               <Select
                 labelId="culture-nutrient-filter-label"
@@ -546,7 +553,7 @@ export function CultureDetail({
               label={t('filters.growthDaysMin')}
               value={growthDaysMin}
               onChange={(event) => setGrowthDaysMin(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <TextField
               size="small"
@@ -554,9 +561,9 @@ export function CultureDetail({
               label={t('filters.growthDaysMax')}
               value={growthDaysMax}
               onChange={(event) => setGrowthDaysMax(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 220 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-sowing-month-filter-label">{t('filters.sowingMonths')}</InputLabel>
               <Select
                 multiple
@@ -581,7 +588,7 @@ export function CultureDetail({
               label={t('filters.yieldMin')}
               value={yieldMin}
               onChange={(event) => setYieldMin(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <TextField
               size="small"
@@ -589,7 +596,7 @@ export function CultureDetail({
               label={t('filters.yieldMax')}
               value={yieldMax}
               onChange={(event) => setYieldMax(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <Button
               variant="text"
@@ -605,12 +612,12 @@ export function CultureDetail({
                 setYieldMax('');
                 setSelectedSowingMonths([]);
               }}
-              sx={{ alignSelf: { xs: 'flex-end', md: 'center' }, whiteSpace: 'nowrap' }}
+              sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
             >
               {t('filters.reset')}
             </Button>
           </Stack>
-        </Collapse>
+        </Popover>
         <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: 'block' }}>
           {t('searchHelperText', { count: filteredCultures.length })}
         </Typography>
@@ -1091,3 +1098,4 @@ export function CultureDetail({
     </Box>
   );
 }
+  const isFilterPopoverOpen = Boolean(filterAnchorEl);

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -948,9 +948,6 @@ function Cultures(): React.ReactElement {
 
   return (
     <PageContainer>
-      <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
-        <Button variant="contained" onClick={handleAddNew}>Kultur hinzufügen</Button>
-      </Box>
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
@@ -100,12 +100,15 @@ import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { getFirstMissingCultivationPlanRequirement } from './requirementFlow';
+import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
+  const outletContext = useOutletContext<RootLayoutOutletContext | null>();
+  const setTopbarContextActions = outletContext?.setTopbarContextActions ?? (() => undefined);
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
   const { selectedCultureId, updateSelectedCultureId } = useSelectedCultureSync();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
@@ -114,7 +117,6 @@ function Cultures(): React.ReactElement {
   const [isCulturesLoading, setIsCulturesLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingCulture, setEditingCulture] = useState<Culture | undefined>(undefined);
-  const [importMenuAnchor, setImportMenuAnchor] = useState<null | HTMLElement>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const {
     state: importState,
@@ -153,6 +155,7 @@ function Cultures(): React.ReactElement {
   const [hasLocations, setHasLocations] = useState(false);
   const [hasFields, setHasFields] = useState(false);
   const [hasBeds, setHasBeds] = useState(false);
+  const selectedCulture = cultures.find((culture) => culture.id === selectedCultureId);
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'info') => {
     setSnackbar({ open: true, message, severity });
@@ -273,7 +276,6 @@ function Cultures(): React.ReactElement {
   };
 
   const handleOpenHistory = async () => {
-    handleImportMenuClose();
     if (!selectedCulture?.id) {
       return;
     }
@@ -364,10 +366,6 @@ function Cultures(): React.ReactElement {
     }
   };
 
-  const handleImportMenuClose = () => {
-    setImportMenuAnchor(null);
-  };
-
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== '?') {
@@ -401,11 +399,10 @@ function Cultures(): React.ReactElement {
     }
   }, [t]);
 
-  const handleOpenPublicLibrary = async () => {
-    handleImportMenuClose();
+  const handleOpenPublicLibrary = useCallback(async () => {
     setPublicLibraryOpen(true);
     await fetchPublicCultures();
-  };
+  }, [fetchPublicCultures]);
 
   const handleImportPublicCulture = async (publicCulture: PublicCulture) => {
     try {
@@ -456,13 +453,12 @@ function Cultures(): React.ReactElement {
     }
   };
 
-  const handleImportFileTrigger = () => {
-    handleImportMenuClose();
+  const handleImportFileTrigger = useCallback(() => {
     resetImportState();
     fileInputRef.current?.click();
-  };
+  }, [resetImportState]);
 
-  const handleExportCurrentCulture = () => {
+  const handleExportCurrentCulture = useCallback(() => {
     if (!selectedCulture) {
       return;
     }
@@ -471,10 +467,9 @@ function Cultures(): React.ReactElement {
     const filename = buildSingleCultureFilename(selectedCulture);
     downloadJsonFile(exportPayload, filename);
     showSnackbar(t('messages.exportSuccess'), 'success');
-    handleImportMenuClose();
-  };
+  }, [selectedCulture, showSnackbar, t]);
 
-  const handleExportAllCultures = async () => {
+  const handleExportAllCultures = useCallback(async () => {
     try {
       const allCultures: Culture[] = [];
       let nextUrl: string | null = '/cultures/';
@@ -492,10 +487,8 @@ function Cultures(): React.ReactElement {
     } catch (error) {
       console.error('Error exporting cultures:', error);
       showSnackbar(t('messages.fetchError'), 'error');
-    } finally {
-      handleImportMenuClose();
     }
-  };
+  }, [showSnackbar, t]);
 
   const handleImportFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -583,7 +576,6 @@ function Cultures(): React.ReactElement {
     setImportDialogOpen(false);
   };
 
-  const selectedCulture = cultures.find(c => c.id === selectedCultureId);
   const firstMissingPlanRequirement = getFirstMissingCultivationPlanRequirement({
     hasLocations,
     hasFields,
@@ -715,6 +707,44 @@ function Cultures(): React.ReactElement {
       setEnrichmentLoading(false);
     }
   };
+
+  const contextActions = useMemo<TopbarContextAction[]>(() => ([
+    {
+      id: 'cultures-open-library',
+      label: 'Öffentliche Kulturbibliothek öffnen',
+      ariaLabel: 'Öffentliche Kulturbibliothek öffnen',
+      onClick: () => {
+        void handleOpenPublicLibrary();
+      },
+    },
+    {
+      id: 'cultures-import-json',
+      label: 'Kulturen importieren (JSON)',
+      ariaLabel: 'Kulturen importieren (JSON)',
+      onClick: handleImportFileTrigger,
+      shortcutHint: 'Alt+I',
+    },
+    {
+      id: 'cultures-export-current-json',
+      label: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
+      ariaLabel: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
+      onClick: handleExportCurrentCulture,
+      disabled: !selectedCulture,
+      shortcutHint: 'Alt+J',
+    },
+    {
+      id: 'cultures-export-all-json',
+      label: 'Alle Kulturen exportieren (JSON)',
+      ariaLabel: 'Alle Kulturen exportieren (JSON)',
+      onClick: handleExportAllCultures,
+      shortcutHint: 'Alt+Shift+J',
+    },
+  ]), [handleExportAllCultures, handleExportCurrentCulture, handleImportFileTrigger, handleOpenPublicLibrary, selectedCulture]);
+
+  useEffect(() => {
+    setTopbarContextActions(contextActions);
+    return () => setTopbarContextActions([]);
+  }, [contextActions, setTopbarContextActions]);
 
   const commandSpecs = useMemo(() => createCulturesCommandSpecs({
     canRunEnrichmentForCulture,
@@ -918,25 +948,6 @@ function Cultures(): React.ReactElement {
 
   return (
     <PageContainer>
-      <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
-        <Button variant="contained" onClick={handleAddNew}>Kultur hinzufügen</Button>
-      </Box>
-        <Menu
-          id="culture-import-menu"
-          anchorEl={importMenuAnchor}
-          open={Boolean(importMenuAnchor)}
-          onClose={handleImportMenuClose}
-        >
-          <MenuItem aria-label="JSON exportieren" onClick={handleExportCurrentCulture} disabled={!selectedCulture}>
-            JSON exportieren
-          </MenuItem>
-          <MenuItem aria-label="Alle Kulturen exportieren" onClick={handleExportAllCultures}>
-            Alle Kulturen exportieren
-          </MenuItem>
-          <MenuItem aria-label="JSON importieren" onClick={handleImportFileTrigger}>
-            JSON importieren
-          </MenuItem>
-        </Menu>
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -948,6 +948,9 @@ function Cultures(): React.ReactElement {
 
   return (
     <PageContainer>
+      <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+        <Button variant="contained" onClick={handleAddNew}>Kultur hinzufügen</Button>
+      </Box>
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,6 +1,6 @@
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
 import GraphicalFields from './GraphicalFields';
 import { AddBedIcon } from '../components/hierarchy/AddBedIcon';
@@ -23,6 +23,7 @@ type InteractionMode = 'view' | 'edit';
 export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
   const navigate = useNavigate();
+  const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
     return stored === 'graphical' ? 'graphical' : 'table';
@@ -98,7 +99,6 @@ export default function FieldsBedsPage(): React.ReactElement {
   const shouldShowGlobalAddButton = viewMode === 'table'
     && !shouldShowProjectRequiredState
     && locations.length <= 1;
-
   const handleGlobalAddField = useCallback((): void => {
     if (locations.length === 0) {
       navigate('/app/locations?create=true');
@@ -125,6 +125,26 @@ export default function FieldsBedsPage(): React.ReactElement {
     setAddFieldDialogOpen(false);
     setNewFieldName('');
   }, [addField, newFieldName, targetLocationId]);
+
+  useEffect(() => {
+    if (!location.pathname.startsWith('/app/fields-beds')) {
+      return;
+    }
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('create') !== 'true') {
+      return;
+    }
+    handleGlobalAddField();
+    searchParams.delete('create');
+    const nextSearch = searchParams.toString();
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      },
+      { replace: true },
+    );
+  }, [handleGlobalAddField, location.pathname, location.search, navigate]);
 
 
   useEffect(() => {
@@ -194,7 +214,7 @@ export default function FieldsBedsPage(): React.ReactElement {
           </Box>
           {shouldShowGlobalAddButton ? (
             <Button
-              variant="contained"
+              variant="outlined"
               onClick={handleGlobalAddField}
               sx={{ width: { xs: '100%', sm: 'auto' } }}
             >

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1098,9 +1098,11 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "notes",
         headerName: t("common:fields.notes"),
-        width: 220,
-        minWidth: dynamicWidths.notes,
-        maxWidth: 260,
+        width: 72,
+        minWidth: 56,
+        maxWidth: 90,
+        align: "center",
+        headerAlign: "center",
         // Notes field will be overridden by NotesCell in EditableDataGrid
       },
     ],
@@ -1782,6 +1784,7 @@ function PlantingPlans(): React.ReactElement {
                   labelKey: "common:fields.notes",
                   attachmentNoteIdField: "id",
                   attachmentCountField: "note_attachment_count",
+                  compactIndicator: true,
                 },
               ],
             }}

--- a/frontend/src/pages/culturesCommandSpecs.ts
+++ b/frontend/src/pages/culturesCommandSpecs.ts
@@ -122,7 +122,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.exportCurrent',
-      label: 'JSON exportieren (Alt+J)',
+      label: (selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)') + ' (Alt+J)',
       group: 'navigation',
       keywords: ['json', 'export', 'kultur'],
       shortcutHint: 'Alt+J',
@@ -133,7 +133,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.exportAll',
-      label: 'Alle Kulturen exportieren (Alt+Shift+J)',
+      label: 'Alle Kulturen exportieren (JSON) (Alt+Shift+J)',
       group: 'navigation',
       keywords: ['json', 'export', 'alle', 'kulturen'],
       shortcutHint: 'Alt+Shift+J',
@@ -144,7 +144,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.import',
-      label: 'JSON importieren (Alt+I)',
+      label: 'Kulturen importieren (JSON) (Alt+I)',
       group: 'navigation',
       keywords: ['json', 'import'],
       shortcutHint: 'Alt+I',

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -6,9 +6,10 @@ const theme = createTheme({
   palette: {
     // Primary color used by contained buttons and primary components
     primary: {
-      main: '#2e7d32',
+      main: '#256f2a',
       dark: '#1b5e20',
-      light: '#60ad5e',
+      light: '#4f9853',
+      contrastText: '#ffffff',
     },
     secondary: {
       main: '#9c27b0',
@@ -28,6 +29,23 @@ const theme = createTheme({
         root: {
           padding: '8px 24px',
           textTransform: 'none',
+          fontSize: '0.95rem',
+          fontWeight: 600,
+          lineHeight: 1.3,
+        },
+        containedPrimary: {
+          color: '#ffffff',
+          '&:hover': {
+            backgroundColor: '#1f6224',
+          },
+        },
+        startIcon: {
+          display: 'inline-flex',
+          alignItems: 'center',
+        },
+        endIcon: {
+          display: 'inline-flex',
+          alignItems: 'center',
         },
       },
     },


### PR DESCRIPTION
### Motivation

- Surface culture-specific actions in the app topbar (open public library, import/export) so users can access them directly from the Cultures page without a separate menu.
- Provide a compact notes indicator mode for dense tables (show icons/counts instead of full excerpt) and adjust planting-plans layout to use it.
- Small UX and theme improvements for consistent button styles and some navigation behaviors.

### Description

- Added `TopbarContextAction` and `RootLayoutOutletContext` types and wired `Outlet` in `App.tsx` to accept `setTopbarContextActions`, plus a topbar UI that shows a `Bibliothek` button and an `Import/Export` dropdown when on the Cultures page.
- Implemented `setTopbarContextActions` state in `RootLayout` and exposed it via the outlet context so pages can register topbar actions dynamically.
- In `pages/Cultures.tsx` registered topbar context actions (`cultures-open-library`, import/export and export-all) and set/cleared them with `useEffect`; refactored several handlers to `useCallback` and removed the old import menu anchor usage.
- Added a `compactIndicator` option to notes field configs and passed it through `EditableDataGrid` -> `NotesCell`; implemented a compact rendering in `NotesCell.tsx` that shows icons/short indicator and accessible labels and preserves the full tooltip/edit behavior when not compact.
- Adjusted the Planting Plans notes column sizing and enabled `compactIndicator` on that notes field so the grid shows the compact indicator in that page.
- In `FieldsBedsPage.tsx` added URL `create=true` handling to auto-open the global add-field flow and changed the global add button to `outlined` variant.
- Updated `culturesCommandSpecs.ts` labels to reflect the new JSON import/export wording and keep shortcut hints in sync.
- Theme tweaks in `theme.ts`: updated primary color shades, added `contrastText`, and applied button style overrides (`fontSize`, `fontWeight`, `containedPrimary` hover color and icon alignment).
- Small cleanups: unify attachment handling variable names and minor UI behavior changes (menus, anchors).

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and the project compiled with no type errors.
- Ran linting with `npm run lint` and code style checks passed.
- Executed the test suite with `npm test` and unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad7c89fd08322b42f7482b81d6d11)