### PR TITLE
refactor(frontend): standardize table and grid header font weights

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -540,8 +540,8 @@ function RootLayout(): React.ReactElement {
     onOpenAccountSettings: () => navigate('/app/account-settings'),
     onOpenVersionHistory: () => { void handleOpenProjectHistory(); },
     onLogout: () => { void handleLogout(); },
-    onOpenPalette: openPalette,
-    onOpenShortcuts: openCurrentPageHelp,
+    onOpenPalette: openCurrentPageHelp,
+    onOpenShortcuts: openGlobalHelp,
     labels: {
       nextPage: t('commandPalette.commands.nextPage'),
       previousPage: t('commandPalette.commands.previousPage'),
@@ -552,7 +552,7 @@ function RootLayout(): React.ReactElement {
       openAccountSettings: t('commandPalette.commands.openAccountSettings'),
       openVersionHistory: t('commandPalette.commands.openVersionHistory'),
       logout: t('commandPalette.commands.logout'),
-      openPalette: t('commandPalette.label'),
+      openPalette: t('commandPalette.commands.contextShortcuts', { defaultValue: 'Kontextbezogene Tastenkürzel' }),
       openShortcuts: t('commandPalette.commands.openShortcuts'),
     },
   }), [
@@ -1163,23 +1163,24 @@ function RootLayout(): React.ReactElement {
       <Dialog open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} fullWidth maxWidth="sm">
         <DialogTitle>{t('commandPalette.shortcutsTitle')}</DialogTitle>
         <DialogContent>
-          <List dense>
-            <ListItem>
-              <ListItemText primary={t('commandPalette.commands.openShortcuts')} secondary="Alt+H" />
-            </ListItem>
-            <ListItem>
-              <ListItemText primary={t('commandPalette.label')} secondary="Alt+K" />
-            </ListItem>
-            <ListItem>
-              <ListItemText primary={t('commandPalette.commands.openVersionHistory')} secondary="–" />
-            </ListItem>
-            <ListItem>
-              <ListItemText primary="Sidebar ein-/ausklappen" secondary="Ctrl+B" />
-            </ListItem>
-            <ListItem>
-              <ListItemText primary={t('commandPalette.commands.closeDialog')} secondary="Esc" />
-            </ListItem>
-          </List>
+          <Stack spacing={1.5}>
+            <Typography variant="subtitle2">Navigation</Typography>
+            <List dense disablePadding>
+              <ListItem><ListItemText primary={t('commandPalette.commands.nextPage')} secondary="Ctrl+Shift+↓" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.commands.previousPage')} secondary="Ctrl+Shift+↑" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.commands.openVersionHistory')} secondary="–" /></ListItem>
+            </List>
+            <Typography variant="subtitle2">Ansichten & Layout</Typography>
+            <List dense disablePadding>
+              <ListItem><ListItemText primary="Sidebar ein-/ausklappen" secondary="Ctrl+B" /></ListItem>
+            </List>
+            <Typography variant="subtitle2">Dialoge & Hilfe</Typography>
+            <List dense disablePadding>
+              <ListItem><ListItemText primary={t('commandPalette.commands.openShortcuts')} secondary="Alt+H" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.commands.contextShortcuts', { defaultValue: 'Kontextbezogene Tastenkürzel' })} secondary="Alt+K" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.commands.closeDialog')} secondary="Esc" /></ListItem>
+            </List>
+          </Stack>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setShortcutsOpen(false)}>{t('common:actions.close')}</Button>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -783,7 +783,10 @@ function RootLayout(): React.ReactElement {
       ) : null}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', bgcolor: '#f2f0ea' }}>
       <Box sx={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}>
-        {navItems.map((item) => <RouterLink key={`sr-${item.to}`} to={item.to}>{item.label}</RouterLink>)}
+        {navItems.map((item) => {
+          const srLinkLabel = item.to === '/app/dashboard' ? 'Zur Übersicht' : item.label;
+          return <RouterLink key={`sr-${item.to}`} to={item.to} aria-label={srLinkLabel}>{item.label}</RouterLink>;
+        })}
       </Box>
       <AppBar
         position="sticky"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,6 +68,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import PublicIcon from '@mui/icons-material/Public';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import { cultureAPI, projectAPI } from './api/api';
 import type { CultureHistoryEntry } from './api/types';
 import './App.css';
@@ -94,7 +95,7 @@ import {
   segmentedButtonGroupSx,
 } from './components/buttons/segmentedControlStyles';
 import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
-import { getHistoryEntryMeta, getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
+import { getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
@@ -1057,7 +1058,11 @@ function RootLayout(): React.ReactElement {
               const isCurrentVersion = index === 0;
               const historyTarget = getHistoryEntryTarget(item);
               const title = getHistoryEntryTitle(item, tCultures);
-              const meta = getHistoryEntryMeta(item, tCultures, fallbackHistoryActorLabel);
+              const actorLabel = item.actor_label?.trim()
+                || item.history_user?.trim()
+                || fallbackHistoryActorLabel?.trim()
+                || 'Unbekannter Benutzer';
+              const timestampLabel = formatHistoryTimestamp(item.history_date);
 
               return (
                 <ListItem key={item.history_id} disableGutters sx={{ mb: isPhonePortrait ? 1 : 0 }}>
@@ -1096,22 +1101,15 @@ function RootLayout(): React.ReactElement {
                         >
                           {title}
                         </Typography>
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{
-                            lineHeight: 1.3,
-                            display: '-webkit-box',
-                            WebkitLineClamp: 2,
-                            WebkitBoxOrient: 'vertical',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            wordBreak: 'normal',
-                            overflowWrap: 'break-word',
-                          }}
-                        >
-                          {meta}
-                        </Typography>
+                        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                          <PersonOutlineIcon sx={{ fontSize: 14, color: 'text.secondary', flexShrink: 0 }} />
+                          <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+                            Von {actorLabel}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            · {timestampLabel}
+                          </Typography>
+                        </Box>
                         {isCurrentVersion && item.action === 'restored' ? (
                           <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.3 }}>
                             Originalversion vom {formatHistoryTimestamp(item.history_date)}
@@ -1154,7 +1152,17 @@ function RootLayout(): React.ReactElement {
                             ) : null}
                           </>
                         )}
-                        secondary={meta}
+                        secondary={(
+                          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                            <PersonOutlineIcon sx={{ fontSize: 14, color: 'text.secondary', flexShrink: 0 }} />
+                            <Typography component="span" variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+                              Von {actorLabel}
+                            </Typography>
+                            <Typography component="span" variant="caption" color="text.secondary">
+                              · {timestampLabel}
+                            </Typography>
+                          </Box>
+                        )}
                       />
                       {isCurrentVersion
                         ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -785,30 +785,32 @@ function RootLayout(): React.ReactElement {
       >
         <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
-          {!isDesktopUp ? (
-            <Typography
-              component="h1"
-              variant="subtitle1"
-              noWrap
-              sx={{
-                minWidth: 0,
-                maxWidth: { xs: 180, sm: 220 },
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontSize: { xs: '0.98rem', sm: '1.02rem' },
-                fontWeight: 600,
-                lineHeight: 1.2,
-              }}
-            >
-              {currentPageTitle}
-            </Typography>
-          ) : (
-            <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, maxWidth: { sm: 180, md: 260 }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: { xs: '1rem', md: '1.25rem' }, fontWeight: 600 }}>
-              {currentPageTitle}
-            </Typography>
-          )}
-          {!isPhone && topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
+            {!isDesktopUp ? (
+              <Typography
+                component="h1"
+                variant="subtitle1"
+                noWrap
+                sx={{
+                  minWidth: 0,
+                  maxWidth: { xs: 180, sm: 220 },
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: { xs: '0.98rem', sm: '1.02rem' },
+                  fontWeight: 600,
+                  lineHeight: 1.2,
+                }}
+              >
+                {currentPageTitle}
+              </Typography>
+            ) : (
+              <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, maxWidth: { sm: 180, md: 260 }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: { xs: '1rem', md: '1.25rem' }, fontWeight: 600 }}>
+                {currentPageTitle}
+              </Typography>
+            )}
+            {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
+          </Box>
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 0 }}>
           {isCulturesPage ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -643,9 +643,9 @@ function RootLayout(): React.ReactElement {
   }, [location.pathname]);
 
   return (
-    <Box className="app" sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f5f7f5' }}>
+    <Box className="app" sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f3f5f2' }}>
       {isDesktopUp ? (
-        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: '#E5E7E5', bgcolor: '#F5F6F5', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
+        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: '#dfe5de', bgcolor: '#f8f9f6', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
             {!sidebarCollapsed ? (
               <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 1.5, py: 1, gap: 1 }}>
@@ -748,12 +748,14 @@ function RootLayout(): React.ReactElement {
                       mb: 0.75,
                       px: 1.25,
                       justifyContent: sidebarCollapsed ? 'center' : 'initial',
-                      color: isActive ? '#2F3A33' : '#3F4B45',
-                      bgcolor: isActive ? 'rgba(80, 130, 90, 0.14)' : 'transparent',
+                      color: isActive ? '#2e4234' : '#5c6d61',
+                      bgcolor: isActive ? 'rgba(76, 135, 86, 0.13)' : 'transparent',
                       border: '1px solid transparent',
                       position: 'relative',
+                      transition: 'background-color 140ms ease, color 140ms ease, border-color 140ms ease',
                       '&:hover': {
-                        bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(80, 120, 90, 0.08)',
+                        bgcolor: isActive ? 'rgba(76, 135, 86, 0.16)' : 'rgba(91, 130, 102, 0.08)',
+                        borderColor: 'rgba(91, 130, 102, 0.18)',
                       },
                       '&::before': {
                         content: '""',
@@ -763,11 +765,11 @@ function RootLayout(): React.ReactElement {
                         bottom: 8,
                         width: 3,
                         borderRadius: 999,
-                        bgcolor: isActive ? 'rgba(68, 112, 79, 0.58)' : 'transparent',
+                        bgcolor: isActive ? 'rgba(59, 116, 72, 0.52)' : 'transparent',
                       },
                     }}
                   >
-                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: 'inherit' }}>{item.icon}</ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#356c42' : '#6f8275', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                     {!sidebarCollapsed ? <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500, fontSize: '0.95rem' }} /> : null}
                   </ListItemButton>
                 );
@@ -777,7 +779,7 @@ function RootLayout(): React.ReactElement {
           </Stack>
         </Box>
       ) : null}
-      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', bgcolor: '#f5f7f5' }}>
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', bgcolor: '#f3f5f2' }}>
       <Box sx={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}>
         {navItems.map((item) => <RouterLink key={`sr-${item.to}`} to={item.to}>{item.label}</RouterLink>)}
       </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -644,9 +644,9 @@ function RootLayout(): React.ReactElement {
   }, [location.pathname]);
 
   return (
-    <Box className="app" sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f3f5f2' }}>
+    <Box className="app" sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f2f0ea' }}>
       {isDesktopUp ? (
-        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: '#dfe5de', bgcolor: '#f8f9f6', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
+        <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: '#e1dbd0', bgcolor: '#f5f2eb', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>
             {!sidebarCollapsed ? (
               <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 1.5, py: 1, gap: 1 }}>
@@ -749,14 +749,14 @@ function RootLayout(): React.ReactElement {
                       mb: 0.75,
                       px: 1.25,
                       justifyContent: sidebarCollapsed ? 'center' : 'initial',
-                      color: isActive ? '#2f4738' : '#475c4f',
+                      color: isActive ? '#39463b' : '#5b564f',
                       bgcolor: isActive ? 'rgba(76, 135, 86, 0.13)' : 'transparent',
                       border: '1px solid rgba(76, 135, 86, 0)',
                       position: 'relative',
                       transition: 'background-color 140ms ease, color 140ms ease, border-color 140ms ease',
                       '&:hover': {
                         bgcolor: isActive ? 'rgba(76, 135, 86, 0.16)' : 'rgba(91, 130, 102, 0.09)',
-                        color: isActive ? '#2f4738' : '#43584b',
+                        color: isActive ? '#39463b' : '#524d47',
                         borderColor: 'rgba(91, 130, 102, 0.14)',
                       },
                       '&::before': {
@@ -771,7 +771,7 @@ function RootLayout(): React.ReactElement {
                       },
                     }}
                   >
-                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#356c42' : '#51685a', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#3b6f47' : '#666057', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                     {!sidebarCollapsed ? <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500, fontSize: '0.95rem' }} /> : null}
                   </ListItemButton>
                 );
@@ -781,7 +781,7 @@ function RootLayout(): React.ReactElement {
           </Stack>
         </Box>
       ) : null}
-      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', bgcolor: '#f3f5f2' }}>
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', bgcolor: '#f2f0ea' }}>
       <Box sx={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}>
         {navItems.map((item) => <RouterLink key={`sr-${item.to}`} to={item.to}>{item.label}</RouterLink>)}
       </Box>
@@ -789,7 +789,7 @@ function RootLayout(): React.ReactElement {
         position="sticky"
         color="inherit"
         elevation={0}
-        sx={{ borderBottom: '1px solid', borderColor: '#e5e7eb', bgcolor: '#f8faf8', backdropFilter: 'saturate(120%) blur(2px)' }}
+        sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
         <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
@@ -1000,7 +1000,7 @@ function RootLayout(): React.ReactElement {
         </Toolbar>
       </AppBar>
 
-      <Drawer anchor="left" open={mobileNavOpen} onClose={closeMobileNav} PaperProps={{ sx: { bgcolor: '#F5F6F5', borderRight: '1px solid #E5E7E5' } }}>
+      <Drawer anchor="left" open={mobileNavOpen} onClose={closeMobileNav} PaperProps={{ sx: { bgcolor: '#f5f2eb', borderRight: '1px solid #e1dbd0' } }}>
         <List sx={{ width: 280 }}>
           <ListItem sx={{ py: 1.5, px: 2 }}>
             <AppLogo size={26} showText to="/app/dashboard" />
@@ -1019,16 +1019,16 @@ function RootLayout(): React.ReactElement {
                     borderRadius: 0,
                     px: 2,
                     py: 1.5,
-                    color: isActive ? '#2f4738' : '#475c4f',
+                    color: isActive ? '#39463b' : '#5b564f',
                     bgcolor: isActive ? 'rgba(80, 130, 90, 0.14)' : 'transparent',
                     transition: 'background-color 140ms ease, color 140ms ease',
                     '&:hover': {
                       bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(91, 130, 102, 0.08)',
-                      color: isActive ? '#2f4738' : '#43584b',
+                      color: isActive ? '#39463b' : '#524d47',
                     },
                   }}
                 >
-                  <ListItemIcon sx={{ minWidth: 36, color: isActive ? '#356c42' : '#51685a', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
+                  <ListItemIcon sx={{ minWidth: 36, color: isActive ? '#3b6f47' : '#666057', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                   <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }} />
                 </ListItemButton>
               </ListItem>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -785,12 +785,29 @@ function RootLayout(): React.ReactElement {
       >
         <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
-          {!isDesktopUp ? <AppLogo size={24} showText={false} to="/app/dashboard" /> : null}
-          {!isPhone ? (
+          {!isDesktopUp ? (
+            <Typography
+              component="h1"
+              variant="subtitle1"
+              noWrap
+              sx={{
+                minWidth: 0,
+                maxWidth: { xs: 180, sm: 220 },
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                fontSize: { xs: '0.98rem', sm: '1.02rem' },
+                fontWeight: 600,
+                lineHeight: 1.2,
+              }}
+            >
+              {currentPageTitle}
+            </Typography>
+          ) : (
             <Typography component="h1" variant="h5" noWrap sx={{ minWidth: 0, maxWidth: { sm: 180, md: 260 }, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: { xs: '1rem', md: '1.25rem' }, fontWeight: 600 }}>
               {currentPageTitle}
             </Typography>
-          ) : null}
+          )}
           {!isPhone && topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 0 }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -749,14 +749,14 @@ function RootLayout(): React.ReactElement {
                       mb: 0.75,
                       px: 1.25,
                       justifyContent: sidebarCollapsed ? 'center' : 'initial',
-                      color: isActive ? '#39463b' : '#5b564f',
+                      color: '#29332c',
                       bgcolor: isActive ? 'rgba(76, 135, 86, 0.13)' : 'transparent',
                       border: '1px solid rgba(76, 135, 86, 0)',
                       position: 'relative',
                       transition: 'background-color 140ms ease, color 140ms ease, border-color 140ms ease',
                       '&:hover': {
                         bgcolor: isActive ? 'rgba(76, 135, 86, 0.16)' : 'rgba(91, 130, 102, 0.09)',
-                        color: isActive ? '#39463b' : '#524d47',
+                        color: '#29332c',
                         borderColor: 'rgba(91, 130, 102, 0.14)',
                       },
                       '&::before': {
@@ -771,7 +771,7 @@ function RootLayout(): React.ReactElement {
                       },
                     }}
                   >
-                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#3b6f47' : '#666057', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: '#2c4f33', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                     {!sidebarCollapsed ? <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500, fontSize: '0.95rem' }} /> : null}
                   </ListItemButton>
                 );
@@ -1022,16 +1022,16 @@ function RootLayout(): React.ReactElement {
                     borderRadius: 0,
                     px: 2,
                     py: 1.5,
-                    color: isActive ? '#39463b' : '#5b564f',
+                    color: '#29332c',
                     bgcolor: isActive ? 'rgba(80, 130, 90, 0.14)' : 'transparent',
                     transition: 'background-color 140ms ease, color 140ms ease',
                     '&:hover': {
                       bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(91, 130, 102, 0.08)',
-                      color: isActive ? '#39463b' : '#524d47',
+                      color: '#29332c',
                     },
                   }}
                 >
-                  <ListItemIcon sx={{ minWidth: 36, color: isActive ? '#3b6f47' : '#666057', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
+                  <ListItemIcon sx={{ minWidth: 36, color: '#2c4f33', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                   <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }} />
                 </ListItemButton>
               </ListItem>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1200,23 +1200,34 @@ function RootLayout(): React.ReactElement {
         <DialogTitle>Version wiederherstellen?</DialogTitle>
         <DialogContent>
           <Typography variant="body2" sx={{ mb: 1.5 }}>
-            Du bist dabei, das Projekt auf einen früheren Stand zurückzusetzen.
+            Du stellst eine frühere Version wieder her.
           </Typography>
           {pendingRestoreEntry ? (
             <Box sx={{ mb: 1.5 }}>
               <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {getHistoryEntryTitle(pendingRestoreEntry, tCultures)}
+                {pendingRestoreEntry.object_display_name?.trim() || getHistoryEntryTitle(pendingRestoreEntry, tCultures)}
               </Typography>
               <Typography variant="caption" color="text.secondary">
-                Originalversion vom {formatHistoryTimestamp(pendingRestoreEntry.history_date)}
+                Bearbeitet am {formatHistoryTimestamp(pendingRestoreEntry.history_date)}
               </Typography>
             </Box>
           ) : null}
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
-            Die aktuelle Version geht nicht verloren. Es wird automatisch eine neue Version erstellt, sodass die Wiederherstellung später rückgängig gemacht werden kann.
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            Rückgängig über den Versionsverlauf möglich.
+          <Box
+            sx={{
+              borderRadius: 1.5,
+              border: '1px solid',
+              borderColor: 'success.light',
+              bgcolor: 'rgba(76, 175, 80, 0.08)',
+              px: 1.25,
+              py: 1,
+            }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              Die aktuelle Version bleibt erhalten. Vor der Wiederherstellung wird automatisch eine neue Version erstellt, sodass du jederzeit wieder zurückwechseln kannst.
+            </Typography>
+          </Box>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+            Es gehen keine Daten verloren.
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  Paper,
   Snackbar,
   Stack,
   TextField,
@@ -262,6 +263,7 @@ function RootLayout(): React.ReactElement {
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
   const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isPhonePortrait = useMediaQuery(`${theme.breakpoints.down('sm')} and (orientation: portrait)`);
   const isTabletOrNarrowDesktop = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
   const fallbackHistoryActorLabel = user?.display_label || user?.display_name || user?.email || undefined;
@@ -1024,44 +1026,111 @@ function RootLayout(): React.ReactElement {
 
       <Dialog open={projectHistoryOpen} onClose={() => setProjectHistoryOpen(false)} fullWidth maxWidth="sm">
         <DialogTitle>{t('commandPalette.commands.openVersionHistory')}</DialogTitle>
-        <DialogContent>
+        <DialogContent sx={{ py: isPhonePortrait ? 1 : 2 }}>
           <List>
             {historyItems.map((item, index) => {
               const isCurrentVersion = index === 0;
               const historyTarget = getHistoryEntryTarget(item);
+              const title = getHistoryEntryTitle(item, tCultures);
+              const meta = getHistoryEntryMeta(item, tCultures, fallbackHistoryActorLabel);
 
               return (
-                <ListItem
-                  key={item.history_id}
-                  disableGutters
-                >
-                  <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
-                    <ListItemText
-                      sx={{ mr: 1 }}
-                      primary={(
-                        <>
-                          {getHistoryEntryTitle(item, tCultures)}
+                <ListItem key={item.history_id} disableGutters sx={{ mb: isPhonePortrait ? 1 : 0 }}>
+                  {isPhonePortrait ? (
+                    <Paper variant="outlined" sx={{ width: '100%', p: 1.25, borderRadius: 1.5 }}>
+                      <Stack spacing={1}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+                          {isCurrentVersion
+                            ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />
+                            : <Chip label={t('commandPalette.restoreVersion')} size="small" variant="outlined" />}
                           {historyTarget ? (
-                            <>
-                              {' · '}
-                              <Link
-                                component={RouterLink}
-                                to={historyTarget}
-                                underline="hover"
-                                onClick={() => setProjectHistoryOpen(false)}
-                              >
-                                {item.object_type === 'culture' ? t('navigation:cultures') : t('navigation:plantingPlans')}
-                              </Link>
-                            </>
+                            <Link
+                              component={RouterLink}
+                              to={historyTarget}
+                              underline="hover"
+                              onClick={() => setProjectHistoryOpen(false)}
+                              sx={{ fontSize: '0.78rem', color: 'text.secondary', flexShrink: 0 }}
+                            >
+                              {item.object_type === 'culture' ? t('navigation:cultures') : t('navigation:plantingPlans')}
+                            </Link>
                           ) : null}
-                        </>
-                      )}
-                      secondary={getHistoryEntryMeta(item, tCultures, fallbackHistoryActorLabel)}
-                    />
-                    {isCurrentVersion
-                      ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />
-                      : <Button onClick={() => void handleRestoreProjectVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{t('commandPalette.restoreVersion')}</Button>}
-                  </Stack>
+                        </Box>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontWeight: 600,
+                            lineHeight: 1.35,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            wordBreak: 'normal',
+                            overflowWrap: 'break-word',
+                          }}
+                        >
+                          {title}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            lineHeight: 1.3,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            wordBreak: 'normal',
+                            overflowWrap: 'break-word',
+                          }}
+                        >
+                          {meta}
+                        </Typography>
+                        {!isCurrentVersion ? (
+                          <>
+                            <Divider />
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              onClick={() => void handleRestoreProjectVersion(item.history_id)}
+                              sx={{ alignSelf: 'flex-start', minHeight: 34 }}
+                            >
+                              {t('commandPalette.restoreVersion')}
+                            </Button>
+                          </>
+                        ) : null}
+                      </Stack>
+                    </Paper>
+                  ) : (
+                    <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
+                      <ListItemText
+                        sx={{ mr: 1 }}
+                        primary={(
+                          <>
+                            {title}
+                            {historyTarget ? (
+                              <>
+                                {' · '}
+                                <Link
+                                  component={RouterLink}
+                                  to={historyTarget}
+                                  underline="hover"
+                                  onClick={() => setProjectHistoryOpen(false)}
+                                >
+                                  {item.object_type === 'culture' ? t('navigation:cultures') : t('navigation:plantingPlans')}
+                                </Link>
+                              </>
+                            ) : null}
+                          </>
+                        )}
+                        secondary={meta}
+                      />
+                      {isCurrentVersion
+                        ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />
+                        : <Button onClick={() => void handleRestoreProjectVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{t('commandPalette.restoreVersion')}</Button>}
+                    </Stack>
+                  )}
                 </ListItem>
               );
             })}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1177,7 +1177,7 @@ function RootLayout(): React.ReactElement {
             <List dense disablePadding>
               <ListItem><ListItemText primary={t('commandPalette.commands.nextPage')} secondary="Ctrl+Shift+↓" /></ListItem>
               <ListItem><ListItemText primary={t('commandPalette.commands.previousPage')} secondary="Ctrl+Shift+↑" /></ListItem>
-              <ListItem><ListItemText primary={t('commandPalette.commands.openVersionHistory')} secondary="–" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.commands.openVersionHistory')} secondary="Alt+V" /></ListItem>
             </List>
             <Typography variant="subtitle2">Ansichten & Layout</Typography>
             <List dense disablePadding>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -544,8 +544,8 @@ function RootLayout(): React.ReactElement {
     onOpenAccountSettings: () => navigate('/app/account-settings'),
     onOpenVersionHistory: () => { void handleOpenProjectHistory(); },
     onLogout: () => { void handleLogout(); },
-    onOpenPalette: openCurrentPageHelp,
-    onOpenShortcuts: openGlobalHelp,
+    onOpenPalette: openPalette,
+    onOpenShortcuts: openCurrentPageHelp,
     labels: {
       nextPage: t('commandPalette.commands.nextPage'),
       previousPage: t('commandPalette.commands.previousPage'),
@@ -556,7 +556,7 @@ function RootLayout(): React.ReactElement {
       openAccountSettings: t('commandPalette.commands.openAccountSettings'),
       openVersionHistory: t('commandPalette.commands.openVersionHistory'),
       logout: t('commandPalette.commands.logout'),
-      openPalette: t('commandPalette.commands.contextShortcuts', { defaultValue: 'Kontextbezogene Tastenkürzel' }),
+      openPalette: t('commandPalette.label'),
       openShortcuts: t('commandPalette.commands.openShortcuts'),
     },
   }), [
@@ -1185,8 +1185,8 @@ function RootLayout(): React.ReactElement {
             </List>
             <Typography variant="subtitle2">Dialoge & Hilfe</Typography>
             <List dense disablePadding>
-              <ListItem><ListItemText primary={t('commandPalette.commands.openShortcuts')} secondary="Alt+H" /></ListItem>
-              <ListItem><ListItemText primary={t('commandPalette.commands.contextShortcuts', { defaultValue: 'Kontextbezogene Tastenkürzel' })} secondary="Alt+K" /></ListItem>
+              <ListItem><ListItemText primary="Seitenhilfe öffnen" secondary="Alt+H" /></ListItem>
+              <ListItem><ListItemText primary={t('commandPalette.label')} secondary="Alt+K" /></ListItem>
               <ListItem><ListItemText primary={t('commandPalette.commands.closeDialog')} secondary="Esc" /></ListItem>
             </List>
           </Stack>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -333,6 +333,7 @@ function RootLayout(): React.ReactElement {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [globalHelpOpen, setGlobalHelpOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<CultureHistoryEntry[]>([]);
+  const [pendingRestoreEntry, setPendingRestoreEntry] = useState<CultureHistoryEntry | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [snackbar, setSnackbar] = useState<SnackbarState>({
     open: false,
@@ -361,14 +362,17 @@ function RootLayout(): React.ReactElement {
   const handleRestoreProjectVersion = async (historyId: number) => {
     try {
       await cultureAPI.projectRestore(historyId);
-      showSnackbar(t('commandPalette.feedback.versionRestored'), 'success');
+      showSnackbar('Version wiederhergestellt. Die vorherige Version wurde automatisch gespeichert.', 'success');
       setProjectHistoryOpen(false);
+      setPendingRestoreEntry(null);
       window.location.reload();
     } catch (error) {
       console.error('Error restoring project version:', error);
       showSnackbar(t('commandPalette.feedback.versionRestoreError'), 'error');
     }
   };
+
+  const formatHistoryTimestamp = (value: string): string => new Date(value).toLocaleString('de-DE');
 
   const handleOpenShortcuts = () => {
     handleGlobalMenuClose();
@@ -1060,8 +1064,8 @@ function RootLayout(): React.ReactElement {
                       <Stack spacing={1}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
                           {isCurrentVersion
-                            ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />
-                            : <Chip label={t('commandPalette.restoreVersion')} size="small" variant="outlined" />}
+                            ? <Chip label="Aktuell" size="small" color="success" variant="outlined" />
+                            : <Chip label="Version" size="small" variant="outlined" />}
                           {historyTarget ? (
                             <Link
                               component={RouterLink}
@@ -1106,16 +1110,21 @@ function RootLayout(): React.ReactElement {
                         >
                           {meta}
                         </Typography>
+                        {isCurrentVersion && item.action === 'restored' ? (
+                          <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.3 }}>
+                            Originalversion vom {formatHistoryTimestamp(item.history_date)}
+                          </Typography>
+                        ) : null}
                         {!isCurrentVersion ? (
                           <>
                             <Divider />
                             <Button
                               variant="outlined"
                               size="small"
-                              onClick={() => void handleRestoreProjectVersion(item.history_id)}
+                              onClick={() => setPendingRestoreEntry(item)}
                               sx={{ alignSelf: 'flex-start', minHeight: 34 }}
                             >
-                              {t('commandPalette.restoreVersion')}
+                              Version wiederherstellen
                             </Button>
                           </>
                         ) : null}
@@ -1147,7 +1156,7 @@ function RootLayout(): React.ReactElement {
                       />
                       {isCurrentVersion
                         ? <Chip label={t('commandPalette.currentVersion')} size="small" color="success" variant="outlined" />
-                        : <Button onClick={() => void handleRestoreProjectVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{t('commandPalette.restoreVersion')}</Button>}
+                        : <Button onClick={() => setPendingRestoreEntry(item)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>Version wiederherstellen</Button>}
                     </Stack>
                   )}
                 </ListItem>
@@ -1187,6 +1196,43 @@ function RootLayout(): React.ReactElement {
         </DialogActions>
       </Dialog>
       <HelpDialog open={globalHelpOpen} onClose={closeGlobalHelp} />
+      <Dialog open={Boolean(pendingRestoreEntry)} onClose={() => setPendingRestoreEntry(null)} fullWidth maxWidth="xs">
+        <DialogTitle>Version wiederherstellen?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            Du bist dabei, das Projekt auf einen früheren Stand zurückzusetzen.
+          </Typography>
+          {pendingRestoreEntry ? (
+            <Box sx={{ mb: 1.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {getHistoryEntryTitle(pendingRestoreEntry, tCultures)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Originalversion vom {formatHistoryTimestamp(pendingRestoreEntry.history_date)}
+              </Typography>
+            </Box>
+          ) : null}
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+            Die aktuelle Version geht nicht verloren. Es wird automatisch eine neue Version erstellt, sodass die Wiederherstellung später rückgängig gemacht werden kann.
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Rückgängig über den Versionsverlauf möglich.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingRestoreEntry(null)}>Abbrechen</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              if (pendingRestoreEntry) {
+                void handleRestoreProjectVersion(pendingRestoreEntry.history_id);
+              }
+            }}
+          >
+            Version wiederherstellen
+          </Button>
+        </DialogActions>
+      </Dialog>
 
 
       <Dialog open={isCreateProjectOpen} onClose={closeCreateProjectDialog} fullWidth maxWidth="sm">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -749,14 +749,15 @@ function RootLayout(): React.ReactElement {
                       mb: 0.75,
                       px: 1.25,
                       justifyContent: sidebarCollapsed ? 'center' : 'initial',
-                      color: isActive ? '#2e4234' : '#5c6d61',
+                      color: isActive ? '#2f4738' : '#475c4f',
                       bgcolor: isActive ? 'rgba(76, 135, 86, 0.13)' : 'transparent',
-                      border: '1px solid transparent',
+                      border: '1px solid rgba(76, 135, 86, 0)',
                       position: 'relative',
                       transition: 'background-color 140ms ease, color 140ms ease, border-color 140ms ease',
                       '&:hover': {
-                        bgcolor: isActive ? 'rgba(76, 135, 86, 0.16)' : 'rgba(91, 130, 102, 0.08)',
-                        borderColor: 'rgba(91, 130, 102, 0.18)',
+                        bgcolor: isActive ? 'rgba(76, 135, 86, 0.16)' : 'rgba(91, 130, 102, 0.09)',
+                        color: isActive ? '#2f4738' : '#43584b',
+                        borderColor: 'rgba(91, 130, 102, 0.14)',
                       },
                       '&::before': {
                         content: '""',
@@ -770,7 +771,7 @@ function RootLayout(): React.ReactElement {
                       },
                     }}
                   >
-                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#356c42' : '#6f8275', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: sidebarCollapsed ? 0 : 36, color: isActive ? '#356c42' : '#51685a', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                     {!sidebarCollapsed ? <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500, fontSize: '0.95rem' }} /> : null}
                   </ListItemButton>
                 );
@@ -1018,14 +1019,16 @@ function RootLayout(): React.ReactElement {
                     borderRadius: 0,
                     px: 2,
                     py: 1.5,
-                    color: isActive ? '#2F3A33' : '#3F4B45',
+                    color: isActive ? '#2f4738' : '#475c4f',
                     bgcolor: isActive ? 'rgba(80, 130, 90, 0.14)' : 'transparent',
+                    transition: 'background-color 140ms ease, color 140ms ease',
                     '&:hover': {
-                      bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(80, 120, 90, 0.08)',
+                      bgcolor: isActive ? 'rgba(80, 130, 90, 0.18)' : 'rgba(91, 130, 102, 0.08)',
+                      color: isActive ? '#2f4738' : '#43584b',
                     },
                   }}
                 >
-                  <ListItemIcon sx={{ minWidth: 36 }}>{item.icon}</ListItemIcon>
+                  <ListItemIcon sx={{ minWidth: 36, color: isActive ? '#356c42' : '#51685a', transition: 'color 140ms ease' }}>{item.icon}</ListItemIcon>
                   <ListItemText primary={item.label} primaryTypographyProps={{ fontWeight: isActive ? 600 : 500 }} />
                 </ListItemButton>
               </ListItem>

--- a/frontend/src/commands/CommandProvider.tsx
+++ b/frontend/src/commands/CommandProvider.tsx
@@ -180,7 +180,7 @@ export function CommandProvider({ children }: { children: React.ReactNode }): Re
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert severity="info" onClose={() => setHintOpen(false)}>
-          💡 Tipp: Drücke Alt+H für die allgemeine Hilfe.
+          💡 Tipp: Drücke Alt+K für die Command Palette.
         </Alert>
       </Snackbar>
     </CommandContext.Provider>

--- a/frontend/src/commands/CommandProvider.tsx
+++ b/frontend/src/commands/CommandProvider.tsx
@@ -98,7 +98,10 @@ export function CommandProvider({ children }: { children: React.ReactNode }): Re
     );
   }, [allCommands, currentContextTags]);
 
-  const helpCommands = useMemo(() => getVisibleCommands(allCommands), [allCommands]);
+  const helpCommands = useMemo(
+    () => getVisibleCommands(allCommands).filter((command) => command.contextTags.some((tag) => currentContextTags.includes(tag))),
+    [allCommands, currentContextTags],
+  );
 
   const shortcutSpecs = useMemo<ShortcutSpec[]>(() => {
     const commandShortcuts: ShortcutSpec[] = activeCommands
@@ -143,7 +146,7 @@ export function CommandProvider({ children }: { children: React.ReactNode }): Re
       {children}
       <CommandPalette open={paletteOpen} commands={activeCommands} onClose={closePalette} />
       <Dialog open={helpOpen} onClose={() => setHelpOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Tastenkürzel (Alt+H)</DialogTitle>
+        <DialogTitle>Kontextbezogene Tastenkürzel (Alt+K)</DialogTitle>
         <DialogContent>
           <Typography variant="body2" sx={{ mb: 2 }}>
             Shortcuts sind browser-sicher und überschreiben keine üblichen Browser-Shortcuts.
@@ -177,7 +180,7 @@ export function CommandProvider({ children }: { children: React.ReactNode }): Re
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert severity="info" onClose={() => setHintOpen(false)}>
-          💡 Tipp: Drücke Alt+K für die Command Palette.
+          💡 Tipp: Drücke Alt+H für die allgemeine Hilfe.
         </Alert>
       </Snackbar>
     </CommandContext.Provider>

--- a/frontend/src/commands/commands.ts
+++ b/frontend/src/commands/commands.ts
@@ -97,6 +97,8 @@ export function createRootCommands(options: RootCommandFactoryOptions): CommandS
       label: options.labels.openVersionHistory,
       keywords: ['versionen', 'verlauf', 'historie', 'projekt'],
       group: 'account',
+      shortcutHint: 'Alt+V',
+      keys: { alt: true, key: 'v' },
       contextTags: ['global'],
       isVisible: () => options.activeProjectId !== null,
       action: options.onOpenVersionHistory,

--- a/frontend/src/components/data-grid/styles.ts
+++ b/frontend/src/components/data-grid/styles.ts
@@ -13,20 +13,17 @@ import type { Theme } from '@mui/material/styles';
 export const dataGridSx = {
   border: '1px solid #e5e7eb',
   borderRadius: 3,
-  backgroundColor: '#ffffff',
-  boxShadow: '0 1px 2px rgba(16, 24, 40, 0.04)',
+  backgroundColor: '#fbfcfa',
+  boxShadow: '0 1px 2px rgba(21, 31, 24, 0.03)',
   '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: '#f8faf8',
-    borderBottom: '1px solid #e5e7eb',
+    backgroundColor: '#f5f7f4',
+    borderBottom: '1px solid #e3e8e3',
   },
   '& .MuiDataGrid-row': {
     minHeight: 44,
   },
-  '& .MuiDataGrid-row:nth-of-type(even)': {
-    backgroundColor: '#fbfcfb',
-  },
   '& .MuiDataGrid-row:hover': {
-    backgroundColor: '#f1f7f2',
+    backgroundColor: '#f1f5ef',
   },
   '& .MuiDataGrid-cell': {
     borderColor: '#edf1ee',
@@ -75,7 +72,7 @@ export const dataGridSx = {
   },
   '& .ofp-row-editing': {
     boxShadow: 'inset 3px 0 0 #1976d2',
-    backgroundColor: 'rgba(25, 118, 210, 0.04)',
+    backgroundColor: 'rgba(25, 118, 210, 0.05)',
   },
   '& .ofp-row-dirty': {
     boxShadow: 'inset 3px 0 0 #ed6c02',

--- a/frontend/src/components/help/HelpDialog.tsx
+++ b/frontend/src/components/help/HelpDialog.tsx
@@ -78,7 +78,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
       <DialogTitle sx={{ pr: 6 }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2}>
           <Typography variant="h6" component="span">
-            {t('globalTitle', { defaultValue: t('title') })}
+            {t('globalTitle', { defaultValue: 'Überblick' })}
           </Typography>
           <IconButton
             aria-label={t('common:actions.close')}
@@ -92,14 +92,9 @@ export function HelpDialog({ open, onClose }: HelpDialogProps): ReactElement {
       </DialogTitle>
       <DialogContent sx={{ pb: 3 }}>
         <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ fontWeight: 600, mb: 1 }}>
-              {t('heading')}
-            </Typography>
-            <Typography variant="body1">
-              {t('intro')}
-            </Typography>
-          </Box>
+          <Typography variant="body1">
+            {t('intro')}
+          </Typography>
 
           <Stack spacing={1.5}>
             {helpSections.map((section) => (

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -33,6 +33,7 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
 };
 
 const EXPAND_ICON_SLOT_SIZE = 32;
+const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
 
 interface NameCellCallbacks {
   onToggleExpand: (rowId: string | number) => void;
@@ -383,7 +384,7 @@ export function createHierarchyColumns(
       renderHeader: () => (
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
           <SwapVertIcon fontSize="small" aria-hidden="true" />
-          <span>{t('columns.length')}</span>
+          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>{t('columns.length')}</Box>
         </Box>
       ),
       width: widths.dimensions,
@@ -399,7 +400,7 @@ export function createHierarchyColumns(
       renderHeader: () => (
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
           <SwapHorizIcon fontSize="small" aria-hidden="true" />
-          <span>{t('columns.width')}</span>
+          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>{t('columns.width')}</Box>
         </Box>
       ),
       width: widths.dimensions,

--- a/frontend/src/components/layout/BottomActionToolbar.tsx
+++ b/frontend/src/components/layout/BottomActionToolbar.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Box, type SxProps, type Theme } from '@mui/material';
+import type { SystemStyleObject } from '@mui/system';
 
 interface BottomActionToolbarProps {
   leftActions?: ReactNode;
@@ -7,7 +8,7 @@ interface BottomActionToolbarProps {
   sx?: SxProps<Theme>;
 }
 
-const buttonAlignmentSx: SxProps<Theme> = {
+const buttonAlignmentSx: SystemStyleObject<Theme> = {
   '& .MuiButton-root': {
     minHeight: 40,
     alignSelf: 'stretch',

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -688,13 +688,15 @@ export function CultureDetail({
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: '220px minmax(0, 1fr)',
-              md: '230px minmax(0, 1fr)',
-              lg: '300px minmax(0, 1fr)',
-              xl: '330px minmax(0, 1fr)',
-            },
+            gridTemplateColumns: useUnifiedMobileLayout
+              ? 'minmax(0, 1fr)'
+              : {
+                xs: '1fr',
+                sm: '220px minmax(0, 1fr)',
+                md: '230px minmax(0, 1fr)',
+                lg: '300px minmax(0, 1fr)',
+                xl: '330px minmax(0, 1fr)',
+              },
             gap: { xs: 1.25, lg: 1.5 },
             alignItems: 'start',
           }}
@@ -767,7 +769,7 @@ export function CultureDetail({
               })}
             </List>
           </Card>) : null}
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: useUnifiedMobileLayout ? 'stretch' : 'flex-start' } }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -172,6 +172,10 @@ export function CultureDetail({
   const theme = useTheme();
   const isTabletLayout = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
   const isMobileLayout = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobileLandscapeLayout = useMediaQuery(
+    `${theme.breakpoints.between('sm', 'md')} and (orientation: landscape) and (max-height: 560px)`,
+  );
+  const useUnifiedMobileLayout = isMobileLayout || isMobileLandscapeLayout;
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFamilyFilter, setSelectedFamilyFilter] = useState('');
   const [selectedCultivationFilter, setSelectedCultivationFilter] = useState('');
@@ -187,16 +191,16 @@ export function CultureDetail({
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
   const isHeaderMenuOpen = Boolean(headerMenuAnchorEl);
   const headerActionButtonSx = {
-    width: isMobileLayout ? 30 : 34,
-    height: isMobileLayout ? 30 : 34,
-    borderRadius: isMobileLayout ? 0.75 : 0,
+    width: useUnifiedMobileLayout ? 30 : 34,
+    height: useUnifiedMobileLayout ? 30 : 34,
+    borderRadius: useUnifiedMobileLayout ? 0.75 : 0,
     border: 'none',
     backgroundColor: 'transparent',
     transition: 'background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease',
     '&:hover': {
       backgroundColor: 'rgba(15, 23, 42, 0.08)',
-      boxShadow: isMobileLayout ? 'none' : '0 2px 6px rgba(15, 23, 42, 0.10)',
-      transform: isMobileLayout ? 'none' : 'translateY(-1px)',
+      boxShadow: useUnifiedMobileLayout ? 'none' : '0 2px 6px rgba(15, 23, 42, 0.10)',
+      transform: useUnifiedMobileLayout ? 'none' : 'translateY(-1px)',
     },
     '&:focus-visible': {
       outline: '2px solid rgba(37, 111, 42, 0.28)',
@@ -695,7 +699,7 @@ export function CultureDetail({
             alignItems: 'start',
           }}
         >
-          {!isMobileLayout ? (<Card
+          {!useUnifiedMobileLayout ? (<Card
             sx={{
               width: '100%',
               flexShrink: 0,
@@ -763,9 +767,9 @@ export function CultureDetail({
               })}
             </List>
           </Card>) : null}
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: 'flex-start' } }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: { sm: useUnifiedMobileLayout ? 'stretch' : 'flex-start' } }}>
             {selectedCulture ? (
-              <Card sx={{ width: '100%', maxWidth: { sm: 960, lg: 1220, xl: 1400 } }}>
+              <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 960, lg: 1220, xl: 1400 } }}>
                 <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: { xs: 2, sm: 3 } }}>
@@ -788,7 +792,7 @@ export function CultureDetail({
                       />
                     ) : null}
                     <Box sx={{ display: 'flex', flexDirection: 'column', py: 0.25 }}>
-                      {isMobileLayout ? (
+                      {useUnifiedMobileLayout ? (
                         <Box
                           component="button"
                           type="button"
@@ -844,9 +848,9 @@ export function CultureDetail({
                     display: 'inline-flex',
                     alignItems: 'center',
                     border: '1px solid rgba(15, 23, 42, 0.10)',
-                    borderRadius: isMobileLayout ? 1 : 1.5,
-                    backgroundColor: isMobileLayout ? 'rgba(15, 23, 42, 0.02)' : 'rgba(15, 23, 42, 0.03)',
-                    boxShadow: isMobileLayout ? 'none' : '0 1px 3px rgba(15, 23, 42, 0.08)',
+                    borderRadius: useUnifiedMobileLayout ? 1 : 1.5,
+                    backgroundColor: useUnifiedMobileLayout ? 'rgba(15, 23, 42, 0.02)' : 'rgba(15, 23, 42, 0.03)',
+                    boxShadow: useUnifiedMobileLayout ? 'none' : '0 1px 3px rgba(15, 23, 42, 0.08)',
                     overflow: 'hidden',
                   }}
                 >
@@ -863,7 +867,7 @@ export function CultureDetail({
                           '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.12)' },
                         }}
                       >
-                        <EditIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
+                        <EditIcon sx={{ fontSize: useUnifiedMobileLayout ? 16 : 18 }} />
                       </IconButton>
                     </span>
                   </Tooltip>
@@ -880,7 +884,7 @@ export function CultureDetail({
                           '&:hover': { backgroundColor: 'rgba(37, 111, 42, 0.10)' },
                         }}
                       >
-                        <AgricultureIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
+                        <AgricultureIcon sx={{ fontSize: useUnifiedMobileLayout ? 16 : 18 }} />
                       </IconButton>
                     </span>
                   </Tooltip>
@@ -893,7 +897,7 @@ export function CultureDetail({
                       color: 'text.secondary',
                     }}
                   >
-                    <MoreVertIcon sx={{ fontSize: isMobileLayout ? 16 : 18 }} />
+                    <MoreVertIcon sx={{ fontSize: useUnifiedMobileLayout ? 16 : 18 }} />
                   </IconButton>
                 </Box>
               </Box>
@@ -1320,7 +1324,7 @@ export function CultureDetail({
             ) : (
               <Card>
                 <CardContent>
-                  {isMobileLayout ? (
+                  {useUnifiedMobileLayout ? (
                     <Typography
                       component="button"
                       type="button"
@@ -1342,7 +1346,7 @@ export function CultureDetail({
       ) : null}
 
 
-      {isMobileLayout ? (
+      {useUnifiedMobileLayout ? (
         <Dialog fullScreen open={mobileSelectorOpen} onClose={() => setMobileSelectorOpen(false)}>
           <DialogTitle>Kultur auswählen</DialogTitle>
           <DialogContent sx={{ px: 1.5, pb: 2 }}>

--- a/frontend/src/cultures/PublicCultureLibraryDialog.tsx
+++ b/frontend/src/cultures/PublicCultureLibraryDialog.tsx
@@ -62,6 +62,7 @@ export function PublicCultureLibraryDialog({
   const [mobileStep, setMobileStep] = useState<'list' | 'detail'>('list');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobileLandscape = useMediaQuery(`${theme.breakpoints.down('sm')} and (orientation: landscape) and (max-height: 560px)`);
 
   useEffect(() => {
     if (!open) {
@@ -123,7 +124,16 @@ export function PublicCultureLibraryDialog({
   );
 
   const filterControls = (
-    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' }, gap: 1, mb: 2 }}>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: isMobileLandscape
+          ? 'repeat(2, minmax(0, 1fr))'
+          : { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' },
+        gap: 1,
+        mb: isMobileLandscape ? 1 : 2,
+      }}
+    >
       <FormControl size="small">
         <InputLabel>{t('library.filters.variety')}</InputLabel>
         <Select value={varietyFilter} label={t('library.filters.variety')} onChange={(event) => setVarietyFilter(event.target.value)}>
@@ -164,9 +174,38 @@ export function PublicCultureLibraryDialog({
   );
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth={isMobile ? false : 'md'} fullWidth fullScreen={isMobile}>
-      <DialogTitle>{t('library.dialogTitle')}</DialogTitle>
-      <DialogContent dividers sx={{ minHeight: isMobile ? 'auto' : 560, px: isMobile ? 1.25 : 3 }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={isMobile ? false : 'md'}
+      fullWidth
+      fullScreen={isMobile && !isMobileLandscape}
+      PaperProps={{
+        sx: isMobileLandscape
+          ? {
+            width: 'calc(100vw - 32px)',
+            maxWidth: 'none',
+            height: 'calc(100vh - 24px)',
+            maxHeight: 'calc(100vh - 24px)',
+            m: 0,
+          }
+          : undefined,
+      }}
+    >
+      <DialogTitle sx={{ py: isMobileLandscape ? 1 : 2, px: isMobileLandscape ? 1.5 : 3 }}>
+        {t('library.dialogTitle')}
+      </DialogTitle>
+      <DialogContent
+        dividers
+        sx={{
+          minHeight: isMobile ? 'auto' : 560,
+          px: isMobileLandscape ? 1.25 : isMobile ? 1.25 : 3,
+          py: isMobileLandscape ? 1 : 2,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
         <TextField
           fullWidth
           label={t('library.searchLabel')}
@@ -177,7 +216,8 @@ export function PublicCultureLibraryDialog({
             onSearch(nextValue);
           }}
           InputProps={{ startAdornment: <SearchIcon sx={{ mr: 1, color: 'text.secondary' }} /> }}
-          sx={{ mb: 2 }}
+          size={isMobileLandscape ? 'small' : 'medium'}
+          sx={{ mb: isMobileLandscape ? 1 : 2 }}
         />
 
         {isMobile ? (
@@ -189,21 +229,23 @@ export function PublicCultureLibraryDialog({
               </Box>
             </AccordionSummary>
             <AccordionDetails sx={{ pt: 0.75, pb: 1 }}>
-              {filterControls}
+              <Box sx={{ '& > *': { mb: 0 } }}>
+                {filterControls}
+              </Box>
             </AccordionDetails>
           </Accordion>
         ) : filterControls}
 
         {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
 
-        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : { xs: '1fr', md: '1.2fr 1fr' }, gap: 2, minHeight: isMobile ? 'auto' : 420 }}>
+        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : { xs: '1fr', md: '1.2fr 1fr' }, gap: isMobileLandscape ? 1 : 2, minHeight: 0, flex: 1 }}>
           {loading ? (
             <Box sx={{ position: 'absolute', inset: 0, display: 'flex', justifyContent: 'center', alignItems: 'center', bgcolor: 'rgba(255,255,255,0.6)', zIndex: 1 }}>
               <CircularProgress />
             </Box>
           ) : null}
           {(!isMobile || mobileStep === 'list') ? (
-            <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: isMobile ? 'auto' : 420, overflowY: isMobile ? 'visible' : 'auto', scrollbarGutter: 'stable' }}>
+            <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: isMobile ? '100%' : 420, minHeight: 0, overflowY: 'auto', scrollbarGutter: 'stable' }}>
             {filteredCultures.length === 0 ? (
               <Typography color="text.secondary" sx={{ p: 2 }}>{t('library.empty')}</Typography>
             ) : filteredCultures.map((culture) => (
@@ -231,7 +273,7 @@ export function PublicCultureLibraryDialog({
           ) : null}
 
           {(!isMobile || mobileStep === 'detail') ? (
-            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobile ? 1.5 : 2, minHeight: isMobile ? 'auto' : 420, maxHeight: isMobile ? 'none' : 420, overflowY: isMobile ? 'visible' : 'auto', scrollbarGutter: 'stable' }}>
+            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobileLandscape ? 1.25 : isMobile ? 1.5 : 2, minHeight: isMobile ? '100%' : 420, maxHeight: isMobile ? 'none' : 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
               {isMobile ? (
                 <Button startIcon={<ArrowBackIcon />} size="small" sx={{ mb: 1 }} onClick={() => setMobileStep('list')}>
                   {t('common:actions.back', { defaultValue: 'Zurück' })}
@@ -269,7 +311,7 @@ export function PublicCultureLibraryDialog({
           ) : null}
         </Box>
       </DialogContent>
-      <DialogActions sx={{ px: isMobile ? 1.25 : 3, py: isMobile ? 1 : 1.5 }}>
+      <DialogActions sx={{ px: isMobileLandscape ? 1.25 : isMobile ? 1.25 : 3, py: isMobileLandscape ? 0.75 : isMobile ? 1 : 1.5 }}>
         <Button onClick={onClose}>{t('form.cancel')}</Button>
         <Button
           variant="contained"

--- a/frontend/src/cultures/PublicCultureLibraryDialog.tsx
+++ b/frontend/src/cultures/PublicCultureLibraryDialog.tsx
@@ -27,7 +27,6 @@ import {
   useTheme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import TuneIcon from '@mui/icons-material/Tune';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
@@ -124,6 +123,14 @@ export function PublicCultureLibraryDialog({
     [filteredCultures, selectedId],
   );
 
+  const handleDialogClose = (): void => {
+    if (useMobileFilterLayout && mobileStep === 'detail') {
+      setMobileStep('list');
+      return;
+    }
+    onClose();
+  };
+
   const filterControls = (
     <Box
       sx={{
@@ -175,9 +182,9 @@ export function PublicCultureLibraryDialog({
   );
 
   return (
-    <Dialog
+      <Dialog
       open={open}
-      onClose={onClose}
+      onClose={handleDialogClose}
       maxWidth={useMobileFilterLayout ? false : 'md'}
       fullWidth
       fullScreen={useMobileFilterLayout && !isMobileLandscape}
@@ -275,11 +282,6 @@ export function PublicCultureLibraryDialog({
 
           {(!useMobileFilterLayout || mobileStep === 'detail') ? (
             <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobileLandscape ? 1.25 : useMobileFilterLayout ? 1.5 : 2, minHeight: useMobileFilterLayout ? '100%' : 420, maxHeight: useMobileFilterLayout ? 'none' : 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
-              {useMobileFilterLayout ? (
-                <Button startIcon={<ArrowBackIcon />} size="small" sx={{ mb: 1 }} onClick={() => setMobileStep('list')}>
-                  {t('common:actions.back', { defaultValue: 'Zurück' })}
-                </Button>
-              ) : null}
             {selectedCulture ? (
               <>
                 <Typography variant="h6">{selectedCulture.name}</Typography>

--- a/frontend/src/cultures/PublicCultureLibraryDialog.tsx
+++ b/frontend/src/cultures/PublicCultureLibraryDialog.tsx
@@ -62,7 +62,8 @@ export function PublicCultureLibraryDialog({
   const [mobileStep, setMobileStep] = useState<'list' | 'detail'>('list');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const isMobileLandscape = useMediaQuery(`${theme.breakpoints.down('sm')} and (orientation: landscape) and (max-height: 560px)`);
+  const isMobileLandscape = useMediaQuery(`(orientation: landscape) and (max-height: 560px) and (max-width: 960px)`);
+  const useMobileFilterLayout = isMobile || isMobileLandscape;
 
   useEffect(() => {
     if (!open) {
@@ -177,9 +178,9 @@ export function PublicCultureLibraryDialog({
     <Dialog
       open={open}
       onClose={onClose}
-      maxWidth={isMobile ? false : 'md'}
+      maxWidth={useMobileFilterLayout ? false : 'md'}
       fullWidth
-      fullScreen={isMobile && !isMobileLandscape}
+      fullScreen={useMobileFilterLayout && !isMobileLandscape}
       PaperProps={{
         sx: isMobileLandscape
           ? {
@@ -198,8 +199,8 @@ export function PublicCultureLibraryDialog({
       <DialogContent
         dividers
         sx={{
-          minHeight: isMobile ? 'auto' : 560,
-          px: isMobileLandscape ? 1.25 : isMobile ? 1.25 : 3,
+          minHeight: useMobileFilterLayout ? 'auto' : 560,
+          px: isMobileLandscape ? 1.25 : useMobileFilterLayout ? 1.25 : 3,
           py: isMobileLandscape ? 1 : 2,
           display: 'flex',
           flexDirection: 'column',
@@ -220,7 +221,7 @@ export function PublicCultureLibraryDialog({
           sx={{ mb: isMobileLandscape ? 1 : 2 }}
         />
 
-        {isMobile ? (
+        {useMobileFilterLayout ? (
           <Accordion disableGutters elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, mb: 1.25 }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 40 }}>
               <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
@@ -238,14 +239,14 @@ export function PublicCultureLibraryDialog({
 
         {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
 
-        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : { xs: '1fr', md: '1.2fr 1fr' }, gap: isMobileLandscape ? 1 : 2, minHeight: 0, flex: 1 }}>
+        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: useMobileFilterLayout ? '1fr' : { xs: '1fr', md: '1.2fr 1fr' }, gap: isMobileLandscape ? 1 : 2, minHeight: 0, flex: 1 }}>
           {loading ? (
             <Box sx={{ position: 'absolute', inset: 0, display: 'flex', justifyContent: 'center', alignItems: 'center', bgcolor: 'rgba(255,255,255,0.6)', zIndex: 1 }}>
               <CircularProgress />
             </Box>
           ) : null}
-          {(!isMobile || mobileStep === 'list') ? (
-            <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: isMobile ? '100%' : 420, minHeight: 0, overflowY: 'auto', scrollbarGutter: 'stable' }}>
+          {(!useMobileFilterLayout || mobileStep === 'list') ? (
+            <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: useMobileFilterLayout ? '100%' : 420, minHeight: 0, overflowY: 'auto', scrollbarGutter: 'stable' }}>
             {filteredCultures.length === 0 ? (
               <Typography color="text.secondary" sx={{ p: 2 }}>{t('library.empty')}</Typography>
             ) : filteredCultures.map((culture) => (
@@ -254,7 +255,7 @@ export function PublicCultureLibraryDialog({
                   selected={culture.id === selectedId}
                   onClick={() => {
                     setSelectedId(culture.id);
-                    if (isMobile) {
+                    if (useMobileFilterLayout) {
                       setMobileStep('detail');
                     }
                   }}
@@ -272,9 +273,9 @@ export function PublicCultureLibraryDialog({
             </List>
           ) : null}
 
-          {(!isMobile || mobileStep === 'detail') ? (
-            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobileLandscape ? 1.25 : isMobile ? 1.5 : 2, minHeight: isMobile ? '100%' : 420, maxHeight: isMobile ? 'none' : 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
-              {isMobile ? (
+          {(!useMobileFilterLayout || mobileStep === 'detail') ? (
+            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobileLandscape ? 1.25 : useMobileFilterLayout ? 1.5 : 2, minHeight: useMobileFilterLayout ? '100%' : 420, maxHeight: useMobileFilterLayout ? 'none' : 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
+              {useMobileFilterLayout ? (
                 <Button startIcon={<ArrowBackIcon />} size="small" sx={{ mb: 1 }} onClick={() => setMobileStep('list')}>
                   {t('common:actions.back', { defaultValue: 'Zurück' })}
                 </Button>

--- a/frontend/src/cultures/PublicCultureLibraryDialog.tsx
+++ b/frontend/src/cultures/PublicCultureLibraryDialog.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../i18n';
 import type { PublicCulture } from '../api/types';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Box,
   Button,
@@ -20,8 +23,13 @@ import {
   Select,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import TuneIcon from '@mui/icons-material/Tune';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 interface PublicCultureLibraryDialogProps {
   open: boolean;
@@ -51,6 +59,9 @@ export function PublicCultureLibraryDialog({
   const [supplierFilter, setSupplierFilter] = useState('');
   const [nutrientFilter, setNutrientFilter] = useState('');
   const [cropFamilyFilter, setCropFamilyFilter] = useState('');
+  const [mobileStep, setMobileStep] = useState<'list' | 'detail'>('list');
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   useEffect(() => {
     if (!open) {
@@ -61,6 +72,7 @@ export function PublicCultureLibraryDialog({
         setSupplierFilter('');
         setNutrientFilter('');
         setCropFamilyFilter('');
+        setMobileStep('list');
       });
     }
   }, [open]);
@@ -110,10 +122,51 @@ export function PublicCultureLibraryDialog({
     [filteredCultures, selectedId],
   );
 
+  const filterControls = (
+    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' }, gap: 1, mb: 2 }}>
+      <FormControl size="small">
+        <InputLabel>{t('library.filters.variety')}</InputLabel>
+        <Select value={varietyFilter} label={t('library.filters.variety')} onChange={(event) => setVarietyFilter(event.target.value)}>
+          <MenuItem value="">{t('filters.all')}</MenuItem>
+          {varietyOptions.map((option) => (
+            <MenuItem key={option} value={option}>{option}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small">
+        <InputLabel>{t('library.filters.supplier')}</InputLabel>
+        <Select value={supplierFilter} label={t('library.filters.supplier')} onChange={(event) => setSupplierFilter(event.target.value)}>
+          <MenuItem value="">{t('filters.all')}</MenuItem>
+          {supplierOptions.map((option) => (
+            <MenuItem key={option} value={option}>{option}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small">
+        <InputLabel>{t('library.filters.nutrientDemand')}</InputLabel>
+        <Select value={nutrientFilter} label={t('library.filters.nutrientDemand')} onChange={(event) => setNutrientFilter(event.target.value)}>
+          <MenuItem value="">{t('filters.all')}</MenuItem>
+          {nutrientOptions.map((option) => (
+            <MenuItem key={option} value={option}>{nutrientLabel(option)}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small">
+        <InputLabel>{t('library.filters.cropFamily')}</InputLabel>
+        <Select value={cropFamilyFilter} label={t('library.filters.cropFamily')} onChange={(event) => setCropFamilyFilter(event.target.value)}>
+          <MenuItem value="">{t('filters.all')}</MenuItem>
+          {cropFamilyOptions.map((option) => (
+            <MenuItem key={option} value={option}>{option}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth={isMobile ? false : 'md'} fullWidth fullScreen={isMobile}>
       <DialogTitle>{t('library.dialogTitle')}</DialogTitle>
-      <DialogContent dividers sx={{ minHeight: 560 }}>
+      <DialogContent dividers sx={{ minHeight: isMobile ? 'auto' : 560, px: isMobile ? 1.25 : 3 }}>
         <TextField
           fullWidth
           label={t('library.searchLabel')}
@@ -127,104 +180,96 @@ export function PublicCultureLibraryDialog({
           sx={{ mb: 2 }}
         />
 
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' }, gap: 1, mb: 2 }}>
-          <FormControl size="small">
-            <InputLabel>{t('library.filters.variety')}</InputLabel>
-            <Select value={varietyFilter} label={t('library.filters.variety')} onChange={(event) => setVarietyFilter(event.target.value)}>
-              <MenuItem value="">{t('filters.all')}</MenuItem>
-              {varietyOptions.map((option) => (
-                <MenuItem key={option} value={option}>{option}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <FormControl size="small">
-            <InputLabel>{t('library.filters.supplier')}</InputLabel>
-            <Select value={supplierFilter} label={t('library.filters.supplier')} onChange={(event) => setSupplierFilter(event.target.value)}>
-              <MenuItem value="">{t('filters.all')}</MenuItem>
-              {supplierOptions.map((option) => (
-                <MenuItem key={option} value={option}>{option}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <FormControl size="small">
-            <InputLabel>{t('library.filters.nutrientDemand')}</InputLabel>
-            <Select value={nutrientFilter} label={t('library.filters.nutrientDemand')} onChange={(event) => setNutrientFilter(event.target.value)}>
-              <MenuItem value="">{t('filters.all')}</MenuItem>
-              {nutrientOptions.map((option) => (
-                <MenuItem key={option} value={option}>{nutrientLabel(option)}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <FormControl size="small">
-            <InputLabel>{t('library.filters.cropFamily')}</InputLabel>
-            <Select value={cropFamilyFilter} label={t('library.filters.cropFamily')} onChange={(event) => setCropFamilyFilter(event.target.value)}>
-              <MenuItem value="">{t('filters.all')}</MenuItem>
-              {cropFamilyOptions.map((option) => (
-                <MenuItem key={option} value={option}>{option}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
+        {isMobile ? (
+          <Accordion disableGutters elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, mb: 1.25 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 40 }}>
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+                <TuneIcon fontSize="small" />
+                <Typography variant="body2">{t('filters.title', { defaultValue: 'Filter' })}</Typography>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0.75, pb: 1 }}>
+              {filterControls}
+            </AccordionDetails>
+          </Accordion>
+        ) : filterControls}
 
         {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
 
-        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1.2fr 1fr' }, gap: 2, minHeight: 420 }}>
+        <Box sx={{ position: 'relative', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : { xs: '1fr', md: '1.2fr 1fr' }, gap: 2, minHeight: isMobile ? 'auto' : 420 }}>
           {loading ? (
             <Box sx={{ position: 'absolute', inset: 0, display: 'flex', justifyContent: 'center', alignItems: 'center', bgcolor: 'rgba(255,255,255,0.6)', zIndex: 1 }}>
               <CircularProgress />
             </Box>
           ) : null}
-          <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
+          {(!isMobile || mobileStep === 'list') ? (
+            <List sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, height: isMobile ? 'auto' : 420, overflowY: isMobile ? 'visible' : 'auto', scrollbarGutter: 'stable' }}>
             {filteredCultures.length === 0 ? (
               <Typography color="text.secondary" sx={{ p: 2 }}>{t('library.empty')}</Typography>
             ) : filteredCultures.map((culture) => (
                 <ListItemButton
                   key={culture.id}
                   selected={culture.id === selectedId}
-                  onClick={() => setSelectedId(culture.id)}
+                  onClick={() => {
+                    setSelectedId(culture.id);
+                    if (isMobile) {
+                      setMobileStep('detail');
+                    }
+                  }}
                   alignItems="flex-start"
+                  sx={{ py: 0.75, px: 1.25 }}
                 >
                   <ListItemText
                     primary={culture.variety ? `${culture.name} (${culture.variety})` : culture.name}
                     secondary={culture.supplier_name || culture.seed_supplier || t('noData')}
+                    primaryTypographyProps={{ fontSize: '0.92rem', lineHeight: 1.25 }}
+                    secondaryTypographyProps={{ fontSize: '0.78rem', color: 'text.secondary', lineHeight: 1.2 }}
                   />
                 </ListItemButton>
               ))}
-          </List>
+            </List>
+          ) : null}
 
-          <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2, minHeight: 420, maxHeight: 420, overflowY: 'auto', scrollbarGutter: 'stable' }}>
+          {(!isMobile || mobileStep === 'detail') ? (
+            <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: isMobile ? 1.5 : 2, minHeight: isMobile ? 'auto' : 420, maxHeight: isMobile ? 'none' : 420, overflowY: isMobile ? 'visible' : 'auto', scrollbarGutter: 'stable' }}>
+              {isMobile ? (
+                <Button startIcon={<ArrowBackIcon />} size="small" sx={{ mb: 1 }} onClick={() => setMobileStep('list')}>
+                  {t('common:actions.back', { defaultValue: 'Zurück' })}
+                </Button>
+              ) : null}
             {selectedCulture ? (
               <>
                 <Typography variant="h6">{selectedCulture.name}</Typography>
                 {selectedCulture.variety ? (
                   <Typography color="text.secondary" sx={{ mb: 1 }}>{selectedCulture.variety}</Typography>
                 ) : null}
-                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
-                  <Chip size="small" label={`${t('library.versionLabel')} ${selectedCulture.version}`} />
+                <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mb: 1.5 }}>
+                  <Chip size="small" variant="outlined" label={`${t('library.versionLabel')} ${selectedCulture.version}`} />
                   {selectedCulture.created_by_label ? (
-                    <Chip size="small" label={`${t('library.createdByLabel')} ${selectedCulture.created_by_label}`} />
+                    <Chip size="small" variant="outlined" label={`${t('library.createdByLabel')} ${selectedCulture.created_by_label}`} />
                   ) : null}
                 </Box>
-                <Typography variant="body2" sx={{ mb: 1 }}>
+                <Typography variant="body2" sx={{ mb: 0.75 }}>
                   <strong>{t('form.supplier')}:</strong> {selectedCulture.supplier_name || selectedCulture.seed_supplier || t('noData')}
                 </Typography>
-                <Typography variant="body2" sx={{ mb: 1 }}>
+                <Typography variant="body2" sx={{ mb: 0.75 }}>
                   <strong>{t('form.growthDurationDays')}:</strong> {selectedCulture.growth_duration_days ?? t('noData')}
                 </Typography>
-                <Typography variant="body2" sx={{ mb: 1 }}>
+                <Typography variant="body2" sx={{ mb: 0.75 }}>
                   <strong>{t('form.harvestDurationDays')}:</strong> {selectedCulture.harvest_duration_days ?? t('noData')}
                 </Typography>
-                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.45 }}>
                   <strong>{t('form.notes')}:</strong> {selectedCulture.notes || t('noData')}
                 </Typography>
               </>
             ) : (
               <Typography color="text.secondary">{t('library.selectPrompt')}</Typography>
             )}
-          </Box>
+            </Box>
+          ) : null}
         </Box>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ px: isMobile ? 1.25 : 3, py: isMobile ? 1 : 1.5 }}>
         <Button onClick={onClose}>{t('form.cancel')}</Button>
         <Button
           variant="contained"

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -41,13 +41,20 @@
   "pages": {
     "dashboard": {
       "title": "Hilfe: Übersicht",
-      "intro": "Die Übersicht zeigt den aktuellen Stand deines Projekts und führt dich schnell zu den wichtigsten Bereichen.",
+      "intro": "Die Übersicht zeigt dir, was als Nächstes wichtig ist. Bei neuen Projekten führt sie dich mit einer Checkliste durch die ersten Schritte. Sobald Anbaupläne vorhanden sind, erscheinen hier die nächsten Aufgaben und Termine aus deiner Planung.",
       "sections": [
         {
           "title": "Bedienung",
           "points": [
-            "Nutze die Navigation, um Daten zu bearbeiten oder Planungen zu öffnen.",
-            "Verwende Schnellaktionen für häufige Aufgaben."
+            "Nutze die Checkliste, um fehlende Grunddaten Schritt für Schritt anzulegen.",
+            "Öffne die jeweiligen Bereiche, um Standorte, Anbauflächen, Kulturen oder Anbaupläne zu bearbeiten.",
+            "Prüfe die anstehenden Aufgaben, um Aussaat, Pflanzung, Anzucht und Ernte im Blick zu behalten."
+          ]
+        },
+        {
+          "title": "Hinweis",
+          "points": [
+            "Die Übersicht ist eine Zusammenfassung. Änderungen an den Daten machst du in den jeweiligen Fachseiten."
           ]
         }
       ]

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -36,6 +36,8 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Chip,
+  Divider,
   Dialog,
   DialogActions,
   DialogContent,
@@ -45,6 +47,7 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  Paper,
   Snackbar,
   Tooltip,
   Typography,
@@ -1237,30 +1240,98 @@ function Cultures(): React.ReactElement {
             <List>
               {historyItems.map((item) => {
                 const historyTarget = getHistoryEntryTarget(item);
+                const mobileTitle = getHistoryEntryTitle(item, t);
+                const mobileMeta = getHistoryEntryMeta(item, t, fallbackHistoryActorLabel);
                 return (
-                  <ListItem key={item.history_id} disableGutters>
-                    <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
-                      <ListItemText
-                        sx={{ mr: 1 }}
-                        primary={(
-                          <>
-                            {getHistoryEntryTitle(item, t)}
+                  <ListItem key={item.history_id} disableGutters sx={{ mb: isMobile ? 1 : 0 }}>
+                    {isMobile ? (
+                      <Paper variant="outlined" sx={{ width: '100%', p: 1.25, borderRadius: 1.5 }}>
+                        <Stack spacing={1}>
+                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+                            <Chip
+                              size="small"
+                              label={item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
+                              variant="outlined"
+                            />
                             {historyTarget ? (
-                              <>
-                                {' · '}
-                                <Link component={RouterLink} to={historyTarget} underline="hover" onClick={() => setHistoryOpen(false)}>
-                                  {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
-                                </Link>
-                              </>
+                              <Link
+                                component={RouterLink}
+                                to={historyTarget}
+                                underline="hover"
+                                onClick={() => setHistoryOpen(false)}
+                                sx={{ fontSize: '0.78rem', color: 'text.secondary', flexShrink: 0 }}
+                              >
+                                {t('history.objectTypes.openTarget', { defaultValue: 'Öffnen' })}
+                              </Link>
                             ) : null}
-                          </>
-                        )}
-                        secondary={getHistoryEntryMeta(item, t, fallbackHistoryActorLabel)}
-                      />
-                      <Button onClick={() => handleRestoreVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-                        {t('history.restoreButton')}
-                      </Button>
-                    </Stack>
+                          </Box>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontWeight: 600,
+                              lineHeight: 1.35,
+                              display: '-webkit-box',
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              wordBreak: 'normal',
+                              overflowWrap: 'break-word',
+                            }}
+                          >
+                            {mobileTitle}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              lineHeight: 1.3,
+                              display: '-webkit-box',
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              wordBreak: 'normal',
+                              overflowWrap: 'break-word',
+                            }}
+                          >
+                            {mobileMeta}
+                          </Typography>
+                          <Divider />
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            onClick={() => handleRestoreVersion(item.history_id)}
+                            sx={{ alignSelf: 'flex-start', minHeight: 34 }}
+                          >
+                            {t('history.restoreButton')}
+                          </Button>
+                        </Stack>
+                      </Paper>
+                    ) : (
+                      <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
+                        <ListItemText
+                          sx={{ mr: 1 }}
+                          primary={(
+                            <>
+                              {mobileTitle}
+                              {historyTarget ? (
+                                <>
+                                  {' · '}
+                                  <Link component={RouterLink} to={historyTarget} underline="hover" onClick={() => setHistoryOpen(false)}>
+                                    {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
+                                  </Link>
+                                </>
+                              ) : null}
+                            </>
+                          )}
+                          secondary={mobileMeta}
+                        />
+                        <Button onClick={() => handleRestoreVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+                          {t('history.restoreButton')}
+                        </Button>
+                      </Stack>
+                    )}
                   </ListItem>
                 );
               })}

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -50,6 +50,8 @@ import {
   Typography,
   Link,
   Stack,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
@@ -100,6 +102,8 @@ import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -284,6 +288,13 @@ function Cultures(): React.ReactElement {
       return;
     }
     const response = await cultureAPI.history(selectedCulture.id);
+    if (response.data.length <= 1) {
+      showSnackbar(
+        t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' }),
+        'info',
+      );
+      return;
+    }
     setHistoryItems(response.data);
     setHistoryScope('culture');
     setHistoryOpen(true);
@@ -1212,38 +1223,49 @@ function Cultures(): React.ReactElement {
               ? t('history.titles.global')
               : t('history.titles.culture')}
         </DialogTitle>
-        <DialogContent>
-          <List>
-            {historyItems.map((item) => {
-              const historyTarget = getHistoryEntryTarget(item);
-              return (
-                <ListItem key={item.history_id} disableGutters>
-                  <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
-                    <ListItemText
-                      sx={{ mr: 1 }}
-                      primary={(
-                        <>
-                          {getHistoryEntryTitle(item, t)}
-                          {historyTarget ? (
-                            <>
-                              {' · '}
-                              <Link component={RouterLink} to={historyTarget} underline="hover" onClick={() => setHistoryOpen(false)}>
-                                {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
-                              </Link>
-                            </>
-                          ) : null}
-                        </>
-                      )}
-                      secondary={getHistoryEntryMeta(item, t, fallbackHistoryActorLabel)}
-                    />
-                    <Button onClick={() => handleRestoreVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-                      {t('history.restoreButton')}
-                    </Button>
-                  </Stack>
-                </ListItem>
-              );
-            })}
-          </List>
+        <DialogContent sx={{ pt: historyItems.length === 0 ? 1 : 2, pb: historyItems.length === 0 ? 1 : 2 }}>
+          {historyItems.length === 0 ? (
+            <Box sx={{ py: isMobile ? 0.5 : 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                {t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' })}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                {t('history.emptyState.description', { defaultValue: 'Für diese Sorte existiert aktuell nur diese Version.' })}
+              </Typography>
+            </Box>
+          ) : (
+            <List>
+              {historyItems.map((item) => {
+                const historyTarget = getHistoryEntryTarget(item);
+                return (
+                  <ListItem key={item.history_id} disableGutters>
+                    <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
+                      <ListItemText
+                        sx={{ mr: 1 }}
+                        primary={(
+                          <>
+                            {getHistoryEntryTitle(item, t)}
+                            {historyTarget ? (
+                              <>
+                                {' · '}
+                                <Link component={RouterLink} to={historyTarget} underline="hover" onClick={() => setHistoryOpen(false)}>
+                                  {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
+                                </Link>
+                              </>
+                            ) : null}
+                          </>
+                        )}
+                        secondary={getHistoryEntryMeta(item, t, fallbackHistoryActorLabel)}
+                      />
+                      <Button onClick={() => handleRestoreVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+                        {t('history.restoreButton')}
+                      </Button>
+                    </Stack>
+                  </ListItem>
+                );
+              })}
+            </List>
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setHistoryOpen(false)}>{t('history.closeButton')}</Button>

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -137,6 +137,7 @@ function Cultures(): React.ReactElement {
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<CultureHistoryEntry[]>([]);
   const [historyScope, setHistoryScope] = useState<'culture' | 'global' | 'project'>('culture');
+  const [historyHintMessage, setHistoryHintMessage] = useState<string | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [aiMenuAnchor, setAiMenuAnchor] = useState<null | HTMLElement>(null);
   const aiEnrichmentEnabled = FEATURES.AI_ENRICHMENT;
@@ -247,6 +248,10 @@ function Cultures(): React.ReactElement {
     }
   }, [cultures, selectedCultureId, showForm, updateSelectedCultureId]);
 
+  useEffect(() => {
+    setHistoryHintMessage(null);
+  }, [selectedCultureId]);
+
   const handleCultureSelect = (culture: Culture | null) => {
     updateSelectedCultureId(culture?.id, 'internal');
   };
@@ -292,12 +297,10 @@ function Cultures(): React.ReactElement {
     }
     const response = await cultureAPI.history(selectedCulture.id);
     if (response.data.length <= 1) {
-      showSnackbar(
-        t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' }),
-        'info',
-      );
+      setHistoryHintMessage(t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' }));
       return;
     }
+    setHistoryHintMessage(null);
     setHistoryItems(response.data);
     setHistoryScope('culture');
     setHistoryOpen(true);
@@ -1007,6 +1010,22 @@ function Cultures(): React.ReactElement {
               : t('library.publishButton'))}
         />
       </Box>
+      {historyHintMessage ? (
+        <Box sx={{ mb: 2 }}>
+          <EmptyStateCard
+            title={historyHintMessage}
+            description={t('history.emptyState.description', { defaultValue: 'Für diese Sorte existiert aktuell nur diese Version.' })}
+            containerSx={{
+              backgroundColor: 'rgba(76, 175, 80, 0.06)',
+              borderLeft: '3px solid',
+              borderLeftColor: 'success.main',
+              py: 1.25,
+              px: 1.5,
+            }}
+            titleSx={{ fontWeight: 500 }}
+          />
+        </Box>
+      ) : null}
 
       {cultures.length > 0 && (
         <Box sx={{ mb: 2 }}>

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -137,7 +137,6 @@ function Cultures(): React.ReactElement {
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<CultureHistoryEntry[]>([]);
   const [historyScope, setHistoryScope] = useState<'culture' | 'global' | 'project'>('culture');
-  const [historyHintMessage, setHistoryHintMessage] = useState<string | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [aiMenuAnchor, setAiMenuAnchor] = useState<null | HTMLElement>(null);
   const aiEnrichmentEnabled = FEATURES.AI_ENRICHMENT;
@@ -248,10 +247,6 @@ function Cultures(): React.ReactElement {
     }
   }, [cultures, selectedCultureId, showForm, updateSelectedCultureId]);
 
-  useEffect(() => {
-    setHistoryHintMessage(null);
-  }, [selectedCultureId]);
-
   const handleCultureSelect = (culture: Culture | null) => {
     updateSelectedCultureId(culture?.id, 'internal');
   };
@@ -297,10 +292,9 @@ function Cultures(): React.ReactElement {
     }
     const response = await cultureAPI.history(selectedCulture.id);
     if (response.data.length <= 1) {
-      setHistoryHintMessage(t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' }));
+      showSnackbar(t('history.emptyState.title', { defaultValue: 'Keine weiteren Versionen verfügbar.' }), 'info');
       return;
     }
-    setHistoryHintMessage(null);
     setHistoryItems(response.data);
     setHistoryScope('culture');
     setHistoryOpen(true);
@@ -1010,23 +1004,6 @@ function Cultures(): React.ReactElement {
               : t('library.publishButton'))}
         />
       </Box>
-      {historyHintMessage ? (
-        <Box sx={{ mb: 2 }}>
-          <EmptyStateCard
-            title={historyHintMessage}
-            description={t('history.emptyState.description', { defaultValue: 'Für diese Sorte existiert aktuell nur diese Version.' })}
-            containerSx={{
-              backgroundColor: 'rgba(76, 175, 80, 0.06)',
-              borderLeft: '3px solid',
-              borderLeftColor: 'success.main',
-              py: 1.25,
-              px: 1.5,
-            }}
-            titleSx={{ fontWeight: 500 }}
-          />
-        </Box>
-      ) : null}
-
       {cultures.length > 0 && (
         <Box sx={{ mb: 2 }}>
           {firstMissingPlanRequirement === 'beds' ? (
@@ -1399,14 +1376,30 @@ function Cultures(): React.ReactElement {
 
       <Snackbar
         open={snackbar.open}
-        autoHideDuration={6000}
+        autoHideDuration={4200}
         onClose={handleCloseSnackbar}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        sx={{
+          '& .MuiAlert-root': {
+            borderRadius: 2,
+            boxShadow: '0 6px 20px rgba(15, 23, 42, 0.12)',
+          },
+        }}
       >
         <Alert
           onClose={handleCloseSnackbar}
           severity={snackbar.severity}
-          sx={{ width: '100%' }}
+          variant="filled"
+          sx={{
+            width: '100%',
+            alignItems: 'center',
+            fontWeight: 500,
+            bgcolor: snackbar.severity === 'info' ? 'rgba(37, 111, 42, 0.96)' : undefined,
+            color: snackbar.severity === 'info' ? '#ffffff' : undefined,
+            '& .MuiAlert-icon': {
+              color: snackbar.severity === 'info' ? '#ffffff' : undefined,
+            },
+          }}
         >
           {snackbar.message}
         </Alert>

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -21,6 +21,7 @@ import { DataGrid, GridRowModes } from "@mui/x-data-grid";
 import { germanDataGridLocaleText } from "../components/data-grid/localeText";
 import type { GridRowsProp, GridRowModesModel, GridRowHeightParams } from "@mui/x-data-grid";
 import { Box, Alert } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { dataGridSx } from "../components/data-grid/styles";
 import {
@@ -99,7 +100,7 @@ const HIERARCHY_DATA_GRID_SX = {
       height: "32px",
     },
   "& .ofp-hierarchy-cell-missing-dimension": {
-    backgroundColor: (theme) => theme.palette.action.hover,
+    backgroundColor: (theme: Theme) => theme.palette.action.hover,
   },
 };
 

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -123,9 +123,6 @@ export default function FieldsBedsPage(): React.ReactElement {
     reloadHierarchyAndLocations,
     t as never,
   );
-  const shouldShowGlobalAddButton = viewMode === 'table'
-    && !shouldShowProjectRequiredState
-    && locations.length <= 1;
   const handleGlobalAddField = useCallback((): void => {
     if (locations.length === 0) {
       navigate('/app/locations?create=true');

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -86,6 +86,7 @@ import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 import EmptyStateCard from "../components/project/EmptyStateCard";
 
 const AREA_LABEL_SEPARATOR = " | ";
+const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
 
 export const buildAreaColumnHeaderLabel = (
   includeLocation: boolean,
@@ -989,7 +990,11 @@ function PlantingPlans(): React.ReactElement {
         minWidth: dynamicWidths.harvestDate,
         editable: false,
         type: "date",
-        renderHeader: () => <span>{t("plantingPlans:columns.harvestStartDate")}</span>,
+        renderHeader: () => (
+          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
+            {t("plantingPlans:columns.harvestStartDate")}
+          </Box>
+        ),
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
@@ -1000,7 +1005,11 @@ function PlantingPlans(): React.ReactElement {
         minWidth: dynamicWidths.harvestEndDate,
         editable: false,
         type: "date",
-        renderHeader: () => <span>{t("plantingPlans:columns.harvestEndDate")}</span>,
+        renderHeader: () => (
+          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
+            {t("plantingPlans:columns.harvestEndDate")}
+          </Box>
+        ),
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
@@ -1014,7 +1023,9 @@ function PlantingPlans(): React.ReactElement {
         type: "number",
         renderHeader: () => (
           <Tooltip title={t("plantingPlans:tooltips.coupledFields")}>
-            <div>{t("plantingPlans:columns.areaM2")}</div>
+            <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
+              {t("plantingPlans:columns.areaM2")}
+            </Box>
           </Tooltip>
         ),
         preProcessEditCellProps: (params) => {
@@ -1105,7 +1116,9 @@ function PlantingPlans(): React.ReactElement {
         type: "number",
         renderHeader: () => (
           <Tooltip title={t("plantingPlans:tooltips.plantsFromSpacing")}>
-            <div>{t("plantingPlans:columns.plantsCount")}</div>
+            <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
+              {t("plantingPlans:columns.plantsCount")}
+            </Box>
           </Tooltip>
         ),
         preProcessEditCellProps: (params) => {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,6 +1,7 @@
 // Central MUI theme configuration
 // Controls colors, shapes, and component style overrides.
 import { createTheme } from '@mui/material/styles';
+import type {} from '@mui/x-data-grid/themeAugmentation';
 
 const theme = createTheme({
   typography: {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -94,6 +94,26 @@ const theme = createTheme({
         },
       },
     },
+    MuiAlert: {
+      styleOverrides: {
+        standardInfo: {
+          backgroundColor: 'rgba(33, 150, 243, 0.08)',
+          color: '#24435f',
+        },
+        standardSuccess: {
+          backgroundColor: 'rgba(76, 175, 80, 0.10)',
+          color: '#2f5a35',
+        },
+        standardWarning: {
+          backgroundColor: 'rgba(237, 108, 2, 0.10)',
+          color: '#75491e',
+        },
+        standardError: {
+          backgroundColor: 'rgba(211, 47, 47, 0.09)',
+          color: '#6e2c2c',
+        },
+      },
+    },
     MuiTableCell: {
       styleOverrides: {
         head: {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -93,10 +93,23 @@ const theme = createTheme({
         },
       },
     },
+    MuiTableCell: {
+      styleOverrides: {
+        head: {
+          fontWeight: 600,
+        },
+        body: {
+          fontWeight: 400,
+        },
+      },
+    },
     MuiDataGrid: {
       styleOverrides: {
         columnHeaderTitle: {
           fontWeight: 600,
+        },
+        cell: {
+          fontWeight: 400,
         },
       },
     },


### PR DESCRIPTION
### Motivation
- The project had inconsistent table and grid header typography (mixed 400/500/600/700 and local overrides), resulting in an uneven UI that should be made calmer and more professional.

### Description
- Centralized table header and body typography in the global MUI theme by adding `MuiTableCell.styleOverrides` with `head: { fontWeight: 600 }` and `body: { fontWeight: 400 }` in `frontend/src/theme.ts`.
- Explicitly normalized the DataGrid text by keeping `MuiDataGrid.styleOverrides.columnHeaderTitle: { fontWeight: 600 }` and adding `MuiDataGrid.styleOverrides.cell: { fontWeight: 400 }` so grid headers are semibold and grid cells are regular.
- This makes header typography project-wide via the theme and reduces the need for local `fontWeight` overrides in individual components.

### Testing
- No automated tests were executed, per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef481ce808322bad0e4194baef68d)