### PR TITLE
ci: add frontend production build workflow

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,35 @@
+name: Frontend Build
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-build.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build


### PR DESCRIPTION
### Motivation
- Add a lightweight CI workflow to verify the frontend production build independently of backend tests and slower checks.

### Description
- Add `.github/workflows/frontend-build.yml` which triggers on `pull_request` when `frontend/**` or the workflow file changes and on `push` to `main` when `frontend/**` changes, runs on `ubuntu-latest`, uses `actions/checkout@v4` and `actions/setup-node@v4` with Node.js `22` and npm caching (`cache: npm`, `cache-dependency-path: frontend/package-lock.json`), sets the working directory to `frontend`, then runs `npm ci` and `npm run build`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a10ad0e08322b7e4e1089b071b99)