### PR TITLE
fix(frontend): make planting plan card headers fully tappable

### DIFF
--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -10,7 +10,10 @@
     "graphicalFields": "Grafische Ansicht"
   },
   "fields": {
-    "plots": "Anbauflächen"
+    "plots": "Anbauflächen",
+    "bed": "Beet",
+    "planting_date": "Pflanzdatum",
+    "culture": "Kultur"
   },
   "common": {
     "actions": {
@@ -83,5 +86,8 @@
       "daysToLastHarvest": "Tage bis zur letzten Ernte"
     },
     "moreInfo": "Mehr Infos (Wikipedia)"
+  },
+  "validation": {
+    "required": "Dieses Feld ist erforderlich."
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -105,7 +105,7 @@
   width: 100%;
   max-width: 1360px;
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
   margin: var(--page-content-margin, 0 auto);
 }
 
@@ -113,7 +113,7 @@
   width: 100%;
   max-width: 1800px;
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
   margin: var(--page-content-margin, 0 auto);
 }
 
@@ -121,7 +121,7 @@
   width: 100%;
   max-width: min(1800px, calc(100vw - 48px));
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
   margin: var(--page-content-margin, 0 auto);
 }
 
@@ -130,7 +130,7 @@
   width: 100%;
   max-width: 1900px;
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
   margin: var(--page-content-margin, 0 auto);
 }
 
@@ -139,7 +139,7 @@
   /* Intentionally bypass the standard centered max-width so wide data tables can use the full workspace width. */
   max-width: none;
   box-sizing: border-box;
-  /* Main already adds responsive horizontal gutters; extra container padding was the effective width limiter on wide pages. */
+  /* RootLayout main owns the global page gutter; workspace pages keep container padding at 0 to avoid double horizontal spacing. */
   padding: 0;
   margin: 0;
 }
@@ -148,14 +148,14 @@
   width: 100%;
   max-width: 1360px;
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
   margin: var(--page-content-margin, 0 auto);
 }
 
 .content--full {
   width: 100%;
   box-sizing: border-box;
-  padding: 0 24px;
+  padding: 0 16px;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -95,7 +95,7 @@
 .content,
 .page-container {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1360px;
   box-sizing: border-box;
   padding: 0 24px;
   margin: 0 auto;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -132,6 +132,28 @@
   padding: 0 24px;
 }
 
+@media (max-width: 900px) {
+  .content,
+  .page-container,
+  .content--wide,
+  .content--workspace,
+  .content--xwide,
+  .content--full {
+    padding: 0 16px;
+  }
+}
+
+@media (max-width: 600px) {
+  .content,
+  .page-container,
+  .content--wide,
+  .content--workspace,
+  .content--xwide,
+  .content--full {
+    padding: 0 10px;
+  }
+}
+
 /* Error Message */
 .error-message {
   color: #d32f2f;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,6 +14,14 @@
   min-height: 100vh;
 }
 
+.app.app--centered {
+  --page-content-margin: 0 auto;
+}
+
+.app.app--left {
+  --page-content-margin: 0;
+}
+
 /* Navigation Styles */
 .nav {
   width: 100%;
@@ -98,7 +106,7 @@
   max-width: 1360px;
   box-sizing: border-box;
   padding: 0 24px;
-  margin: 0 auto;
+  margin: var(--page-content-margin, 0 auto);
 }
 
 .content--wide {
@@ -106,7 +114,7 @@
   max-width: 1800px;
   box-sizing: border-box;
   padding: 0 24px;
-  margin: 0 auto;
+  margin: var(--page-content-margin, 0 auto);
 }
 
 .content--workspace {
@@ -114,7 +122,7 @@
   max-width: min(1800px, calc(100vw - 48px));
   box-sizing: border-box;
   padding: 0 24px;
-  margin: 0 auto;
+  margin: var(--page-content-margin, 0 auto);
 }
 
 
@@ -123,7 +131,7 @@
   max-width: 1900px;
   box-sizing: border-box;
   padding: 0 24px;
-  margin: 0 auto;
+  margin: var(--page-content-margin, 0 auto);
 }
 
 .content--full {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -178,7 +178,7 @@
   .content--xwide,
   .content--compact-centered-page,
   .content--full {
-    padding: 0 8px;
+    padding: 0;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -136,10 +136,11 @@
 
 .content--workspace-table {
   width: 100%;
-  max-width: 1800px;
+  /* Intentionally bypass the standard centered max-width so wide data tables can use the full workspace width. */
+  max-width: none;
   box-sizing: border-box;
   padding: 0 24px;
-  margin: var(--page-content-margin, 0 auto);
+  margin: 0;
 }
 
 .content--compact-centered-table {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -134,7 +134,7 @@
   margin: var(--page-content-margin, 0 auto);
 }
 
-.content--workspace-table {
+.content--workspace-page {
   width: 100%;
   /* Intentionally bypass the standard centered max-width so wide data tables can use the full workspace width. */
   max-width: none;
@@ -144,7 +144,7 @@
   margin: 0;
 }
 
-.content--compact-centered-table {
+.content--compact-centered-page {
   width: 100%;
   max-width: 1360px;
   box-sizing: border-box;
@@ -164,7 +164,7 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
-  .content--compact-centered-table,
+  .content--compact-centered-page,
   .content--full {
     padding: 0 16px;
   }
@@ -176,7 +176,7 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
-  .content--compact-centered-table,
+  .content--compact-centered-page,
   .content--full {
     padding: 0 8px;
   }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -139,7 +139,8 @@
   /* Intentionally bypass the standard centered max-width so wide data tables can use the full workspace width. */
   max-width: none;
   box-sizing: border-box;
-  padding: 0 24px;
+  /* Main already adds responsive horizontal gutters; extra container padding was the effective width limiter on wide pages. */
+  padding: 0;
   margin: 0;
 }
 
@@ -163,7 +164,6 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
-  .content--workspace-table,
   .content--compact-centered-table,
   .content--full {
     padding: 0 16px;
@@ -176,7 +176,6 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
-  .content--workspace-table,
   .content--compact-centered-table,
   .content--full {
     padding: 0 8px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -150,7 +150,7 @@
   .content--workspace,
   .content--xwide,
   .content--full {
-    padding: 0 10px;
+    padding: 0 8px;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -134,6 +134,22 @@
   margin: var(--page-content-margin, 0 auto);
 }
 
+.content--workspace-table {
+  width: 100%;
+  max-width: 1800px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  margin: var(--page-content-margin, 0 auto);
+}
+
+.content--compact-centered-table {
+  width: 100%;
+  max-width: 1360px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  margin: var(--page-content-margin, 0 auto);
+}
+
 .content--full {
   width: 100%;
   box-sizing: border-box;
@@ -146,6 +162,8 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
+  .content--workspace-table,
+  .content--compact-centered-table,
   .content--full {
     padding: 0 16px;
   }
@@ -157,6 +175,8 @@
   .content--wide,
   .content--workspace,
   .content--xwide,
+  .content--workspace-table,
+  .content--compact-centered-table,
   .content--full {
     padding: 0 8px;
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -796,7 +796,7 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: { xs: 'wrap', md: 'nowrap' } }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
             {!isDesktopUp ? (
@@ -824,8 +824,8 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
-          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: isMobile ? 'auto' : 'visible', scrollbarWidth: 'thin' }}>
+          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, flexWrap: { xs: 'wrap', md: 'nowrap' }, width: { xs: '100%', md: 'auto' } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: isMobile ? 'auto' : 'visible', scrollbarWidth: 'thin', order: { xs: 2, md: 1 }, width: { xs: '100%', md: 'auto' }, pt: { xs: 0.5, md: 0 } }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (
@@ -949,8 +949,7 @@ function RootLayout(): React.ReactElement {
             </Tooltip>
           ) : null}
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 1, md: 3 } }}>
-          {!isPhone ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 'auto', md: 3 }, order: { xs: 1, md: 2 }, width: { xs: '100%', md: 'auto' }, justifyContent: { xs: 'space-between', md: 'flex-start' } }}>
           <Button
             aria-label={t('projectSwitcher.ariaLabel')}
             aria-controls={projectMenuAnchor ? 'project-switcher-menu' : undefined}
@@ -961,15 +960,14 @@ function RootLayout(): React.ReactElement {
             sx={{
               color: 'text.primary',
               textTransform: 'none',
-              maxWidth: { sm: 190, md: 240, lg: 320 },
+              maxWidth: { xs: 210, sm: 190, md: 240, lg: 320 },
               minWidth: 0,
             }}
             startIcon={<FolderOpenOutlinedIcon fontSize="small" />}
-            endIcon={<KeyboardArrowDownIcon fontSize="small" />}
+            endIcon={!isPhone ? <KeyboardArrowDownIcon fontSize="small" /> : undefined}
           >
             <span className="project-switcher-label">{activeProjectLabel}</span>
           </Button>
-          ) : null}
           <ProjectMenu
             anchorEl={projectMenuAnchor}
             open={Boolean(projectMenuAnchor)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1051,7 +1051,9 @@ function RootLayout(): React.ReactElement {
         component="main"
         sx={{
           width: '100%',
-          px: { xs: 1.5, sm: 2.5, md: 3.5 },
+          // Global outer page gutter (single source of truth for workspace pages).
+          // Uses smaller desktop gutters on wide monitors while keeping clear edge spacing.
+          px: { xs: 1.5, sm: 2, md: 2.5, lg: 2.25, xl: 2 },
           py: { xs: 1.5, md: 2.5 },
           display: 'flex',
           flexDirection: 'column',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -823,7 +823,7 @@ function RootLayout(): React.ReactElement {
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: isMobile ? 'auto' : 'visible', scrollbarWidth: 'thin' }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (
@@ -880,7 +880,7 @@ function RootLayout(): React.ReactElement {
               </Menu>
             </>
           ) : null}
-          {!isMobile ? (() => {
+          {(() => {
             const groups: TopbarContextAction[][] = [];
             genericTopbarContextActions.forEach((action) => {
               const lastGroup = groups[groups.length - 1];
@@ -907,6 +907,7 @@ function RootLayout(): React.ReactElement {
                     active: Boolean(action.active),
                     hidden: Boolean(action.hidden),
                   })}
+                  style={isMobile ? { minWidth: 0, paddingLeft: 8, paddingRight: 8, fontSize: '0.74rem' } : undefined}
                 >
                   {action.label}
                 </Button>
@@ -922,15 +923,15 @@ function RootLayout(): React.ReactElement {
                   key={`group-${group[0]?.groupId}-${index}`}
                   size="small"
                   variant="outlined"
-                  sx={segmentedButtonGroupSx}
+                  sx={{ ...segmentedButtonGroupSx, flexShrink: 0 }}
                 >
                   {content}
                 </ButtonGroup>
               ) : (
-                <Box key={`group-${index}`} sx={{ display: 'inline-flex' }}>{content}</Box>
+                <Box key={`group-${index}`} sx={{ display: 'inline-flex', flexShrink: 0 }}>{content}</Box>
               );
             });
-          })() : null}
+          })()}
           {topbarPrimaryAction ? (
             <Tooltip title={topbarPrimaryAction.label}>
               <Button

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,6 +101,8 @@ import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
 import { PanelLeft } from 'lucide-react';
 
+const CONTENT_ALIGNMENT_MODE = 'centered';
+
 interface SnackbarState {
   open: boolean;
   message: string;
@@ -644,7 +646,7 @@ function RootLayout(): React.ReactElement {
   }, [location.pathname]);
 
   return (
-    <Box className="app" sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f2f0ea' }}>
+    <Box className={`app app--${CONTENT_ALIGNMENT_MODE}`} sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f2f0ea' }}>
       {isDesktopUp ? (
         <Box component="aside" sx={{ width: sidebarWidth, flexShrink: 0, borderRight: '1px solid', borderColor: '#e1dbd0', bgcolor: '#f5f2eb', transition: 'width 0.25s ease', position: 'relative', overflow: 'visible' }}>
           <Stack sx={{ height: '100%' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -794,7 +794,7 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, flexWrap: 'nowrap' }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
             {!isDesktopUp ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1053,7 +1053,7 @@ function RootLayout(): React.ReactElement {
           width: '100%',
           // Global outer page gutter (single source of truth for workspace pages).
           // Uses smaller desktop gutters on wide monitors while keeping clear edge spacing.
-          px: { xs: 1.5, sm: 2, md: 2.5, lg: 2.25, xl: 2 },
+          px: { xs: 0, sm: 2, md: 2.5, lg: 2.25, xl: 2 },
           py: { xs: 1.5, md: 2.5 },
           display: 'flex',
           flexDirection: 'column',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -931,15 +931,19 @@ function RootLayout(): React.ReactElement {
               );
             });
           })() : null}
-          {topbarPrimaryAction && (!isMobile || isCulturesPage) ? (
-            <Button
-              size="small"
-              variant="contained"
-              onClick={() => navigate(topbarPrimaryAction.to)}
-              sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 34 : 'auto', px: isPhone ? 0.75 : 1.5 }}
-            >
-              {isPhone ? '+' : `+ ${topbarPrimaryAction.label}`}
-            </Button>
+          {topbarPrimaryAction ? (
+            <Tooltip title={topbarPrimaryAction.label}>
+              <Button
+                size="small"
+                variant="contained"
+                onClick={() => navigate(topbarPrimaryAction.to)}
+                aria-label={topbarPrimaryAction.label}
+                startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.5 }}
+              >
+                {isPhone ? <AddIcon fontSize="small" /> : topbarPrimaryAction.label}
+              </Button>
+            </Tooltip>
           ) : null}
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 1, md: 3 } }}>

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -81,7 +81,10 @@ describe('hierarchy components and behaviors', () => {
     expect(nameColumn?.width).toBe(280);
     expect(nameColumn).not.toHaveProperty('flex');
     expect(areaColumn?.width).toBe(120);
-    expect(notesColumn?.width).toBe(320);
+    // Notes column default was intentionally reduced to tighten content-fit hierarchy tables.
+    expect(notesColumn?.width).toBe(220);
+    expect(notesColumn?.minWidth).toBe(180);
+    expect(notesColumn?.maxWidth).toBe(260);
 
     const { rerender } = render(
       <>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -129,6 +129,7 @@ export const plantingPlanAPI = {
   get: (id: number) => http.get<PlantingPlan>(`/planting-plans/${id}/`),
   create: (data: PlantingPlan) => http.post<PlantingPlan>('/planting-plans/', withActiveProject(data)),
   update: (id: number, data: PlantingPlan) => http.put<PlantingPlan>(`/planting-plans/${id}/`, withActiveProject(data)),
+  patch: (id: number, data: Partial<PlantingPlan>) => http.patch<PlantingPlan>(`/planting-plans/${id}/`, withActiveProject(data)),
   delete: (id: number) => http.delete(`/planting-plans/${id}/`),
   remainingArea: (params: { bed_id: number; start_date: string; end_date: string; exclude_plan_id?: number }) =>
     http.get<RemainingAreaResponse>('/planting-plans/remaining-area/', { params }),

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -762,7 +762,13 @@ export function EditableDataGrid<T extends EditableRow>({
             ...dataGridSx,
             width: isContentSizedSurface ? 'fit-content' : '100%',
             minWidth: isContentSizedSurface ? 0 : '100%',
-            ...(shouldDisableTrailingFiller ? { '& .MuiDataGrid-filler': { display: 'none' } } : {}),
+            ...(shouldDisableTrailingFiller ? {
+              '& .MuiDataGrid-filler': { display: 'none' },
+              '& .MuiDataGrid-scrollbarFiller': { display: 'none' },
+              '& .MuiDataGrid-main': { width: 'fit-content' },
+              '& .MuiDataGrid-virtualScrollerContent': { width: 'fit-content !important' },
+              '& .MuiDataGrid-columnHeaders': { width: 'fit-content !important' },
+            } : {}),
           }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -128,6 +128,7 @@ export function EditableDataGrid<T extends EditableRow>({
   fitContentWidth = false,
   layoutMode = 'standard',
 }: EditableDataGridProps<T>): React.ReactElement {
+  const shouldUseFitContentWidth = fitContentWidth && layoutMode !== 'workspace';
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
   const [error, setError] = useState<string>('');
@@ -807,4 +808,3 @@ export function EditableDataGrid<T extends EditableRow>({
     </>
   );
 }
-  const shouldUseFitContentWidth = fitContentWidth && layoutMode !== 'workspace';

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -96,6 +96,7 @@ export interface EditableDataGridProps<T extends EditableRow> {
   onRowsStateChange?: (rows: T[]) => void;
   onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean; error: string }) => void;
   fitContentWidth?: boolean;
+  layoutMode?: 'standard' | 'workspace';
 }
 
 export function EditableDataGrid<T extends EditableRow>({
@@ -125,6 +126,7 @@ export function EditableDataGrid<T extends EditableRow>({
   onRowsStateChange,
   onLoadStateChange,
   fitContentWidth = false,
+  layoutMode = 'standard',
 }: EditableDataGridProps<T>): React.ReactElement {
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
@@ -710,8 +712,8 @@ export function EditableDataGrid<T extends EditableRow>({
     <>
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
-      <Box sx={{ width: fitContentWidth ? 'fit-content' : '100%', maxWidth: '100%', overflowX: 'auto', overflowY: 'visible' }}>
-        <Box sx={{ display: 'block', width: fitContentWidth ? 'fit-content' : '100%', minWidth: 0 }}>
+      <Box sx={{ width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: '100%', maxWidth: '100%', overflowX: 'auto', overflowY: 'visible' }}>
+        <Box sx={{ display: 'block', width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: shouldUseFitContentWidth ? 0 : '100%' }}>
           <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -732,7 +734,7 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: fitContentWidth ? 'fit-content' : '100%' }}
+          sx={{ ...dataGridSx, width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: shouldUseFitContentWidth ? 0 : '100%' }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {
@@ -805,3 +807,4 @@ export function EditableDataGrid<T extends EditableRow>({
     </>
   );
 }
+  const shouldUseFitContentWidth = fitContentWidth && layoutMode !== 'workspace';

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -762,6 +762,7 @@ export function EditableDataGrid<T extends EditableRow>({
             ...dataGridSx,
             width: isContentSizedSurface ? 'fit-content' : '100%',
             minWidth: isContentSizedSurface ? 0 : '100%',
+            display: isContentSizedSurface ? 'inline-block' : 'block',
             ...(shouldDisableTrailingFiller ? {
               '& .MuiDataGrid-filler': { display: 'none' },
               '& .MuiDataGrid-scrollbarFiller': { display: 'none' },

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -95,8 +95,17 @@ export interface EditableDataGridProps<T extends EditableRow> {
   showRowEditActions?: boolean;
   onRowsStateChange?: (rows: T[]) => void;
   onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean; error: string }) => void;
+  /** @deprecated Use surfaceSizing instead. */
   fitContentWidth?: boolean;
+  /** @deprecated Use surfaceSizing instead. */
   layoutMode?: 'standard' | 'workspace';
+  /**
+   * Controls how the grid surface uses available page/workspace width:
+   * - contentFit: fit to content and center, but never exceed container width
+   * - fullWorkspace: fill available workspace width
+   * - compact: compact content-sized mode for small tables
+   */
+  surfaceSizing?: 'contentFit' | 'fullWorkspace' | 'compact';
 }
 
 export function EditableDataGrid<T extends EditableRow>({
@@ -127,8 +136,12 @@ export function EditableDataGrid<T extends EditableRow>({
   onLoadStateChange,
   fitContentWidth = false,
   layoutMode = 'standard',
+  surfaceSizing,
 }: EditableDataGridProps<T>): React.ReactElement {
-  const shouldUseFitContentWidth = fitContentWidth && layoutMode !== 'workspace';
+  const resolvedSurfaceSizing = surfaceSizing
+    ?? (layoutMode === 'workspace' ? 'fullWorkspace' : 'contentFit');
+  const isContentSizedSurface = resolvedSurfaceSizing === 'contentFit' || resolvedSurfaceSizing === 'compact';
+  const shouldUseCompactContainer = resolvedSurfaceSizing === 'compact';
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
   const [error, setError] = useState<string>('');
@@ -713,8 +726,24 @@ export function EditableDataGrid<T extends EditableRow>({
     <>
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
-      <Box sx={{ width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: '100%', maxWidth: '100%', overflowX: 'auto', overflowY: 'visible' }}>
-        <Box sx={{ display: 'block', width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: shouldUseFitContentWidth ? 0 : '100%' }}>
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: '100%',
+          overflowX: 'auto',
+          overflowY: 'visible',
+          display: 'flex',
+          justifyContent: shouldUseCompactContainer || isContentSizedSurface ? 'center' : 'flex-start',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'block',
+            width: isContentSizedSurface ? 'fit-content' : '100%',
+            minWidth: isContentSizedSurface ? 0 : '100%',
+            maxWidth: '100%',
+          }}
+        >
           <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -735,7 +764,7 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: shouldUseFitContentWidth ? 'fit-content' : '100%', minWidth: shouldUseFitContentWidth ? 0 : '100%' }}
+          sx={{ ...dataGridSx, width: isContentSizedSurface ? 'fit-content' : '100%', minWidth: isContentSizedSurface ? 0 : '100%' }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -95,10 +95,6 @@ export interface EditableDataGridProps<T extends EditableRow> {
   showRowEditActions?: boolean;
   onRowsStateChange?: (rows: T[]) => void;
   onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean; error: string }) => void;
-  /** @deprecated Use surfaceSizing instead. */
-  fitContentWidth?: boolean;
-  /** @deprecated Use surfaceSizing instead. */
-  layoutMode?: 'standard' | 'workspace';
   /**
    * Controls how the grid surface uses available page/workspace width:
    * - contentFit: fit to content and center, but never exceed container width
@@ -134,12 +130,9 @@ export function EditableDataGrid<T extends EditableRow>({
   showRowEditActions = false,
   onRowsStateChange,
   onLoadStateChange,
-  fitContentWidth = false,
-  layoutMode = 'standard',
   surfaceSizing,
 }: EditableDataGridProps<T>): React.ReactElement {
-  const resolvedSurfaceSizing = surfaceSizing
-    ?? (layoutMode === 'workspace' ? 'fullWorkspace' : 'contentFit');
+  const resolvedSurfaceSizing = surfaceSizing ?? 'contentFit';
   const isContentSizedSurface = resolvedSurfaceSizing === 'contentFit' || resolvedSurfaceSizing === 'compact';
   const shouldUseCompactContainer = resolvedSurfaceSizing === 'compact';
   const [rows, setRows] = useState<GridRowsProp<T>>([]);

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -135,6 +135,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const resolvedSurfaceSizing = surfaceSizing ?? 'contentFit';
   const isContentSizedSurface = resolvedSurfaceSizing === 'contentFit' || resolvedSurfaceSizing === 'compact';
   const shouldUseCompactContainer = resolvedSurfaceSizing === 'compact';
+  const shouldDisableTrailingFiller = isContentSizedSurface;
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
   const [error, setError] = useState<string>('');
@@ -757,7 +758,12 @@ export function EditableDataGrid<T extends EditableRow>({
           slots={{
             footer: CustomFooter,
           }}
-          sx={{ ...dataGridSx, width: isContentSizedSurface ? 'fit-content' : '100%', minWidth: isContentSizedSurface ? 0 : '100%' }}
+          sx={{
+            ...dataGridSx,
+            width: isContentSizedSurface ? 'fit-content' : '100%',
+            minWidth: isContentSizedSurface ? 0 : '100%',
+            ...(shouldDisableTrailingFiller ? { '& .MuiDataGrid-filler': { display: 'none' } } : {}),
+          }}
           getRowClassName={(params) => {
             const rowKey = String(params.id);
             if (rowModesModel[params.id]?.mode === GridRowModes.Edit) {

--- a/frontend/src/components/data-grid/NotesDrawer.tsx
+++ b/frontend/src/components/data-grid/NotesDrawer.tsx
@@ -328,33 +328,42 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, loa
 
         {noteId && (
           <Box sx={{ mb: 2 }} ref={attachmentsSectionRef} tabIndex={-1}>
-            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1, flexWrap: 'wrap' }}>
-              <Button variant="outlined" component="label">
-                {t('notesDrawer.takePhoto')}
-                <input
-                  type="file"
-                  accept="image/*"
-                  capture="environment"
-                  hidden
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) openCropDialog(file);
-                  }}
-                />
-              </Button>
-              <Button variant="outlined" component="label">
-                {t('notesDrawer.selectFromGallery')}
-                <input
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) openCropDialog(file);
-                  }}
-                />
-              </Button>
-              {uploading && <Typography variant="body2">{t('notesDrawer.uploading')}</Typography>}
+            <Stack
+              spacing={1}
+              sx={{
+                mb: 1.5,
+                width: '100%',
+                maxWidth: { xs: '100%', sm: 420 },
+              }}
+            >
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ width: '100%' }}>
+                <Button variant="outlined" component="label" sx={{ flex: 1, minHeight: 40 }}>
+                  {t('notesDrawer.takePhoto')}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    hidden
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) openCropDialog(file);
+                    }}
+                  />
+                </Button>
+                <Button variant="outlined" component="label" sx={{ flex: 1, minHeight: 40 }}>
+                  {t('notesDrawer.selectFromGallery')}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) openCropDialog(file);
+                    }}
+                  />
+                </Button>
+              </Stack>
+              {uploading ? <Typography variant="body2">{t('notesDrawer.uploading')}</Typography> : null}
             </Stack>
             {uploading && <LinearProgress variant="determinate" value={uploadProgress} />}
             <ImageList cols={4} rowHeight={84}>

--- a/frontend/src/components/data-grid/NotesDrawer.tsx
+++ b/frontend/src/components/data-grid/NotesDrawer.tsx
@@ -33,7 +33,7 @@ export interface NotesDrawerProps {
   title: string;
   value: string;
   onChange: (value: string) => void;
-  onSave: () => void;
+  onSave: () => void | Promise<void>;
   onClose: () => void;
   loading?: boolean;
   noteId?: number;
@@ -306,8 +306,15 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, loa
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
       event.preventDefault();
-      onSave();
+      void handleSaveClick();
     }
+  };
+
+  const handleSaveClick = async (): Promise<void> => {
+    if (loading) {
+      return;
+    }
+    await onSave();
   };
 
   return (
@@ -381,7 +388,7 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, loa
 
         <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
           <Button onClick={onClose} disabled={loading} variant="outlined">{t('actions.cancel')}</Button>
-          <Button onClick={onSave} disabled={loading} variant="contained" color="primary" startIcon={loading ? <CircularProgress size={16} /> : undefined}>{t('actions.save')}</Button>
+          <Button onClick={() => void handleSaveClick()} disabled={loading} variant="contained" color="primary" startIcon={loading ? <CircularProgress size={16} /> : undefined}>{t('actions.save')}</Button>
         </Box>
       </Box>
 

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -29,7 +29,7 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
   name: 280,
   area: 120,
   dimensions: 130,
-  notes: 320,
+  notes: 220,
 };
 
 const EXPAND_ICON_SLOT_SIZE = 32;
@@ -424,6 +424,8 @@ export function createHierarchyColumns(
       field: 'notes',
       headerName: t('common:fields.notes'),
       width: widths.notes,
+      minWidth: 180,
+      maxWidth: 260,
       editable: false,
       renderCell: (params) => {
         const value = (params.value as string) || '';

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,6 +1,13 @@
 import type { ReactElement, ReactNode } from 'react';
 
-type PageContainerVariant = 'standard' | 'wide' | 'workspace' | 'xwide' | 'full';
+type PageContainerVariant =
+  | 'standard'
+  | 'wide'
+  | 'workspace'
+  | 'xwide'
+  | 'full'
+  | 'compactCenteredTable'
+  | 'wideWorkspaceTable';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -14,6 +21,8 @@ const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   workspace: 'content content--workspace',
   xwide: 'content content--xwide',
   full: 'content--full',
+  compactCenteredTable: 'content content--compact-centered-table',
+  wideWorkspaceTable: 'content content--workspace-table',
 };
 
 function PageContainer({

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -7,7 +7,8 @@ type PageContainerVariant =
   | 'xwide'
   | 'full'
   | 'compactCenteredTable'
-  | 'wideWorkspaceTable';
+  | 'wideWorkspaceTable'
+  | 'workspaceFullWidth';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -23,6 +24,7 @@ const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   full: 'content--full',
   compactCenteredTable: 'content content--compact-centered-table',
   wideWorkspaceTable: 'content content--workspace-table',
+  workspaceFullWidth: 'content content--workspace-table',
 };
 
 function PageContainer({

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -2,14 +2,15 @@ import type { ReactElement, ReactNode } from 'react';
 
 type PageContainerVariant =
   | 'standardCenteredPage'
-  | 'wideWorkspace'
-  | 'compactCenteredTable'
+  | 'compactCenteredPage'
+  | 'workspacePage'
   | 'standard'
   | 'wide'
   | 'workspace'
   | 'xwide'
   | 'full'
-  | 'wideWorkspaceTable';
+  | 'wideWorkspace'
+  | 'compactCenteredTable';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -20,17 +21,19 @@ interface PageContainerProps {
 const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   // Recommended categories:
   // - standardCenteredPage: default readable centered page width
-  // - compactCenteredTable: compact, centered table pages (e.g. Suppliers)
-  // - wideWorkspace: full workspace width for data-heavy pages (e.g. Planting Plans, Gantt)
+  // - compactCenteredPage: compact, centered pages (e.g. Suppliers)
+  // - workspacePage: full workspace width for data-heavy pages (e.g. Planting Plans, Gantt)
   standardCenteredPage: 'content',
-  wideWorkspace: 'content content--workspace-table',
-  compactCenteredTable: 'content content--compact-centered-table',
+  workspacePage: 'content content--workspace-page',
+  compactCenteredPage: 'content content--compact-centered-page',
+  // Legacy aliases kept for compatibility with older pages.
+  wideWorkspace: 'content content--workspace-page',
+  compactCenteredTable: 'content content--compact-centered-page',
   standard: 'content',
   wide: 'content content--wide',
   workspace: 'content content--workspace',
   xwide: 'content content--xwide',
   full: 'content--full',
-  wideWorkspaceTable: 'content content--workspace-table',
 };
 
 function PageContainer({

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -1,12 +1,14 @@
 import type { ReactElement, ReactNode } from 'react';
 
 type PageContainerVariant =
+  | 'standardCenteredPage'
+  | 'wideWorkspace'
+  | 'compactCenteredTable'
   | 'standard'
   | 'wide'
   | 'workspace'
   | 'xwide'
   | 'full'
-  | 'compactCenteredTable'
   | 'wideWorkspaceTable';
 
 interface PageContainerProps {
@@ -16,12 +18,18 @@ interface PageContainerProps {
 }
 
 const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
+  // Recommended categories:
+  // - standardCenteredPage: default readable centered page width
+  // - compactCenteredTable: compact, centered table pages (e.g. Suppliers)
+  // - wideWorkspace: full workspace width for data-heavy pages (e.g. Planting Plans, Gantt)
+  standardCenteredPage: 'content',
+  wideWorkspace: 'content content--workspace-table',
+  compactCenteredTable: 'content content--compact-centered-table',
   standard: 'content',
   wide: 'content content--wide',
   workspace: 'content content--workspace',
   xwide: 'content content--xwide',
   full: 'content--full',
-  compactCenteredTable: 'content content--compact-centered-table',
   wideWorkspaceTable: 'content content--workspace-table',
 };
 

--- a/frontend/src/components/layout/PageContainer.tsx
+++ b/frontend/src/components/layout/PageContainer.tsx
@@ -7,8 +7,7 @@ type PageContainerVariant =
   | 'xwide'
   | 'full'
   | 'compactCenteredTable'
-  | 'wideWorkspaceTable'
-  | 'workspaceFullWidth';
+  | 'wideWorkspaceTable';
 
 interface PageContainerProps {
   children: ReactNode;
@@ -24,7 +23,6 @@ const VARIANT_CLASSNAME: Record<PageContainerVariant, string> = {
   full: 'content--full',
   compactCenteredTable: 'content content--compact-centered-table',
   wideWorkspaceTable: 'content content--workspace-table',
-  workspaceFullWidth: 'content content--workspace-table',
 };
 
 function PageContainer({

--- a/frontend/src/components/layout/PageSurface.tsx
+++ b/frontend/src/components/layout/PageSurface.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Box } from '@mui/material';
 
-type PageSurfaceVariant = 'standardCenteredPage' | 'compactCenteredTable' | 'wideWorkspace';
+type PageSurfaceVariant = 'standardCenteredPage' | 'compact' | 'contentFit' | 'fullWorkspace' | 'compactCenteredTable' | 'wideWorkspace';
 
 interface PageSurfaceProps {
   children: ReactNode;
@@ -11,6 +11,10 @@ interface PageSurfaceProps {
 
 const VARIANT_SX: Record<PageSurfaceVariant, Record<string, unknown>> = {
   standardCenteredPage: { width: '100%' },
+  compact: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
+  contentFit: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
+  fullWorkspace: { width: '100%', maxWidth: '100%' },
+  // Legacy aliases
   compactCenteredTable: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
   wideWorkspace: { width: '100%', maxWidth: '100%' },
 };

--- a/frontend/src/components/layout/PageSurface.tsx
+++ b/frontend/src/components/layout/PageSurface.tsx
@@ -1,6 +1,12 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Box } from '@mui/material';
 
+// Visual regression checklist for table-like surfaces:
+// 1) Is the page container centered/workspace as intended?
+// 2) Is the visible surface centered when using compact/contentFit?
+// 3) Does the surface width match content (contentFit/compact) or intentionally fill width (fullWorkspace)?
+// 4) Is max-width capped at 100% with horizontal overflow handled by the table/grid?
+// 5) Are there no extra page-local fit-content/full-width wrapper hacks?
 type PageSurfaceVariant = 'standardCenteredPage' | 'compact' | 'contentFit' | 'fullWorkspace' | 'compactCenteredTable' | 'wideWorkspace';
 
 interface PageSurfaceProps {

--- a/frontend/src/components/layout/PageSurface.tsx
+++ b/frontend/src/components/layout/PageSurface.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Box } from '@mui/material';
+
+type PageSurfaceVariant = 'standardCenteredPage' | 'compactCenteredTable' | 'wideWorkspace';
+
+interface PageSurfaceProps {
+  children: ReactNode;
+  variant: PageSurfaceVariant;
+  sx?: Record<string, unknown>;
+}
+
+const VARIANT_SX: Record<PageSurfaceVariant, Record<string, unknown>> = {
+  standardCenteredPage: { width: '100%' },
+  compactCenteredTable: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
+  wideWorkspace: { width: '100%', maxWidth: '100%' },
+};
+
+export default function PageSurface({ children, variant, sx }: PageSurfaceProps): ReactElement {
+  return (
+    <Box sx={{ ...VARIANT_SX[variant], ...sx }}>
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/components/layout/TableSurface.tsx
+++ b/frontend/src/components/layout/TableSurface.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Box, Paper } from '@mui/material';
+
+export type TableSizingMode = 'compact' | 'contentFit' | 'fullWorkspace';
+
+interface TableSurfaceProps {
+  sizingMode: TableSizingMode;
+  children: ReactNode;
+}
+
+const shellByMode: Record<TableSizingMode, Record<string, unknown>> = {
+  compact: { width: '100%', display: 'flex', justifyContent: 'center', overflowX: 'auto' },
+  contentFit: { width: '100%', display: 'flex', justifyContent: 'center', overflowX: 'auto' },
+  fullWorkspace: { width: '100%', display: 'block', overflowX: 'auto' },
+};
+
+const paperByMode: Record<TableSizingMode, Record<string, unknown>> = {
+  compact: { width: 'fit-content', maxWidth: '100%' },
+  contentFit: { width: 'fit-content', maxWidth: '100%' },
+  fullWorkspace: { width: '100%', maxWidth: '100%' },
+};
+
+export default function TableSurface({ sizingMode, children }: TableSurfaceProps): ReactElement {
+  return (
+    <Box sx={shellByMode[sizingMode]}>
+      <Paper variant="outlined" sx={{ ...paperByMode[sizingMode], borderRadius: 2, boxShadow: '0 1px 2px rgba(15, 23, 42, 0.06)' }}>
+        {children}
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/components/layout/TableSurface.tsx
+++ b/frontend/src/components/layout/TableSurface.tsx
@@ -20,6 +20,12 @@ const paperByMode: Record<TableSizingMode, Record<string, unknown>> = {
   fullWorkspace: { width: '100%', maxWidth: '100%' },
 };
 
+const innerByMode: Record<TableSizingMode, Record<string, unknown>> = {
+  compact: { display: 'block', width: 'fit-content', minWidth: 0, maxWidth: '100%' },
+  contentFit: { display: 'block', width: 'fit-content', minWidth: 0, maxWidth: '100%' },
+  fullWorkspace: { display: 'block', width: '100%', minWidth: 0, maxWidth: '100%' },
+};
+
 export default function TableSurface({ sizingMode, children }: TableSurfaceProps): ReactElement {
   return (
     <Box sx={shellByMode[sizingMode]}>
@@ -34,7 +40,9 @@ export default function TableSurface({ sizingMode, children }: TableSurfaceProps
           '& .MuiTableCell-head': { fontWeight: 600 },
         }}
       >
-        {children}
+        <Box sx={innerByMode[sizingMode]}>
+          {children}
+        </Box>
       </Paper>
     </Box>
   );

--- a/frontend/src/components/layout/TableSurface.tsx
+++ b/frontend/src/components/layout/TableSurface.tsx
@@ -23,7 +23,17 @@ const paperByMode: Record<TableSizingMode, Record<string, unknown>> = {
 export default function TableSurface({ sizingMode, children }: TableSurfaceProps): ReactElement {
   return (
     <Box sx={shellByMode[sizingMode]}>
-      <Paper variant="outlined" sx={{ ...paperByMode[sizingMode], borderRadius: 2, boxShadow: '0 1px 2px rgba(15, 23, 42, 0.06)' }}>
+      <Paper
+        variant="outlined"
+        sx={{
+          ...paperByMode[sizingMode],
+          borderRadius: 2,
+          boxShadow: '0 1px 2px rgba(15, 23, 42, 0.06)',
+          '& .MuiTableContainer-root': { width: 'fit-content', maxWidth: '100%' },
+          '& .MuiTable-root': { width: 'auto' },
+          '& .MuiTableCell-head': { fontWeight: 600 },
+        }}
+      >
         {children}
       </Paper>
     </Box>

--- a/frontend/src/components/mobile/MobileCardList.tsx
+++ b/frontend/src/components/mobile/MobileCardList.tsx
@@ -1,5 +1,5 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Box, Card, CardContent, Collapse, Stack, Typography } from '@mui/material';
+import { Box, Card, CardActionArea, CardContent, Collapse, Stack, Typography } from '@mui/material';
 
 export interface MobileCardListItem {
   id: string | number;
@@ -42,20 +42,19 @@ export function MobileCardList<T extends MobileCardListItem>({
           <Card key={item.id} variant="outlined">
             <CardContent sx={{ px: 1.5, py: 1.25, '&:last-child': { pb: 1.25 } }}>
               <Stack spacing={1}>
-                <Box
+                <CardActionArea
                   component="button"
                   type="button"
                   onClick={() => onToggleExpanded(item.id)}
                   aria-expanded={isExpanded}
                   aria-label={isExpanded ? detailsHideLabel : detailsShowLabel}
                   sx={{
-                    border: 0,
-                    background: 'transparent',
+                    display: 'block',
                     borderRadius: 1,
+                    minHeight: 44,
+                    width: '100%',
                     p: 0.5,
                     mx: -0.5,
-                    minHeight: 44,
-                    width: 'calc(100% + 8px)',
                     textAlign: 'left',
                     cursor: 'pointer',
                     transition: 'background-color 120ms ease-in-out',
@@ -94,7 +93,7 @@ export function MobileCardList<T extends MobileCardListItem>({
                       <ExpandMoreIcon fontSize="small" />
                     </Box>
                   </Stack>
-                </Box>
+                </CardActionArea>
 
                 <Collapse in={isExpanded}>
                   <Box sx={{ pt: 0.25 }}>

--- a/frontend/src/components/mobile/MobileCardList.tsx
+++ b/frontend/src/components/mobile/MobileCardList.tsx
@@ -1,6 +1,5 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import { Box, Card, CardContent, Collapse, IconButton, Stack, Typography } from '@mui/material';
+import { Box, Card, CardContent, Collapse, Stack, Typography } from '@mui/material';
 
 export interface MobileCardListItem {
   id: string | number;
@@ -43,25 +42,59 @@ export function MobileCardList<T extends MobileCardListItem>({
           <Card key={item.id} variant="outlined">
             <CardContent sx={{ px: 1.5, py: 1.25, '&:last-child': { pb: 1.25 } }}>
               <Stack spacing={1}>
-                <Stack direction="row" spacing={1} alignItems="flex-start" justifyContent="space-between">
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3, pr: 0.5 }}>
-                    {renderPrimary(item)}
-                  </Typography>
-                  <IconButton
-                    size="small"
-                    onClick={() => onToggleExpanded(item.id)}
-                    aria-label={isExpanded ? detailsHideLabel : detailsShowLabel}
-                    sx={{ mt: -0.25, mr: -0.5, flexShrink: 0 }}
-                  >
-                    {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-                  </IconButton>
-                </Stack>
+                <Box
+                  component="button"
+                  type="button"
+                  onClick={() => onToggleExpanded(item.id)}
+                  aria-expanded={isExpanded}
+                  aria-label={isExpanded ? detailsHideLabel : detailsShowLabel}
+                  sx={{
+                    border: 0,
+                    background: 'transparent',
+                    borderRadius: 1,
+                    p: 0.5,
+                    mx: -0.5,
+                    minHeight: 44,
+                    width: 'calc(100% + 8px)',
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    transition: 'background-color 120ms ease-in-out',
+                    '&:hover': { backgroundColor: 'action.hover' },
+                    '&:active': { backgroundColor: 'action.selected' },
+                    '&:focus-visible': {
+                      outline: (theme) => `2px solid ${theme.palette.primary.main}`,
+                      outlineOffset: 1,
+                    },
+                  }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="flex-start" justifyContent="space-between">
+                    <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3, pr: 0.5 }}>
+                        {renderPrimary(item)}
+                      </Typography>
+                      {renderSecondary ? (
+                        <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.35 }}>
+                          {renderSecondary(item)}
+                        </Typography>
+                      ) : null}
+                    </Stack>
 
-                {renderSecondary ? (
-                  <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.35 }}>
-                    {renderSecondary(item)}
-                  </Typography>
-                ) : null}
+                    <Box
+                      aria-hidden="true"
+                      sx={{
+                        mt: -0.25,
+                        mr: -0.5,
+                        flexShrink: 0,
+                        display: 'inline-flex',
+                        color: 'action.active',
+                        transition: 'transform 160ms ease-in-out',
+                        transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                      }}
+                    >
+                      <ExpandMoreIcon fontSize="small" />
+                    </Box>
+                  </Stack>
+                </Box>
 
                 <Collapse in={isExpanded}>
                   <Box sx={{ pt: 0.25 }}>

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -707,7 +707,7 @@ export function CultureDetail({
                 lg: '300px minmax(0, 1fr)',
                 xl: '330px minmax(0, 1fr)',
               },
-            gap: { xs: 1.25, lg: 1.5 },
+            gap: { xs: 1.25, lg: 1.1, xl: 1.25 },
             alignItems: 'start',
           }}
         >
@@ -779,7 +779,7 @@ export function CultureDetail({
               })}
             </List>
           </Card>) : null}
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'center' }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 920, lg: 980, xl: 1040 } }}>
                 <CardContent sx={{ p: { xs: 1, sm: 2, lg: 2.5 } }}>

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -207,6 +207,16 @@ export function CultureDetail({
       outlineOffset: 1,
     },
   } as const;
+  const detailSectionGridSx = {
+    display: 'grid',
+    gridTemplateColumns: {
+      xs: '1fr',
+      sm: 'repeat(2, minmax(180px, 1fr))',
+      lg: 'repeat(3, minmax(180px, 1fr))',
+    },
+    gap: 2,
+    justifyContent: 'start',
+  } as const;
 
   const activeFilterCount = useMemo(
     () => [
@@ -769,10 +779,10 @@ export function CultureDetail({
               })}
             </List>
           </Card>) : null}
-          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
+          <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'center' }}>
             {selectedCulture ? (
-              <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 960, lg: 1220, xl: 1400 } }}>
-                <CardContent sx={{ p: { xs: 1, sm: 2, lg: 3 } }}>
+              <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 920, lg: 980, xl: 1040 } }}>
+                <CardContent sx={{ p: { xs: 1, sm: 2, lg: 2.5 } }}>
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: { xs: 2, sm: 3 } }}>
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 1, sm: 2 }, mb: 0.75 }}>
@@ -927,24 +937,14 @@ export function CultureDetail({
               </Menu>
             </Box>
 
-            <Divider sx={{ mb: 3 }} />
+            <Divider sx={{ mb: 2.5 }} />
 
             {/* General Information Section */}
-            <Box sx={{ mb: 4, p: { xs: 1.5, sm: 2.5 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>
+            <Box sx={{ mb: 3, p: { xs: 1.25, sm: 2 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Typography variant="h6" gutterBottom>
                 Allgemeine Informationen
               </Typography>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
-                  },
-                  gap: 2,
-                  justifyContent: 'start',
-                }}
-              >
+              <Box sx={detailSectionGridSx}>
                 {selectedCulture.crop_family && (
                   <Box>
                     <Typography variant="body2" color="text.secondary">
@@ -988,24 +988,14 @@ export function CultureDetail({
               </Box>
             </Box>
 
-            <Divider sx={{ mb: 3 }} />
+            <Divider sx={{ mb: 2.5 }} />
 
             {/* Timing Section */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 3 }}>
               <Typography variant="h6" gutterBottom>
                 Zeitplanung
               </Typography>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
-                  },
-                  gap: 2,
-                  justifyContent: 'start',
-                }}
-              >
+              <Box sx={detailSectionGridSx}>
                 <Box>
                   <Typography variant="body2" color="text.secondary">
                     Wachstumszeitraum
@@ -1035,24 +1025,14 @@ export function CultureDetail({
               </Box>
             </Box>
 
-            <Divider sx={{ mb: 3 }} />
+            <Divider sx={{ mb: 2.5 }} />
 
             {/* Spacing Section */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 3 }}>
               <Typography variant="h6" gutterBottom>
                 Abstände
               </Typography>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
-                  },
-                  gap: 2,
-                  justifyContent: 'start',
-                }}
-              >
+              <Box sx={detailSectionGridSx}>
                 {selectedCulture.distance_within_row_cm !== null && selectedCulture.distance_within_row_cm !== undefined && (
                   <Box>
                     <Typography variant="body2" color="text.secondary">
@@ -1086,30 +1066,24 @@ export function CultureDetail({
               </Box>
             </Box>
 
-            <Divider sx={{ mb: 3 }} />
+            <Divider sx={{ mb: 2.5 }} />
 
             {/* Seeding Section */}
-            <Box sx={{ mb: 4 }}>
+            <Box sx={{ mb: 3 }}>
               <Typography variant="h6" gutterBottom>
                 Saatgut
               </Typography>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(auto-fit, minmax(180px, 260px))',
-                  },
-                  gap: 2,
-                  justifyContent: 'start',
-                }}
-              >
+              <Box sx={detailSectionGridSx}>
                 {seedRateRows.length > 0 && activeCultivationTypes.length <= 1 && (
-                  <Box sx={{ gridColumn: '1 / -1' }}>
+                  <Box>
                     <Typography variant="body2" color="text.secondary">Menge</Typography>
                     <Typography variant="body1">
                       {formatNumber(seedRateRows[0].value, t)} {formatSeedUnitLabel(seedRateRows[0].unit)}
                     </Typography>
+                  </Box>
+                )}
+                {seedRateRows.length > 0 && activeCultivationTypes.length <= 1 && (
+                  <Box>
                     <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
                       Sicherheitszuschlag Saatgut
                     </Typography>
@@ -1179,14 +1153,7 @@ export function CultureDetail({
                   </Typography>
                 </Box>
               </Box>
-              <Box
-                sx={{
-                  mt: 3,
-                  display: 'grid',
-                  gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
-                  gap: 2,
-                }}
-              >
+              <Box sx={{ mt: 2.5, display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' }, gap: 1.5 }}>
                 <Typography variant="subtitle1" component="h3" gutterBottom>
                   {hasMultipleSupplierRows ? 'Saatgutdaten je Lieferant' : 'Lieferant'}
                 </Typography>
@@ -1196,7 +1163,10 @@ export function CultureDetail({
                   </Typography>
                 )}
                 {orderedSupplierRows.length === 0 ? (
-                  <Typography variant="body2" color="text.secondary">Keine Lieferantendaten vorhanden.</Typography>
+                  <Box sx={{ gridColumn: '1 / -1', display: 'inline-flex', alignItems: 'center', gap: 0.75, color: 'text.secondary' }}>
+                    <Typography variant="body2">ℹ️</Typography>
+                    <Typography variant="body2">Keine Lieferantendaten vorhanden.</Typography>
+                  </Box>
                 ) : (
                   <Stack spacing={2} sx={{ gridColumn: '1 / -1' }}>
                     {orderedSupplierRows.map((row, index) => (

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -772,7 +772,7 @@ export function CultureDetail({
           <Box sx={{ flex: 1, minWidth: 0, width: '100%', display: 'flex', justifyContent: 'flex-start' }}>
             {selectedCulture ? (
               <Card sx={{ width: '100%', maxWidth: useUnifiedMobileLayout ? '100%' : { sm: 960, lg: 1220, xl: 1400 } }}>
-                <CardContent sx={{ p: { xs: 1.5, sm: 2, lg: 3 } }}>
+                <CardContent sx={{ p: { xs: 1, sm: 2, lg: 3 } }}>
             {/* Header with crop name and badge */}
                   <Box sx={{ mb: { xs: 2, sm: 3 } }}>
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 1, sm: 2 }, mb: 0.75 }}>
@@ -930,7 +930,7 @@ export function CultureDetail({
             <Divider sx={{ mb: 3 }} />
 
             {/* General Information Section */}
-            <Box sx={{ mb: 4, p: 2.5, border: '1px solid #e5e7eb', borderRadius: 2 }}>
+            <Box sx={{ mb: 4, p: { xs: 1.5, sm: 2.5 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Typography variant="h6" gutterBottom>
                 Allgemeine Informationen
               </Typography>
@@ -1287,7 +1287,7 @@ export function CultureDetail({
             <Divider sx={{ mb: 3 }} />
 
             {/* Notes Section */}
-            <Box sx={{ p: 2.5, border: '1px solid #e5e7eb', borderRadius: 2 }}>
+            <Box sx={{ p: { xs: 1.5, sm: 2.5 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Typography variant="h6" gutterBottom>
                 Notizen
               </Typography>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import SproutOutlinedIcon from '@mui/icons-material/SpaOutlined';
 import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, type Bed, type Culture, type Field, type Location, type PlantingPlan } from '../api/api';
 import PageContainer from '../components/layout/PageContainer';
+import PageSurface from '../components/layout/PageSurface';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import { getFirstMissingRequirement } from './requirementFlow';
@@ -88,8 +89,8 @@ export default function Dashboard(): React.ReactElement {
 
   const locationNameById = useMemo(() => new Map(locations.filter((l) => l.id !== undefined).map((l) => [l.id as number, l.name])), [locations]);
 
-  if (loading) return <PageContainer><Typography>{t('common:messages.loading')}</Typography></PageContainer>;
-  if (shouldShowProjectRequiredState && missingProjectReason) return <PageContainer><ProjectRequiredState reason={missingProjectReason} /></PageContainer>;
+  if (loading) return <PageContainer><PageSurface variant="contentFit"><Typography>{t('common:messages.loading')}</Typography></PageSurface></PageContainer>;
+  if (shouldShowProjectRequiredState && missingProjectReason) return <PageContainer><PageSurface variant="contentFit"><ProjectRequiredState reason={missingProjectReason} /></PageSurface></PageContainer>;
 
   const isSetupComplete = firstMissingRequirement === null;
 
@@ -98,7 +99,8 @@ export default function Dashboard(): React.ReactElement {
       {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
 
       {!isSetupComplete ? (
-        <Card variant="outlined" sx={{ mb: 2, maxWidth: 860 }}>
+        <PageSurface variant="contentFit" sx={{ mb: 2, minWidth: { md: 560 }, width: '100%' }}>
+        <Card variant="outlined" sx={{ maxWidth: 860 }}>
           <CardContent>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.75 }}>
               <SproutOutlinedIcon fontSize="small" sx={{ color: 'text.secondary' }} />
@@ -141,9 +143,11 @@ export default function Dashboard(): React.ReactElement {
             ) : null}
           </CardContent>
         </Card>
+        </PageSurface>
       ) : null}
 
       {(isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0)) ? (
+      <PageSurface variant="contentFit" sx={{ minWidth: { md: 560 }, width: '100%' }}>
       <Card variant="outlined">
         <CardContent>
           <Typography variant="h6" gutterBottom>{t('dashboard:tasks.title')}</Typography>
@@ -164,6 +168,7 @@ export default function Dashboard(): React.ReactElement {
           )}
         </CardContent>
       </Card>
+      </PageSurface>
       ) : null}
     </PageContainer>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -99,8 +99,8 @@ export default function Dashboard(): React.ReactElement {
       {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
 
       {!isSetupComplete ? (
-        <PageSurface variant="contentFit" sx={{ mb: 2, minWidth: { md: 560 }, width: '100%' }}>
-        <Card variant="outlined" sx={{ maxWidth: 860 }}>
+        <PageSurface variant="contentFit" sx={{ mb: 2, minWidth: { md: 480 } }}>
+        <Card variant="outlined" sx={{ width: 'fit-content', maxWidth: '100%' }}>
           <CardContent>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.75 }}>
               <SproutOutlinedIcon fontSize="small" sx={{ color: 'text.secondary' }} />
@@ -147,8 +147,8 @@ export default function Dashboard(): React.ReactElement {
       ) : null}
 
       {(isSetupComplete || (!isSetupComplete && upcomingTasks.length > 0)) ? (
-      <PageSurface variant="contentFit" sx={{ minWidth: { md: 560 }, width: '100%' }}>
-      <Card variant="outlined">
+      <PageSurface variant="contentFit" sx={{ minWidth: { md: 460 } }}>
+      <Card variant="outlined" sx={{ width: 'fit-content', maxWidth: '100%' }}>
         <CardContent>
           <Typography variant="h6" gutterBottom>{t('dashboard:tasks.title')}</Typography>
           {upcomingTasks.length === 0 ? (

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -61,6 +61,8 @@ const HIERARCHY_DATA_GRID_SX = {
   ...dataGridSx,
   width: "fit-content",
   maxWidth: "100%",
+  minWidth: "unset",
+  display: "inline-block",
   "& .MuiDataGrid-filler": {
     display: "none",
   },

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -59,7 +59,11 @@ interface FieldsBedsHierarchyProps {
 
 const HIERARCHY_DATA_GRID_SX = {
   ...dataGridSx,
-  width: "100%",
+  width: "fit-content",
+  maxWidth: "100%",
+  "& .MuiDataGrid-filler": {
+    display: "none",
+  },
   "& .MuiDataGrid-columnHeader": {
     py: 0.25,
   },
@@ -925,7 +929,7 @@ function FieldsBedsHierarchy({
 
         <Box
           ref={tableWrapperRef}
-          sx={{ width: "100%", minWidth: 0, overflowX: "auto" }}
+          sx={{ width: "100%", minWidth: 0, overflowX: "auto", display: "flex", justifyContent: "center" }}
           onClick={() => setTreeActive(true)}
         >
           <DataGrid

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -60,9 +60,7 @@ interface FieldsBedsHierarchyProps {
 const HIERARCHY_DATA_GRID_SX = {
   ...dataGridSx,
   width: "fit-content",
-  maxWidth: "100%",
-  minWidth: "unset",
-  display: "inline-block",
+  minWidth: 0,
   "& .MuiDataGrid-filler": {
     display: "none",
   },
@@ -943,9 +941,10 @@ function FieldsBedsHierarchy({
 
         <Box
           ref={tableWrapperRef}
-          sx={{ width: "100%", minWidth: 0, overflowX: "auto", display: "flex", justifyContent: "center" }}
+          sx={{ width: "100%", maxWidth: "100%", minWidth: 0, overflowX: "auto", overflowY: "visible", display: "flex", justifyContent: "center" }}
           onClick={() => setTreeActive(true)}
         >
+          <Box sx={{ display: "block", width: "fit-content", minWidth: 0, maxWidth: "100%" }}>
           <DataGrid
             rows={rows}
             columns={columns}
@@ -978,6 +977,7 @@ function FieldsBedsHierarchy({
             }}
             localeText={germanDataGridLocaleText}
           />
+          </Box>
         </Box>
       </Box>
 

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -64,6 +64,18 @@ const HIERARCHY_DATA_GRID_SX = {
   "& .MuiDataGrid-filler": {
     display: "none",
   },
+  "& .MuiDataGrid-scrollbarFiller": {
+    display: "none",
+  },
+  "& .MuiDataGrid-main": {
+    width: "fit-content",
+  },
+  "& .MuiDataGrid-virtualScrollerContent": {
+    width: "fit-content !important",
+  },
+  "& .MuiDataGrid-columnHeaders": {
+    width: "fit-content !important",
+  },
   "& .MuiDataGrid-columnHeader": {
     py: 0.25,
   },

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -63,7 +63,7 @@ export default function FieldsBedsPage(): React.ReactElement {
     },
     {
       id: 'areas.showGraphicalView',
-      label: 'Grafikansicht umschalten',
+      label: 'Grafikansicht',
       group: 'navigation',
       keywords: ['grafik', 'grafisch', 'anbauflächen'],
       shortcutHint: 'Alt+G',

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -63,15 +63,15 @@ export default function FieldsBedsPage(): React.ReactElement {
     },
     {
       id: 'areas.showGraphicalView',
-      label: 'Grafikansicht',
+      label: 'Grafikansicht umschalten',
       group: 'navigation',
       keywords: ['grafik', 'grafisch', 'anbauflächen'],
       shortcutHint: 'Alt+G',
       keys: { alt: true, key: 'g' },
       contextTags: ['areas'],
-      isEnabled: () => viewMode !== 'graphical',
+      isEnabled: () => true,
       action: () => {
-        setViewMode('graphical');
+        setViewMode((prev) => (prev === 'graphical' ? 'table' : 'graphical'));
       },
     },
   ], [viewMode]);

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -37,6 +37,7 @@ import './GanttChart.css';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
 import { useOutletContext } from 'react-router-dom';
 import PageContainer from '../components/layout/PageContainer';
+import PageSurface from '../components/layout/PageSurface';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import type { CommandSpec } from '../commands/types';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
@@ -455,24 +456,26 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="wideWorkspaceTable">
-        <Box sx={{ width: '100%', py: 2 }}>
+      <PageContainer variant="wideWorkspace">
+        <PageSurface variant="wideWorkspace" sx={{ py: 2 }}>
           <Typography variant="body1">{t('ganttChart:loading')}</Typography>
-        </Box>
+        </PageSurface>
       </PageContainer>
     );
   }
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer variant="wideWorkspaceTable">
-        <ProjectRequiredState reason={missingProjectReason} />
+      <PageContainer variant="wideWorkspace">
+        <PageSurface variant="wideWorkspace">
+          <ProjectRequiredState reason={missingProjectReason} />
+        </PageSurface>
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer variant="wideWorkspaceTable">
+    <PageContainer variant="wideWorkspace">
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
         {hasCalendarRequirements ? (
@@ -506,7 +509,8 @@ function GanttChartPage(): React.ReactElement {
         ) : null}
 
         {!hasCalendarRequirements ? (
-          <Box className="gantt-container-wrapper" sx={{ mt: 0.5, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
+          <PageSurface variant="wideWorkspace" sx={{ mt: 0.5 }}>
+          <Box className="gantt-container-wrapper" sx={{ border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Box sx={{ p: 2 }}>
               <EmptyStateCard
                 title={t('ganttChart:emptyStates.requirementsTitle')}
@@ -526,8 +530,10 @@ function GanttChartPage(): React.ReactElement {
               />
             </Box>
           </Box>
+          </PageSurface>
         ) : (
-          <Box className="gantt-container-wrapper" sx={{ mt: 0.5, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
+          <PageSurface variant="wideWorkspace" sx={{ mt: 0.5 }}>
+          <Box className="gantt-container-wrapper" sx={{ border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
               <GanttChart
                 key={ganttRenderKey}
@@ -578,10 +584,12 @@ function GanttChartPage(): React.ReactElement {
               />
             </GanttRenderBoundary>
           </Box>
+          </PageSurface>
         )}
 
         {hasCalendarRequirements && calendarMode === 'occupancy' && hasYieldData ? (
-          <Box className="gantt-container-wrapper" sx={{ mt: 3, p: 2, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
+          <PageSurface variant="wideWorkspace" sx={{ mt: 3 }}>
+          <Box className="gantt-container-wrapper" sx={{ p: 2, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
               {t('ganttChart:yieldDistributionTitle')}
             </Typography>
@@ -643,6 +651,7 @@ function GanttChartPage(): React.ReactElement {
                 </Box>
               </Box>
           </Box>
+          </PageSurface>
         ) : null}
     </PageContainer>
   );

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -456,8 +456,8 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="wideWorkspace">
-        <PageSurface variant="wideWorkspace" sx={{ py: 2 }}>
+      <PageContainer variant="workspacePage">
+        <PageSurface variant="fullWorkspace" sx={{ py: 2 }}>
           <Typography variant="body1">{t('ganttChart:loading')}</Typography>
         </PageSurface>
       </PageContainer>
@@ -466,8 +466,8 @@ function GanttChartPage(): React.ReactElement {
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer variant="wideWorkspace">
-        <PageSurface variant="wideWorkspace">
+      <PageContainer variant="workspacePage">
+        <PageSurface variant="fullWorkspace">
           <ProjectRequiredState reason={missingProjectReason} />
         </PageSurface>
       </PageContainer>
@@ -475,7 +475,7 @@ function GanttChartPage(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="wideWorkspace">
+    <PageContainer variant="workspacePage">
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
         {hasCalendarRequirements ? (
@@ -509,7 +509,7 @@ function GanttChartPage(): React.ReactElement {
         ) : null}
 
         {!hasCalendarRequirements ? (
-          <PageSurface variant="wideWorkspace" sx={{ mt: 0.5 }}>
+          <PageSurface variant="fullWorkspace" sx={{ mt: 0.5 }}>
           <Box className="gantt-container-wrapper" sx={{ border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Box sx={{ p: 2 }}>
               <EmptyStateCard
@@ -532,7 +532,7 @@ function GanttChartPage(): React.ReactElement {
           </Box>
           </PageSurface>
         ) : (
-          <PageSurface variant="wideWorkspace" sx={{ mt: 0.5 }}>
+          <PageSurface variant="fullWorkspace" sx={{ mt: 0.5 }}>
           <Box className="gantt-container-wrapper" sx={{ border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
               <GanttChart
@@ -588,7 +588,7 @@ function GanttChartPage(): React.ReactElement {
         )}
 
         {hasCalendarRequirements && calendarMode === 'occupancy' && hasYieldData ? (
-          <PageSurface variant="wideWorkspace" sx={{ mt: 3 }}>
+          <PageSurface variant="fullWorkspace" sx={{ mt: 3 }}>
           <Box className="gantt-container-wrapper" sx={{ p: 2, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
               {t('ganttChart:yieldDistributionTitle')}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -455,7 +455,7 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="workspaceFullWidth">
+      <PageContainer variant="wideWorkspaceTable">
         <Box sx={{ width: '100%', py: 2 }}>
           <Typography variant="body1">{t('ganttChart:loading')}</Typography>
         </Box>
@@ -465,14 +465,14 @@ function GanttChartPage(): React.ReactElement {
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer variant="workspaceFullWidth">
+      <PageContainer variant="wideWorkspaceTable">
         <ProjectRequiredState reason={missingProjectReason} />
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer variant="workspaceFullWidth">
+    <PageContainer variant="wideWorkspaceTable">
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
         {hasCalendarRequirements ? (

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -14,7 +14,6 @@ import {
   Box,
   Button,
   ButtonGroup,
-  Paper,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -456,22 +455,24 @@ function GanttChartPage(): React.ReactElement {
 
   if (loading) {
     return (
-      <PageContainer variant="full">
-        <p>{t('ganttChart:loading')}</p>
+      <PageContainer variant="workspaceFullWidth">
+        <Box sx={{ width: '100%', py: 2 }}>
+          <Typography variant="body1">{t('ganttChart:loading')}</Typography>
+        </Box>
       </PageContainer>
     );
   }
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer variant="full">
+      <PageContainer variant="workspaceFullWidth">
         <ProjectRequiredState reason={missingProjectReason} />
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer variant="full">
+    <PageContainer variant="workspaceFullWidth">
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
         {hasCalendarRequirements ? (
@@ -505,7 +506,7 @@ function GanttChartPage(): React.ReactElement {
         ) : null}
 
         {!hasCalendarRequirements ? (
-          <Paper className="gantt-container-wrapper" sx={{ mt: 0.5 }}>
+          <Box className="gantt-container-wrapper" sx={{ mt: 0.5, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Box sx={{ p: 2 }}>
               <EmptyStateCard
                 title={t('ganttChart:emptyStates.requirementsTitle')}
@@ -524,9 +525,9 @@ function GanttChartPage(): React.ReactElement {
                 ]}
               />
             </Box>
-          </Paper>
+          </Box>
         ) : (
-          <Paper className="gantt-container-wrapper" sx={{ mt: 0.5 }}>
+          <Box className="gantt-container-wrapper" sx={{ mt: 0.5, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
               <GanttChart
                 key={ganttRenderKey}
@@ -576,11 +577,11 @@ function GanttChartPage(): React.ReactElement {
                   : undefined}
               />
             </GanttRenderBoundary>
-          </Paper>
+          </Box>
         )}
 
         {hasCalendarRequirements && calendarMode === 'occupancy' && hasYieldData ? (
-          <Paper className="gantt-container-wrapper" sx={{ mt: 3, p: 2 }}>
+          <Box className="gantt-container-wrapper" sx={{ mt: 3, p: 2, border: '1px solid #e3e7df', borderRadius: 2, bgcolor: '#fff' }}>
             <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
               {t('ganttChart:yieldDistributionTitle')}
             </Typography>
@@ -641,7 +642,7 @@ function GanttChartPage(): React.ReactElement {
                   </Box>
                 </Box>
               </Box>
-          </Paper>
+          </Box>
         ) : null}
     </PageContainer>
   );

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1542,7 +1542,7 @@ function PlantingPlans(): React.ReactElement {
   }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
 
   return (
-    <PageContainer variant="xwide">
+    <PageContainer variant="wideWorkspaceTable">
 
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1652,7 +1652,7 @@ function PlantingPlans(): React.ReactElement {
         <Box
           sx={{
             display: isMobile || shouldShowPrerequisiteState ? "none" : "block",
-            width: "fit-content",
+            width: "100%",
             maxWidth: "100%",
           }}
         >
@@ -1671,7 +1671,6 @@ function PlantingPlans(): React.ReactElement {
             onLoadStateChange={({ loading, dataFetched }) => {
               setIsPlansLoading(loading || !dataFetched);
             }}
-            fitContentWidth
             createNewRow={() => ({
             id: -Date.now(),
             culture: 0,

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1543,7 +1543,7 @@ function PlantingPlans(): React.ReactElement {
   }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
 
   return (
-    <PageContainer variant="wideWorkspace">
+    <PageContainer variant="workspacePage">
 
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1651,7 +1651,7 @@ function PlantingPlans(): React.ReactElement {
         ) : null}
 
         <PageSurface
-          variant="wideWorkspace"
+          variant="fullWorkspace"
           sx={{ display: isMobile || shouldShowPrerequisiteState ? "none" : "block" }}
         >
           <EditableDataGrid<PlantingPlanRow>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1542,7 +1542,7 @@ function PlantingPlans(): React.ReactElement {
   }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
 
   return (
-    <PageContainer variant="workspaceFullWidth">
+    <PageContainer variant="wideWorkspaceTable">
 
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1542,7 +1542,7 @@ function PlantingPlans(): React.ReactElement {
   }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
 
   return (
-    <PageContainer variant="wideWorkspaceTable">
+    <PageContainer variant="workspaceFullWidth">
 
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -43,6 +43,7 @@ import {
   resolveCultivationTypeForAllowedOptions,
 } from "./plantingPlansUtils";
 import PageContainer from "../components/layout/PageContainer";
+import PageSurface from "../components/layout/PageSurface";
 import {
   plantingPlanAPI,
   cultureAPI,
@@ -1542,7 +1543,7 @@ function PlantingPlans(): React.ReactElement {
   }, [canCreatePlan, isMobile, searchParams, setSearchParams]);
 
   return (
-    <PageContainer variant="wideWorkspaceTable">
+    <PageContainer variant="wideWorkspace">
 
       {areaWarning ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1649,12 +1650,9 @@ function PlantingPlans(): React.ReactElement {
           </Box>
         ) : null}
 
-        <Box
-          sx={{
-            display: isMobile || shouldShowPrerequisiteState ? "none" : "block",
-            width: "100%",
-            maxWidth: "100%",
-          }}
+        <PageSurface
+          variant="wideWorkspace"
+          sx={{ display: isMobile || shouldShowPrerequisiteState ? "none" : "block" }}
         >
           <EditableDataGrid<PlantingPlanRow>
             layoutMode="workspace"
@@ -1870,7 +1868,7 @@ function PlantingPlans(): React.ReactElement {
               ],
             }}
           />
-        </Box>
+        </PageSurface>
 
       </Box>
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1655,7 +1655,7 @@ function PlantingPlans(): React.ReactElement {
           sx={{ display: isMobile || shouldShowPrerequisiteState ? "none" : "block" }}
         >
           <EditableDataGrid<PlantingPlanRow>
-            layoutMode="workspace"
+            surfaceSizing="contentFit"
             columns={columns}
             api={plantingPlanAPI as unknown as DataGridAPI<PlantingPlanRow>}
             commandApiRef={gridCommandApiRef}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1657,6 +1657,7 @@ function PlantingPlans(): React.ReactElement {
           }}
         >
           <EditableDataGrid<PlantingPlanRow>
+            layoutMode="workspace"
             columns={columns}
             api={plantingPlanAPI as unknown as DataGridAPI<PlantingPlanRow>}
             commandApiRef={gridCommandApiRef}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1319,21 +1319,26 @@ function PlantingPlans(): React.ReactElement {
   };
 
   const saveMobileNotes = async (): Promise<void> => {
-    if (!mobileNotesTarget?.id) {
+    if (isMobileNotesSaving || !mobileNotesTarget?.id) {
       return;
     }
 
+    const targetId = mobileNotesTarget.id;
+    const draftToSave = mobileNotesDraft;
+
     setIsMobileNotesSaving(true);
     try {
-      await plantingPlanAPI.update(mobileNotesTarget.id, {
-        notes: mobileNotesDraft,
+      await plantingPlanAPI.update(targetId, {
+        notes: draftToSave,
       } as PlantingPlan);
-      closeMobileNotesDialog();
+
       await gridCommandApiRef.current?.reload();
+      closeMobileNotesDialog();
     } catch (error) {
       setMobileCreateError(
         extractApiErrorMessage(error, t, t("plantingPlans:errors.save")),
       );
+    } finally {
       setIsMobileNotesSaving(false);
     }
   };

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -23,7 +23,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Fab,
   FormControl,
   InputLabel,
   MenuItem,
@@ -35,7 +34,6 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
 import { useTranslation } from "../i18n";
@@ -1874,18 +1872,6 @@ function PlantingPlans(): React.ReactElement {
           />
         </Box>
 
-        {isMobile ? (
-          <Fab
-            color="primary"
-            variant="extended"
-            onClick={() => openMobileCreateDialog()}
-            sx={{ position: "fixed", bottom: 24, right: 16, zIndex: theme.zIndex.fab }}
-            aria-label={t("plantingPlans:mobile.fabAria")}
-          >
-            <AddIcon sx={{ mr: 0.75 }} />
-            {t("plantingPlans:mobile.fabLabel")}
-          </Fab>
-        ) : null}
       </Box>
 
       <Dialog open={isMobileCreateOpen} onClose={closeMobileCreateDialog} fullWidth maxWidth="sm">

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1326,7 +1326,7 @@ function PlantingPlans(): React.ReactElement {
 
     setIsMobileNotesSaving(true);
     try {
-      await plantingPlanAPI.update(targetId, {
+      await plantingPlanAPI.patch(targetId, {
         notes: draftToSave,
       } as PlantingPlan);
 

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -181,7 +181,7 @@ export default function SeedDemandPage(): React.ReactElement {
 
         {!isLoading && !error && canCalculateSeedDemand && (
           <TableSurface sizingMode="contentFit">
-          <TableContainer sx={{ width: 'fit-content', maxWidth: '100%' }}>
+          <TableContainer>
             <Table
               sx={{
                 '& .MuiTableCell-root': { py: 1 },

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -7,7 +7,6 @@ import {
   FormControl,
   Link,
   MenuItem,
-  Paper,
   Select,
   Table,
   TableBody,
@@ -23,6 +22,7 @@ import { useTranslation } from '../i18n';
 import { useCommandContextTag } from '../commands/useCommandContext';
 import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
+import TableSurface from '../components/layout/TableSurface';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
@@ -180,7 +180,8 @@ export default function SeedDemandPage(): React.ReactElement {
         )}
 
         {!isLoading && !error && canCalculateSeedDemand && (
-          <TableContainer component={Paper} sx={{ width: 'fit-content', maxWidth: '100%' }}>
+          <TableSurface sizingMode="contentFit">
+          <TableContainer sx={{ width: 'fit-content', maxWidth: '100%' }}>
             <Table
               sx={{
                 '& .MuiTableCell-root': { py: 1 },
@@ -289,6 +290,7 @@ export default function SeedDemandPage(): React.ReactElement {
               </Box>
             ) : null}
           </TableContainer>
+          </TableSurface>
         )}
       </PageSurface>
     </PageContainer>

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -22,6 +22,7 @@ import { bedAPI, cultureAPI, locationAPI, plantingPlanAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import { useCommandContextTag } from '../commands/useCommandContext';
 import PageContainer from '../components/layout/PageContainer';
+import PageSurface from '../components/layout/PageSurface';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
@@ -155,17 +156,17 @@ export default function SeedDemandPage(): React.ReactElement {
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer>
-        <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+      <PageContainer variant="standardCenteredPage">
+        <PageSurface variant="contentFit">
           <ProjectRequiredState reason={missingProjectReason} />
-        </Box>
+        </PageSurface>
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer>
-      <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+    <PageContainer variant="standardCenteredPage">
+      <PageSurface variant="contentFit">
 
         {isLoading && <CircularProgress />}
         {error && <Alert severity="error">{error}</Alert>}
@@ -289,7 +290,7 @@ export default function SeedDemandPage(): React.ReactElement {
             ) : null}
           </TableContainer>
         )}
-      </Box>
+      </PageSurface>
     </PageContainer>
   );
 }

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -194,8 +194,8 @@ export default function Suppliers(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="compactCenteredTable">
-      <PageSurface variant="compactCenteredTable">
+    <PageContainer variant="compactCenteredPage">
+      <PageSurface variant="compact">
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -206,8 +206,8 @@ export default function Suppliers(): React.ReactElement {
           </Box>
         ) : (
           <TableSurface sizingMode="compact">
-          <TableContainer sx={{ width: 'fit-content', maxWidth: '100%' }}>
-            <Table size="medium" sx={{ width: 'auto' }}>
+          <TableContainer>
+            <Table size="medium">
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ py: 1.5, minWidth: { xs: 140, sm: 180 } }}>{t('name')}</TableCell>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -24,6 +24,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
+import PageSurface from '../components/layout/PageSurface';
 import type { Supplier } from '../api/types';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
@@ -194,7 +195,7 @@ export default function Suppliers(): React.ReactElement {
 
   return (
     <PageContainer variant="compactCenteredTable">
-      <Box sx={{ width: 'fit-content', maxWidth: '100%', mx: 'auto' }}>
+      <PageSurface variant="compactCenteredTable">
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard
@@ -250,7 +251,7 @@ export default function Suppliers(): React.ReactElement {
             </Table>
           </TableContainer>
         )}
-      </Box>
+      </PageSurface>
 
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} fullWidth maxWidth="sm">
         <DialogTitle>{draft.id ? t('edit') : t('create')}</DialogTitle>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -193,8 +193,8 @@ export default function Suppliers(): React.ReactElement {
   }
 
   return (
-    <PageContainer variant="xwide">
-      <Box sx={{ width: '100%', maxWidth: 760 }}>
+    <PageContainer variant="compactCenteredTable">
+      <Box sx={{ width: 'fit-content', maxWidth: '100%', mx: 'auto' }}>
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -184,7 +184,7 @@ export default function Suppliers(): React.ReactElement {
 
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
-      <PageContainer>
+      <PageContainer variant="xwide">
         <Box sx={{ width: '100%' }}>
           <ProjectRequiredState reason={missingProjectReason} />
         </Box>
@@ -193,8 +193,13 @@ export default function Suppliers(): React.ReactElement {
   }
 
   return (
-    <PageContainer>
-      <Box sx={{ width: '100%' }}>
+    <PageContainer variant="xwide">
+      <Box sx={{ width: '100%', maxWidth: 1600 }}>
+        <Box sx={{ mb: 1.5 }}>
+          <Box sx={{ color: 'text.secondary', fontSize: '0.92rem' }}>
+            Verwalte Saatgut- und Materiallieferanten für dein Projekt.
+          </Box>
+        </Box>
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard
@@ -205,26 +210,27 @@ export default function Suppliers(): React.ReactElement {
           </Box>
         ) : (
           <TableContainer component={Paper} sx={{ width: '100%', maxWidth: '100%' }}>
-            <Table size="small" sx={{ width: 'auto' }}>
+            <Table size="medium" sx={{ width: '100%' }}>
               <TableHead>
                 <TableRow>
-                  <TableCell>{t('name')}</TableCell>
-                  <TableCell>{t('homepage')}</TableCell>
-                  <TableCell align="right">{t('actions')}</TableCell>
+                  <TableCell sx={{ py: 1.5 }}>{t('name')}</TableCell>
+                  <TableCell sx={{ py: 1.5 }}>{t('homepage')}</TableCell>
+                  <TableCell align="right" sx={{ py: 1.5, width: 120 }}>{t('actions')}</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {suppliers.map((supplier) => (
                   <TableRow key={supplier.id} hover>
-                    <TableCell>{supplier.name}</TableCell>
-                    <TableCell>
+                    <TableCell sx={{ py: 1.25 }}>{supplier.name}</TableCell>
+                    <TableCell sx={{ py: 1.25 }}>
                       {supplier.homepage_url ? (
                         <Link href={supplier.homepage_url} target="_blank" rel="noopener noreferrer" underline="hover">
                           {supplier.homepage_url}
                         </Link>
                       ) : null}
                     </TableCell>
-                    <TableCell align="right">
+                    <TableCell align="right" sx={{ py: 1.25 }}>
+                      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
                       <IconButton
                         size="small"
                         color="primary"
@@ -241,6 +247,7 @@ export default function Suppliers(): React.ReactElement {
                       >
                         <CloseIcon fontSize="small" />
                       </IconButton>
+                      </Box>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
   IconButton,
   Link,
-  Paper,
   Table,
   TableBody,
   TableCell,
@@ -25,6 +24,7 @@ import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
+import TableSurface from '../components/layout/TableSurface';
 import type { Supplier } from '../api/types';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
@@ -205,7 +205,8 @@ export default function Suppliers(): React.ReactElement {
             />
           </Box>
         ) : (
-          <TableContainer component={Paper} sx={{ width: 'fit-content', maxWidth: '100%' }}>
+          <TableSurface sizingMode="compact">
+          <TableContainer sx={{ width: 'fit-content', maxWidth: '100%' }}>
             <Table size="medium" sx={{ width: 'auto' }}>
               <TableHead>
                 <TableRow>
@@ -250,6 +251,7 @@ export default function Suppliers(): React.ReactElement {
               </TableBody>
             </Table>
           </TableContainer>
+          </TableSurface>
         )}
       </PageSurface>
 

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -185,7 +185,7 @@ export default function Suppliers(): React.ReactElement {
   if (shouldShowProjectRequiredState && missingProjectReason) {
     return (
       <PageContainer>
-        <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+        <Box sx={{ width: '100%' }}>
           <ProjectRequiredState reason={missingProjectReason} />
         </Box>
       </PageContainer>
@@ -194,7 +194,7 @@ export default function Suppliers(): React.ReactElement {
 
   return (
     <PageContainer>
-      <Box sx={{ width: 'fit-content', maxWidth: '100%' }}>
+      <Box sx={{ width: '100%' }}>
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard
@@ -204,7 +204,7 @@ export default function Suppliers(): React.ReactElement {
             />
           </Box>
         ) : (
-          <TableContainer component={Paper} sx={{ width: 'fit-content', maxWidth: '100%' }}>
+          <TableContainer component={Paper} sx={{ width: '100%', maxWidth: '100%' }}>
             <Table size="small" sx={{ width: 'auto' }}>
               <TableHead>
                 <TableRow>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -194,12 +194,7 @@ export default function Suppliers(): React.ReactElement {
 
   return (
     <PageContainer variant="xwide">
-      <Box sx={{ width: '100%', maxWidth: 1600 }}>
-        <Box sx={{ mb: 1.5 }}>
-          <Box sx={{ color: 'text.secondary', fontSize: '0.92rem' }}>
-            Verwalte Saatgut- und Materiallieferanten für dein Projekt.
-          </Box>
-        </Box>
+      <Box sx={{ width: '100%', maxWidth: 760 }}>
         {suppliers.length === 0 ? (
           <Box sx={{ width: '100%', maxWidth: 880 }}>
             <EmptyStateCard
@@ -209,13 +204,13 @@ export default function Suppliers(): React.ReactElement {
             />
           </Box>
         ) : (
-          <TableContainer component={Paper} sx={{ width: '100%', maxWidth: '100%' }}>
-            <Table size="medium" sx={{ width: '100%' }}>
+          <TableContainer component={Paper} sx={{ width: 'fit-content', maxWidth: '100%' }}>
+            <Table size="medium" sx={{ width: 'auto' }}>
               <TableHead>
                 <TableRow>
-                  <TableCell sx={{ py: 1.5 }}>{t('name')}</TableCell>
-                  <TableCell sx={{ py: 1.5 }}>{t('homepage')}</TableCell>
-                  <TableCell align="right" sx={{ py: 1.5, width: 120 }}>{t('actions')}</TableCell>
+                  <TableCell sx={{ py: 1.5, minWidth: { xs: 140, sm: 180 } }}>{t('name')}</TableCell>
+                  <TableCell sx={{ py: 1.5, minWidth: { xs: 180, sm: 280 } }}>{t('homepage')}</TableCell>
+                  <TableCell align="right" sx={{ py: 1.5, width: 1, whiteSpace: 'nowrap' }}>{t('actions')}</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>


### PR DESCRIPTION
### Motivation
- Mobile users had to tap a small chevron icon to expand planting plan cards, which is hard to discover and difficult on touch devices. 
- The change aims to improve touch usability and discoverability while preserving the existing card layout and actions.
- Accessibility must be preserved by providing keyboard operability and proper ARIA state.

### Description
- Replaced the icon-only expand control with a full-width header wrapper implemented as a `button` (`Box component`), so the title, metadata, empty header space and chevron all toggle expand/collapse (`frontend/src/components/mobile/MobileCardList.tsx`).
- Kept the chevron as a visual indicator only and added a smooth rotation using `transform` with a short `160ms` transition bound to the expanded state.
- Improved touch ergonomics by enforcing a `minHeight: 44px` touch target, adding `cursor: pointer`, subtle hover/pressed background feedback, and an explicit `:focus-visible` outline to maintain focus visibility.
- Preserved layout and interaction separation by keeping action buttons inside the `Collapse` details area so taps on actions (e.g. `Bearbeiten`, `Fotos`) do not toggle the header.

### Testing
- No automated tests were run (intentionally skipped per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01acbdec2483228a23aec11789e34e)