### PR TITLE
refactor: unify typography weight hierarchy across ui

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -670,7 +670,7 @@ function RootLayout(): React.ReactElement {
                   <Typography
                     variant="subtitle2"
                     noWrap
-                    sx={{ fontWeight: 700, color: '#2F3A33', letterSpacing: 0.1 }}
+                    sx={{ color: '#2F3A33', letterSpacing: 0.1 }}
                   >
                     OpenFarmPlanner
                   </Typography>
@@ -969,7 +969,6 @@ function RootLayout(): React.ReactElement {
                     px: 2,
                     py: 1.5,
                     color: isActive ? '#2F3A33' : '#3F4B45',
-                    fontWeight: isActive ? 700 : 500,
                     bgcolor: isActive ? 'rgba(80, 130, 90, 0.14)' : 'transparent',
                     '&:hover': {
                       bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(80, 120, 90, 0.08)',
@@ -977,7 +976,7 @@ function RootLayout(): React.ReactElement {
                   }}
                 >
                   <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
-                  <ListItemText primary={item.label} />
+                  <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }} />
                 </ListItemButton>
               </ListItem>
             );

--- a/frontend/src/components/data-grid/styles.ts
+++ b/frontend/src/components/data-grid/styles.ts
@@ -19,9 +19,6 @@ export const dataGridSx = {
     backgroundColor: '#f8faf8',
     borderBottom: '1px solid #e5e7eb',
   },
-  '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 600,
-  },
   '& .MuiDataGrid-row': {
     minHeight: 44,
   },

--- a/frontend/src/components/help/HelpDialog.tsx
+++ b/frontend/src/components/help/HelpDialog.tsx
@@ -93,7 +93,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
       <DialogContent sx={{ pb: 3 }}>
         <Stack spacing={2}>
           <Box>
-            <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+            <Typography variant="h5" sx={{ fontWeight: 600, mb: 1 }}>
               {t('heading')}
             </Typography>
             <Typography variant="body1">
@@ -104,7 +104,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
           <Stack spacing={1.5}>
             {helpSections.map((section) => (
               <Box key={section.title}>
-                <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.5 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
                   {section.title}
                 </Typography>
                 <List dense disablePadding>
@@ -119,7 +119,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
           </Stack>
 
           <Box sx={{ pt: 1 }}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 0.5 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
               {t('workflowTitle')}
             </Typography>
             <Box

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -259,7 +259,7 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
 
   const renderSection = (section: HelpSection, key: string): ReactElement => (
     <Box key={key} sx={{ mb: 1.25 }}>
-      <Typography variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
+      <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
         {section.title}
       </Typography>
       <List dense disablePadding>
@@ -313,7 +313,7 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
       ))}
 
       <Box>
-        <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
+        <Typography variant="body1" sx={{ fontWeight: 600, mb: 1 }}>
           {t('pages.graphical.symbolsTitle')}
         </Typography>
         <Stack spacing={1}>
@@ -324,11 +324,11 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
       </Box>
 
       <Box>
-        <Typography variant="body1" sx={{ fontWeight: 700, mb: 1 }}>
+        <Typography variant="body1" sx={{ fontWeight: 600, mb: 1 }}>
           {t('pages.graphical.modeTitle')}
         </Typography>
         <Box sx={{ display: 'inline-flex', flexDirection: 'column', gap: 1, p: 1.25, borderRadius: 1.5, border: '1px solid', borderColor: 'divider' }}>
-          <Typography variant="caption" sx={{ fontWeight: 700 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600 }}>
             {t('pages.graphical.modeLabel')}
           </Typography>
           <ToggleButtonGroup value="view" exclusive size="small" aria-label={t('pages.graphical.modeLabel')}>
@@ -354,7 +354,7 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
 
   const renderSymbolsContent = (): ReactElement => (
     <Box>
-      <Typography variant="body1" sx={{ fontWeight: 700, mb: 0.75 }}>
+      <Typography variant="body1" sx={{ fontWeight: 600, mb: 0.75 }}>
         {symbolsTitle}
       </Typography>
       <Stack spacing={1}>
@@ -381,7 +381,7 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
         <Box sx={{ maxWidth: 720, width: { xs: 1, sm: 680 }, p: 2.5 }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>{title}</Typography>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>{title}</Typography>
           {pageKey === 'graphical' ? renderGraphicalHelpContent() : sections && sections.length > 0 ? (
             <>
               {renderIntro()}

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -51,7 +51,7 @@ export default function AppLogo({ to = '/app/dashboard', size = 28, showText = t
         sx={{ height: size, width: size, borderRadius: 0.5, flexShrink: 0 }}
       />
       {showText ? (
-        <Box component="span" sx={{ fontWeight: 700, fontSize: 16, whiteSpace: 'nowrap' }}>
+        <Box component="span" sx={{ fontWeight: 600, fontSize: 16, whiteSpace: 'nowrap' }}>
           OpenFarmPlanner
         </Box>
       ) : null}

--- a/frontend/src/components/project/ProjectRequiredState.tsx
+++ b/frontend/src/components/project/ProjectRequiredState.tsx
@@ -28,7 +28,7 @@ export default function ProjectRequiredState({
   return (
     <Alert severity="info">
       <Stack spacing={1.5}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
           {t(titleKey)}
         </Typography>
         <Typography variant="body2">{t(descriptionKey)}</Typography>

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -332,7 +332,7 @@ function GanttChartPage(): React.ReactElement {
 
   const renderOccupancyTooltip = useCallback(({ task }: { task: GanttTask }) => (
     <Box sx={{ p: 0.5 }}>
-      <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.75 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.75 }}>
         {formatSeedlingTooltipTitle(task)}
       </Typography>
       {buildOccupancyTooltipDetails(task).map((detail) => (
@@ -345,7 +345,7 @@ function GanttChartPage(): React.ReactElement {
 
   const renderSeedlingTooltip = useCallback(({ task }: { task: GanttTask }) => (
     <Box sx={{ p: 0.5 }}>
-      <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.75 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.75 }}>
         {formatSeedlingTooltipTitle(task)}
       </Typography>
       {buildSeedlingTooltipDetails(task).map((detail) => (

--- a/frontend/src/pages/ProjectSelectionPage.tsx
+++ b/frontend/src/pages/ProjectSelectionPage.tsx
@@ -23,7 +23,7 @@ export default function ProjectSelectionPage(): React.ReactElement {
         {memberships.length === 0 ? (
           <Alert severity="info">
             <Stack spacing={1.5}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                 {t('common:projectRequired.noProjectsTitle')}
               </Typography>
               <Typography variant="body2">

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -3,6 +3,29 @@
 import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
+  typography: {
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    subtitle1: {
+      fontWeight: 600,
+    },
+    subtitle2: {
+      fontWeight: 600,
+    },
+    body1: {
+      fontWeight: 400,
+    },
+    body2: {
+      fontWeight: 400,
+    },
+    caption: {
+      fontWeight: 400,
+    },
+  },
   palette: {
     // Primary color used by contained buttons and primary components
     primary: {
@@ -56,6 +79,24 @@ const theme = createTheme({
         endIcon: {
           display: 'inline-flex',
           alignItems: 'center',
+        },
+      },
+    },
+    MuiListItemText: {
+      styleOverrides: {
+        primary: {
+          fontWeight: 400,
+        },
+        secondary: {
+          fontWeight: 400,
+          color: 'rgba(47, 58, 51, 0.66)',
+        },
+      },
+    },
+    MuiDataGrid: {
+      styleOverrides: {
+        columnHeaderTitle: {
+          fontWeight: 600,
         },
       },
     },


### PR DESCRIPTION
### Motivation
- The app used inconsistent font weights across pages and components causing visual noise and unclear hierarchy.
- Centralizing typography weights in the theme makes it easier to maintain consistent emphasis for page titles, section headers, table headers, navigation, and meta text.

### Description
- Added centralized typography defaults in `frontend/src/theme.ts` for `h5`, `h6`, `subtitle1`, `subtitle2`, `body1`, `body2`, and `caption` to align with the requested weights (`600` for titles/section-like variants and `400` for body/meta text). 
- Added `MuiListItemText` overrides to keep list primary and secondary text at weight `400` and to lower contrast for secondary text, and added a `MuiDataGrid.columnHeaderTitle` override for header weight `600` to centralize DataGrid header styling. 
- Removed the duplicated column header weight from `frontend/src/components/data-grid/styles.ts` and replaced per-component heavy weights (`700`) with `600` in shared UI areas such as help dialogs, page help, app logo, project-required state, Gantt tooltips, and project selection to harmonize emphasis. 
- Aligned sidebar navigation typography so active items use `600` and inactive items `500` consistently on desktop and mobile by moving weight control to `ListItemText` props and removing ad-hoc `fontWeight: 700` overrides in `frontend/src/App.tsx`.

### Testing
- No automated tests were run for this change as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcbe62c608322a9b22618aaee570b)