### PR TITLE
refactor(frontend): centralize topbar context action synchronization

### DIFF
--- a/frontend/src/hooks/useTopbarContextActions.ts
+++ b/frontend/src/hooks/useTopbarContextActions.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import type { TopbarContextAction } from '../App';
+
+export function useTopbarContextActions(
+  setActions: (actions: TopbarContextAction[]) => void,
+  actions: TopbarContextAction[],
+): void {
+  useEffect(() => {
+    setActions(actions);
+    return () => setActions([]);
+  }, [actions, setActions]);
+}

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -102,6 +102,7 @@ import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { getFirstMissingCultivationPlanRequirement } from './requirementFlow';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
+import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 
 function Cultures(): React.ReactElement {
   const { t } = useTranslation('cultures');
@@ -757,10 +758,7 @@ function Cultures(): React.ReactElement {
     },
   ]), [handleExportAllCultures, handleExportCurrentCulture, handleImportFileTrigger, handleOpenPublicLibrary, selectedCulture]);
 
-  useEffect(() => {
-    setTopbarContextActions(contextActions);
-    return () => setTopbarContextActions([]);
-  }, [contextActions, setTopbarContextActions]);
+  useTopbarContextActions(setTopbarContextActions, contextActions);
 
   const commandSpecs = useMemo(() => createCulturesCommandSpecs({
     canRunEnrichmentForCulture,

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -14,6 +14,7 @@ import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
+import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 
@@ -188,56 +189,54 @@ export default function FieldsBedsPage(): React.ReactElement {
   }, [viewMode]);
 
 
-  useEffect(() => {
-    const contextActions: TopbarContextAction[] = [
-      {
-        id: 'fields-interaction-mode-view',
-        label: t('fields:graphical.viewModeOption'),
-        onClick: () => {
-          setInteractionMode('view');
-        },
-        active: interactionMode === 'view',
-        hidden: viewMode !== 'graphical',
-        reserveSpace: true,
-        ariaLabel: t('fields:graphical.modeAriaLabel'),
-        groupId: 'fields-interaction-mode',
+  const contextActions = useMemo<TopbarContextAction[]>(() => [
+    {
+      id: 'fields-interaction-mode-view',
+      label: t('fields:graphical.viewModeOption'),
+      onClick: () => {
+        setInteractionMode('view');
       },
-      {
-        id: 'fields-interaction-mode-edit',
-        label: t('fields:graphical.editModeOption'),
-        onClick: () => {
-          setInteractionMode('edit');
-        },
-        active: interactionMode === 'edit',
-        hidden: viewMode !== 'graphical',
-        reserveSpace: true,
-        ariaLabel: t('fields:graphical.modeAriaLabel'),
-        groupId: 'fields-interaction-mode',
+      active: interactionMode === 'view',
+      hidden: viewMode !== 'graphical',
+      reserveSpace: true,
+      ariaLabel: t('fields:graphical.modeAriaLabel'),
+      groupId: 'fields-interaction-mode',
+    },
+    {
+      id: 'fields-interaction-mode-edit',
+      label: t('fields:graphical.editModeOption'),
+      onClick: () => {
+        setInteractionMode('edit');
       },
-      {
-        id: 'fields-view-mode-list',
-        label: t('fields:representation.table'),
-        onClick: () => {
-          setViewMode('table');
-        },
-        active: viewMode === 'table',
-        ariaLabel: t('fields:representation.ariaLabel'),
-        groupId: 'fields-view-mode',
+      active: interactionMode === 'edit',
+      hidden: viewMode !== 'graphical',
+      reserveSpace: true,
+      ariaLabel: t('fields:graphical.modeAriaLabel'),
+      groupId: 'fields-interaction-mode',
+    },
+    {
+      id: 'fields-view-mode-list',
+      label: t('fields:representation.table'),
+      onClick: () => {
+        setViewMode('table');
       },
-      {
-        id: 'fields-view-mode-graphical',
-        label: t('fields:representation.graphical'),
-        onClick: () => {
-          setViewMode('graphical');
-        },
-        active: viewMode === 'graphical',
-        ariaLabel: t('fields:representation.ariaLabel'),
-        groupId: 'fields-view-mode',
+      active: viewMode === 'table',
+      ariaLabel: t('fields:representation.ariaLabel'),
+      groupId: 'fields-view-mode',
+    },
+    {
+      id: 'fields-view-mode-graphical',
+      label: t('fields:representation.graphical'),
+      onClick: () => {
+        setViewMode('graphical');
       },
-    ];
-    setTopbarContextActions(contextActions);
-    return () => setTopbarContextActions([]);
-  }, [interactionMode, setTopbarContextActions, t, viewMode]);
+      active: viewMode === 'graphical',
+      ariaLabel: t('fields:representation.ariaLabel'),
+      groupId: 'fields-view-mode',
+    },
+  ], [interactionMode, t, viewMode]);
+
+  useTopbarContextActions(setTopbarContextActions, contextActions);
 
   return (
     <>

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -59,6 +59,7 @@ import {
   segmentedButtonGroupSx,
 } from '../components/buttons/segmentedControlStyles';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
+import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 
 interface WeeklyYieldCultureMeta {
   id: number;
@@ -426,34 +427,32 @@ function GanttChartPage(): React.ReactElement {
   }, [maxTotalYield]);
 
 
-  useEffect(() => {
-    const topbarActions: TopbarContextAction[] = [
-      {
-        id: 'calendar-mode-view',
-        label: t('ganttChart:modeViewOption'),
-        onClick: () => setEditMode(false),
-        active: !editMode,
-        hidden: calendarMode !== 'occupancy',
-        reserveSpace: true,
-        groupId: 'calendar-interaction-mode',
-        ariaLabel: t('ganttChart:modeAriaLabel'),
-        tooltip: t('ganttChart:modeViewTooltip'),
-      },
-      {
-        id: 'calendar-mode-edit',
-        label: t('ganttChart:modeEditOption'),
-        onClick: () => setEditMode(true),
-        active: editMode,
-        hidden: calendarMode !== 'occupancy',
-        reserveSpace: true,
-        groupId: 'calendar-interaction-mode',
-        ariaLabel: t('ganttChart:modeAriaLabel'),
-        tooltip: t('ganttChart:modeEditTooltip'),
-      },
-    ];
-    setTopbarContextActions(topbarActions);
-    return () => setTopbarContextActions([]);
-  }, [calendarMode, editMode, setTopbarContextActions, t]);
+  const topbarActions = useMemo<TopbarContextAction[]>(() => [
+    {
+      id: 'calendar-mode-view',
+      label: t('ganttChart:modeViewOption'),
+      onClick: () => setEditMode(false),
+      active: !editMode,
+      hidden: calendarMode !== 'occupancy',
+      reserveSpace: true,
+      groupId: 'calendar-interaction-mode',
+      ariaLabel: t('ganttChart:modeAriaLabel'),
+      tooltip: t('ganttChart:modeViewTooltip'),
+    },
+    {
+      id: 'calendar-mode-edit',
+      label: t('ganttChart:modeEditOption'),
+      onClick: () => setEditMode(true),
+      active: editMode,
+      hidden: calendarMode !== 'occupancy',
+      reserveSpace: true,
+      groupId: 'calendar-interaction-mode',
+      ariaLabel: t('ganttChart:modeAriaLabel'),
+      tooltip: t('ganttChart:modeEditTooltip'),
+    },
+  ], [calendarMode, editMode, t]);
+
+  useTopbarContextActions(setTopbarContextActions, topbarActions);
 
   if (loading) {
     return (


### PR DESCRIPTION
### Motivation
- Several pages duplicated the same `useEffect` pattern to set and clear topbar context actions, which increases maintenance burden and risks inconsistent cleanup.
- Centralize this small, low-risk concern to reduce duplication while keeping UI behavior unchanged.

### Description
- Add a reusable hook `useTopbarContextActions` at `frontend/src/hooks/useTopbarContextActions.ts` that encapsulates the `set/clear` lifecycle for topbar actions.
- Migrate `Cultures`, `FieldsBedsPage`, and `GanttChart` to use the new hook and convert inline action arrays into memoized `TopbarContextAction[]` values where applicable, preserving existing labels, handlers, visibility, and grouping.
- Changes are limited to topbar action wiring and related imports; no API, data-flow, UX, or behavioral changes were introduced.

### Testing
- No automated tests were executed for this change (requested in the task); no test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01aadc62048322af7ee03b9aec75c9)