### PR TITLE
UI: responsive sidebar, topbar context actions, cultures UX & Notes compact mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,10 +61,9 @@ import EventNoteOutlinedIcon from '@mui/icons-material/EventNoteOutlined';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import PublicIcon from '@mui/icons-material/Public';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
 import { cultureAPI, projectAPI } from './api/api';
@@ -93,6 +92,7 @@ import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
+import { PanelLeft } from 'lucide-react';
 
 interface SnackbarState {
   open: boolean;
@@ -221,6 +221,19 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
   );
 }
 
+export interface TopbarContextAction {
+  id: string;
+  label: string;
+  ariaLabel?: string;
+  onClick: () => void;
+  disabled?: boolean;
+  shortcutHint?: string;
+}
+
+export interface RootLayoutOutletContext {
+  setTopbarContextActions: (actions: TopbarContextAction[]) => void;
+}
+
 
 /**
  * Root layout component with navigation.
@@ -237,18 +250,21 @@ function RootLayout(): React.ReactElement {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
+  const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
   const { openPalette } = useCommandContext();
   const [globalMenuAnchor, setGlobalMenuAnchor] = useState<null | HTMLElement>(null);
   const [projectMenuAnchor, setProjectMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(!isLargeDesktop);
   const [isSwitchingProject, setIsSwitchingProject] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [isCreatingProject, setIsCreatingProject] = useState(false);
+  const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
+  const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },
     ...MAIN_NAV_ITEMS.map((item) => ({
@@ -406,6 +422,22 @@ function RootLayout(): React.ReactElement {
     handleGlobalMenuClose();
     navigate(path);
   };
+  const handleCultureActionsMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setCultureActionsMenuAnchor(event.currentTarget);
+  };
+
+  const handleCultureActionsMenuClose = () => {
+    setCultureActionsMenuAnchor(null);
+  };
+  const isCulturesPage = location.pathname.startsWith('/app/cultures');
+  const cultureLibraryAction = useMemo(
+    () => topbarContextActions.find((action) => action.id === 'cultures-open-library'),
+    [topbarContextActions],
+  );
+  const cultureImportExportActions = useMemo(
+    () => topbarContextActions.filter((action) => action.id !== 'cultures-open-library'),
+    [topbarContextActions],
+  );
 
   const handleCreateProject = async (): Promise<void> => {
     if (!newProjectName.trim()) {
@@ -556,6 +588,9 @@ function RootLayout(): React.ReactElement {
     window.addEventListener('keydown', handleSidebarShortcut);
     return () => window.removeEventListener('keydown', handleSidebarShortcut);
   }, [isDesktopUp]);
+  useEffect(() => {
+    setSidebarCollapsed(!isLargeDesktop);
+  }, [isLargeDesktop]);
   
   const sidebarWidth = sidebarCollapsed ? 64 : 240;
   const currentPageTitle = useMemo(() => {
@@ -585,13 +620,58 @@ function RootLayout(): React.ReactElement {
   return (
     <Box className="app" sx={{ display: 'flex', minHeight: '100vh' }}>
       {isDesktopUp ? (
-        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.2s ease' }}>
+        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: 'divider', bgcolor: 'background.paper', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
-            <Stack direction="row" alignItems="center" justifyContent={sidebarCollapsed ? 'center' : 'space-between'} sx={{ px: sidebarCollapsed ? 1 : 2, py: 1 }}>
-              <AppLogo size={26} showText={!sidebarCollapsed} to="/app/dashboard" />
-              {!sidebarCollapsed ? <IconButton aria-label="Sidebar einklappen" size="small" onClick={toggleSidebarCollapsed}><ChevronLeftIcon fontSize="small" /></IconButton> : null}
-            </Stack>
-            {sidebarCollapsed ? <IconButton aria-label="Sidebar ausklappen" size="small" onClick={toggleSidebarCollapsed} sx={{ mx: 'auto', mb: 1 }}><ChevronRightIcon fontSize="small" /></IconButton> : null}
+            {!sidebarCollapsed ? (
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 2, py: 1, gap: 1 }}>
+                <AppLogo size={26} showText to="/app/dashboard" />
+                <Tooltip
+                  title="Seitenleiste schließen"
+                  placement="right"
+                  enterDelay={350}
+                  slotProps={{ tooltip: { sx: { bgcolor: '#111827', fontSize: '0.72rem', px: 1, py: 0.5 } } }}
+                >
+                  <IconButton
+                    aria-label="Sidebar einklappen"
+                    onClick={toggleSidebarCollapsed}
+                    size="small"
+                    sx={{
+                      width: 30,
+                      height: 30,
+                      color: '#6B7280',
+                      cursor: 'w-resize',
+                      '&:hover': { bgcolor: '#F3F4F6' },
+                    }}
+                  >
+                    <PanelLeft size={19} strokeWidth={1.8} />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            ) : (
+              <Stack direction="row" alignItems="center" justifyContent="center" sx={{ py: 1, mb: 0.5 }}>
+                <Tooltip
+                  title="Seitenleiste öffnen"
+                  placement="right"
+                  enterDelay={350}
+                  slotProps={{ tooltip: { sx: { bgcolor: '#111827', fontSize: '0.72rem', px: 1, py: 0.5 } } }}
+                >
+                  <IconButton
+                    aria-label="Sidebar ausklappen"
+                    onClick={toggleSidebarCollapsed}
+                    size="small"
+                    sx={{
+                      width: 30,
+                      height: 30,
+                      color: '#6B7280',
+                      cursor: 'e-resize',
+                      '&:hover': { bgcolor: '#F3F4F6' },
+                    }}
+                  >
+                    <PanelLeft size={19} strokeWidth={1.8} />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            )}
             <List sx={{ px: 1 }}>
               {navItems.map((item) => {
                 const isActive = location.pathname === item.to || item.activeAliases.includes(location.pathname);
@@ -619,7 +699,68 @@ function RootLayout(): React.ReactElement {
             {currentPageTitle}
           </Typography>
           {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
+          {isCulturesPage ? (
+            <Box
+              id="cultures-selector-topbar-slot"
+              sx={{
+                ml: 1,
+                flex: 1,
+                minWidth: 0,
+                maxWidth: { md: 420, lg: 520 },
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            />
+          ) : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {isCulturesPage && !isMobile ? (
+            <>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => cultureLibraryAction?.onClick()}
+                aria-label="Öffentliche Kulturbibliothek öffnen"
+                startIcon={<PublicIcon fontSize="small" />}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+                disabled={!cultureLibraryAction || cultureLibraryAction.disabled}
+              >
+                Bibliothek
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                aria-label="Import/Export öffnen"
+                aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={Boolean(cultureActionsMenuAnchor)}
+                onClick={handleCultureActionsMenuOpen}
+                endIcon={<KeyboardArrowDownIcon fontSize="small" />}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
+              >
+                Import/Export
+              </Button>
+              <Menu
+                id="culture-actions-menu"
+                anchorEl={cultureActionsMenuAnchor}
+                open={Boolean(cultureActionsMenuAnchor)}
+                onClose={handleCultureActionsMenuClose}
+              >
+                {cultureImportExportActions.map((action) => (
+                  <MenuItem
+                    key={action.id}
+                    aria-label={action.ariaLabel ?? action.label}
+                    onClick={() => {
+                      action.onClick();
+                      handleCultureActionsMenuClose();
+                    }}
+                    disabled={action.disabled}
+                  >
+                    <ListItemText primary={action.label} secondary={action.shortcutHint} />
+                  </MenuItem>
+                ))}
+              </Menu>
+            </>
+          ) : null}
           {topbarPrimaryAction && !isMobile ? (
             <Button size="small" variant="contained" onClick={() => navigate(topbarPrimaryAction.to)} sx={{ textTransform: 'none' }}>
               + {topbarPrimaryAction.label}
@@ -714,7 +855,7 @@ function RootLayout(): React.ReactElement {
         </List>
       </Drawer>
 
-      <Outlet />
+      <Outlet context={{ setTopbarContextActions } satisfies RootLayoutOutletContext} />
       </Box>
 
       <Dialog open={projectHistoryOpen} onClose={() => setProjectHistoryOpen(false)} fullWidth maxWidth="sm">

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -64,6 +64,7 @@ export interface NotesFieldConfig {
   titleKey?: string;
   attachmentNoteIdField?: string;
   attachmentCountField?: string;
+  compactIndicator?: boolean;
 }
 
 export interface EditableDataGridProps<T extends EditableRow> {
@@ -563,6 +564,7 @@ export function EditableDataGrid<T extends EditableRow>({
               excerpt={excerpt}
               rawValue={value}
               attachmentCount={attachmentCount}
+              compactIndicator={Boolean(fieldConfig?.compactIndicator)}
               onOpen={() => notesEditor.handleOpen(params.id, col.field)}
               onOpenAttachments={(event) => {
                 event.preventDefault();

--- a/frontend/src/components/data-grid/NotesCell.tsx
+++ b/frontend/src/components/data-grid/NotesCell.tsx
@@ -17,6 +17,7 @@ export interface NotesCellProps {
   rawValue: string;
   onOpen: () => void;
   attachmentCount?: number;
+  compactIndicator?: boolean;
   onOpenAttachments?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -26,6 +27,7 @@ export function NotesCell({
   rawValue,
   onOpen,
   attachmentCount = 0,
+  compactIndicator = false,
   onOpenAttachments,
 }: NotesCellProps): React.ReactElement {
   const { t } = useTranslation('common');
@@ -68,6 +70,59 @@ export function NotesCell({
 
   const notesAria = hasValue ? t('notes.editWithContent') : t('notes.editEmpty');
   const attachmentTooltip = t('notes.attachmentsCount', { count: attachmentCount });
+  const hasAttachments = attachmentCount > 0;
+  const compactAriaLabel = hasValue && hasAttachments
+    ? 'Notiz und Bilder vorhanden'
+    : hasValue
+      ? 'Notiz vorhanden'
+      : hasAttachments
+        ? 'Bilder vorhanden'
+        : 'Keine Notiz oder Bilder vorhanden';
+  const compactTooltip = hasValue && hasAttachments
+    ? `Notiz vorhanden. ${attachmentTooltip}`
+    : hasValue
+      ? 'Notiz vorhanden'
+      : hasAttachments
+        ? attachmentTooltip
+        : 'Keine Notiz oder Bilder vorhanden';
+
+  if (compactIndicator) {
+    return (
+      <Tooltip title={hasValue || hasAttachments ? compactTooltip : '—'} arrow>
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-label={compactAriaLabel}
+          onClick={onOpen}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              onOpen();
+            }
+          }}
+          sx={{
+            width: '100%',
+            height: '100%',
+            minHeight: 32,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.25,
+            whiteSpace: 'nowrap',
+            cursor: 'pointer',
+          }}
+        >
+          {hasValue ? <NotesIcon fontSize="small" color="action" /> : null}
+          {hasAttachments ? <PhotoLibraryIcon fontSize="small" color="action" /> : null}
+          {!hasValue && !hasAttachments ? (
+            <Typography variant="body2" color="text.disabled" aria-hidden>
+              —
+            </Typography>
+          ) : null}
+        </Box>
+      </Tooltip>
+    );
+  }
 
   return (
     <Tooltip
@@ -142,7 +197,7 @@ export function NotesCell({
           {hasValue && hasMore ? ' ...' : ''}
         </Typography>
 
-        {attachmentCount > 0 && onOpenAttachments && (
+        {hasAttachments && onOpenAttachments && (
           <Tooltip title={attachmentTooltip} arrow>
             <IconButton
               size="small"

--- a/frontend/src/components/inputs/SearchableSelect.tsx
+++ b/frontend/src/components/inputs/SearchableSelect.tsx
@@ -21,6 +21,7 @@
 import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
+import type { ReactNode } from 'react';
 
 export interface SearchableSelectOption<T = unknown> {
   value: number;
@@ -41,6 +42,7 @@ export interface SearchableSelectProps<T = unknown> {
   textFieldSx?: SxProps<Theme>;
   inputValue?: string;
   onInputChange?: (value: string) => void;
+  endAdornment?: ReactNode;
 }
 
 export function SearchableSelect<T = unknown>({
@@ -56,6 +58,7 @@ export function SearchableSelect<T = unknown>({
   textFieldSx,
   inputValue,
   onInputChange,
+  endAdornment,
 }: SearchableSelectProps<T>): React.ReactElement {
   const [internalInputValue, setInternalInputValue] = useState('');
   const resolvedInputValue = inputValue ?? internalInputValue;
@@ -95,6 +98,15 @@ export function SearchableSelect<T = unknown>({
           placeholder={placeholder}
           autoFocus={autoFocus}
           sx={textFieldSx}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                {params.InputProps.endAdornment}
+                {endAdornment}
+              </span>
+            ),
+          }}
         />
       )}
     />

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -11,18 +11,16 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
-import FilterListIcon from '@mui/icons-material/FilterList';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import TuneIcon from '@mui/icons-material/Tune';
 import {
   Badge,
   Box,
   Card,
   CardContent,
-  Collapse,
   CircularProgress,
   Typography,
   Chip,
@@ -33,12 +31,17 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  List,
+  ListItemButton,
+  ListItemText,
   FormControl,
   InputLabel,
   Select,
   MenuItem,
   Stack,
   Button,
+  IconButton,
+  Popover,
   TextField,
 } from '@mui/material';
 import type { Culture } from '../api/api';
@@ -147,7 +150,9 @@ export function CultureDetail({
   const [yieldMin, setYieldMin] = useState('');
   const [yieldMax, setYieldMax] = useState('');
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
-  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
+  const isFilterPopoverOpen = Boolean(filterAnchorEl);
+  const [topbarSlot, setTopbarSlot] = useState<HTMLElement | null>(null);
 
   const activeFilterCount = useMemo(
     () => [
@@ -239,6 +244,10 @@ export function CultureDetail({
     yieldMax,
     yieldMin,
   ]);
+
+  useEffect(() => {
+    setTopbarSlot(document.getElementById('cultures-selector-topbar-slot'));
+  }, []);
 
   const filteredCultures = useMemo(() => {
     const parsedGrowthDaysMin = growthDaysMin ? Number(growthDaysMin) : null;
@@ -455,11 +464,8 @@ export function CultureDetail({
     return [];
   }, [activeCultivationTypes, selectedCulture]);
 
-  return (
-    <Box sx={{ width: '100%' }}>
-      {/* Searchable Dropdown */}
-      {cultures.length > 0 ? (
-      <Box sx={{ mb: 3 }}>
+  const selectorControl = cultures.length > 0 ? (
+      <Box sx={{ width: '100%' }}>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
           <Box sx={{ flexGrow: 1, minWidth: { xs: '100%', sm: 280 } }}>
             <SearchableSelect
@@ -469,36 +475,45 @@ export function CultureDetail({
               label={t('searchPlaceholder')}
               placeholder={t('searchInputPlaceholderEnhanced')}
               noOptionsText={t('noOptionsEnhanced')}
-              textFieldSx={{ width: '100%' }}
+              textFieldSx={{
+                width: '100%',
+              }}
               inputValue={searchQuery}
               onInputChange={setSearchQuery}
+              endAdornment={(
+                <IconButton
+                  size="small"
+                  onClick={(event) => setFilterAnchorEl(event.currentTarget)}
+                  aria-expanded={isFilterPopoverOpen}
+                  aria-haspopup="dialog"
+                  aria-controls={isFilterPopoverOpen ? 'culture-filters-popover' : undefined}
+                  aria-label="Erweiterte Filter öffnen"
+                  sx={{ bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent' }}
+                >
+                  <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
+                    <TuneIcon fontSize="small" />
+                  </Badge>
+                </IconButton>
+              )}
             />
           </Box>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={() => setFiltersExpanded((prev) => !prev)}
-            startIcon={
-              <Badge color="primary" badgeContent={activeFilterCount > 0 ? activeFilterCount : null}>
-                <FilterListIcon fontSize="small" />
-              </Badge>
-            }
-            endIcon={filtersExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            sx={{ alignSelf: { xs: 'flex-end', sm: 'center' }, whiteSpace: 'nowrap' }}
-            aria-expanded={filtersExpanded}
-            aria-label={t('filters.toggle')}
-          >
-            {t('filters.toggle')}
-          </Button>
         </Stack>
 
-        <Collapse in={filtersExpanded}>
+        <Popover
+          id="culture-filters-popover"
+          open={isFilterPopoverOpen}
+          anchorEl={filterAnchorEl}
+          onClose={() => setFilterAnchorEl(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          PaperProps={{ sx: { width: { xs: 'min(92vw, 360px)', sm: 360 }, p: 1.5 } }}
+        >
           <Stack
-            direction={{ xs: 'column', md: 'row' }}
+            direction="column"
             spacing={1}
             sx={{ pt: 0.5, pb: 0.5 }}
           >
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-family-filter-label">{t('filters.cropFamily')}</InputLabel>
               <Select
                 labelId="culture-family-filter-label"
@@ -512,7 +527,7 @@ export function CultureDetail({
                 ))}
               </Select>
             </FormControl>
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-method-filter-label">{t('filters.cultivationType')}</InputLabel>
               <Select
                 labelId="culture-method-filter-label"
@@ -526,7 +541,7 @@ export function CultureDetail({
                 <MenuItem value="both">{t('filters.both')}</MenuItem>
               </Select>
             </FormControl>
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 180 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-nutrient-filter-label">{t('filters.nutrientDemand')}</InputLabel>
               <Select
                 labelId="culture-nutrient-filter-label"
@@ -546,7 +561,7 @@ export function CultureDetail({
               label={t('filters.growthDaysMin')}
               value={growthDaysMin}
               onChange={(event) => setGrowthDaysMin(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <TextField
               size="small"
@@ -554,9 +569,9 @@ export function CultureDetail({
               label={t('filters.growthDaysMax')}
               value={growthDaysMax}
               onChange={(event) => setGrowthDaysMax(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
-            <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 220 } }}>
+            <FormControl size="small" sx={{ minWidth: '100%' }}>
               <InputLabel id="culture-sowing-month-filter-label">{t('filters.sowingMonths')}</InputLabel>
               <Select
                 multiple
@@ -581,7 +596,7 @@ export function CultureDetail({
               label={t('filters.yieldMin')}
               value={yieldMin}
               onChange={(event) => setYieldMin(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <TextField
               size="small"
@@ -589,7 +604,7 @@ export function CultureDetail({
               label={t('filters.yieldMax')}
               value={yieldMax}
               onChange={(event) => setYieldMax(event.target.value)}
-              sx={{ minWidth: { xs: '100%', md: 140 } }}
+              sx={{ minWidth: '100%' }}
             />
             <Button
               variant="text"
@@ -604,25 +619,62 @@ export function CultureDetail({
                 setYieldMin('');
                 setYieldMax('');
                 setSelectedSowingMonths([]);
+                setFilterAnchorEl(null);
               }}
-              sx={{ alignSelf: { xs: 'flex-end', md: 'center' }, whiteSpace: 'nowrap' }}
+              sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
             >
               {t('filters.reset')}
             </Button>
           </Stack>
-        </Collapse>
-        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.75, display: 'block' }}>
-          {t('searchHelperText', { count: filteredCultures.length })}
-        </Typography>
+        </Popover>
       </Box>
-      ) : null}
+  ) : null;
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      {topbarSlot && selectorControl ? createPortal(selectorControl, topbarSlot) : selectorControl}
 
       {/* Detail View */}
-      {selectedCulture && (
-        <Card>
-          <CardContent>
+      {!isLoading && cultures.length > 0 ? (
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+          <Card sx={{ width: { xs: '100%', md: 340 }, flexShrink: 0, maxHeight: { md: 'calc(100vh - 220px)' }, overflowY: 'auto' }}>
+            <List dense sx={{ py: 0.5 }}>
+              {filteredCultures.map((culture) => {
+                const cultivationValues = culture.cultivation_types && culture.cultivation_types.length > 0
+                  ? culture.cultivation_types
+                  : (culture.cultivation_type ? [culture.cultivation_type] : []);
+                const cultivationLabel = cultivationValues.includes('direct_sowing') && cultivationValues.includes('pre_cultivation')
+                  ? t('filters.both')
+                  : cultivationValues.includes('direct_sowing')
+                    ? t('filters.directSowing')
+                    : cultivationValues.includes('pre_cultivation')
+                      ? t('filters.preCultivation')
+                      : '';
+                const secondaryParts = [culture.variety, cultivationLabel, culture.seed_supplier].filter(Boolean);
+                const secondary = secondaryParts.join(' • ');
+
+                return (
+                  <ListItemButton
+                    key={culture.id}
+                    selected={selectedCulture?.id === culture.id}
+                    onClick={() => onCultureSelect(culture)}
+                    sx={{ borderRadius: 1, mx: 0.5, mb: 0.5, alignItems: 'flex-start' }}
+                  >
+                    <ListItemText
+                      primary={culture.name}
+                      secondary={secondary || culture.crop_family || undefined}
+                    />
+                  </ListItemButton>
+                );
+              })}
+            </List>
+          </Card>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {selectedCulture ? (
+              <Card>
+                <CardContent>
             {/* Header with crop name and badge */}
-            <Box sx={{ mb: 3 }}>
+                  <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
                 <Box sx={{ flexGrow: 1 }}>
                   <Typography variant="h4" component="h2">
@@ -1024,10 +1076,21 @@ export function CultureDetail({
                   </Box>
                 )}
               </Box>
-            </Box>
-          </CardContent>
-        </Card>
-      )}
+                  </Box>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardContent>
+                  <Typography variant="body2" color="text.secondary">
+                    {t('selectPrompt')}
+                  </Typography>
+                </CardContent>
+              </Card>
+            )}
+          </Box>
+        </Box>
+      ) : null}
 
       {/* Empty State */}
       {isLoading && (
@@ -1039,16 +1102,6 @@ export function CultureDetail({
                 {t('messages.loadingCultures')}
               </Typography>
             </Box>
-          </CardContent>
-        </Card>
-      )}
-
-      {!isLoading && !selectedCulture && filteredCultures.length > 0 && (
-        <Card>
-          <CardContent>
-            <Typography variant="body1" color="text.secondary" align="center">
-              {t('selectPrompt')}
-            </Typography>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
@@ -100,12 +100,15 @@ import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { getFirstMissingCultivationPlanRequirement } from './requirementFlow';
+import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
+  const outletContext = useOutletContext<RootLayoutOutletContext | null>();
+  const setTopbarContextActions = outletContext?.setTopbarContextActions ?? (() => undefined);
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
   const { selectedCultureId, updateSelectedCultureId } = useSelectedCultureSync();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
@@ -114,7 +117,6 @@ function Cultures(): React.ReactElement {
   const [isCulturesLoading, setIsCulturesLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingCulture, setEditingCulture] = useState<Culture | undefined>(undefined);
-  const [importMenuAnchor, setImportMenuAnchor] = useState<null | HTMLElement>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const {
     state: importState,
@@ -153,6 +155,7 @@ function Cultures(): React.ReactElement {
   const [hasLocations, setHasLocations] = useState(false);
   const [hasFields, setHasFields] = useState(false);
   const [hasBeds, setHasBeds] = useState(false);
+  const selectedCulture = cultures.find((culture) => culture.id === selectedCultureId);
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'info') => {
     setSnackbar({ open: true, message, severity });
@@ -273,7 +276,6 @@ function Cultures(): React.ReactElement {
   };
 
   const handleOpenHistory = async () => {
-    handleImportMenuClose();
     if (!selectedCulture?.id) {
       return;
     }
@@ -364,10 +366,6 @@ function Cultures(): React.ReactElement {
     }
   };
 
-  const handleImportMenuClose = () => {
-    setImportMenuAnchor(null);
-  };
-
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== '?') {
@@ -401,11 +399,10 @@ function Cultures(): React.ReactElement {
     }
   }, [t]);
 
-  const handleOpenPublicLibrary = async () => {
-    handleImportMenuClose();
+  const handleOpenPublicLibrary = useCallback(async () => {
     setPublicLibraryOpen(true);
     await fetchPublicCultures();
-  };
+  }, [fetchPublicCultures]);
 
   const handleImportPublicCulture = async (publicCulture: PublicCulture) => {
     try {
@@ -456,13 +453,12 @@ function Cultures(): React.ReactElement {
     }
   };
 
-  const handleImportFileTrigger = () => {
-    handleImportMenuClose();
+  const handleImportFileTrigger = useCallback(() => {
     resetImportState();
     fileInputRef.current?.click();
-  };
+  }, [resetImportState]);
 
-  const handleExportCurrentCulture = () => {
+  const handleExportCurrentCulture = useCallback(() => {
     if (!selectedCulture) {
       return;
     }
@@ -471,10 +467,9 @@ function Cultures(): React.ReactElement {
     const filename = buildSingleCultureFilename(selectedCulture);
     downloadJsonFile(exportPayload, filename);
     showSnackbar(t('messages.exportSuccess'), 'success');
-    handleImportMenuClose();
-  };
+  }, [selectedCulture, showSnackbar, t]);
 
-  const handleExportAllCultures = async () => {
+  const handleExportAllCultures = useCallback(async () => {
     try {
       const allCultures: Culture[] = [];
       let nextUrl: string | null = '/cultures/';
@@ -492,10 +487,8 @@ function Cultures(): React.ReactElement {
     } catch (error) {
       console.error('Error exporting cultures:', error);
       showSnackbar(t('messages.fetchError'), 'error');
-    } finally {
-      handleImportMenuClose();
     }
-  };
+  }, [showSnackbar, t]);
 
   const handleImportFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -583,7 +576,6 @@ function Cultures(): React.ReactElement {
     setImportDialogOpen(false);
   };
 
-  const selectedCulture = cultures.find(c => c.id === selectedCultureId);
   const firstMissingPlanRequirement = getFirstMissingCultivationPlanRequirement({
     hasLocations,
     hasFields,
@@ -715,6 +707,44 @@ function Cultures(): React.ReactElement {
       setEnrichmentLoading(false);
     }
   };
+
+  const contextActions = useMemo<TopbarContextAction[]>(() => ([
+    {
+      id: 'cultures-open-library',
+      label: 'Öffentliche Kulturbibliothek öffnen',
+      ariaLabel: 'Öffentliche Kulturbibliothek öffnen',
+      onClick: () => {
+        void handleOpenPublicLibrary();
+      },
+    },
+    {
+      id: 'cultures-import-json',
+      label: 'Kulturen importieren (JSON)',
+      ariaLabel: 'Kulturen importieren (JSON)',
+      onClick: handleImportFileTrigger,
+      shortcutHint: 'Alt+I',
+    },
+    {
+      id: 'cultures-export-current-json',
+      label: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
+      ariaLabel: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
+      onClick: handleExportCurrentCulture,
+      disabled: !selectedCulture,
+      shortcutHint: 'Alt+J',
+    },
+    {
+      id: 'cultures-export-all-json',
+      label: 'Alle Kulturen exportieren (JSON)',
+      ariaLabel: 'Alle Kulturen exportieren (JSON)',
+      onClick: handleExportAllCultures,
+      shortcutHint: 'Alt+Shift+J',
+    },
+  ]), [handleExportAllCultures, handleExportCurrentCulture, handleImportFileTrigger, handleOpenPublicLibrary, selectedCulture]);
+
+  useEffect(() => {
+    setTopbarContextActions(contextActions);
+    return () => setTopbarContextActions([]);
+  }, [contextActions, setTopbarContextActions]);
 
   const commandSpecs = useMemo(() => createCulturesCommandSpecs({
     canRunEnrichmentForCulture,
@@ -918,25 +948,6 @@ function Cultures(): React.ReactElement {
 
   return (
     <PageContainer>
-      <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
-        <Button variant="contained" onClick={handleAddNew}>Kultur hinzufügen</Button>
-      </Box>
-        <Menu
-          id="culture-import-menu"
-          anchorEl={importMenuAnchor}
-          open={Boolean(importMenuAnchor)}
-          onClose={handleImportMenuClose}
-        >
-          <MenuItem aria-label="JSON exportieren" onClick={handleExportCurrentCulture} disabled={!selectedCulture}>
-            JSON exportieren
-          </MenuItem>
-          <MenuItem aria-label="Alle Kulturen exportieren" onClick={handleExportAllCultures}>
-            Alle Kulturen exportieren
-          </MenuItem>
-          <MenuItem aria-label="JSON importieren" onClick={handleImportFileTrigger}>
-            JSON importieren
-          </MenuItem>
-        </Menu>
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,6 +1,6 @@
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
 import GraphicalFields from './GraphicalFields';
 import { AddBedIcon } from '../components/hierarchy/AddBedIcon';
@@ -23,6 +23,7 @@ type InteractionMode = 'view' | 'edit';
 export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
   const navigate = useNavigate();
+  const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
     return stored === 'graphical' ? 'graphical' : 'table';
@@ -98,7 +99,6 @@ export default function FieldsBedsPage(): React.ReactElement {
   const shouldShowGlobalAddButton = viewMode === 'table'
     && !shouldShowProjectRequiredState
     && locations.length <= 1;
-
   const handleGlobalAddField = useCallback((): void => {
     if (locations.length === 0) {
       navigate('/app/locations?create=true');
@@ -125,6 +125,26 @@ export default function FieldsBedsPage(): React.ReactElement {
     setAddFieldDialogOpen(false);
     setNewFieldName('');
   }, [addField, newFieldName, targetLocationId]);
+
+  useEffect(() => {
+    if (!location.pathname.startsWith('/app/fields-beds')) {
+      return;
+    }
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('create') !== 'true') {
+      return;
+    }
+    handleGlobalAddField();
+    searchParams.delete('create');
+    const nextSearch = searchParams.toString();
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      },
+      { replace: true },
+    );
+  }, [handleGlobalAddField, location.pathname, location.search, navigate]);
 
 
   useEffect(() => {
@@ -194,7 +214,7 @@ export default function FieldsBedsPage(): React.ReactElement {
           </Box>
           {shouldShowGlobalAddButton ? (
             <Button
-              variant="contained"
+              variant="outlined"
               onClick={handleGlobalAddField}
               sx={{ width: { xs: '100%', sm: 'auto' } }}
             >

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1098,9 +1098,11 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "notes",
         headerName: t("common:fields.notes"),
-        width: 220,
-        minWidth: dynamicWidths.notes,
-        maxWidth: 260,
+        width: 72,
+        minWidth: 56,
+        maxWidth: 90,
+        align: "center",
+        headerAlign: "center",
         // Notes field will be overridden by NotesCell in EditableDataGrid
       },
     ],
@@ -1782,6 +1784,7 @@ function PlantingPlans(): React.ReactElement {
                   labelKey: "common:fields.notes",
                   attachmentNoteIdField: "id",
                   attachmentCountField: "note_attachment_count",
+                  compactIndicator: true,
                 },
               ],
             }}

--- a/frontend/src/pages/culturesCommandSpecs.ts
+++ b/frontend/src/pages/culturesCommandSpecs.ts
@@ -122,7 +122,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.exportCurrent',
-      label: 'JSON exportieren (Alt+J)',
+      label: (selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)') + ' (Alt+J)',
       group: 'navigation',
       keywords: ['json', 'export', 'kultur'],
       shortcutHint: 'Alt+J',
@@ -133,7 +133,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.exportAll',
-      label: 'Alle Kulturen exportieren (Alt+Shift+J)',
+      label: 'Alle Kulturen exportieren (JSON) (Alt+Shift+J)',
       group: 'navigation',
       keywords: ['json', 'export', 'alle', 'kulturen'],
       shortcutHint: 'Alt+Shift+J',
@@ -144,7 +144,7 @@ export function createCulturesCommandSpecs({
     },
     {
       id: 'culture.import',
-      label: 'JSON importieren (Alt+I)',
+      label: 'Kulturen importieren (JSON) (Alt+I)',
       group: 'navigation',
       keywords: ['json', 'import'],
       shortcutHint: 'Alt+I',

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -6,9 +6,10 @@ const theme = createTheme({
   palette: {
     // Primary color used by contained buttons and primary components
     primary: {
-      main: '#2e7d32',
+      main: '#256f2a',
       dark: '#1b5e20',
-      light: '#60ad5e',
+      light: '#4f9853',
+      contrastText: '#ffffff',
     },
     secondary: {
       main: '#9c27b0',
@@ -28,6 +29,23 @@ const theme = createTheme({
         root: {
           padding: '8px 24px',
           textTransform: 'none',
+          fontSize: '0.95rem',
+          fontWeight: 600,
+          lineHeight: 1.3,
+        },
+        containedPrimary: {
+          color: '#ffffff',
+          '&:hover': {
+            backgroundColor: '#1f6224',
+          },
+        },
+        startIcon: {
+          display: 'inline-flex',
+          alignItems: 'center',
+        },
+        endIcon: {
+          display: 'inline-flex',
+          alignItems: 'center',
         },
       },
     },


### PR DESCRIPTION
### Motivation
- Improve the root layout and topbar to support contextual actions from pages and provide a more responsive sidebar experience. 
- Enhance the Cultures UI with an inline selector in the topbar, advanced filtering, and import/export/publish actions surfaced to the topbar. 
- Add a compact notes indicator for data grids and make several component ergonomics improvements (searchable select adornments, button theme tuning). 

### Description
- Add topbar context action support by introducing `TopbarContextAction` and `RootLayoutOutletContext`, store `setTopbarContextActions` in `App.tsx`, and pass it into the `Outlet` context. 
- Make the sidebar responsive: collapse defaults to non-large-desktop, add a modern collapse/expand `PanelLeft` icon button with tooltip, and animate/overflow tweaks in `App.tsx`. 
- Implement cultures topbar integration: `CultureDetail` now renders its selector into a topbar slot via `createPortal`, provide a filter `Popover` with badge/count and expose context actions (library, import/export) from `Cultures` which register with the layout. 
- Add a culture actions menu in the topbar and wire up context actions to buttons and a menu when on the cultures page. 
- Introduce a compact notes indicator flow: add `compactIndicator` to `NotesFieldConfig`, thread it through `DataGrid` and implement compact rendering and improved ARIA/tooltips in `NotesCell.tsx`. 
- Enhance `SearchableSelect` with an `endAdornment` prop to allow custom trailing controls inside the input. 
- Add URL-driven create handling to `FieldsBedsPage` (honor `?create=true` on mount via `useLocation`) and change the global add button style. 
- Adjust `PlantingPlans` notes column to use a compact width and centered layout to pair with the new notes indicator. 
- Tidy up several `Cultures` page callbacks with `useCallback`/`useMemo`, remove unused menu anchor state, and centralize import/export handlers and topbar command specs. 
- Update theme colors and button style overrides in `theme.ts` (primary color shades and consistent button sizing/weights). 

### Testing
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad7c89fd08322b42f7482b81d6d11)