### PR TITLE
Make cultures topbar and detail views responsive with compact controls on small screens

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -17,3 +17,25 @@ npm run test:e2e
   - `E2E_TEST_TOKEN` is set for the backend process started by Playwright
 
 See `frontend/playwright.config.ts` for exact runtime settings.
+
+
+## Responsive screenshot baseline
+
+Run responsive visual baselines:
+
+```bash
+cd frontend
+npx playwright test e2e/responsive-layouts.spec.ts
+```
+
+Update screenshots intentionally:
+
+```bash
+cd frontend
+npx playwright test e2e/responsive-layouts.spec.ts --update-snapshots
+```
+
+Notes:
+- Viewports covered: `375x800`, `768x900`, `1024x900`, `1440x900`.
+- Route coverage: dashboard, standorte, anbauflaechen, kulturen, anbauplaene, anbaukalender, saatgutbedarf, lieferanten.
+- Helpers are in `e2e/utils.ts` for deterministic login, viewport presets, and stable-page waiting.

--- a/frontend/e2e/responsive-layouts.spec.ts
+++ b/frontend/e2e/responsive-layouts.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { loginWithDeterministicProject, MAIN_ROUTES, setViewportPreset, VIEWPORTS, waitForPageStable } from './utils';
+
+test.describe('responsive layout baselines', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    await loginWithDeterministicProject(page, request, `responsive-${testInfo.workerIndex}`);
+  });
+
+  for (const viewport of VIEWPORTS) {
+    test(`captures main routes at ${viewport.key}`, async ({ page }) => {
+      await setViewportPreset(page, viewport);
+      for (const route of MAIN_ROUTES) {
+        await page.goto(route.path);
+        await waitForPageStable(page, route.ready);
+        await expect(page).toHaveScreenshot(`${route.key}-${viewport.key}.png`, {
+          fullPage: false,
+          animations: 'disabled',
+        });
+      }
+    });
+  }
+});

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -1,0 +1,57 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+const e2eApiBase = process.env.PLAYWRIGHT_E2E_API_BASE ?? 'http://127.0.0.1:8000/api/__e2e__/invite-flow/';
+const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
+
+export const VIEWPORTS = [
+  { key: 'mobile', width: 375, height: 800 },
+  { key: 'tablet', width: 768, height: 900 },
+  { key: 'small-desktop', width: 1024, height: 900 },
+  { key: 'desktop', width: 1440, height: 900 },
+] as const;
+
+export const MAIN_ROUTES = [
+  { key: 'dashboard', path: '/app/dashboard', ready: /Übersicht|Dashboard/i },
+  { key: 'standorte', path: '/app/locations', ready: /Standorte/i },
+  { key: 'anbauflaechen', path: '/app/fields-beds', ready: /Anbauflächen|Parzellen|Beete/i },
+  { key: 'kulturen', path: '/app/cultures', ready: /Kulturen/i },
+  { key: 'anbauplaene', path: '/app/anbauplaene', ready: /Anbaupläne|Anbauplan/i },
+  { key: 'anbaukalender', path: '/app/gantt-chart', ready: /Anbaukalender|Kalender/i },
+  { key: 'saatgutbedarf', path: '/app/seed-demand', ready: /Saatgutbedarf/i },
+  { key: 'lieferanten', path: '/app/suppliers', ready: /Lieferanten/i },
+] as const;
+
+async function invokeE2EAction(request: APIRequestContext, action: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const response = await request.post(e2eApiBase, {
+    headers: { 'X-E2E-Token': e2eToken },
+    data: { action, ...payload },
+  });
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()) as Record<string, unknown>;
+}
+
+export async function loginWithDeterministicProject(page: Page, request: APIRequestContext, scenarioId: string): Promise<void> {
+  await invokeE2EAction(request, 'reset', { scenario_id: scenarioId });
+  const fixture = await invokeE2EAction(request, 'setup', { scenario_id: scenarioId, invitation_state: 'pending' }) as {
+    inviteUrl: string;
+    invitee: { email: string; password: string };
+  };
+
+  await page.goto(fixture.inviteUrl);
+  await page.getByLabel('E-Mail').fill(fixture.invitee.email);
+  await page.getByLabel('Passwort').fill(fixture.invitee.password);
+  await page.getByRole('button', { name: 'Anmelden' }).click();
+  await expect(page).toHaveURL(/\/app\//);
+}
+
+export async function setViewportPreset(page: Page, preset: (typeof VIEWPORTS)[number]): Promise<void> {
+  await page.setViewportSize({ width: preset.width, height: preset.height });
+}
+
+export async function waitForPageStable(page: Page, readyPattern?: RegExp): Promise<void> {
+  await page.waitForLoadState('networkidle');
+  if (readyPattern) {
+    await expect(page.getByText(readyPattern).first()).toBeVisible();
+  }
+  await expect(page.locator('main, [role="main"]').first()).toBeVisible();
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -783,13 +783,15 @@ function RootLayout(): React.ReactElement {
       >
         <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
-          {!isDesktopUp ? <AppLogo size={24} showText to="/app/dashboard" /> : null}
-          <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, fontSize: { xs: '1.1rem', md: '1.25rem' }, fontWeight: 600 }}>
-            {currentPageTitle}
-          </Typography>
-          {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
+          {!isDesktopUp ? <AppLogo size={24} showText={false} to="/app/dashboard" /> : null}
+          {!isPhone ? (
+            <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, maxWidth: { sm: 180, md: 260 }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: { xs: '1rem', md: '1.25rem' }, fontWeight: 600 }}>
+              {currentPageTitle}
+            </Typography>
+          ) : null}
+          {!isPhone && topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0, flexShrink: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 0 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (
@@ -902,7 +904,7 @@ function RootLayout(): React.ReactElement {
               size="small"
               variant="contained"
               onClick={() => navigate(topbarPrimaryAction.to)}
-              sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 1 : 1.5 }}
+              sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 34 : 'auto', px: isPhone ? 0.75 : 1.5 }}
             >
               {isPhone ? '+' : `+ ${topbarPrimaryAction.label}`}
             </Button>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -455,8 +455,8 @@ function RootLayout(): React.ReactElement {
     [isCulturesPage, topbarContextActions],
   );
   const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
-  const showIconOnlyCultureLibrary = isCulturesPage && isPhone;
-  const showCultureImportExportButton = isCulturesPage && !isMobile && isLargeDesktop;
+  const showIconOnlyCultureLibrary = isCulturesPage && (isPhone || isTabletOrNarrowDesktop);
+  const showCultureImportExportButton = isCulturesPage;
 
   const handleCreateProject = async (): Promise<void> => {
     if (!newProjectName.trim()) {
@@ -781,7 +781,7 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e5e7eb', bgcolor: '#f8faf8', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5 }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
           {!isDesktopUp ? <AppLogo size={24} showText to="/app/dashboard" /> : null}
           <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, fontSize: { xs: '1.1rem', md: '1.25rem' }, fontWeight: 600 }}>
@@ -789,7 +789,7 @@ function RootLayout(): React.ReactElement {
           </Typography>
           {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0, flexShrink: 0 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -261,6 +261,8 @@ function RootLayout(): React.ReactElement {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
   const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTabletOrNarrowDesktop = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
   const { openPalette } = useCommandContext();
@@ -452,6 +454,9 @@ function RootLayout(): React.ReactElement {
     () => (isCulturesPage ? [] : topbarContextActions),
     [isCulturesPage, topbarContextActions],
   );
+  const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
+  const showIconOnlyCultureLibrary = isCulturesPage && isPhone;
+  const showCultureImportExportButton = isCulturesPage && !isMobile && isLargeDesktop;
 
   const handleCreateProject = async (): Promise<void> => {
     if (!newProjectName.trim()) {
@@ -785,32 +790,40 @@ function RootLayout(): React.ReactElement {
           {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0 }}>
-          {isCulturesPage && !isMobile ? (
+          {isCulturesPage ? (
             <>
-              <Button
-                size="small"
-                variant="outlined"
-                onClick={() => cultureLibraryAction?.onClick()}
-                aria-label="Kulturbibliothek öffnen"
-                startIcon={<PublicIcon fontSize="small" />}
-                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
-                disabled={!cultureLibraryAction || cultureLibraryAction.disabled}
-              >
-                Kulturbibliothek
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                aria-label="Import/Export öffnen"
-                aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
-                aria-haspopup="true"
-                aria-expanded={Boolean(cultureActionsMenuAnchor)}
-                onClick={handleCultureActionsMenuOpen}
-                endIcon={<KeyboardArrowDownIcon fontSize="small" />}
-                sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}
-              >
-                Import/Export
-              </Button>
+              {cultureLibraryAction ? (
+                <Tooltip title="Kulturbibliothek öffnen">
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => cultureLibraryAction.onClick()}
+                      aria-label="Kulturbibliothek öffnen"
+                      startIcon={<PublicIcon fontSize="small" />}
+                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: showIconOnlyCultureLibrary ? 36 : 'auto', px: showIconOnlyCultureLibrary ? 0.75 : 1.25 }}
+                      disabled={cultureLibraryAction.disabled}
+                    >
+                      {!showIconOnlyCultureLibrary ? (showCompactCultureLibrary ? 'Bibliothek' : 'Kulturbibliothek') : null}
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : null}
+              {showCultureImportExportButton || isMobile ? (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  aria-label="Import/Export öffnen"
+                  aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={Boolean(cultureActionsMenuAnchor)}
+                  onClick={handleCultureActionsMenuOpen}
+                  endIcon={!isPhone ? <KeyboardArrowDownIcon fontSize="small" /> : undefined}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.25 }}
+                >
+                  {isPhone ? '⋯' : 'Import/Export'}
+                </Button>
+              ) : null}
               <Menu
                 id="culture-actions-menu"
                 anchorEl={cultureActionsMenuAnchor}
@@ -884,13 +897,19 @@ function RootLayout(): React.ReactElement {
               );
             });
           })() : null}
-          {topbarPrimaryAction && !isMobile ? (
-            <Button size="small" variant="contained" onClick={() => navigate(topbarPrimaryAction.to)} sx={{ textTransform: 'none', whiteSpace: 'nowrap' }}>
-              + {topbarPrimaryAction.label}
+          {topbarPrimaryAction && (!isMobile || isCulturesPage) ? (
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => navigate(topbarPrimaryAction.to)}
+              sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 1 : 1.5 }}
+            >
+              {isPhone ? '+' : `+ ${topbarPrimaryAction.label}`}
             </Button>
           ) : null}
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 2, md: 3 } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 1, md: 3 } }}>
+          {!isPhone ? (
           <Button
             aria-label={t('projectSwitcher.ariaLabel')}
             aria-controls={projectMenuAnchor ? 'project-switcher-menu' : undefined}
@@ -901,7 +920,7 @@ function RootLayout(): React.ReactElement {
             sx={{
               color: 'text.primary',
               textTransform: 'none',
-              maxWidth: { xs: 180, sm: 260, md: 320 },
+              maxWidth: { sm: 190, md: 240, lg: 320 },
               minWidth: 0,
             }}
             startIcon={<FolderOpenOutlinedIcon fontSize="small" />}
@@ -909,6 +928,7 @@ function RootLayout(): React.ReactElement {
           >
             <span className="project-switcher-label">{activeProjectLabel}</span>
           </Button>
+          ) : null}
           <ProjectMenu
             anchorEl={projectMenuAnchor}
             open={Boolean(projectMenuAnchor)}

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -59,6 +59,7 @@ vi.mock('../cultures/CultureDetail', () => ({
     onPublishCulture,
     onEditCulture,
     canCreatePlan,
+    publishActionLabel,
   }: {
     cultures: Array<{ id?: number; name: string }>;
     onCultureSelect: (culture: { id?: number; name: string } | null) => void;
@@ -67,10 +68,11 @@ vi.mock('../cultures/CultureDetail', () => ({
     onPublishCulture?: () => void;
     onEditCulture?: (culture: { id?: number; name: string }) => void;
     canCreatePlan?: boolean;
+    publishActionLabel?: string;
   }): ReactElement => (
     <div data-testid="culture-detail-mock">
       <button type="button" onClick={() => onCreateCulture?.()}>Kultur hinzufügen</button>
-      <button type="button" onClick={() => onPublishCulture?.()}>Veröffentlichen</button>
+      <button type="button" onClick={() => onPublishCulture?.()}>{publishActionLabel ?? 'Veröffentlichen'}</button>
       <button type="button" onClick={() => onCreatePlan?.()} disabled={!canCreatePlan}>Anbauplan erstellen</button>
       <button type="button" onClick={() => onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
       <button type="button" onClick={() => onCultureSelect(cultures[0] ?? null)}>select-culture</button>
@@ -245,7 +247,7 @@ describe('Cultures action area', () => {
     expect(screen.queryByRole('link', { name: 'Beet anlegen' })).not.toBeInTheDocument();
 
     fireEvent.mouseOver(createPlanButton.parentElement as HTMLElement);
-    expect(await screen.findByText('Du brauchst zuerst mindestens ein Beet. Beete legst du auf der Seite Anbauflächen an.')).toBeInTheDocument();
+    expect(await screen.findByText('Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt.')).toBeInTheDocument();
   });
 
   it('enables create planting plan button when all prerequisites are present', async () => {

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -58,6 +58,7 @@ vi.mock('../cultures/CultureDetail', () => ({
     onCreatePlan,
     onPublishCulture,
     onEditCulture,
+    canCreatePlan,
   }: {
     cultures: Array<{ id?: number; name: string }>;
     onCultureSelect: (culture: { id?: number; name: string } | null) => void;
@@ -65,11 +66,12 @@ vi.mock('../cultures/CultureDetail', () => ({
     onCreatePlan?: () => void;
     onPublishCulture?: () => void;
     onEditCulture?: (culture: { id?: number; name: string }) => void;
+    canCreatePlan?: boolean;
   }): ReactElement => (
     <div data-testid="culture-detail-mock">
       <button type="button" onClick={() => onCreateCulture?.()}>Kultur hinzufügen</button>
       <button type="button" onClick={() => onPublishCulture?.()}>Veröffentlichen</button>
-      <button type="button" onClick={() => onCreatePlan?.()}>Anbauplan erstellen</button>
+      <button type="button" onClick={() => onCreatePlan?.()} disabled={!canCreatePlan}>Anbauplan erstellen</button>
       <button type="button" onClick={() => onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
       <button type="button" onClick={() => onCultureSelect(cultures[0] ?? null)}>select-culture</button>
     </div>
@@ -226,7 +228,7 @@ describe('Cultures action area', () => {
     renderCultures('/cultures?cultureId=1');
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Öffentliche Version aktualisieren' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Öffentliche Kulturbibliothek aktualisieren' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: 'Veröffentlichen' })).not.toBeInTheDocument();
   });

--- a/frontend/src/__tests__/CulturesSavePayload.test.tsx
+++ b/frontend/src/__tests__/CulturesSavePayload.test.tsx
@@ -32,11 +32,13 @@ vi.mock('../cultures/CultureDetail', () => ({
     selectedCultureId,
     onCultureSelect,
     onEditCulture,
+    onCreateCulture,
   }: {
     cultures: Culture[];
     selectedCultureId?: number;
     onCultureSelect: (culture: Culture | null) => void;
     onEditCulture?: (culture: Culture) => void;
+    onCreateCulture?: () => void;
   }): ReactElement => (
     <div>
       <button
@@ -54,6 +56,7 @@ vi.mock('../cultures/CultureDetail', () => ({
       </button>
       <div data-testid="culture-list">{cultures.map((culture) => culture.name).join(', ')}</div>
       <div data-testid="selected-culture-id">{selectedCultureId ?? 'none'}</div>
+      <button type="button" onClick={() => onCreateCulture?.()}>Kultur hinzufügen</button>
       <button type="button" onClick={() => cultures[0] && onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
     </div>
   ),

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -19,6 +19,7 @@ import TuneIcon from '@mui/icons-material/Tune';
 import EditIcon from '@mui/icons-material/Edit';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import PublicIcon from '@mui/icons-material/Public';
 import HistoryIcon from '@mui/icons-material/History';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -766,11 +767,6 @@ export function CultureDetail({
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
-                  {isMobileLayout ? (
-                    <Button size="small" variant="text" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 0.5, px: 0.5, minHeight: 28, color: 'text.secondary', alignSelf: 'flex-start' }}>
-                      {selectedCulture.name} ▼
-                    </Button>
-                  ) : null}
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: { xs: 2, sm: 3 } }}>
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 1, sm: 2 }, mb: 0.75 }}>
@@ -792,9 +788,39 @@ export function CultureDetail({
                       />
                     ) : null}
                     <Box sx={{ display: 'flex', flexDirection: 'column', py: 0.25 }}>
-                      <Typography component="h2" sx={{ fontSize: { xs: '1.25rem', sm: '2rem' }, lineHeight: 1.2, fontWeight: 600 }}>
-                        {selectedCulture.name}
-                      </Typography>
+                      {isMobileLayout ? (
+                        <Box
+                          component="button"
+                          type="button"
+                          onClick={() => setMobileSelectorOpen(true)}
+                          sx={{
+                            appearance: 'none',
+                            border: 'none',
+                            background: 'transparent',
+                            p: 0,
+                            m: 0,
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 0.5,
+                            cursor: 'pointer',
+                            color: 'inherit',
+                            textAlign: 'left',
+                            borderRadius: 0.75,
+                            '&:hover': { bgcolor: 'rgba(15, 23, 42, 0.04)' },
+                            '&:focus-visible': { outline: '2px solid rgba(37, 111, 42, 0.28)', outlineOffset: 2 },
+                          }}
+                          aria-label="Kultur auswählen"
+                        >
+                          <Typography component="span" sx={{ fontSize: '1.25rem', lineHeight: 1.2, fontWeight: 600 }}>
+                            {selectedCulture.name}
+                          </Typography>
+                          <ExpandMoreIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+                        </Box>
+                      ) : (
+                        <Typography component="h2" sx={{ fontSize: { xs: '1.25rem', sm: '2rem' }, lineHeight: 1.2, fontWeight: 600 }}>
+                          {selectedCulture.name}
+                        </Typography>
+                      )}
                       {selectedCulture.variety && (
                         <Typography variant="body2" color="text.secondary">
                           {selectedCulture.variety}
@@ -1295,13 +1321,19 @@ export function CultureDetail({
               <Card>
                 <CardContent>
                   {isMobileLayout ? (
-                    <Button size="small" variant="text" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 0.5, px: 0.5, minHeight: 28, color: 'text.secondary', alignSelf: 'flex-start' }}>
+                    <Typography
+                      component="button"
+                      type="button"
+                      onClick={() => setMobileSelectorOpen(true)}
+                      sx={{ border: 'none', background: 'transparent', p: 0, m: 0, color: 'text.secondary', textAlign: 'left', cursor: 'pointer' }}
+                    >
                       Kultur auswählen ▼
-                    </Button>
-                  ) : null}
-                  <Typography variant="body2" color="text.secondary">
-                    {t('selectPrompt')}
-                  </Typography>
+                    </Typography>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      {t('selectPrompt')}
+                    </Typography>
+                  )}
                 </CardContent>
               </Card>
             )}

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -51,6 +51,9 @@ import {
   TextField,
   Menu,
   Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
 } from '@mui/material';
 import type { Culture } from '../api/api';
 import { SearchableSelect } from '../components/inputs/SearchableSelect';
@@ -179,6 +182,7 @@ export function CultureDetail({
   const [selectedSowingMonths, setSelectedSowingMonths] = useState<number[]>([]);
   const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
   const [headerMenuAnchorEl, setHeaderMenuAnchorEl] = useState<HTMLElement | null>(null);
+  const [mobileSelectorOpen, setMobileSelectorOpen] = useState(false);
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
   const isHeaderMenuOpen = Boolean(headerMenuAnchorEl);
   const headerActionButtonSx = {
@@ -690,7 +694,7 @@ export function CultureDetail({
             alignItems: 'start',
           }}
         >
-          {(!isMobileLayout || !selectedCulture) ? (<Card
+          {!isMobileLayout ? (<Card
             sx={{
               width: '100%',
               flexShrink: 0,
@@ -758,10 +762,15 @@ export function CultureDetail({
               })}
             </List>
           </Card>) : null}
-          {(!isMobileLayout || selectedCulture) ? (<Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
+                  {isMobileLayout ? (
+                    <Button size="small" variant="outlined" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 1 }}>
+                      {selectedCulture.name} ▼
+                    </Button>
+                  ) : null}
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
@@ -1285,14 +1294,52 @@ export function CultureDetail({
             ) : (
               <Card>
                 <CardContent>
+                  {isMobileLayout ? (
+                    <Button size="small" variant="outlined" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 1 }}>
+                      Kultur auswählen ▼
+                    </Button>
+                  ) : null}
                   <Typography variant="body2" color="text.secondary">
                     {t('selectPrompt')}
                   </Typography>
                 </CardContent>
               </Card>
             )}
-          </Box>) : null}
+          </Box>
         </Box>
+      ) : null}
+
+
+      {isMobileLayout ? (
+        <Dialog fullScreen open={mobileSelectorOpen} onClose={() => setMobileSelectorOpen(false)}>
+          <DialogTitle>Kultur auswählen</DialogTitle>
+          <DialogContent sx={{ px: 1.5, pb: 2 }}>
+            {selectorControl}
+            <List dense sx={{ py: 0.5, px: 0.25, overflowY: 'auto' }}>
+              {filteredCultures.map((culture) => {
+                const secondary = [culture.variety].filter(Boolean).join(' • ');
+                return (
+                  <ListItemButton
+                    key={`mobile-${culture.id}`}
+                    selected={selectedCulture?.id === culture.id}
+                    onClick={() => {
+                      onCultureSelect(culture);
+                      setMobileSelectorOpen(false);
+                    }}
+                    sx={{ borderRadius: 1.25, mb: 0.375 }}
+                  >
+                    <ListItemText
+                      primary={culture.name}
+                      secondary={secondary || culture.crop_family || undefined}
+                      primaryTypographyProps={{ fontSize: '0.95rem', fontWeight: 600 }}
+                      secondaryTypographyProps={{ fontSize: '0.8rem', color: 'text.secondary' }}
+                    />
+                  </ListItemButton>
+                );
+              })}
+            </List>
+          </DialogContent>
+        </Dialog>
       ) : null}
 
       {/* Empty State */}

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import { useMediaQuery, useTheme } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
@@ -164,6 +165,8 @@ export function CultureDetail({
   publishActionLabel,
 }: CultureDetailProps): React.ReactElement {
   const { t } = useTranslation('cultures');
+  const theme = useTheme();
+  const isTabletLayout = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFamilyFilter, setSelectedFamilyFilter] = useState('');
   const [selectedCultivationFilter, setSelectedCultivationFilter] = useState('');
@@ -672,7 +675,20 @@ export function CultureDetail({
 
       {/* Detail View */}
       {!isLoading && cultures.length > 0 ? (
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '300px minmax(0, 1fr)', xl: '330px minmax(0, 1fr)' }, gap: 1.5, alignItems: 'start' }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: '220px minmax(0, 1fr)',
+              md: '230px minmax(0, 1fr)',
+              lg: '300px minmax(0, 1fr)',
+              xl: '330px minmax(0, 1fr)',
+            },
+            gap: { xs: 1.25, lg: 1.5 },
+            alignItems: 'start',
+          }}
+        >
           <Card
             sx={{
               width: '100%',
@@ -685,7 +701,15 @@ export function CultureDetail({
             }}
           >
             {selectorControl}
-            <List dense sx={{ py: 0.75, px: 0.75, overflowY: 'auto', maxHeight: { md: 'calc(100vh - 290px)' } }}>
+            <List
+              dense
+              sx={{
+                py: { xs: 0.5, lg: 0.75 },
+                px: { xs: 0.5, lg: 0.75 },
+                overflowY: 'auto',
+                maxHeight: { sm: 'calc(100vh - 290px)' },
+              }}
+            >
               {filteredCultures.map((culture) => {
                 const cultivationValues = culture.cultivation_types && culture.cultivation_types.length > 0
                   ? culture.cultivation_types
@@ -697,8 +721,10 @@ export function CultureDetail({
                     : cultivationValues.includes('pre_cultivation')
                       ? t('filters.preCultivation')
                       : '';
-                const secondaryParts = [culture.variety, cultivationLabel, culture.seed_supplier].filter(Boolean);
-                const secondary = secondaryParts.join(' • ');
+                const secondaryParts = isTabletLayout
+                  ? [culture.variety]
+                  : [culture.variety, cultivationLabel, culture.seed_supplier].filter(Boolean);
+                const secondary = secondaryParts.filter(Boolean).join(' • ');
 
                 return (
                   <ListItemButton
@@ -707,9 +733,9 @@ export function CultureDetail({
                     onClick={() => onCultureSelect(culture)}
                     sx={{
                       borderRadius: 1.5,
-                      px: 1,
-                      py: 0.75,
-                      mb: 0.5,
+                      px: { xs: 0.875, lg: 1 },
+                      py: { xs: 0.5, lg: 0.75 },
+                      mb: { xs: 0.375, lg: 0.5 },
                       alignItems: 'flex-start',
                       border: '1px solid transparent',
                       '&:hover': { bgcolor: '#f4f8f4', borderColor: '#d6e6d8' },
@@ -722,19 +748,19 @@ export function CultureDetail({
                   >
                     <ListItemText
                       primary={culture.name}
-                      primaryTypographyProps={{ fontSize: '0.95rem', fontWeight: 600, lineHeight: 1.25 }}
+                      primaryTypographyProps={{ fontSize: { xs: '0.9rem', lg: '0.95rem' }, fontWeight: 600, lineHeight: 1.25 }}
                       secondary={secondary || culture.crop_family || undefined}
-                      secondaryTypographyProps={{ fontSize: '0.8rem', color: 'text.secondary', lineHeight: 1.25 }}
+                      secondaryTypographyProps={{ fontSize: { xs: '0.76rem', lg: '0.8rem' }, color: 'text.secondary', lineHeight: 1.25 }}
                     />
                   </ListItemButton>
                 );
               })}
             </List>
           </Card>
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { md: 'flex-start' } }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
             {selectedCulture ? (
-              <Card sx={{ width: '100%', maxWidth: { md: 1220, xl: 1400 } }}>
-                <CardContent>
+              <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
+                <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: 3 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -167,6 +167,7 @@ export function CultureDetail({
   const { t } = useTranslation('cultures');
   const theme = useTheme();
   const isTabletLayout = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
+  const isMobileLayout = useMediaQuery(theme.breakpoints.down('sm'));
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFamilyFilter, setSelectedFamilyFilter] = useState('');
   const [selectedCultivationFilter, setSelectedCultivationFilter] = useState('');
@@ -689,7 +690,7 @@ export function CultureDetail({
             alignItems: 'start',
           }}
         >
-          <Card
+          {(!isMobileLayout || !selectedCulture) ? (<Card
             sx={{
               width: '100%',
               flexShrink: 0,
@@ -756,8 +757,8 @@ export function CultureDetail({
                 );
               })}
             </List>
-          </Card>
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
+          </Card>) : null}
+          {(!isMobileLayout || selectedCulture) ? (<Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
@@ -1290,7 +1291,7 @@ export function CultureDetail({
                 </CardContent>
               </Card>
             )}
-          </Box>
+          </Box>) : null}
         </Box>
       ) : null}
 

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -186,16 +186,16 @@ export function CultureDetail({
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
   const isHeaderMenuOpen = Boolean(headerMenuAnchorEl);
   const headerActionButtonSx = {
-    width: 34,
-    height: 34,
-    borderRadius: 0,
+    width: isMobileLayout ? 30 : 34,
+    height: isMobileLayout ? 30 : 34,
+    borderRadius: isMobileLayout ? 0.75 : 0,
     border: 'none',
     backgroundColor: 'transparent',
     transition: 'background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease',
     '&:hover': {
       backgroundColor: 'rgba(15, 23, 42, 0.08)',
-      boxShadow: '0 2px 6px rgba(15, 23, 42, 0.10)',
-      transform: 'translateY(-1px)',
+      boxShadow: isMobileLayout ? 'none' : '0 2px 6px rgba(15, 23, 42, 0.10)',
+      transform: isMobileLayout ? 'none' : 'translateY(-1px)',
     },
     '&:focus-visible': {
       outline: '2px solid rgba(37, 111, 42, 0.28)',
@@ -767,13 +767,13 @@ export function CultureDetail({
               <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
                   {isMobileLayout ? (
-                    <Button size="small" variant="outlined" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 1 }}>
+                    <Button size="small" variant="text" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 0.5, px: 0.5, minHeight: 28, color: 'text.secondary', alignSelf: 'flex-start' }}>
                       {selectedCulture.name} ▼
                     </Button>
                   ) : null}
             {/* Header with crop name and badge */}
-                  <Box sx={{ mb: 3 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+                  <Box sx={{ mb: { xs: 2, sm: 3 } }}>
+              <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 1, sm: 2 }, mb: 0.75 }}>
                 <Box sx={{ flexGrow: 1 }}>
                   <Box sx={{ display: 'flex', alignItems: 'stretch', gap: 1.75 }}>
                     {selectedCulture.display_color ? (
@@ -792,7 +792,7 @@ export function CultureDetail({
                       />
                     ) : null}
                     <Box sx={{ display: 'flex', flexDirection: 'column', py: 0.25 }}>
-                      <Typography variant="h4" component="h2">
+                      <Typography component="h2" sx={{ fontSize: { xs: '1.25rem', sm: '2rem' }, lineHeight: 1.2, fontWeight: 600 }}>
                         {selectedCulture.name}
                       </Typography>
                       {selectedCulture.variety && (
@@ -818,9 +818,9 @@ export function CultureDetail({
                     display: 'inline-flex',
                     alignItems: 'center',
                     border: '1px solid rgba(15, 23, 42, 0.10)',
-                    borderRadius: 1.5,
-                    backgroundColor: 'rgba(15, 23, 42, 0.03)',
-                    boxShadow: '0 1px 3px rgba(15, 23, 42, 0.08)',
+                    borderRadius: isMobileLayout ? 1 : 1.5,
+                    backgroundColor: isMobileLayout ? 'rgba(15, 23, 42, 0.02)' : 'rgba(15, 23, 42, 0.03)',
+                    boxShadow: isMobileLayout ? 'none' : '0 1px 3px rgba(15, 23, 42, 0.08)',
                     overflow: 'hidden',
                   }}
                 >
@@ -837,7 +837,7 @@ export function CultureDetail({
                           '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.12)' },
                         }}
                       >
-                        <EditIcon sx={{ fontSize: 18 }} />
+                        <EditIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
                       </IconButton>
                     </span>
                   </Tooltip>
@@ -854,7 +854,7 @@ export function CultureDetail({
                           '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.10)' },
                         }}
                       >
-                        <AgricultureIcon sx={{ fontSize: 18 }} />
+                        <AgricultureIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
                       </IconButton>
                     </span>
                   </Tooltip>
@@ -867,7 +867,7 @@ export function CultureDetail({
                       color: 'text.secondary',
                     }}
                   >
-                    <MoreVertIcon sx={{ fontSize: 18 }} />
+                    <MoreVertIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
                   </IconButton>
                 </Box>
               </Box>
@@ -1295,7 +1295,7 @@ export function CultureDetail({
               <Card>
                 <CardContent>
                   {isMobileLayout ? (
-                    <Button size="small" variant="outlined" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 1 }}>
+                    <Button size="small" variant="text" onClick={() => setMobileSelectorOpen(true)} sx={{ textTransform: 'none', mb: 0.5, px: 0.5, minHeight: 28, color: 'text.secondary', alignSelf: 'flex-start' }}>
                       Kultur auswählen ▼
                     </Button>
                   ) : null}

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -329,7 +329,7 @@
     "aiClose": "Schließen",
     "createPlantingPlanMissingBedsTitle": "Um einen Anbauplan zu erstellen, brauchst du mindestens ein Beet.",
     "createPlantingPlanMissingBedsHint": "Für einen Anbauplan brauchst du zuerst mindestens ein Beet.",
-    "createPlantingPlanMissingBedsTooltip": "Du brauchst zuerst mindestens ein Beet. Beete legst du auf der Seite Anbauflächen an."
+    "createPlantingPlanMissingBedsTooltip": "Du brauchst zuerst mindestens ein Beet. Beete werden innerhalb einer Parzelle auf der Seite Anbauflächen hinzugefügt."
   },
   "ai": {
     "menuLabel": "KI-Aktionen",
@@ -413,7 +413,7 @@
     "importError": "Die öffentliche Kultur konnte nicht importiert werden.",
     "publishButton": "Veröffentlichen",
     "publishTooltip": "Veröffentlicht die ausgewählte Kultur in der Kulturbibliothek.",
-    "updateButton": "Öffentliche Version aktualisieren",
+    "updateButton": "Öffentliche Kulturbibliothek aktualisieren",
     "publishing": "Veröffentliche…",
     "updating": "Aktualisiere…",
     "publishSuccess": "„{{name}}“ wurde in die Kulturbibliothek veröffentlicht.",

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -147,8 +147,8 @@
           "title": "Bedienung",
           "points": [
             "Wähle eine Kultur aus, um Details anzuzeigen, zu bearbeiten oder Anbaupläne dafür zu erstellen.",
-            "Öffne über das Drei-Punkte-Menü Versionen, die Veröffentlichung bzw. Aktualisierung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.",
-            "Nutze die öffentliche Kulturbibliothek, um Kulturen zu veröffentlichen, zu aktualisieren oder zu übernehmen."
+            "Über ⋯ erreichst du weitere Aktionen wie Versionen, Veröffentlichung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.",
+            "Nutze die öffentliche Kulturbibliothek, um Kulturen zu entdecken, zu verwenden oder zu veröffentlichen."
           ]
         },
         {

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -989,8 +989,8 @@ function Cultures(): React.ReactElement {
           publishActionLabel={publishingCultureId === selectedCulture?.id
             ? (isUpdatingOwnPublicCulture ? t('library.updating') : t('library.publishing'))
             : (isUpdatingOwnPublicCulture
-              ? 'Öffentliche Kulturbibliothek aktualisieren'
-              : 'In Kulturbibliothek veröffentlichen')}
+              ? t('library.updateButton')
+              : t('library.publishButton'))}
         />
       </Box>
 


### PR DESCRIPTION
### Motivation
- Improve usability of the cultures page and topbar on small viewports by providing compact/icon-only controls and adjusting layout for phones and narrow tablets. 
- Reduce cramped elements and better fit project/topbar controls on small screens while preserving full desktop experience. 

### Description
- Added new media queries in `RootLayout` (`isPhone`, `isTabletOrNarrowDesktop`) and computed flags (`showCompactCultureLibrary`, `showIconOnlyCultureLibrary`, `showCultureImportExportButton`) to drive responsive topbar behavior. 
- Reworked cultures topbar buttons to support compact labels and icon-only modes, wrapped the library button in a `Tooltip`, and made the import/export control render as an overflow or short icon on phones. 
- Allowed the primary topbar action to remain available on the cultures page in mobile, and hid the project switcher button on very small screens while adjusting spacing and max widths. 
- Updated `CultureDetail` to use `useTheme`/`useMediaQuery`, changed grid column templates, list sizing, typography, paddings and max widths to create a more compact and consistent responsive layout, and simplified the list item secondary text on tablet layout. 
- Updated German help copy in `i18n/locales/de/help.json` to reflect the new compact action affordances. 

### Testing
- Ran a TypeScript build and typecheck with `yarn build`/`tsc` to validate types and compilation, which succeeded. 
- Executed the existing frontend unit tests with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fedbb1f758832295b5c3d3b4a0fdf8)