### PR TITLE
fix(seed-demand): clarify seed data empty state guidance

### DIFF
--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -248,8 +248,9 @@
       },
       "seedData": {
         "title": "Noch kein Saatgutbedarf berechenbar",
-        "description": "Ergänze Saatgutdaten bei deinen Kulturen, damit der Bedarf berechnet werden kann.",
-        "action": "Saatgutdaten ergänzen"
+        "description": "Ergänze bei deinen Kulturen Saatgutdaten, damit der Bedarf berechnet werden kann.",
+        "action": "Saatgutdaten ergänzen",
+        "hint": "Öffne dazu eine Kultur und klicke auf „Bearbeiten“"
       }
     },
     "selectSupplier": "Lieferant auswählen",

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -87,7 +87,14 @@ export default function SeedDemandPage(): React.ReactElement {
     if (!hasSeedData) {
       return {
         title: t('seedDemand.progressive.seedData.title'),
-        description: t('seedDemand.progressive.seedData.description'),
+        description: (
+          <>
+            <Typography variant="body2">{t('seedDemand.progressive.seedData.description')}</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              {t('seedDemand.progressive.seedData.hint')}
+            </Typography>
+          </>
+        ),
         action: { label: t('seedDemand.progressive.seedData.action'), to: '/app/cultures' },
       };
     }


### PR DESCRIPTION
### Motivation
- The empty state for the Seed Demand page was too vague and did not explain how users should add seed data to cultures, so users could not see the concrete next step to make seed demand calculable.

### Description
- Update the missing seed-data empty state to include the clearer German description and an additional concise hint rendered as smaller, secondary text beneath the main description, by adding a `hint` translation key in `frontend/src/i18n/locales/de/cultures.json` and rendering it in `frontend/src/pages/SeedDemand.tsx`; the existing CTA and empty-state selection logic remain unchanged.

### Testing
- No automated tests were run, per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9a014a5c8322ab3def2e6220c337)