### PR TITLE
Culture detail: add header actions (edit/plan/history/publish/delete) and responsive layout improvements

### DIFF
--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -51,7 +51,29 @@ vi.mock('../api/api', async () => {
 });
 
 vi.mock('../cultures/CultureDetail', () => ({
-  CultureDetail: (): ReactElement => <div data-testid="culture-detail-mock" />,
+  CultureDetail: ({
+    cultures,
+    onCultureSelect,
+    onCreateCulture,
+    onCreatePlan,
+    onPublishCulture,
+    onEditCulture,
+  }: {
+    cultures: Array<{ id?: number; name: string }>;
+    onCultureSelect: (culture: { id?: number; name: string } | null) => void;
+    onCreateCulture?: () => void;
+    onCreatePlan?: () => void;
+    onPublishCulture?: () => void;
+    onEditCulture?: (culture: { id?: number; name: string }) => void;
+  }): ReactElement => (
+    <div data-testid="culture-detail-mock">
+      <button type="button" onClick={() => onCreateCulture?.()}>Kultur hinzufügen</button>
+      <button type="button" onClick={() => onPublishCulture?.()}>Veröffentlichen</button>
+      <button type="button" onClick={() => onCreatePlan?.()}>Anbauplan erstellen</button>
+      <button type="button" onClick={() => onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
+      <button type="button" onClick={() => onCultureSelect(cultures[0] ?? null)}>select-culture</button>
+    </div>
+  ),
 }));
 
 vi.mock('../auth/useAuth', () => ({

--- a/frontend/src/__tests__/CulturesSavePayload.test.tsx
+++ b/frontend/src/__tests__/CulturesSavePayload.test.tsx
@@ -31,10 +31,12 @@ vi.mock('../cultures/CultureDetail', () => ({
     cultures,
     selectedCultureId,
     onCultureSelect,
+    onEditCulture,
   }: {
     cultures: Culture[];
     selectedCultureId?: number;
     onCultureSelect: (culture: Culture | null) => void;
+    onEditCulture?: (culture: Culture) => void;
   }): ReactElement => (
     <div>
       <button
@@ -52,6 +54,7 @@ vi.mock('../cultures/CultureDetail', () => ({
       </button>
       <div data-testid="culture-list">{cultures.map((culture) => culture.name).join(', ')}</div>
       <div data-testid="selected-culture-id">{selectedCultureId ?? 'none'}</div>
+      <button type="button" onClick={() => cultures[0] && onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
     </div>
   ),
 }));

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -110,8 +110,8 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
     { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
     { key: 'library', icon: <PublicIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
     { key: 'createPlan', icon: <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
-    { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
-    { key: 'more', icon: <MoreVertIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
+    { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'rgba(37, 111, 42, 0.86)' }} /> },
+    { key: 'more', icon: <MoreVertIcon fontSize="small" sx={{ color: 'text.secondary' }} /> },
     { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
   ],
   plantingPlans: [

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -796,8 +796,9 @@ export function CultureDetail({
                         disabled={!onEditCulture}
                         sx={{
                           ...headerActionButtonSx,
-                          color: 'text.secondary',
+                          color: 'rgba(37, 111, 42, 0.72)',
                           borderRight: '1px solid rgba(15, 23, 42, 0.08)',
+                          '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.08)' },
                         }}
                       >
                         <EditIcon sx={{ fontSize: 18 }} />
@@ -846,8 +847,9 @@ export function CultureDetail({
                 <MenuItem
                   onClick={() => { setHeaderMenuAnchorEl(null); onPublishCulture?.(); }}
                   disabled={isPublishingCulture}
+                  sx={{ color: 'rgba(37, 111, 42, 0.86)' }}
                 >
-                  <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'text.secondary' }} />
+                  <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'rgba(37, 111, 42, 0.78)' }} />
                   {publishActionLabel ?? t('library.publishButton')}
                 </MenuItem>
                 <MenuItem onClick={() => { setHeaderMenuAnchorEl(null); onDeleteCulture?.(selectedCulture); }} sx={{ color: 'error.main' }}>

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -15,6 +15,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
 import TuneIcon from '@mui/icons-material/Tune';
+import EditIcon from '@mui/icons-material/Edit';
+import AgricultureIcon from '@mui/icons-material/Agriculture';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import PublicIcon from '@mui/icons-material/Public';
+import HistoryIcon from '@mui/icons-material/History';
+import DeleteIcon from '@mui/icons-material/Delete';
 import {
   Badge,
   Box,
@@ -42,6 +48,8 @@ import {
   IconButton,
   Popover,
   TextField,
+  Menu,
+  Tooltip,
 } from '@mui/material';
 import type { Culture } from '../api/api';
 import { SearchableSelect } from '../components/inputs/SearchableSelect';
@@ -56,6 +64,14 @@ interface CultureDetailProps {
   onCultureSelect: (culture: Culture | null) => void;
   onCreateCulture?: () => void;
   onOpenPublicLibrary?: () => void;
+  onEditCulture?: (culture: Culture) => void;
+  onCreatePlan?: () => void;
+  onOpenHistory?: () => void;
+  onPublishCulture?: () => void;
+  onDeleteCulture?: (culture: Culture) => void;
+  canCreatePlan?: boolean;
+  isPublishingCulture?: boolean;
+  publishActionLabel?: string;
 }
 
 const CULTURE_FILTERS_STORAGE_KEY = 'culturesDetailFiltersV1';
@@ -138,6 +154,14 @@ export function CultureDetail({
   onCultureSelect,
   onCreateCulture,
   onOpenPublicLibrary,
+  onEditCulture,
+  onCreatePlan,
+  onOpenHistory,
+  onPublishCulture,
+  onDeleteCulture,
+  canCreatePlan = true,
+  isPublishingCulture = false,
+  publishActionLabel,
 }: CultureDetailProps): React.ReactElement {
   const { t } = useTranslation('cultures');
   const [searchQuery, setSearchQuery] = useState('');
@@ -150,7 +174,26 @@ export function CultureDetail({
   const [yieldMax, setYieldMax] = useState('');
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
   const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
+  const [headerMenuAnchorEl, setHeaderMenuAnchorEl] = useState<HTMLElement | null>(null);
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
+  const isHeaderMenuOpen = Boolean(headerMenuAnchorEl);
+  const headerActionButtonSx = {
+    width: 34,
+    height: 34,
+    borderRadius: 0,
+    border: 'none',
+    backgroundColor: 'transparent',
+    transition: 'background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease',
+    '&:hover': {
+      backgroundColor: 'rgba(15, 23, 42, 0.08)',
+      boxShadow: '0 2px 6px rgba(15, 23, 42, 0.10)',
+      transform: 'translateY(-1px)',
+    },
+    '&:focus-visible': {
+      outline: '2px solid rgba(37, 111, 42, 0.28)',
+      outlineOffset: 1,
+    },
+  } as const;
 
   const activeFilterCount = useMemo(
     () => [
@@ -629,7 +672,7 @@ export function CultureDetail({
 
       {/* Detail View */}
       {!isLoading && cultures.length > 0 ? (
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '350px minmax(0, 1fr)' }, gap: 1.5, alignItems: 'start' }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '300px minmax(0, 1fr)', xl: '330px minmax(0, 1fr)' }, gap: 1.5, alignItems: 'start' }}>
           <Card
             sx={{
               width: '100%',
@@ -688,59 +731,148 @@ export function CultureDetail({
               })}
             </List>
           </Card>
-          <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { md: 'flex-start' } }}>
             {selectedCulture ? (
-              <Card>
+              <Card sx={{ width: '100%', maxWidth: { md: 1220, xl: 1400 } }}>
                 <CardContent>
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
                 <Box sx={{ flexGrow: 1 }}>
-                  <Typography variant="h4" component="h2">
-                    {selectedCulture.name}
-                  </Typography>
-                  {selectedCulture.variety && (
-                    <Typography variant="body2" color="text.secondary">
-                      {selectedCulture.variety}
-                    </Typography>
-                  )}
-                  <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
-                    <Chip
-                      size="small"
-                      color={selectedCulture.origin_type === 'imported' ? 'secondary' : 'default'}
-                      label={selectedCulture.origin_type === 'imported' ? t('library.badges.imported') : t('library.badges.local')}
-                    />
-                    {selectedCulture.is_modified_from_source ? (
-                      <Chip size="small" color="warning" label={t('library.badges.modified')} />
+                  <Box sx={{ display: 'flex', alignItems: 'stretch', gap: 1.75 }}>
+                    {selectedCulture.display_color ? (
+                      <Box
+                        sx={{
+                          width: 4,
+                          borderRadius: 1,
+                          backgroundColor: selectedCulture.display_color,
+                          opacity: 0.75,
+                          my: 0.5,
+                          alignSelf: 'stretch',
+                          flexShrink: 0,
+                        }}
+                        aria-label="Kulturfarbe"
+                        title={selectedCulture.display_color}
+                      />
                     ) : null}
+                    <Box sx={{ display: 'flex', flexDirection: 'column', py: 0.25 }}>
+                      <Typography variant="h4" component="h2">
+                        {selectedCulture.name}
+                      </Typography>
+                      {selectedCulture.variety && (
+                        <Typography variant="body2" color="text.secondary">
+                          {selectedCulture.variety}
+                        </Typography>
+                      )}
+                      <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+                        <Chip
+                          size="small"
+                          color={selectedCulture.origin_type === 'imported' ? 'secondary' : 'default'}
+                          label={selectedCulture.origin_type === 'imported' ? t('library.badges.imported') : t('library.badges.local')}
+                        />
+                        {selectedCulture.is_modified_from_source ? (
+                          <Chip size="small" color="warning" label={t('library.badges.modified')} />
+                        ) : null}
+                      </Box>
+                    </Box>
                   </Box>
                 </Box>
-                {selectedCulture.display_color && (
-                  <Box
+                <Box
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    border: '1px solid rgba(15, 23, 42, 0.10)',
+                    borderRadius: 1.5,
+                    backgroundColor: 'rgba(15, 23, 42, 0.03)',
+                    boxShadow: '0 1px 3px rgba(15, 23, 42, 0.08)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <Tooltip title={t('buttons.edit')}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={() => onEditCulture?.(selectedCulture)}
+                        disabled={!onEditCulture}
+                        sx={{
+                          ...headerActionButtonSx,
+                          color: 'text.secondary',
+                          borderRight: '1px solid rgba(15, 23, 42, 0.08)',
+                        }}
+                      >
+                        <EditIcon sx={{ fontSize: 18 }} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title={canCreatePlan ? t('buttons.createPlantingPlan') : t('buttons.createPlantingPlanMissingBedsTooltip')}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={() => onCreatePlan?.()}
+                        disabled={!canCreatePlan || !onCreatePlan}
+                        sx={{
+                          ...headerActionButtonSx,
+                          color: 'success.main',
+                          borderRight: '1px solid rgba(15, 23, 42, 0.08)',
+                          '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.10)' },
+                        }}
+                      >
+                        <AgricultureIcon sx={{ fontSize: 18 }} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <IconButton
+                    size="small"
+                    onClick={(event) => setHeaderMenuAnchorEl(event.currentTarget)}
+                    aria-label="Weitere Aktionen"
                     sx={{
-                      width: '40px',
-                      height: '40px',
-                      borderRadius: '8px',
-                      backgroundColor: selectedCulture.display_color,
-                      border: '1px solid #ccc',
+                      ...headerActionButtonSx,
+                      color: 'text.secondary',
                     }}
-                  />
-                )}
+                  >
+                    <MoreVertIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </Box>
               </Box>
+              <Menu
+                anchorEl={headerMenuAnchorEl}
+                open={isHeaderMenuOpen}
+                onClose={() => setHeaderMenuAnchorEl(null)}
+              >
+                <MenuItem onClick={() => { setHeaderMenuAnchorEl(null); onOpenHistory?.(); }}>
+                  <HistoryIcon sx={{ fontSize: 18, mr: 1, color: 'text.secondary' }} />
+                  Versionen
+                </MenuItem>
+                <MenuItem
+                  onClick={() => { setHeaderMenuAnchorEl(null); onPublishCulture?.(); }}
+                  disabled={isPublishingCulture}
+                >
+                  <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'text.secondary' }} />
+                  {publishActionLabel ?? t('library.publishButton')}
+                </MenuItem>
+                <MenuItem onClick={() => { setHeaderMenuAnchorEl(null); onDeleteCulture?.(selectedCulture); }} sx={{ color: 'error.main' }}>
+                  <DeleteIcon sx={{ fontSize: 18, mr: 1, color: 'error.main' }} />
+                  {t('buttons.delete')}
+                </MenuItem>
+              </Menu>
             </Box>
 
             <Divider sx={{ mb: 3 }} />
 
             {/* General Information Section */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 4, p: 2.5, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Typography variant="h6" gutterBottom>
                 Allgemeine Informationen
               </Typography>
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
+                  },
                   gap: 2,
+                  justifyContent: 'start',
                 }}
               >
                 {selectedCulture.crop_family && (
@@ -796,8 +928,12 @@ export function CultureDetail({
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
+                  },
                   gap: 2,
+                  justifyContent: 'start',
                 }}
               >
                 <Box>
@@ -839,8 +975,12 @@ export function CultureDetail({
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
+                  },
                   gap: 2,
+                  justifyContent: 'start',
                 }}
               >
                 {selectedCulture.distance_within_row_cm !== null && selectedCulture.distance_within_row_cm !== undefined && (
@@ -886,8 +1026,12 @@ export function CultureDetail({
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
+                  },
                   gap: 2,
+                  justifyContent: 'start',
                 }}
               >
                 {seedRateRows.length > 0 && activeCultivationTypes.length <= 1 && (
@@ -965,7 +1109,14 @@ export function CultureDetail({
                   </Typography>
                 </Box>
               </Box>
-              <Box sx={{ mt: 3, ml: { xs: 0, sm: 2 } }}>
+              <Box
+                sx={{
+                  mt: 3,
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+                  gap: 2,
+                }}
+              >
                 <Typography variant="subtitle1" component="h3" gutterBottom>
                   {hasMultipleSupplierRows ? 'Saatgutdaten je Lieferant' : 'Lieferant'}
                 </Typography>
@@ -977,7 +1128,7 @@ export function CultureDetail({
                 {orderedSupplierRows.length === 0 ? (
                   <Typography variant="body2" color="text.secondary">Keine Lieferantendaten vorhanden.</Typography>
                 ) : (
-                  <Stack spacing={2}>
+                  <Stack spacing={2} sx={{ gridColumn: '1 / -1' }}>
                     {orderedSupplierRows.map((row, index) => (
                       <Box key={row.id ?? `${row.supplier?.id ?? row.supplier_id ?? 'supplier'}-${index}`}>
                         {hasMultipleSupplierRows && index > 0 ? <Divider sx={{ mb: 2 }} /> : null}
@@ -1019,8 +1170,12 @@ export function CultureDetail({
               <Box
                 sx={{
                   display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gridTemplateColumns: {
+                    xs: '1fr',
+                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
+                  },
                   gap: 2,
+                  justifyContent: 'start',
                 }}
               >
                 {selectedCulture.harvest_method && (
@@ -1062,17 +1217,17 @@ export function CultureDetail({
             <Divider sx={{ mb: 3 }} />
 
             {/* Notes Section */}
-            <Box>
+            <Box sx={{ p: 2.5, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Typography variant="h6" gutterBottom>
                 Notizen
               </Typography>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: { xs: '100%', xl: 1180 } }}>
                 {selectedCulture.notes && (
                   <Box>
                     <Box
                       sx={{
                         '& h3': { mt: 2, mb: 1, fontSize: '1.05rem' },
-                        '& p': { mb: 1 },
+                        '& p': { mb: 1, maxWidth: '95ch' },
                         '& ul': { pl: 3, mb: 1 },
                         '& li': { mb: 0.5 },
                         '& a': { color: 'primary.main' },

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -796,9 +796,9 @@ export function CultureDetail({
                         disabled={!onEditCulture}
                         sx={{
                           ...headerActionButtonSx,
-                          color: 'rgba(37, 111, 42, 0.72)',
+                          color: 'rgba(37, 111, 42, 0.86)',
                           borderRight: '1px solid rgba(15, 23, 42, 0.08)',
-                          '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.08)' },
+                          '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.12)' },
                         }}
                       >
                         <EditIcon sx={{ fontSize: 18 }} />
@@ -847,7 +847,7 @@ export function CultureDetail({
                 <MenuItem
                   onClick={() => { setHeaderMenuAnchorEl(null); onPublishCulture?.(); }}
                   disabled={isPublishingCulture}
-                  sx={{ color: 'rgba(37, 111, 42, 0.86)' }}
+                  sx={{ color: 'text.primary' }}
                 >
                   <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'rgba(37, 111, 42, 0.78)' }} />
                   {publishActionLabel ?? t('library.publishButton')}

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -146,9 +146,9 @@
         {
           "title": "Bedienung",
           "points": [
-            "Wähle eine Kultur aus, um Details zu sehen oder zu bearbeiten.",
-            "Erstelle, exportiere, lösche oder verwende Kulturen direkt für einen Anbauplan.",
-            "Nutze die Kulturbibliothek, um Kulturen zu teilen oder zu übernehmen."
+            "Wähle eine Kultur aus, um Details anzuzeigen, zu bearbeiten oder Anbaupläne dafür zu erstellen.",
+            "Öffne über das Drei-Punkte-Menü Versionen, die Veröffentlichung bzw. Aktualisierung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.",
+            "Nutze die öffentliche Kulturbibliothek, um Kulturen zu veröffentlichen, zu aktualisieren oder zu übernehmen."
           ]
         },
         {

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -52,12 +52,8 @@ import {
   Stack,
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AgricultureIcon from '@mui/icons-material/Agriculture';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import ManageSearchIcon from '@mui/icons-material/ManageSearch';
-import PublicIcon from '@mui/icons-material/Public';
 import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
 import {
   buildAllCulturesExport,
@@ -99,7 +95,6 @@ import { EnrichmentLoadingDialog } from './EnrichmentLoadingDialog';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
-import BottomActionToolbar from '../components/layout/BottomActionToolbar';
 import { getFirstMissingCultivationPlanRequirement } from './requirementFlow';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 
@@ -950,14 +945,14 @@ function Cultures(): React.ReactElement {
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer>
+      <PageContainer variant="xwide">
         <ProjectRequiredState reason={missingProjectReason} />
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer>
+    <PageContainer variant="xwide">
         <input
           ref={fileInputRef}
           type="file"
@@ -982,95 +977,25 @@ function Cultures(): React.ReactElement {
           onOpenPublicLibrary={() => {
             void handleOpenPublicLibrary();
           }}
+          onEditCulture={handleEdit}
+          onCreatePlan={handleCreatePlantingPlan}
+          onOpenHistory={handleOpenHistory}
+          onPublishCulture={() => {
+            void handlePublishCurrentCulture();
+          }}
+          onDeleteCulture={handleDelete}
+          canCreatePlan={canCreatePlantingPlan}
+          isPublishingCulture={Boolean(selectedCulture && publishingCultureId === selectedCulture.id)}
+          publishActionLabel={publishingCultureId === selectedCulture?.id
+            ? (isUpdatingOwnPublicCulture ? t('library.updating') : t('library.publishing'))
+            : (isUpdatingOwnPublicCulture
+              ? 'Öffentliche Kulturbibliothek aktualisieren'
+              : 'In Kulturbibliothek veröffentlichen')}
         />
       </Box>
 
-      {/* Action buttons for selected culture */}
       {cultures.length > 0 && (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            mb: 2,
-            gap: 1.25,
-          }}
-        >
-          <BottomActionToolbar
-            leftActions={
-              <Tooltip title="Kultur löschen">
-                <span>
-                  <Button
-                    aria-label="Kultur löschen"
-                    variant="text"
-                    color="error"
-                    startIcon={<DeleteIcon />}
-                    onClick={() => selectedCulture && handleDelete(selectedCulture)}
-                    disabled={!selectedCulture}
-                  >
-                    {t('buttons.delete')}
-                  </Button>
-                </span>
-              </Tooltip>
-            }
-            rightActions={
-              <>
-                <Button variant="contained" onClick={handleAddNew}>
-                  Kultur hinzufügen
-                </Button>
-              <Button variant="outlined" onClick={handleOpenHistory} disabled={!selectedCulture}>
-                Versionen
-              </Button>
-              <Tooltip title="Kultur bearbeiten">
-                <span>
-                  <Button
-                    aria-label="Kultur bearbeiten"
-                    variant="outlined"
-                    startIcon={<EditIcon />}
-                    onClick={() => selectedCulture && handleEdit(selectedCulture)}
-                    disabled={!selectedCulture}
-                  >
-                    {t('buttons.edit')}
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title={t('library.publishTooltip')}>
-                <span>
-                  <Button
-                    variant="outlined"
-                    startIcon={<PublicIcon />}
-                    onClick={() => void handlePublishCurrentCulture()}
-                    disabled={!selectedCulture || publishingCultureId === selectedCulture?.id}
-                  >
-                    {publishingCultureId === selectedCulture?.id
-                      ? (isUpdatingOwnPublicCulture ? t('library.updating') : t('library.publishing'))
-                      : (isUpdatingOwnPublicCulture ? t('library.updateButton') : t('library.publishButton'))}
-                  </Button>
-                </span>
-              </Tooltip>
-                <Tooltip
-                  title={
-                    canCreatePlantingPlan
-                      ? "Anbauplan erstellen"
-                      : t('buttons.createPlantingPlanMissingBedsTooltip')
-                  }
-                >
-                  <span>
-                    <Button
-                      aria-label="Anbauplan erstellen"
-                      variant="contained"
-                      color="success"
-                      startIcon={<AgricultureIcon />}
-                      onClick={handleCreatePlantingPlan}
-                      disabled={!canCreatePlantingPlan}
-                    >
-                      {t('buttons.createPlantingPlan')}
-                    </Button>
-                  </span>
-                </Tooltip>
-              </>
-            }
-          />
-
+        <Box sx={{ mb: 2 }}>
           {firstMissingPlanRequirement === 'beds' ? (
             <EmptyStateCard
               title={t('buttons.createPlantingPlanMissingBedsTitle')}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -407,6 +407,7 @@ export const buildMobileCreateForm = (
     culture:
       typeof prefill?.cultureId === "number" ? String(prefill.cultureId) : "",
     bed: typeof prefill?.bedId === "number" ? String(prefill.bedId) : "",
+    cultivation_type: "pre_cultivation",
     area_m2:
       prefilledArea !== null
         ? formatLocalizedNumber(prefilledArea, locale, {


### PR DESCRIPTION
### Motivation

- Provide quick inline actions for cultures (edit, create planting plan, view versions, publish, delete) and surface publishing state in the detail view. 
- Improve layout and responsiveness of the culture detail panel for larger viewports and better visual hierarchy. 
- Set a sensible default for mobile planting plan creation to reduce friction when prefilling forms.

### Description

- Extended `CultureDetail` with new props (`onEditCulture`, `onCreatePlan`, `onOpenHistory`, `onPublishCulture`, `onDeleteCulture`, `canCreatePlan`, `isPublishingCulture`, `publishActionLabel`) and implemented header action buttons (edit, create plan) plus an overflow `Menu` with `History`, `Publish`, and `Delete` actions, including tooltips and disabled states. 
- Reworked header and detail layout in `frontend/src/cultures/CultureDetail.tsx` to include a left color strip, updated card widths (`md`/`xl` breakpoints), added padding/borders around sections, adjusted many `gridTemplateColumns` to `repeat(auto-fit, minmax(...))` for improved responsiveness, and refined notes markdown styling. 
- Updated `frontend/src/pages/Cultures.tsx` to pass the new handlers and flags into `CultureDetail`, removed the previous bottom action toolbar, and changed `PageContainer` to `variant="xwide"` to accommodate the wider detail layout. 
- Set default `cultivation_type` to `"pre_cultivation"` in the mobile form builder in `frontend/src/pages/PlantingPlans.tsx` and added/removed related icon/component imports as needed.

### Testing

- Ran TypeScript type-check and app build with `yarn build`, which completed successfully. 
- Executed the test suite with `yarn test`, and existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcd0a44a4832282df0b1e72eda08c)