### PR TITLE
refactor: redesign mobile topbar and action layout for single-row stability

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -188,7 +188,11 @@
   .content--xwide,
   .content--compact-centered-page,
   .content--full {
-    padding: 0;
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -68,11 +68,9 @@
 }
 
 .mobile-action-scroll {
-  overflow-x: auto;
-  overflow-y: hidden;
-  white-space: nowrap;
-  scrollbar-width: none;
-  -webkit-overflow-scrolling: touch;
+  overflow-x: hidden;
+  overflow-y: visible;
+  white-space: normal;
 }
 
 .mobile-action-scroll::-webkit-scrollbar {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -67,6 +67,18 @@
   font-size: 15px;
 }
 
+.mobile-action-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mobile-action-scroll::-webkit-scrollbar {
+  display: none;
+}
+
 .nav-link {
   color: white;
   text-decoration: none;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,15 +44,7 @@ import { useTheme } from '@mui/material/styles';
 import { useTranslation } from './i18n';
 import { useCommandContext, useRegisterCommands } from './commands/useCommandContext';
 import { createRootCommands } from './commands/commands';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import Locations from './pages/Locations';
-import FieldsBedsPage from './pages/FieldsBedsPage';
-import Cultures from './pages/Cultures';
-import PlantingPlans from './pages/PlantingPlans';
-import GanttChart from './pages/GanttChart';
-import SeedDemandPage from './pages/SeedDemand';
-import Suppliers from './pages/Suppliers';
-import Dashboard from './pages/Dashboard';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import MenuIcon from '@mui/icons-material/Menu';
 import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
@@ -81,19 +73,6 @@ import type { CultureHistoryEntry } from './api/types';
 import './App.css';
 import { useAuth } from './auth/useAuth';
 import ProtectedRoute from './auth/ProtectedRoute';
-import HomePage from './pages/public/HomePage';
-import ImprintPage from './pages/public/ImprintPage';
-import PrivacyPolicyPage from './pages/public/PrivacyPolicyPage';
-import LoginPage from './pages/auth/LoginPage';
-import RegisterPage from './pages/auth/RegisterPage';
-import ActivatePage from './pages/auth/ActivatePage';
-import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
-import ResetPasswordPage from './pages/auth/ResetPasswordPage';
-import ConfirmEmailChangePage from './pages/auth/ConfirmEmailChangePage';
-import ProjectSelectionPage from './pages/ProjectSelectionPage';
-import AccountSettingsPage from './pages/AccountSettingsPage';
-import ProjectSettingsPage from './pages/ProjectSettingsPage';
-import InvitationAcceptPage from './pages/InvitationAcceptPage';
 import AppLogo from './components/layout/AppLogo';
 import { HelpDialog } from './components/help/HelpDialog';
 import PageHelp from './components/help/PageHelp';
@@ -111,6 +90,27 @@ import { PanelLeft } from 'lucide-react';
 const CONTENT_ALIGNMENT_MODE = 'centered';
 const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
 const ACTION_MENU_ICON_PROPS = { fontSize: 'small' } as const;
+const HomePage = React.lazy(() => import('./pages/public/HomePage'));
+const ImprintPage = React.lazy(() => import('./pages/public/ImprintPage'));
+const PrivacyPolicyPage = React.lazy(() => import('./pages/public/PrivacyPolicyPage'));
+const LoginPage = React.lazy(() => import('./pages/auth/LoginPage'));
+const RegisterPage = React.lazy(() => import('./pages/auth/RegisterPage'));
+const ActivatePage = React.lazy(() => import('./pages/auth/ActivatePage'));
+const ForgotPasswordPage = React.lazy(() => import('./pages/auth/ForgotPasswordPage'));
+const ResetPasswordPage = React.lazy(() => import('./pages/auth/ResetPasswordPage'));
+const ConfirmEmailChangePage = React.lazy(() => import('./pages/auth/ConfirmEmailChangePage'));
+const ProjectSelectionPage = React.lazy(() => import('./pages/ProjectSelectionPage'));
+const AccountSettingsPage = React.lazy(() => import('./pages/AccountSettingsPage'));
+const ProjectSettingsPage = React.lazy(() => import('./pages/ProjectSettingsPage'));
+const InvitationAcceptPage = React.lazy(() => import('./pages/InvitationAcceptPage'));
+const Dashboard = React.lazy(() => import('./pages/Dashboard'));
+const Locations = React.lazy(() => import('./pages/Locations'));
+const FieldsBedsPage = React.lazy(() => import('./pages/FieldsBedsPage'));
+const Cultures = React.lazy(() => import('./pages/Cultures'));
+const PlantingPlans = React.lazy(() => import('./pages/PlantingPlans'));
+const GanttChart = React.lazy(() => import('./pages/GanttChart'));
+const SeedDemandPage = React.lazy(() => import('./pages/SeedDemand'));
+const Suppliers = React.lazy(() => import('./pages/Suppliers'));
 
 interface SnackbarState {
   open: boolean;
@@ -1612,43 +1612,47 @@ function TokenInvitationRedirect(): React.ReactElement {
   return <Navigate to={buildInvitationAcceptPath(token)} replace />;
 }
 
+function withLazyFallback(element: React.ReactElement): React.ReactElement {
+  return <Suspense fallback={null}>{element}</Suspense>;
+}
+
 function createAppRouter(basename: string) {
   return createBrowserRouter([
     {
       path: '/',
-      element: <HomePage />,
+      element: withLazyFallback(<HomePage />),
     },
     {
       path: '/impressum',
-      element: <ImprintPage />,
+      element: withLazyFallback(<ImprintPage />),
     },
     {
       path: '/datenschutz',
-      element: <PrivacyPolicyPage />,
+      element: withLazyFallback(<PrivacyPolicyPage />),
     },
     {
       path: '/login',
-      element: <LoginPage />,
+      element: withLazyFallback(<LoginPage />),
     },
     {
       path: '/register',
-      element: <RegisterPage />,
+      element: withLazyFallback(<RegisterPage />),
     },
     {
       path: '/activate',
-      element: <ActivatePage />,
+      element: withLazyFallback(<ActivatePage />),
     },
     {
       path: '/forgot-password',
-      element: <ForgotPasswordPage />,
+      element: withLazyFallback(<ForgotPasswordPage />),
     },
     {
       path: '/reset-password',
-      element: <ResetPasswordPage />,
+      element: withLazyFallback(<ResetPasswordPage />),
     },
     {
       path: '/confirm-email-change',
-      element: <ConfirmEmailChangePage />,
+      element: withLazyFallback(<ConfirmEmailChangePage />),
     },
     {
       path: '/invitation',
@@ -1656,7 +1660,7 @@ function createAppRouter(basename: string) {
     },
     {
       path: '/invite/accept',
-      element: <InvitationAcceptPage />,
+      element: withLazyFallback(<InvitationAcceptPage />),
     },
     {
       path: '/invite/:token',
@@ -1674,18 +1678,18 @@ function createAppRouter(basename: string) {
               index: true,
               loader: () => redirect('/app/dashboard'),
             },
-            { path: 'dashboard', element: <Dashboard /> },
-            { path: 'locations', element: <Locations /> },
-            { path: 'fields-beds', element: <FieldsBedsPage /> },
-            { path: 'cultures', element: <Cultures /> },
-            { path: 'anbauplaene', element: <PlantingPlans /> },
-            { path: 'suppliers', element: <Suppliers /> },
-            { path: 'planting-plans', element: <PlantingPlans /> },
-            { path: 'gantt-chart', element: <GanttChart /> },
-            { path: 'seed-demand', element: <SeedDemandPage /> },
-            { path: 'project-selection', element: <ProjectSelectionPage /> },
-            { path: 'account-settings', element: <AccountSettingsPage /> },
-            { path: 'project-settings', element: <ProjectSettingsPage /> },
+            { path: 'dashboard', element: withLazyFallback(<Dashboard />) },
+            { path: 'locations', element: withLazyFallback(<Locations />) },
+            { path: 'fields-beds', element: withLazyFallback(<FieldsBedsPage />) },
+            { path: 'cultures', element: withLazyFallback(<Cultures />) },
+            { path: 'anbauplaene', element: withLazyFallback(<PlantingPlans />) },
+            { path: 'suppliers', element: withLazyFallback(<Suppliers />) },
+            { path: 'planting-plans', element: withLazyFallback(<PlantingPlans />) },
+            { path: 'gantt-chart', element: withLazyFallback(<GanttChart />) },
+            { path: 'seed-demand', element: withLazyFallback(<SeedDemandPage />) },
+            { path: 'project-selection', element: withLazyFallback(<ProjectSelectionPage />) },
+            { path: 'account-settings', element: withLazyFallback(<AccountSettingsPage />) },
+            { path: 'project-settings', element: withLazyFallback(<ProjectSettingsPage />) },
           ],
         },
       ],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -683,6 +683,16 @@ function RootLayout(): React.ReactElement {
     if (location.pathname.startsWith('/app/fields-beds')) return fieldsGlobalAddAction ? { label: fieldsGlobalAddAction.label, to: '', onClick: fieldsGlobalAddAction.onClick } : null;
     return null;
   }, [fieldsGlobalAddAction, location.pathname]);
+  const handleTopbarPrimaryAction = useCallback((): void => {
+    if (!topbarPrimaryAction) {
+      return;
+    }
+    if (topbarPrimaryAction.onClick) {
+      topbarPrimaryAction.onClick();
+      return;
+    }
+    navigate(topbarPrimaryAction.to);
+  }, [navigate, topbarPrimaryAction]);
 
   return (
     <Box className={`app app--${CONTENT_ALIGNMENT_MODE}`} sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f2f0ea' }}>
@@ -979,13 +989,7 @@ function RootLayout(): React.ReactElement {
               <Button
                 size="small"
                 variant="contained"
-                onClick={() => {
-                  if (topbarPrimaryAction.onClick) {
-                    topbarPrimaryAction.onClick();
-                    return;
-                  }
-                  navigate(topbarPrimaryAction.to);
-                }}
+                onClick={handleTopbarPrimaryAction}
                 aria-label={topbarPrimaryAction.label}
                 startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
                 sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.5 }}
@@ -1058,6 +1062,19 @@ function RootLayout(): React.ReactElement {
           </Box>
           ) : (
             <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.25 }}>
+              {topbarPrimaryAction ? (
+                <Tooltip title={topbarPrimaryAction.label}>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    onClick={handleTopbarPrimaryAction}
+                    aria-label={topbarPrimaryAction.label}
+                    sx={{ textTransform: 'none', minWidth: 32, px: 0.75, minHeight: 30 }}
+                  >
+                    <AddIcon fontSize="small" />
+                  </Button>
+                </Tooltip>
+              ) : null}
               <IconButton
                 aria-label="Mehr"
                 aria-controls={globalMenuAnchor ? 'global-actions-menu' : undefined}
@@ -1205,23 +1222,6 @@ function RootLayout(): React.ReactElement {
                   </Menu>,
                 ];
               })()}
-              {topbarPrimaryAction ? (
-                <Button
-                  size="small"
-                  variant="contained"
-                  onClick={() => {
-                    if (topbarPrimaryAction.onClick) {
-                      topbarPrimaryAction.onClick();
-                      return;
-                    }
-                    navigate(topbarPrimaryAction.to);
-                  }}
-                  aria-label={topbarPrimaryAction.label}
-                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', px: 1, minHeight: 30 }}
-                >
-                  <AddIcon fontSize="small" />
-                </Button>
-              ) : null}
             </Box>
           </Box>
         ) : null}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -339,9 +339,9 @@ function RootLayout(): React.ReactElement {
     setProjectMenuAnchor(event.currentTarget);
   };
 
-  const handleProjectMenuClose = () => {
+  const handleProjectMenuClose = useCallback(() => {
     setProjectMenuAnchor(null);
-  };
+  }, []);
   const closeMobileNav = () => {
     setMobileNavOpen(false);
   };
@@ -371,9 +371,9 @@ function RootLayout(): React.ReactElement {
     message: '',
     severity: 'success',
   });
-  const showSnackbar = (message: string, severity: 'success' | 'error') => {
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error') => {
     setSnackbar({ open: true, message, severity });
-  };
+  }, []);
 
   const handleOpenProjectHistory = useCallback(async () => {
     handleGlobalMenuClose();
@@ -388,7 +388,7 @@ function RootLayout(): React.ReactElement {
     } finally {
       setHistoryLoading(false);
     }
-  }, [activeProjectId, showSnackbar, t]);
+  }, [showSnackbar, t]);
 
   const handleRestoreProjectVersion = async (historyId: number) => {
     try {
@@ -429,7 +429,7 @@ function RootLayout(): React.ReactElement {
       console.error('Error logging out:', error);
       showSnackbar(t('commandPalette.feedback.logoutError'), 'error');
     }
-  }, [logout, navigate]);
+  }, [logout, navigate, showSnackbar, t]);
 
   const memberships = useMemo(() => user?.memberships ?? [], [user?.memberships]);
   const activeMembership = memberships.find((membership) => membership.project_id === activeProjectId) ?? null;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,78 +221,30 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
     t,
   } = props;
 
-  return (
-    <Menu
-      id="global-actions-menu"
-      anchorEl={anchorEl}
-      open={open}
-      onClose={onClose}
->
-      {isMobile ? (
-        <>
-          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Projektaktionen</MenuItem>
-          <MenuItem onClick={onOpenProjectSwitcher}>
-            <ListItemIcon sx={{ minWidth: 32 }}><SwapHorizIcon fontSize="small" /></ListItemIcon>
-            {t('projectSwitcher.ariaLabel')}
-          </MenuItem>
-          <MenuItem onClick={onOpenCreateProject}>
-            <ListItemIcon sx={{ minWidth: 32 }}><AddIcon fontSize="small" /></ListItemIcon>
-            {t('project.create')}
-          </MenuItem>
-          <MenuItem onClick={onOpenProjectSettings}>
-            <ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>
-            {t('project.settings')}
-          </MenuItem>
-          <MenuItem onClick={onOpenProjectMembers}>
-            <ListItemIcon sx={{ minWidth: 32 }}><GroupOutlinedIcon fontSize="small" /></ListItemIcon>
-            {t('commandPalette.commands.openProjectMembers')}
-          </MenuItem>
-          <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
-            <ListItemIcon sx={{ minWidth: 32 }}><HistoryOutlinedIcon fontSize="small" /></ListItemIcon>
-            {t('commandPalette.commands.openVersionHistory')}
-          </MenuItem>
-          <Divider />
-          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>App</MenuItem>
-          <MenuItem onClick={onOpenShortcuts}>
-            <ListItemIcon sx={{ minWidth: 32 }}><KeyboardOutlinedIcon fontSize="small" /></ListItemIcon>
-            Tastenkürzel
-          </MenuItem>
-          <MenuItem onClick={onOpenHelp}>
-            <ListItemIcon sx={{ minWidth: 32 }}><HelpOutlineIcon fontSize="small" /></ListItemIcon>
-            App-Hilfe
-          </MenuItem>
-          <MenuItem onClick={onOpenAccountSettings}>
-            <ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>
-            {t('accountSettings')}
-          </MenuItem>
-          <Divider />
-          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Account</MenuItem>
-          <MenuItem onClick={() => void onLogout()}>
-            <ListItemIcon sx={{ minWidth: 32 }}><LogoutIcon fontSize="small" /></ListItemIcon>
-            {t('commandPalette.commands.logout')} {userLabel}
-          </MenuItem>
-        </>
-      ) : (
-        <>
-          <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
-            {t('commandPalette.commands.openVersionHistory')}
-          </MenuItem>
-          <MenuItem onClick={onOpenAccountSettings}>
-            {t('accountSettings')}
-          </MenuItem>
-          <MenuItem onClick={onOpenShortcuts}>
-            Tastenkürzel
-          </MenuItem>
-          <MenuItem onClick={onOpenHelp}>
-            App-Hilfe
-          </MenuItem>
-          <MenuItem onClick={() => void onLogout()}>
-            {t('commandPalette.commands.logout')} {userLabel}
-          </MenuItem>
-        </>
-      )}
-    </Menu>
-  );
+  const mobileMenuItems = [
+    <MenuItem key="mobile-section-project" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Projektaktionen</MenuItem>,
+    <MenuItem key="mobile-project-switcher" onClick={onOpenProjectSwitcher}><ListItemIcon sx={{ minWidth: 32 }}><SwapHorizIcon fontSize="small" /></ListItemIcon>{t('projectSwitcher.ariaLabel')}</MenuItem>,
+    <MenuItem key="mobile-project-create" onClick={onOpenCreateProject}><ListItemIcon sx={{ minWidth: 32 }}><AddIcon fontSize="small" /></ListItemIcon>{t('project.create')}</MenuItem>,
+    <MenuItem key="mobile-project-settings" onClick={onOpenProjectSettings}><ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>{t('project.settings')}</MenuItem>,
+    <MenuItem key="mobile-project-members" onClick={onOpenProjectMembers}><ListItemIcon sx={{ minWidth: 32 }}><GroupOutlinedIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.openProjectMembers')}</MenuItem>,
+    <MenuItem key="mobile-project-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}><ListItemIcon sx={{ minWidth: 32 }}><HistoryOutlinedIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <Divider key="mobile-divider-project-app" />,
+    <MenuItem key="mobile-section-app" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>App</MenuItem>,
+    <MenuItem key="mobile-app-shortcuts" onClick={onOpenShortcuts}><ListItemIcon sx={{ minWidth: 32 }}><KeyboardOutlinedIcon fontSize="small" /></ListItemIcon>Tastenkürzel</MenuItem>,
+    <MenuItem key="mobile-app-help" onClick={onOpenHelp}><ListItemIcon sx={{ minWidth: 32 }}><HelpOutlineIcon fontSize="small" /></ListItemIcon>App-Hilfe</MenuItem>,
+    <MenuItem key="mobile-app-account-settings" onClick={onOpenAccountSettings}><ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>{t('accountSettings')}</MenuItem>,
+    <Divider key="mobile-divider-app-account" />,
+    <MenuItem key="mobile-section-account" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Account</MenuItem>,
+    <MenuItem key="mobile-account-logout" onClick={() => void onLogout()}><ListItemIcon sx={{ minWidth: 32 }}><LogoutIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
+  ];
+  const desktopMenuItems = [
+    <MenuItem key="desktop-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <MenuItem key="desktop-account-settings" onClick={onOpenAccountSettings}>{t('accountSettings')}</MenuItem>,
+    <MenuItem key="desktop-shortcuts" onClick={onOpenShortcuts}>Tastenkürzel</MenuItem>,
+    <MenuItem key="desktop-help" onClick={onOpenHelp}>App-Hilfe</MenuItem>,
+    <MenuItem key="desktop-logout" onClick={() => void onLogout()}>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
+  ];
+  return <Menu id="global-actions-menu" anchorEl={anchorEl} open={open} onClose={onClose}>{isMobile ? mobileMenuItems : desktopMenuItems}</Menu>;
 }
 
 export interface TopbarContextAction {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -897,8 +897,8 @@ function RootLayout(): React.ReactElement {
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
           {!isPhone ? (
-          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
+          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, flex: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: 'auto', overflowY: 'hidden', pr: 0.5, scrollbarWidth: 'thin' }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -501,6 +501,19 @@ function RootLayout(): React.ReactElement {
     () => (isCulturesPage ? [] : topbarContextActions.filter((action) => action.id !== 'fields-global-add-field')),
     [isCulturesPage, topbarContextActions],
   );
+  const topbarModeControls = useMemo(
+    () => genericTopbarContextActions.filter((action) => (
+      action.groupId?.includes('mode')
+      || action.id.includes('view-mode')
+      || action.id.includes('interaction-mode')
+      || action.id.includes('calendar-mode')
+    )),
+    [genericTopbarContextActions],
+  );
+  const topbarOverflowActions = useMemo(
+    () => genericTopbarContextActions.filter((action) => !topbarModeControls.some((modeAction) => modeAction.id === action.id)),
+    [genericTopbarContextActions, topbarModeControls],
+  );
   const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
   const showIconOnlyCultureLibrary = isCulturesPage && (isPhone || isTabletOrNarrowDesktop);
   const showCultureImportExportButton = isCulturesPage;
@@ -934,7 +947,7 @@ function RootLayout(): React.ReactElement {
           ) : null}
           {(() => {
             const groups: TopbarContextAction[][] = [];
-            genericTopbarContextActions.forEach((action) => {
+            [...topbarModeControls, ...topbarOverflowActions].forEach((action) => {
               const lastGroup = groups[groups.length - 1];
               if (!lastGroup || !action.groupId || lastGroup[0]?.groupId !== action.groupId) {
                 groups.push([action]);
@@ -1146,7 +1159,7 @@ function RootLayout(): React.ReactElement {
               ) : null}
               {(() => {
                 const groups: TopbarContextAction[][] = [];
-                genericTopbarContextActions.forEach((action) => {
+                [...topbarModeControls, ...topbarOverflowActions].forEach((action) => {
                   const lastGroup = groups[groups.length - 1];
                   if (!lastGroup || !action.groupId || lastGroup[0]?.groupId !== action.groupId) {
                     groups.push([action]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,6 +109,8 @@ import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './n
 import { PanelLeft } from 'lucide-react';
 
 const CONTENT_ALIGNMENT_MODE = 'centered';
+const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
+const ACTION_MENU_ICON_PROPS = { fontSize: 'small' } as const;
 
 interface SnackbarState {
   open: boolean;
@@ -169,14 +171,13 @@ function ProjectMenu(props: ProjectMenuProps): React.ReactElement {
       )}
       <Divider />
       <MenuItem onClick={onOpenProjectSettings}>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
         {t('project.settings')}
       </MenuItem>
       <Divider />
       <MenuItem onClick={onOpenCreateProject}>
-        <Stack direction="row" alignItems="center" spacing={1}>
-          <AddIcon fontSize="small" />
-          <span>{t('project.create')}</span>
-        </Stack>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+        {t('project.create')}
       </MenuItem>
     </Menu>
   );
@@ -223,26 +224,26 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
 
   const mobileMenuItems = [
     <MenuItem key="mobile-section-project" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Projektaktionen</MenuItem>,
-    <MenuItem key="mobile-project-switcher" onClick={onOpenProjectSwitcher}><ListItemIcon sx={{ minWidth: 32 }}><SwapHorizIcon fontSize="small" /></ListItemIcon>{t('projectSwitcher.ariaLabel')}</MenuItem>,
-    <MenuItem key="mobile-project-create" onClick={onOpenCreateProject}><ListItemIcon sx={{ minWidth: 32 }}><AddIcon fontSize="small" /></ListItemIcon>{t('project.create')}</MenuItem>,
-    <MenuItem key="mobile-project-settings" onClick={onOpenProjectSettings}><ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>{t('project.settings')}</MenuItem>,
-    <MenuItem key="mobile-project-members" onClick={onOpenProjectMembers}><ListItemIcon sx={{ minWidth: 32 }}><GroupOutlinedIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.openProjectMembers')}</MenuItem>,
-    <MenuItem key="mobile-project-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}><ListItemIcon sx={{ minWidth: 32 }}><HistoryOutlinedIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <MenuItem key="mobile-project-switcher" onClick={onOpenProjectSwitcher}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SwapHorizIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('projectSwitcher.ariaLabel')}</MenuItem>,
+    <MenuItem key="mobile-project-create" onClick={onOpenCreateProject}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.create')}</MenuItem>,
+    <MenuItem key="mobile-project-settings" onClick={onOpenProjectSettings}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.settings')}</MenuItem>,
+    <MenuItem key="mobile-project-members" onClick={onOpenProjectMembers}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><GroupOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openProjectMembers')}</MenuItem>,
+    <MenuItem key="mobile-project-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
     <Divider key="mobile-divider-project-app" />,
     <MenuItem key="mobile-section-app" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>App</MenuItem>,
-    <MenuItem key="mobile-app-shortcuts" onClick={onOpenShortcuts}><ListItemIcon sx={{ minWidth: 32 }}><KeyboardOutlinedIcon fontSize="small" /></ListItemIcon>Tastenkürzel</MenuItem>,
-    <MenuItem key="mobile-app-help" onClick={onOpenHelp}><ListItemIcon sx={{ minWidth: 32 }}><HelpOutlineIcon fontSize="small" /></ListItemIcon>App-Hilfe</MenuItem>,
-    <MenuItem key="mobile-app-account-settings" onClick={onOpenAccountSettings}><ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>{t('accountSettings')}</MenuItem>,
+    <MenuItem key="mobile-app-shortcuts" onClick={onOpenShortcuts}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>Tastenkürzel</MenuItem>,
+    <MenuItem key="mobile-app-help" onClick={onOpenHelp}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>App-Hilfe</MenuItem>,
+    <MenuItem key="mobile-app-account-settings" onClick={onOpenAccountSettings}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
     <Divider key="mobile-divider-app-account" />,
     <MenuItem key="mobile-section-account" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Account</MenuItem>,
-    <MenuItem key="mobile-account-logout" onClick={() => void onLogout()}><ListItemIcon sx={{ minWidth: 32 }}><LogoutIcon fontSize="small" /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
+    <MenuItem key="mobile-account-logout" onClick={() => void onLogout()}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
   ];
   const desktopMenuItems = [
-    <MenuItem key="desktop-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
-    <MenuItem key="desktop-account-settings" onClick={onOpenAccountSettings}>{t('accountSettings')}</MenuItem>,
-    <MenuItem key="desktop-shortcuts" onClick={onOpenShortcuts}>Tastenkürzel</MenuItem>,
-    <MenuItem key="desktop-help" onClick={onOpenHelp}>App-Hilfe</MenuItem>,
-    <MenuItem key="desktop-logout" onClick={() => void onLogout()}>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
+    <MenuItem key="desktop-history" onClick={() => void onOpenProjectHistory()} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <MenuItem key="desktop-account-settings" onClick={onOpenAccountSettings}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
+    <MenuItem key="desktop-shortcuts" onClick={onOpenShortcuts}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>Tastenkürzel</MenuItem>,
+    <MenuItem key="desktop-help" onClick={onOpenHelp}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>App-Hilfe</MenuItem>,
+    <MenuItem key="desktop-logout" onClick={() => void onLogout()}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem>,
   ];
   return <Menu id="global-actions-menu" anchorEl={anchorEl} open={open} onClose={onClose}>{isMobile ? mobileMenuItems : desktopMenuItems}</Menu>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1301,6 +1301,15 @@ function RootLayout(): React.ReactElement {
           minWidth: 0,
         }}
       >
+        {memberships.length === 0 ? (
+          <Button
+            variant="contained"
+            onClick={handleOpenCreateProject}
+            sx={{ alignSelf: 'flex-start', mx: { xs: 1.5, sm: 0 } }}
+          >
+            {t('common:projectRequired.createFirstProjectAction')}
+          </Button>
+        ) : null}
         <Outlet context={{ setTopbarContextActions } satisfies RootLayoutOutletContext} />
       </Box>
       </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -831,7 +831,7 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 0, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
             {!isDesktopUp ? (
@@ -1080,7 +1080,7 @@ function RootLayout(): React.ReactElement {
           )}
         </Toolbar>
         {isMobile ? (
-          <Box className="mobile-action-scroll" sx={{ px: 1, pb: 0.5 }}>
+          <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (
                 <>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,6 +107,7 @@ import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
 import { PanelLeft } from 'lucide-react';
+import { OPEN_ADD_BED_EVENT } from './pages/fieldsBedsEvents';
 
 const CONTENT_ALIGNMENT_MODE = 'centered';
 const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
@@ -303,6 +304,7 @@ function RootLayout(): React.ReactElement {
   const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
   const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileActionsOverflowAnchor, setMobileActionsOverflowAnchor] = useState<null | HTMLElement>(null);
+  const [areasAddMenuAnchor, setAreasAddMenuAnchor] = useState<null | HTMLElement>(null);
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },
     ...MAIN_NAV_ITEMS.map((item) => ({
@@ -483,6 +485,12 @@ function RootLayout(): React.ReactElement {
   };
   const handleMobileActionsOverflowClose = () => {
     setMobileActionsOverflowAnchor(null);
+  };
+  const handleAreasAddMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAreasAddMenuAnchor(event.currentTarget);
+  };
+  const handleAreasAddMenuClose = () => {
+    setAreasAddMenuAnchor(null);
   };
   const isCulturesPage = location.pathname.startsWith('/app/cultures');
   const cultureLibraryAction = useMemo(
@@ -975,7 +983,13 @@ function RootLayout(): React.ReactElement {
               <Button
                 size="small"
                 variant="contained"
-                onClick={() => navigate(topbarPrimaryAction.to)}
+                onClick={(event) => {
+                  if (location.pathname.startsWith('/app/fields-beds')) {
+                    handleAreasAddMenuOpen(event);
+                    return;
+                  }
+                  navigate(topbarPrimaryAction.to);
+                }}
                 aria-label={topbarPrimaryAction.label}
                 startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
                 sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.5 }}
@@ -1079,6 +1093,19 @@ function RootLayout(): React.ReactElement {
             </Box>
           )}
         </Toolbar>
+        {location.pathname.startsWith('/app/fields-beds') ? (
+          <Menu anchorEl={areasAddMenuAnchor} open={Boolean(areasAddMenuAnchor)} onClose={handleAreasAddMenuClose}>
+            <MenuItem onClick={() => { handleAreasAddMenuClose(); navigate('/app/locations?create=true'); }}>
+              Standort hinzufügen
+            </MenuItem>
+            <MenuItem onClick={() => { handleAreasAddMenuClose(); navigate('/app/fields-beds?create=true'); }}>
+              Parzelle hinzufügen
+            </MenuItem>
+            <MenuItem onClick={() => { handleAreasAddMenuClose(); window.dispatchEvent(new CustomEvent(OPEN_ADD_BED_EVENT)); }}>
+              Beet hinzufügen
+            </MenuItem>
+          </Menu>
+        ) : null}
         {isMobile ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
@@ -1199,7 +1226,13 @@ function RootLayout(): React.ReactElement {
                 <Button
                   size="small"
                   variant="contained"
-                  onClick={() => navigate(topbarPrimaryAction.to)}
+                  onClick={(event) => {
+                    if (location.pathname.startsWith('/app/fields-beds')) {
+                      handleAreasAddMenuOpen(event);
+                      return;
+                    }
+                    navigate(topbarPrimaryAction.to);
+                  }}
                   aria-label={topbarPrimaryAction.label}
                   sx={{ textTransform: 'none', whiteSpace: 'nowrap', px: 1, minHeight: 30 }}
                 >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -517,7 +517,17 @@ function RootLayout(): React.ReactElement {
   const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
   const showIconOnlyCultureLibrary = isCulturesPage && (isPhone || isTabletOrNarrowDesktop);
   const showCultureImportExportButton = isCulturesPage;
-
+  const hasVisibleMobileContextActions = useMemo(
+    () => [...topbarModeControls, ...topbarOverflowActions].some((action) => !action.hidden),
+    [topbarModeControls, topbarOverflowActions],
+  );
+  const hasMobileSecondaryRow = useMemo(
+    () => (
+      (isCulturesPage && (Boolean(cultureLibraryAction) || showCultureImportExportButton))
+      || hasVisibleMobileContextActions
+    ),
+    [cultureLibraryAction, hasVisibleMobileContextActions, isCulturesPage, showCultureImportExportButton],
+  );
   const handleCreateProject = async (): Promise<void> => {
     if (!newProjectName.trim()) {
       return;
@@ -1119,7 +1129,7 @@ function RootLayout(): React.ReactElement {
             </Box>
           )}
         </Toolbar>
-        {isMobile ? (
+        {isMobile && hasMobileSecondaryRow ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -284,6 +284,7 @@ function RootLayout(): React.ReactElement {
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
   const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isVeryNarrowMobile = useMediaQuery('(max-width:360px)');
   const isPhonePortrait = useMediaQuery(`${theme.breakpoints.down('sm')} and (orientation: portrait)`);
   const isTabletOrNarrowDesktop = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
   const { user, logout, activeProjectId, switchActiveProject } = useAuth();
@@ -301,6 +302,7 @@ function RootLayout(): React.ReactElement {
   const [isCreatingProject, setIsCreatingProject] = useState(false);
   const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
   const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
+  const [mobileActionsOverflowAnchor, setMobileActionsOverflowAnchor] = useState<null | HTMLElement>(null);
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },
     ...MAIN_NAV_ITEMS.map((item) => ({
@@ -475,6 +477,12 @@ function RootLayout(): React.ReactElement {
 
   const handleCultureActionsMenuClose = () => {
     setCultureActionsMenuAnchor(null);
+  };
+  const handleMobileActionsOverflowOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setMobileActionsOverflowAnchor(event.currentTarget);
+  };
+  const handleMobileActionsOverflowClose = () => {
+    setMobileActionsOverflowAnchor(null);
   };
   const isCulturesPage = location.pathname.startsWith('/app/cultures');
   const cultureLibraryAction = useMemo(
@@ -1073,7 +1081,7 @@ function RootLayout(): React.ReactElement {
         </Toolbar>
         {isMobile ? (
           <Box className="mobile-action-scroll" sx={{ px: 1, pb: 0.5 }}>
-            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (
                 <>
                   {cultureLibraryAction ? (
@@ -1119,7 +1127,9 @@ function RootLayout(): React.ReactElement {
                   }
                   lastGroup.push(action);
                 });
-                return groups.map((group, index) => {
+                const visibleGroups = isVeryNarrowMobile ? groups.slice(0, 2) : groups;
+                const overflowGroups = isVeryNarrowMobile ? groups.slice(2) : [];
+                const visibleNodes = visibleGroups.map((group, index) => {
                   const isSegmentedGroup = group.length > 1 && group[0]?.groupId;
                   const content = group.map((action) => (
                     <Button
@@ -1144,6 +1154,46 @@ function RootLayout(): React.ReactElement {
                     <Box key={`mobile-group-${index}`} sx={{ display: 'inline-flex', flexShrink: 0 }}>{content}</Box>
                   );
                 });
+                if (overflowGroups.length === 0) {
+                  return visibleNodes;
+                }
+                return [
+                  ...visibleNodes,
+                  <IconButton
+                    key="mobile-actions-overflow-trigger"
+                    size="small"
+                    aria-label="Weitere Aktionen"
+                    aria-controls={mobileActionsOverflowAnchor ? 'mobile-actions-overflow-menu' : undefined}
+                    aria-haspopup="true"
+                    aria-expanded={Boolean(mobileActionsOverflowAnchor)}
+                    onClick={handleMobileActionsOverflowOpen}
+                    sx={{ border: '1px solid', borderColor: 'divider' }}
+                  >
+                    <MoreVertIcon fontSize="small" />
+                  </IconButton>,
+                  <Menu
+                    key="mobile-actions-overflow-menu"
+                    id="mobile-actions-overflow-menu"
+                    anchorEl={mobileActionsOverflowAnchor}
+                    open={Boolean(mobileActionsOverflowAnchor)}
+                    onClose={handleMobileActionsOverflowClose}
+                  >
+                    {overflowGroups.flatMap((group, groupIndex) =>
+                      group.map((action) => (
+                        <MenuItem
+                          key={`mobile-overflow-action-${groupIndex}-${action.id}`}
+                          onClick={() => {
+                            action.onClick();
+                            handleMobileActionsOverflowClose();
+                          }}
+                          disabled={action.disabled}
+                        >
+                          {action.label}
+                        </MenuItem>
+                      ))
+                    )}
+                  </Menu>,
+                ];
               })()}
               {topbarPrimaryAction ? (
                 <Button

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -896,7 +896,7 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
-          {!isMobile ? (
+          {!isPhone ? (
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
           {isCulturesPage ? (
@@ -1113,7 +1113,7 @@ function RootLayout(): React.ReactElement {
                 open={Boolean(globalMenuAnchor)}
                 historyLoading={historyLoading}
                 userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
-                isMobile={isMobile}
+                isMobile={isPhone}
                 onClose={handleGlobalMenuClose}
                 onOpenProjectSwitcher={handleOpenMobileProjectSwitcher}
                 onOpenCreateProject={handleOpenCreateProject}
@@ -1129,7 +1129,7 @@ function RootLayout(): React.ReactElement {
             </Box>
           )}
         </Toolbar>
-        {isMobile && hasMobileSecondaryRow ? (
+        {isPhone && hasMobileSecondaryRow ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,6 +69,13 @@ import PublicIcon from '@mui/icons-material/Public';
 import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
+import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
+import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import LogoutIcon from '@mui/icons-material/Logout';
 import { cultureAPI, projectAPI } from './api/api';
 import type { CultureHistoryEntry } from './api/types';
 import './App.css';
@@ -181,12 +188,11 @@ interface GlobalMenuProps {
   historyLoading: boolean;
   userLabel: string;
   isMobile: boolean;
-  memberships: { project_id: number; project_name: string; role: 'admin' | 'member' }[];
-  activeProjectId: number | null;
-  isSwitchingProject: boolean;
   onClose: () => void;
-  onSwitchProject: (projectId: number) => Promise<void>;
+  onOpenProjectSwitcher: () => void;
+  onOpenCreateProject: () => void;
   onOpenProjectSettings: () => void;
+  onOpenProjectMembers: () => void;
   onOpenProjectHistory: () => Promise<void>;
   onOpenAccountSettings: () => void;
   onOpenShortcuts: () => void;
@@ -202,12 +208,11 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
     historyLoading,
     userLabel,
     isMobile,
-    memberships,
-    activeProjectId,
-    isSwitchingProject,
     onClose,
-    onSwitchProject,
+    onOpenProjectSwitcher,
+    onOpenCreateProject,
     onOpenProjectSettings,
+    onOpenProjectMembers,
     onOpenProjectHistory,
     onOpenAccountSettings,
     onOpenShortcuts,
@@ -225,48 +230,67 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
 >
       {isMobile ? (
         <>
-          <MenuItem disabled>{t('projectSwitcher.ariaLabel')}</MenuItem>
-          {memberships.length === 0 ? (
-            <MenuItem disabled>{t('projectSwitcher.zeroProjects')}</MenuItem>
-          ) : (
-            memberships.map((membership) => (
-              <MenuItem
-                key={`mobile-project-${membership.project_id}`}
-                onClick={() => void onSwitchProject(membership.project_id)}
-                selected={membership.project_id === activeProjectId}
-                disabled={isSwitchingProject}
-              >
-                <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
-                  <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{membership.project_name}</span>
-                  {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" /> : null}
-                </Stack>
-              </MenuItem>
-            ))
-          )}
+          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Projektaktionen</MenuItem>
+          <MenuItem onClick={onOpenProjectSwitcher}>
+            <ListItemIcon sx={{ minWidth: 32 }}><SwapHorizIcon fontSize="small" /></ListItemIcon>
+            {t('projectSwitcher.ariaLabel')}
+          </MenuItem>
+          <MenuItem onClick={onOpenCreateProject}>
+            <ListItemIcon sx={{ minWidth: 32 }}><AddIcon fontSize="small" /></ListItemIcon>
+            {t('project.create')}
+          </MenuItem>
           <MenuItem onClick={onOpenProjectSettings}>
+            <ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>
             {t('project.settings')}
           </MenuItem>
-          <MenuItem onClick={onOpenProjectSettings}>
+          <MenuItem onClick={onOpenProjectMembers}>
+            <ListItemIcon sx={{ minWidth: 32 }}><GroupOutlinedIcon fontSize="small" /></ListItemIcon>
             {t('commandPalette.commands.openProjectMembers')}
           </MenuItem>
+          <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
+            <ListItemIcon sx={{ minWidth: 32 }}><HistoryOutlinedIcon fontSize="small" /></ListItemIcon>
+            {t('commandPalette.commands.openVersionHistory')}
+          </MenuItem>
           <Divider />
+          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>App</MenuItem>
+          <MenuItem onClick={onOpenShortcuts}>
+            <ListItemIcon sx={{ minWidth: 32 }}><KeyboardOutlinedIcon fontSize="small" /></ListItemIcon>
+            Tastenkürzel
+          </MenuItem>
+          <MenuItem onClick={onOpenHelp}>
+            <ListItemIcon sx={{ minWidth: 32 }}><HelpOutlineIcon fontSize="small" /></ListItemIcon>
+            App-Hilfe
+          </MenuItem>
+          <MenuItem onClick={onOpenAccountSettings}>
+            <ListItemIcon sx={{ minWidth: 32 }}><SettingsOutlinedIcon fontSize="small" /></ListItemIcon>
+            {t('accountSettings')}
+          </MenuItem>
+          <Divider />
+          <MenuItem disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>Account</MenuItem>
+          <MenuItem onClick={() => void onLogout()}>
+            <ListItemIcon sx={{ minWidth: 32 }}><LogoutIcon fontSize="small" /></ListItemIcon>
+            {t('commandPalette.commands.logout')} {userLabel}
+          </MenuItem>
         </>
-      ) : null}
-      <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
-        {t('commandPalette.commands.openVersionHistory')}
-      </MenuItem>
-      <MenuItem onClick={onOpenAccountSettings}>
-        {t('accountSettings')}
-      </MenuItem>
-      <MenuItem onClick={onOpenShortcuts}>
-        Tastenkürzel
-      </MenuItem>
-      <MenuItem onClick={onOpenHelp}>
-        App-Hilfe
-      </MenuItem>
-      <MenuItem onClick={() => void onLogout()}>
-        {t('commandPalette.commands.logout')} {userLabel}
-      </MenuItem>
+      ) : (
+        <>
+          <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
+            {t('commandPalette.commands.openVersionHistory')}
+          </MenuItem>
+          <MenuItem onClick={onOpenAccountSettings}>
+            {t('accountSettings')}
+          </MenuItem>
+          <MenuItem onClick={onOpenShortcuts}>
+            Tastenkürzel
+          </MenuItem>
+          <MenuItem onClick={onOpenHelp}>
+            App-Hilfe
+          </MenuItem>
+          <MenuItem onClick={() => void onLogout()}>
+            {t('commandPalette.commands.logout')} {userLabel}
+          </MenuItem>
+        </>
+      )}
     </Menu>
   );
 }
@@ -315,6 +339,7 @@ function RootLayout(): React.ReactElement {
   const [globalMenuAnchor, setGlobalMenuAnchor] = useState<null | HTMLElement>(null);
   const [projectMenuAnchor, setProjectMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [mobileProjectSwitcherOpen, setMobileProjectSwitcherOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(!isLargeDesktop);
   const [isSwitchingProject, setIsSwitchingProject] = useState(false);
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
@@ -346,6 +371,13 @@ function RootLayout(): React.ReactElement {
 
   const handleGlobalMenuClose = () => {
     setGlobalMenuAnchor(null);
+  };
+  const handleOpenMobileProjectSwitcher = (): void => {
+    handleGlobalMenuClose();
+    setMobileProjectSwitcherOpen(true);
+  };
+  const handleCloseMobileProjectSwitcher = (): void => {
+    setMobileProjectSwitcherOpen(false);
   };
 
   const handleProjectMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -530,6 +562,7 @@ function RootLayout(): React.ReactElement {
   };
 
   const handleSwitchProject = async (projectId: number): Promise<void> => {
+    setMobileProjectSwitcherOpen(false);
     handleProjectMenuClose();
     if (projectId === activeProjectId) {
       return;
@@ -1038,12 +1071,11 @@ function RootLayout(): React.ReactElement {
             historyLoading={historyLoading}
             userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
             isMobile={false}
-            memberships={memberships}
-            activeProjectId={activeProjectId}
-            isSwitchingProject={isSwitchingProject}
             onClose={handleGlobalMenuClose}
-            onSwitchProject={handleSwitchProject}
+            onOpenProjectSwitcher={handleOpenMobileProjectSwitcher}
+            onOpenCreateProject={handleOpenCreateProject}
             onOpenProjectSettings={handleOpenProjectSettings}
+            onOpenProjectMembers={handleOpenProjectSettings}
             onOpenProjectHistory={handleOpenProjectHistory}
             onOpenAccountSettings={() => navigateFromGlobalMenu('/app/account-settings')}
             onOpenShortcuts={handleOpenShortcuts}
@@ -1071,12 +1103,11 @@ function RootLayout(): React.ReactElement {
                 historyLoading={historyLoading}
                 userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
                 isMobile={isMobile}
-                memberships={memberships}
-                activeProjectId={activeProjectId}
-                isSwitchingProject={isSwitchingProject}
                 onClose={handleGlobalMenuClose}
-                onSwitchProject={handleSwitchProject}
+                onOpenProjectSwitcher={handleOpenMobileProjectSwitcher}
+                onOpenCreateProject={handleOpenCreateProject}
                 onOpenProjectSettings={handleOpenProjectSettings}
+                onOpenProjectMembers={handleOpenProjectSettings}
                 onOpenProjectHistory={handleOpenProjectHistory}
                 onOpenAccountSettings={() => navigateFromGlobalMenu('/app/account-settings')}
                 onOpenShortcuts={handleOpenShortcuts}
@@ -1388,6 +1419,48 @@ function RootLayout(): React.ReactElement {
         </DialogActions>
       </Dialog>
       <HelpDialog open={globalHelpOpen} onClose={closeGlobalHelp} />
+      <Dialog open={mobileProjectSwitcherOpen} onClose={handleCloseMobileProjectSwitcher} fullWidth maxWidth="sm">
+        <DialogTitle>{t('projectSwitcher.ariaLabel')}</DialogTitle>
+        <DialogContent>
+          <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
+            Aktives Projekt
+          </Typography>
+          <Paper variant="outlined" sx={{ p: 1.25, mb: 2 }}>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <CheckIcon fontSize="small" color="success" />
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>{activeProjectLabel}</Typography>
+            </Stack>
+          </Paper>
+          <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
+            Projekte
+          </Typography>
+          <List dense sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, py: 0 }}>
+            {memberships.length === 0 ? (
+              <ListItem><ListItemText primary={t('projectSwitcher.zeroProjects')} /></ListItem>
+            ) : memberships.map((membership) => (
+              <ListItemButton
+                key={`switcher-${membership.project_id}`}
+                onClick={() => void handleSwitchProject(membership.project_id)}
+                selected={membership.project_id === activeProjectId}
+                disabled={isSwitchingProject}
+              >
+                <ListItemIcon sx={{ minWidth: 28 }}>
+                  {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" color="success" /> : null}
+                </ListItemIcon>
+                <ListItemText primary={membership.project_name} />
+              </ListItemButton>
+            ))}
+          </List>
+          <Button
+            startIcon={<AddIcon fontSize="small" />}
+            variant="outlined"
+            onClick={handleOpenCreateProject}
+            sx={{ mt: 2, textTransform: 'none' }}
+          >
+            {t('project.create')}
+          </Button>
+        </DialogContent>
+      </Dialog>
       <Dialog open={Boolean(pendingRestoreEntry)} onClose={() => setPendingRestoreEntry(null)} fullWidth maxWidth="xs">
         <DialogTitle>Version wiederherstellen?</DialogTitle>
         <DialogContent>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -375,7 +375,7 @@ function RootLayout(): React.ReactElement {
     setSnackbar({ open: true, message, severity });
   };
 
-  const handleOpenProjectHistory = async () => {
+  const handleOpenProjectHistory = useCallback(async () => {
     handleGlobalMenuClose();
     setHistoryLoading(true);
     try {
@@ -388,7 +388,7 @@ function RootLayout(): React.ReactElement {
     } finally {
       setHistoryLoading(false);
     }
-  };
+  }, [activeProjectId, showSnackbar, t]);
 
   const handleRestoreProjectVersion = async (historyId: number) => {
     try {
@@ -410,9 +410,9 @@ function RootLayout(): React.ReactElement {
     setShortcutsOpen(true);
   };
 
-  const openCurrentPageHelp = (): void => {
+  const openCurrentPageHelp = useCallback((): void => {
     window.dispatchEvent(new CustomEvent('ofp:open-page-help'));
-  };
+  }, []);
   const openGlobalHelp = (): void => {
     setGlobalHelpOpen(true);
   };
@@ -420,7 +420,7 @@ function RootLayout(): React.ReactElement {
     setGlobalHelpOpen(false);
   };
 
-  const handleLogout = async (): Promise<void> => {
+  const handleLogout = useCallback(async (): Promise<void> => {
     try {
       await logout();
       handleGlobalMenuClose();
@@ -429,9 +429,9 @@ function RootLayout(): React.ReactElement {
       console.error('Error logging out:', error);
       showSnackbar(t('commandPalette.feedback.logoutError'), 'error');
     }
-  };
+  }, [logout, navigate]);
 
-  const memberships = user?.memberships ?? [];
+  const memberships = useMemo(() => user?.memberships ?? [], [user?.memberships]);
   const activeMembership = memberships.find((membership) => membership.project_id === activeProjectId) ?? null;
   const activeProjectLabel = activeMembership?.project_name ?? t('projectSwitcher.noProject');
 
@@ -451,15 +451,15 @@ function RootLayout(): React.ReactElement {
     return () => window.removeEventListener(OPEN_CREATE_PROJECT_EVENT, handleCreateProjectRequest);
   }, [handleOpenCreateProject]);
 
-  const handleOpenProjectSettings = (): void => {
+  const handleOpenProjectSettings = useCallback((): void => {
     handleProjectMenuClose();
     navigate('/app/project-settings');
-  };
+  }, [handleProjectMenuClose, navigate]);
 
-  const applyProjectContextChange = async (projectId: number): Promise<void> => {
+  const applyProjectContextChange = useCallback(async (projectId: number): Promise<void> => {
     await switchActiveProject(projectId);
     window.location.reload();
-  };
+  }, [switchActiveProject]);
 
   const closeCreateProjectDialog = (): void => {
     setIsCreateProjectOpen(false);
@@ -549,7 +549,7 @@ function RootLayout(): React.ReactElement {
     }
   };
 
-  const handleSwitchProject = async (projectId: number): Promise<void> => {
+  const handleSwitchProject = useCallback(async (projectId: number): Promise<void> => {
     setMobileProjectSwitcherOpen(false);
     handleProjectMenuClose();
     if (projectId === activeProjectId) {
@@ -564,7 +564,7 @@ function RootLayout(): React.ReactElement {
     } finally {
       setIsSwitchingProject(false);
     }
-  };
+  }, [activeProjectId, applyProjectContextChange, handleProjectMenuClose, showSnackbar, t]);
 
   const activeMembershipRole = activeMembership?.role ?? null;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,7 +107,6 @@ import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
 import { PanelLeft } from 'lucide-react';
-import { OPEN_ADD_BED_EVENT } from './pages/fieldsBedsEvents';
 
 const CONTENT_ALIGNMENT_MODE = 'centered';
 const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
@@ -304,7 +303,6 @@ function RootLayout(): React.ReactElement {
   const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
   const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileActionsOverflowAnchor, setMobileActionsOverflowAnchor] = useState<null | HTMLElement>(null);
-  const [areasAddMenuAnchor, setAreasAddMenuAnchor] = useState<null | HTMLElement>(null);
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },
     ...MAIN_NAV_ITEMS.map((item) => ({
@@ -486,12 +484,6 @@ function RootLayout(): React.ReactElement {
   const handleMobileActionsOverflowClose = () => {
     setMobileActionsOverflowAnchor(null);
   };
-  const handleAreasAddMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAreasAddMenuAnchor(event.currentTarget);
-  };
-  const handleAreasAddMenuClose = () => {
-    setAreasAddMenuAnchor(null);
-  };
   const isCulturesPage = location.pathname.startsWith('/app/cultures');
   const cultureLibraryAction = useMemo(
     () => topbarContextActions.find((action) => action.id === 'cultures-open-library'),
@@ -501,8 +493,12 @@ function RootLayout(): React.ReactElement {
     () => topbarContextActions.filter((action) => action.id !== 'cultures-open-library'),
     [topbarContextActions],
   );
+  const fieldsGlobalAddAction = useMemo(
+    () => topbarContextActions.find((action) => action.id === 'fields-global-add-field') ?? null,
+    [topbarContextActions],
+  );
   const genericTopbarContextActions = useMemo(
-    () => (isCulturesPage ? [] : topbarContextActions),
+    () => (isCulturesPage ? [] : topbarContextActions.filter((action) => action.id !== 'fields-global-add-field')),
     [isCulturesPage, topbarContextActions],
   );
   const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
@@ -684,9 +680,9 @@ function RootLayout(): React.ReactElement {
     if (location.pathname.startsWith('/app/cultures')) return { label: 'Kultur hinzufügen', to: '/app/cultures?create=true' };
     if (location.pathname.startsWith('/app/anbauplaene') || location.pathname.startsWith('/app/planting-plans')) return { label: 'Anbauplan hinzufügen', to: '/app/planting-plans?create=true' };
     if (location.pathname.startsWith('/app/suppliers')) return { label: 'Lieferant hinzufügen', to: '/app/suppliers?create=true' };
-    if (location.pathname.startsWith('/app/fields-beds')) return { label: 'Parzelle hinzufügen', to: '/app/fields-beds' };
+    if (location.pathname.startsWith('/app/fields-beds')) return fieldsGlobalAddAction ? { label: fieldsGlobalAddAction.label, to: '', onClick: fieldsGlobalAddAction.onClick } : null;
     return null;
-  }, [location.pathname]);
+  }, [fieldsGlobalAddAction, location.pathname]);
 
   return (
     <Box className={`app app--${CONTENT_ALIGNMENT_MODE}`} sx={{ display: 'flex', minHeight: '100vh', bgcolor: '#f2f0ea' }}>
@@ -983,9 +979,9 @@ function RootLayout(): React.ReactElement {
               <Button
                 size="small"
                 variant="contained"
-                onClick={(event) => {
-                  if (location.pathname.startsWith('/app/fields-beds')) {
-                    handleAreasAddMenuOpen(event);
+                onClick={() => {
+                  if (topbarPrimaryAction.onClick) {
+                    topbarPrimaryAction.onClick();
                     return;
                   }
                   navigate(topbarPrimaryAction.to);
@@ -1093,19 +1089,6 @@ function RootLayout(): React.ReactElement {
             </Box>
           )}
         </Toolbar>
-        {location.pathname.startsWith('/app/fields-beds') ? (
-          <Menu anchorEl={areasAddMenuAnchor} open={Boolean(areasAddMenuAnchor)} onClose={handleAreasAddMenuClose}>
-            <MenuItem onClick={() => { handleAreasAddMenuClose(); navigate('/app/locations?create=true'); }}>
-              Standort hinzufügen
-            </MenuItem>
-            <MenuItem onClick={() => { handleAreasAddMenuClose(); navigate('/app/fields-beds?create=true'); }}>
-              Parzelle hinzufügen
-            </MenuItem>
-            <MenuItem onClick={() => { handleAreasAddMenuClose(); window.dispatchEvent(new CustomEvent(OPEN_ADD_BED_EVENT)); }}>
-              Beet hinzufügen
-            </MenuItem>
-          </Menu>
-        ) : null}
         {isMobile ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
@@ -1226,9 +1209,9 @@ function RootLayout(): React.ReactElement {
                 <Button
                   size="small"
                   variant="contained"
-                  onClick={(event) => {
-                    if (location.pathname.startsWith('/app/fields-beds')) {
-                      handleAreasAddMenuOpen(event);
+                  onClick={() => {
+                    if (topbarPrimaryAction.onClick) {
+                      topbarPrimaryAction.onClick();
                       return;
                     }
                     navigate(topbarPrimaryAction.to);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -180,7 +180,13 @@ interface GlobalMenuProps {
   open: boolean;
   historyLoading: boolean;
   userLabel: string;
+  isMobile: boolean;
+  memberships: { project_id: number; project_name: string; role: 'admin' | 'member' }[];
+  activeProjectId: number | null;
+  isSwitchingProject: boolean;
   onClose: () => void;
+  onSwitchProject: (projectId: number) => Promise<void>;
+  onOpenProjectSettings: () => void;
   onOpenProjectHistory: () => Promise<void>;
   onOpenAccountSettings: () => void;
   onOpenShortcuts: () => void;
@@ -195,7 +201,13 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
     open,
     historyLoading,
     userLabel,
+    isMobile,
+    memberships,
+    activeProjectId,
+    isSwitchingProject,
     onClose,
+    onSwitchProject,
+    onOpenProjectSettings,
     onOpenProjectHistory,
     onOpenAccountSettings,
     onOpenShortcuts,
@@ -210,7 +222,36 @@ function GlobalMenu(props: GlobalMenuProps): React.ReactElement {
       anchorEl={anchorEl}
       open={open}
       onClose={onClose}
-    >
+>
+      {isMobile ? (
+        <>
+          <MenuItem disabled>{t('projectSwitcher.ariaLabel')}</MenuItem>
+          {memberships.length === 0 ? (
+            <MenuItem disabled>{t('projectSwitcher.zeroProjects')}</MenuItem>
+          ) : (
+            memberships.map((membership) => (
+              <MenuItem
+                key={`mobile-project-${membership.project_id}`}
+                onClick={() => void onSwitchProject(membership.project_id)}
+                selected={membership.project_id === activeProjectId}
+                disabled={isSwitchingProject}
+              >
+                <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
+                  <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{membership.project_name}</span>
+                  {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" /> : null}
+                </Stack>
+              </MenuItem>
+            ))
+          )}
+          <MenuItem onClick={onOpenProjectSettings}>
+            {t('project.settings')}
+          </MenuItem>
+          <MenuItem onClick={onOpenProjectSettings}>
+            {t('commandPalette.commands.openProjectMembers')}
+          </MenuItem>
+          <Divider />
+        </>
+      ) : null}
       <MenuItem onClick={() => void onOpenProjectHistory()} disabled={historyLoading}>
         {t('commandPalette.commands.openVersionHistory')}
       </MenuItem>
@@ -796,7 +837,7 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: { xs: 'wrap', md: 'nowrap' } }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 1, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
             {!isDesktopUp ? (
@@ -824,8 +865,9 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
-          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, flexWrap: { xs: 'wrap', md: 'nowrap' }, width: { xs: '100%', md: 'auto' } }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: isMobile ? 'auto' : 'visible', scrollbarWidth: 'thin', order: { xs: 2, md: 1 }, width: { xs: '100%', md: 'auto' }, pt: { xs: 0.5, md: 0 } }}>
+          {!isMobile ? (
+          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (
@@ -949,7 +991,7 @@ function RootLayout(): React.ReactElement {
             </Tooltip>
           ) : null}
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: { xs: 'auto', md: 3 }, order: { xs: 1, md: 2 }, width: { xs: '100%', md: 'auto' }, justifyContent: { xs: 'space-between', md: 'flex-start' } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 3 }}>
           <Button
             aria-label={t('projectSwitcher.ariaLabel')}
             aria-controls={projectMenuAnchor ? 'project-switcher-menu' : undefined}
@@ -995,7 +1037,13 @@ function RootLayout(): React.ReactElement {
             open={Boolean(globalMenuAnchor)}
             historyLoading={historyLoading}
             userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
+            isMobile={false}
+            memberships={memberships}
+            activeProjectId={activeProjectId}
+            isSwitchingProject={isSwitchingProject}
             onClose={handleGlobalMenuClose}
+            onSwitchProject={handleSwitchProject}
+            onOpenProjectSettings={handleOpenProjectSettings}
             onOpenProjectHistory={handleOpenProjectHistory}
             onOpenAccountSettings={() => navigateFromGlobalMenu('/app/account-settings')}
             onOpenShortcuts={handleOpenShortcuts}
@@ -1005,7 +1053,128 @@ function RootLayout(): React.ReactElement {
           />
             </Box>
           </Box>
+          ) : (
+            <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 0.25 }}>
+              <IconButton
+                aria-label="Mehr"
+                aria-controls={globalMenuAnchor ? 'global-actions-menu' : undefined}
+                aria-haspopup="true"
+                onClick={handleGlobalMenuOpen}
+                size="small"
+                sx={{ color: 'text.primary' }}
+              >
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+              <GlobalMenu
+                anchorEl={globalMenuAnchor}
+                open={Boolean(globalMenuAnchor)}
+                historyLoading={historyLoading}
+                userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
+                isMobile={isMobile}
+                memberships={memberships}
+                activeProjectId={activeProjectId}
+                isSwitchingProject={isSwitchingProject}
+                onClose={handleGlobalMenuClose}
+                onSwitchProject={handleSwitchProject}
+                onOpenProjectSettings={handleOpenProjectSettings}
+                onOpenProjectHistory={handleOpenProjectHistory}
+                onOpenAccountSettings={() => navigateFromGlobalMenu('/app/account-settings')}
+                onOpenShortcuts={handleOpenShortcuts}
+                onOpenHelp={openGlobalHelp}
+                onLogout={handleLogout}
+                t={t}
+              />
+            </Box>
+          )}
         </Toolbar>
+        {isMobile ? (
+          <Box className="mobile-action-scroll" sx={{ px: 1, pb: 0.5 }}>
+            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'nowrap', whiteSpace: 'nowrap' }}>
+              {isCulturesPage ? (
+                <>
+                  {cultureLibraryAction ? (
+                    <Tooltip title="Kulturbibliothek öffnen">
+                      <span>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => cultureLibraryAction.onClick()}
+                          aria-label="Kulturbibliothek öffnen"
+                          startIcon={<PublicIcon fontSize="small" />}
+                          sx={{ textTransform: 'none', whiteSpace: 'nowrap', px: 1, minHeight: 30 }}
+                          disabled={cultureLibraryAction.disabled}
+                        >
+                          Bibliothek
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  ) : null}
+                  {showCultureImportExportButton || isMobile ? (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      aria-label="Import/Export öffnen"
+                      aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
+                      aria-haspopup="true"
+                      aria-expanded={Boolean(cultureActionsMenuAnchor)}
+                      onClick={handleCultureActionsMenuOpen}
+                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', px: 1, minHeight: 30 }}
+                    >
+                      Import/Export
+                    </Button>
+                  ) : null}
+                </>
+              ) : null}
+              {(() => {
+                const groups: TopbarContextAction[][] = [];
+                genericTopbarContextActions.forEach((action) => {
+                  const lastGroup = groups[groups.length - 1];
+                  if (!lastGroup || !action.groupId || lastGroup[0]?.groupId !== action.groupId) {
+                    groups.push([action]);
+                    return;
+                  }
+                  lastGroup.push(action);
+                });
+                return groups.map((group, index) => {
+                  const isSegmentedGroup = group.length > 1 && group[0]?.groupId;
+                  const content = group.map((action) => (
+                    <Button
+                      key={action.id}
+                      size="small"
+                      variant={action.active ? 'contained' : 'outlined'}
+                      color={action.active ? 'success' : 'inherit'}
+                      onClick={action.onClick}
+                      aria-label={action.ariaLabel ?? action.label}
+                      aria-pressed={action.active}
+                      disabled={action.disabled}
+                      sx={{ ...getSegmentedActionButtonSx({ active: Boolean(action.active), hidden: Boolean(action.hidden) }), minHeight: 30, px: 1 }}
+                    >
+                      {action.label}
+                    </Button>
+                  ));
+                  return isSegmentedGroup ? (
+                    <ButtonGroup key={`mobile-group-${group[0]?.groupId}-${index}`} size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0 }}>
+                      {content}
+                    </ButtonGroup>
+                  ) : (
+                    <Box key={`mobile-group-${index}`} sx={{ display: 'inline-flex', flexShrink: 0 }}>{content}</Box>
+                  );
+                });
+              })()}
+              {topbarPrimaryAction ? (
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => navigate(topbarPrimaryAction.to)}
+                  aria-label={topbarPrimaryAction.label}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', px: 1, minHeight: 30 }}
+                >
+                  <AddIcon fontSize="small" />
+                </Button>
+              ) : null}
+            </Box>
+          </Box>
+        ) : null}
       </AppBar>
 
       <Drawer anchor="left" open={mobileNavOpen} onClose={closeMobileNav} PaperProps={{ sx: { bgcolor: '#f5f2eb', borderRight: '1px solid #e1dbd0' } }}>

--- a/frontend/src/components/layout/PageSurface.tsx
+++ b/frontend/src/components/layout/PageSurface.tsx
@@ -17,11 +17,11 @@ interface PageSurfaceProps {
 
 const VARIANT_SX: Record<PageSurfaceVariant, Record<string, unknown>> = {
   standardCenteredPage: { width: '100%' },
-  compact: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
-  contentFit: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
+  compact: { width: { xs: '100%', sm: 'fit-content' }, maxWidth: '100%', mx: { xs: 0, sm: 'auto' } },
+  contentFit: { width: { xs: '100%', sm: 'fit-content' }, maxWidth: '100%', mx: { xs: 0, sm: 'auto' } },
   fullWorkspace: { width: '100%', maxWidth: '100%' },
   // Legacy aliases
-  compactCenteredTable: { width: 'fit-content', maxWidth: '100%', mx: 'auto' },
+  compactCenteredTable: { width: { xs: '100%', sm: 'fit-content' }, maxWidth: '100%', mx: { xs: 0, sm: 'auto' } },
   wideWorkspace: { width: '100%', maxWidth: '100%' },
 };
 

--- a/frontend/src/hooks/useTopbarContextActions.ts
+++ b/frontend/src/hooks/useTopbarContextActions.ts
@@ -1,12 +1,31 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { TopbarContextAction } from '../App';
 
 export function useTopbarContextActions(
   setActions: (actions: TopbarContextAction[]) => void,
   actions: TopbarContextAction[],
 ): void {
+  const lastSignatureRef = useRef<string>('');
+
   useEffect(() => {
+    const signature = JSON.stringify(
+      actions.map((action) => ({
+        id: action.id,
+        label: action.label,
+        ariaLabel: action.ariaLabel,
+        disabled: Boolean(action.disabled),
+        active: Boolean(action.active),
+        hidden: Boolean(action.hidden),
+        groupId: action.groupId ?? '',
+        tooltip: action.tooltip ?? '',
+      })),
+    );
+    if (signature === lastSignatureRef.current) {
+      return;
+    }
+    lastSignatureRef.current = signature;
     setActions(actions);
-    return () => setActions([]);
   }, [actions, setActions]);
+
+  useEffect(() => () => setActions([]), [setActions]);
 }

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -941,10 +941,10 @@ function FieldsBedsHierarchy({
 
         <Box
           ref={tableWrapperRef}
-          sx={{ width: "100%", maxWidth: "100%", minWidth: 0, overflowX: "auto", overflowY: "visible", display: "flex", justifyContent: "center" }}
+          sx={{ width: "100%", maxWidth: "100%", minWidth: 0, overflowX: "auto", overflowY: "visible", display: "block" }}
           onClick={() => setTreeActive(true)}
         >
-          <Box sx={{ display: "block", width: "fit-content", minWidth: 0, maxWidth: "100%" }}>
+          <Box sx={{ display: "inline-block", width: "fit-content", minWidth: "100%", maxWidth: "100%" }}>
           <DataGrid
             rows={rows}
             columns={columns}

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -941,10 +941,10 @@ function FieldsBedsHierarchy({
 
         <Box
           ref={tableWrapperRef}
-          sx={{ width: "100%", maxWidth: "100%", minWidth: 0, overflowX: "auto", overflowY: "visible", display: "block" }}
+          sx={{ width: "100%", maxWidth: "100%", minWidth: 1, overflowX: "auto", overflowY: "visible", display: "block" }}
           onClick={() => setTreeActive(true)}
         >
-          <Box sx={{ display: "inline-block", width: "fit-content", minWidth: "100%", maxWidth: "100%" }}>
+          <Box sx={{ display: "inline-block", width: "fit-content", minWidth: 320, maxWidth: "100%" }}>
           <DataGrid
             rows={rows}
             columns={columns}

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -320,7 +320,7 @@ function FieldsBedsHierarchy({
     [navigate],
   );
 
-  const parseAreaExpression = (input: string): number | undefined => {
+  const parseAreaExpression = useCallback((input: string): number | undefined => {
     const normalizedInput = input.trim().replace(/,/g, ".");
     if (!normalizedInput) {
       return undefined;
@@ -348,7 +348,7 @@ function FieldsBedsHierarchy({
     }
 
     return Number.isFinite(product) ? product : undefined;
-  };
+  }, []);
 
   const normalizeAreaValue = (
     value: number | undefined,
@@ -359,7 +359,7 @@ function FieldsBedsHierarchy({
     return Math.round(value * 10) / 10;
   };
 
-  const parseAreaValue = (
+  const parseAreaValue = useCallback((
     value: number | string | undefined,
   ): number | undefined => {
     if (typeof value === "number") {
@@ -369,9 +369,9 @@ function FieldsBedsHierarchy({
       return parseAreaExpression(value);
     }
     return undefined;
-  };
+  }, [parseAreaExpression]);
 
-  const parseDimensionValue = (
+  const parseDimensionValue = useCallback((
     value: number | string | null | undefined,
   ): number | null | undefined => {
     if (value === null) return null;
@@ -385,7 +385,7 @@ function FieldsBedsHierarchy({
       return Number.isFinite(parsed) ? parsed : undefined;
     }
     return undefined;
-  };
+  }, []);
 
   const getBedAreaSum = (
     fieldId: number,

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -641,7 +641,7 @@ function FieldsBedsHierarchy({
     if (selectedRow.type === "bed" && selectedRow.field) {
       handleAddBed(selectedRow.field);
     }
-  }, [addField, handleAddBed, selectedRow]);
+  }, [addField, handleAddBed, selectedRow, t]);
 
   const handleEditSelected = useCallback(() => {
     if (!selectedRow) {

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -52,6 +52,7 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { isTypingInEditableElement } from "../hooks/useKeyboardShortcuts";
+import { OPEN_ADD_BED_EVENT } from "./fieldsBedsEvents";
 
 interface FieldsBedsHierarchyProps {
   showTitle?: boolean;
@@ -642,6 +643,31 @@ function FieldsBedsHierarchy({
       handleAddBed(selectedRow.field);
     }
   }, [addField, handleAddBed, selectedRow]);
+
+  const handleGlobalAddBed = useCallback((): void => {
+    if (selectedRow?.type === "field" && selectedRow.fieldId) {
+      handleAddBed(selectedRow.fieldId);
+      return;
+    }
+    if (selectedRow?.type === "bed" && selectedRow.field) {
+      handleAddBed(selectedRow.field);
+      return;
+    }
+    const firstFieldId = fields[0]?.id;
+    if (typeof firstFieldId === "number") {
+      handleAddBed(firstFieldId);
+      return;
+    }
+    setError("Bitte zuerst eine Parzelle anlegen.");
+  }, [fields, handleAddBed, selectedRow]);
+
+  useEffect(() => {
+    const handleOpenAddBed = (): void => {
+      handleGlobalAddBed();
+    };
+    window.addEventListener(OPEN_ADD_BED_EVENT, handleOpenAddBed);
+    return () => window.removeEventListener(OPEN_ADD_BED_EVENT, handleOpenAddBed);
+  }, [handleGlobalAddBed]);
 
   const handleEditSelected = useCallback(() => {
     if (!selectedRow) {

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -52,7 +52,6 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { isTypingInEditableElement } from "../hooks/useKeyboardShortcuts";
-import { OPEN_ADD_BED_EVENT } from "./fieldsBedsEvents";
 
 interface FieldsBedsHierarchyProps {
   showTitle?: boolean;
@@ -643,31 +642,6 @@ function FieldsBedsHierarchy({
       handleAddBed(selectedRow.field);
     }
   }, [addField, handleAddBed, selectedRow]);
-
-  const handleGlobalAddBed = useCallback((): void => {
-    if (selectedRow?.type === "field" && selectedRow.fieldId) {
-      handleAddBed(selectedRow.fieldId);
-      return;
-    }
-    if (selectedRow?.type === "bed" && selectedRow.field) {
-      handleAddBed(selectedRow.field);
-      return;
-    }
-    const firstFieldId = fields[0]?.id;
-    if (typeof firstFieldId === "number") {
-      handleAddBed(firstFieldId);
-      return;
-    }
-    setError("Bitte zuerst eine Parzelle anlegen.");
-  }, [fields, handleAddBed, selectedRow]);
-
-  useEffect(() => {
-    const handleOpenAddBed = (): void => {
-      handleGlobalAddBed();
-    };
-    window.addEventListener(OPEN_ADD_BED_EVENT, handleOpenAddBed);
-    return () => window.removeEventListener(OPEN_ADD_BED_EVENT, handleOpenAddBed);
-  }, [handleGlobalAddBed]);
 
   const handleEditSelected = useCallback(() => {
     if (!selectedRow) {

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -190,6 +190,12 @@ export default function FieldsBedsPage(): React.ReactElement {
 
 
   const contextActions = useMemo<TopbarContextAction[]>(() => [
+    ...(locations.length === 1 && !shouldShowProjectRequiredState ? [{
+      id: 'fields-global-add-field',
+      label: 'Parzelle hinzufügen',
+      onClick: handleGlobalAddField,
+      ariaLabel: 'Parzelle hinzufügen',
+    }] satisfies TopbarContextAction[] : []),
     {
       id: 'fields-interaction-mode-view',
       label: t('fields:graphical.viewModeOption'),
@@ -234,7 +240,7 @@ export default function FieldsBedsPage(): React.ReactElement {
       ariaLabel: t('fields:representation.ariaLabel'),
       groupId: 'fields-view-mode',
     },
-  ], [interactionMode, t, viewMode]);
+  ], [handleGlobalAddField, interactionMode, locations.length, shouldShowProjectRequiredState, t, viewMode]);
 
   useTopbarContextActions(setTopbarContextActions, contextActions);
 

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -17,6 +17,7 @@ import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
+const NOOP_SET_TOPBAR_ACTIONS = (): void => undefined;
 
 type ViewMode = 'table' | 'graphical';
 type InteractionMode = 'view' | 'edit';
@@ -43,7 +44,7 @@ export default function FieldsBedsPage(): React.ReactElement {
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
 
   const outletContext = useOutletContext<RootLayoutOutletContext | null>();
-  const setTopbarContextActions = outletContext?.setTopbarContextActions ?? (() => undefined);
+  const setTopbarContextActions = outletContext?.setTopbarContextActions ?? NOOP_SET_TOPBAR_ACTIONS;
 
   useCommandContextTag('areas');
 

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, TextField } from '@mui/material';
+import { Alert, Box, Button, ButtonGroup, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, MenuItem, TextField, Tooltip, useMediaQuery } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
@@ -15,7 +15,10 @@ import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
-import ModeToggle from '../components/ModeToggle';
+import { getSegmentedActionButtonSx, segmentedButtonGroupSx } from '../components/buttons/segmentedControlStyles';
+import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import { useTheme } from '@mui/material/styles';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 const NOOP_SET_TOPBAR_ACTIONS = (): void => undefined;
@@ -25,6 +28,8 @@ type InteractionMode = 'view' | 'edit';
 
 export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
+  const theme = useTheme();
+  const isXs = useMediaQuery(theme.breakpoints.down('sm'));
   const navigate = useNavigate();
   const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -191,16 +196,58 @@ export default function FieldsBedsPage(): React.ReactElement {
   }, [viewMode]);
 
 
-  const contextActions = useMemo<TopbarContextAction[]>(() => (
-    locations.length === 1 && !shouldShowProjectRequiredState
+  const contextActions = useMemo<TopbarContextAction[]>(() => {
+    const globalActions: TopbarContextAction[] = locations.length === 1 && !shouldShowProjectRequiredState
       ? [{
         id: 'fields-global-add-field',
         label: 'Parzelle hinzufügen',
         onClick: handleGlobalAddField,
         ariaLabel: 'Parzelle hinzufügen',
       }]
-      : []
-  ), [handleGlobalAddField, locations.length, shouldShowProjectRequiredState]);
+      : [];
+    if (isXs) {
+      return globalActions;
+    }
+    return [
+      ...globalActions,
+      {
+        id: 'fields-interaction-mode-view',
+        label: t('fields:graphical.viewModeOption'),
+        onClick: () => setInteractionMode('view'),
+        active: interactionMode === 'view',
+        hidden: viewMode !== 'graphical',
+        reserveSpace: true,
+        ariaLabel: t('fields:graphical.modeAriaLabel'),
+        groupId: 'fields-interaction-mode',
+      },
+      {
+        id: 'fields-interaction-mode-edit',
+        label: t('fields:graphical.editModeOption'),
+        onClick: () => setInteractionMode('edit'),
+        active: interactionMode === 'edit',
+        hidden: viewMode !== 'graphical',
+        reserveSpace: true,
+        ariaLabel: t('fields:graphical.modeAriaLabel'),
+        groupId: 'fields-interaction-mode',
+      },
+      {
+        id: 'fields-view-mode-list',
+        label: t('fields:representation.table'),
+        onClick: () => setViewMode('table'),
+        active: viewMode === 'table',
+        ariaLabel: t('fields:representation.ariaLabel'),
+        groupId: 'fields-view-mode',
+      },
+      {
+        id: 'fields-view-mode-graphical',
+        label: t('fields:representation.graphical'),
+        onClick: () => setViewMode('graphical'),
+        active: viewMode === 'graphical',
+        ariaLabel: t('fields:representation.ariaLabel'),
+        groupId: 'fields-view-mode',
+      },
+    ];
+  }, [handleGlobalAddField, interactionMode, isXs, locations.length, shouldShowProjectRequiredState, t, viewMode]);
 
   useTopbarContextActions(setTopbarContextActions, contextActions);
 
@@ -249,25 +296,55 @@ export default function FieldsBedsPage(): React.ReactElement {
       </PageContainer>
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
-        {!shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
+        {isXs && !shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1.5 }}>
-            <ModeToggle
-              label={t('fields:representation.label')}
-              ariaLabel={t('fields:representation.ariaLabel')}
-              viewLabel={t('fields:representation.table')}
-              editLabel={t('fields:representation.graphical')}
-              value={viewMode === 'table' ? 'view' : 'edit'}
-              onChange={(nextMode) => setViewMode(nextMode === 'view' ? 'table' : 'graphical')}
-            />
+            <ButtonGroup size="small" variant="outlined" sx={segmentedButtonGroupSx}>
+              <Button
+                aria-label={t('fields:representation.table')}
+                aria-pressed={viewMode === 'table'}
+                variant={viewMode === 'table' ? 'contained' : 'outlined'}
+                color={viewMode === 'table' ? 'success' : 'inherit'}
+                onClick={() => setViewMode('table')}
+                sx={getSegmentedActionButtonSx({ active: viewMode === 'table' })}
+              >
+                {t('fields:representation.table')}
+              </Button>
+              <Button
+                aria-label={t('fields:representation.graphical')}
+                aria-pressed={viewMode === 'graphical'}
+                variant={viewMode === 'graphical' ? 'contained' : 'outlined'}
+                color={viewMode === 'graphical' ? 'success' : 'inherit'}
+                onClick={() => setViewMode('graphical')}
+                sx={getSegmentedActionButtonSx({ active: viewMode === 'graphical' })}
+              >
+                {t('fields:representation.graphical')}
+              </Button>
+            </ButtonGroup>
             {viewMode === 'graphical' ? (
-              <ModeToggle
-                label={t('fields:graphical.viewMode')}
-                ariaLabel={t('fields:graphical.modeAriaLabel')}
-                viewLabel={t('fields:graphical.viewModeOption')}
-                editLabel={t('fields:graphical.editModeOption')}
-                value={interactionMode}
-                onChange={setInteractionMode}
-              />
+              <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, alignSelf: 'flex-start' }}>
+                <Tooltip title={t('fields:graphical.viewModeOption')}>
+                  <IconButton
+                    size="small"
+                    aria-label={t('fields:graphical.viewModeOption')}
+                    aria-pressed={interactionMode === 'view'}
+                    onClick={() => setInteractionMode('view')}
+                    sx={getSegmentedActionButtonSx({ active: interactionMode === 'view' })}
+                  >
+                    <VisibilityOutlinedIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('fields:graphical.editModeOption')}>
+                  <IconButton
+                    size="small"
+                    aria-label={t('fields:graphical.editModeOption')}
+                    aria-pressed={interactionMode === 'edit'}
+                    onClick={() => setInteractionMode('edit')}
+                    sx={getSegmentedActionButtonSx({ active: interactionMode === 'edit' })}
+                  >
+                    <EditOutlinedIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </ButtonGroup>
             ) : null}
           </Box>
         ) : null}

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, ButtonGroup, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, MenuItem, TextField, Tooltip, useMediaQuery } from '@mui/material';
+import { Alert, Box, Button, ButtonGroup, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, TextField, useMediaQuery } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import FieldsBedsHierarchy from './FieldsBedsHierarchy';
@@ -16,8 +16,6 @@ import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 import { getSegmentedActionButtonSx, segmentedButtonGroupSx } from '../components/buttons/segmentedControlStyles';
-import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { useTheme } from '@mui/material/styles';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
@@ -297,8 +295,8 @@ export default function FieldsBedsPage(): React.ReactElement {
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
         {isXs && !shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1.5 }}>
-            <ButtonGroup size="small" variant="outlined" sx={segmentedButtonGroupSx}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mb: 1 }}>
+            <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, alignSelf: 'flex-start' }}>
               <Button
                 aria-label={t('fields:representation.table')}
                 aria-pressed={viewMode === 'table'}
@@ -322,28 +320,26 @@ export default function FieldsBedsPage(): React.ReactElement {
             </ButtonGroup>
             {viewMode === 'graphical' ? (
               <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, alignSelf: 'flex-start' }}>
-                <Tooltip title={t('fields:graphical.viewModeOption')}>
-                  <IconButton
-                    size="small"
-                    aria-label={t('fields:graphical.viewModeOption')}
-                    aria-pressed={interactionMode === 'view'}
-                    onClick={() => setInteractionMode('view')}
-                    sx={getSegmentedActionButtonSx({ active: interactionMode === 'view' })}
-                  >
-                    <VisibilityOutlinedIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title={t('fields:graphical.editModeOption')}>
-                  <IconButton
-                    size="small"
-                    aria-label={t('fields:graphical.editModeOption')}
-                    aria-pressed={interactionMode === 'edit'}
-                    onClick={() => setInteractionMode('edit')}
-                    sx={getSegmentedActionButtonSx({ active: interactionMode === 'edit' })}
-                  >
-                    <EditOutlinedIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                <Button
+                  aria-label={t('fields:graphical.viewModeOption')}
+                  aria-pressed={interactionMode === 'view'}
+                  variant={interactionMode === 'view' ? 'contained' : 'outlined'}
+                  color={interactionMode === 'view' ? 'success' : 'inherit'}
+                  onClick={() => setInteractionMode('view')}
+                  sx={getSegmentedActionButtonSx({ active: interactionMode === 'view' })}
+                >
+                  {t('fields:graphical.viewModeOption')}
+                </Button>
+                <Button
+                  aria-label={t('fields:graphical.editModeOption')}
+                  aria-pressed={interactionMode === 'edit'}
+                  variant={interactionMode === 'edit' ? 'contained' : 'outlined'}
+                  color={interactionMode === 'edit' ? 'success' : 'inherit'}
+                  onClick={() => setInteractionMode('edit')}
+                  sx={getSegmentedActionButtonSx({ active: interactionMode === 'edit' })}
+                >
+                  {t('fields:graphical.editModeOption')}
+                </Button>
               </ButtonGroup>
             ) : null}
           </Box>

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -146,7 +146,7 @@ export default function FieldsBedsPage(): React.ReactElement {
     setTargetLocationId(firstLocation?.id ?? '');
     setNewFieldName('');
     setAddFieldDialogOpen(true);
-  }, [addField, locations, navigate, t]);
+  }, [locations, navigate]);
 
   const handleConfirmAddField = useCallback((): void => {
     if (typeof targetLocationId !== 'number' || !newFieldName.trim()) {

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -28,6 +28,7 @@ export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
   const theme = useTheme();
   const isXs = useMediaQuery(theme.breakpoints.down('sm'));
+  const isVeryNarrowPhone = useMediaQuery('(max-width:360px)');
   const navigate = useNavigate();
   const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -295,15 +296,25 @@ export default function FieldsBedsPage(): React.ReactElement {
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
         {isXs && !shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mb: 1 }}>
-            <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, alignSelf: 'flex-start' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 0.5,
+              flexWrap: isVeryNarrowPhone ? 'wrap' : 'nowrap',
+              minWidth: 0,
+              mb: 0.75,
+            }}
+          >
+            <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
               <Button
                 aria-label={t('fields:representation.table')}
                 aria-pressed={viewMode === 'table'}
                 variant={viewMode === 'table' ? 'contained' : 'outlined'}
                 color={viewMode === 'table' ? 'success' : 'inherit'}
                 onClick={() => setViewMode('table')}
-                sx={getSegmentedActionButtonSx({ active: viewMode === 'table' })}
+                sx={{ ...getSegmentedActionButtonSx({ active: viewMode === 'table' }), px: 1, minHeight: 30 }}
               >
                 {t('fields:representation.table')}
               </Button>
@@ -313,20 +324,20 @@ export default function FieldsBedsPage(): React.ReactElement {
                 variant={viewMode === 'graphical' ? 'contained' : 'outlined'}
                 color={viewMode === 'graphical' ? 'success' : 'inherit'}
                 onClick={() => setViewMode('graphical')}
-                sx={getSegmentedActionButtonSx({ active: viewMode === 'graphical' })}
+                sx={{ ...getSegmentedActionButtonSx({ active: viewMode === 'graphical' }), px: 1, minHeight: 30 }}
               >
                 {t('fields:representation.graphical')}
               </Button>
             </ButtonGroup>
             {viewMode === 'graphical' ? (
-              <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, alignSelf: 'flex-start' }}>
+              <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
                 <Button
                   aria-label={t('fields:graphical.viewModeOption')}
                   aria-pressed={interactionMode === 'view'}
                   variant={interactionMode === 'view' ? 'contained' : 'outlined'}
                   color={interactionMode === 'view' ? 'success' : 'inherit'}
                   onClick={() => setInteractionMode('view')}
-                  sx={getSegmentedActionButtonSx({ active: interactionMode === 'view' })}
+                  sx={{ ...getSegmentedActionButtonSx({ active: interactionMode === 'view' }), px: 1, minHeight: 30 }}
                 >
                   {t('fields:graphical.viewModeOption')}
                 </Button>
@@ -336,7 +347,7 @@ export default function FieldsBedsPage(): React.ReactElement {
                   variant={interactionMode === 'edit' ? 'contained' : 'outlined'}
                   color={interactionMode === 'edit' ? 'success' : 'inherit'}
                   onClick={() => setInteractionMode('edit')}
-                  sx={getSegmentedActionButtonSx({ active: interactionMode === 'edit' })}
+                  sx={{ ...getSegmentedActionButtonSx({ active: interactionMode === 'edit' }), px: 1, minHeight: 30 }}
                 >
                   {t('fields:graphical.editModeOption')}
                 </Button>

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -15,6 +15,7 @@ import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
+import ModeToggle from '../components/ModeToggle';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 const NOOP_SET_TOPBAR_ACTIONS = (): void => undefined;
@@ -190,58 +191,16 @@ export default function FieldsBedsPage(): React.ReactElement {
   }, [viewMode]);
 
 
-  const contextActions = useMemo<TopbarContextAction[]>(() => [
-    ...(locations.length === 1 && !shouldShowProjectRequiredState ? [{
-      id: 'fields-global-add-field',
-      label: 'Parzelle hinzufügen',
-      onClick: handleGlobalAddField,
-      ariaLabel: 'Parzelle hinzufügen',
-    }] satisfies TopbarContextAction[] : []),
-    {
-      id: 'fields-interaction-mode-view',
-      label: t('fields:graphical.viewModeOption'),
-      onClick: () => {
-        setInteractionMode('view');
-      },
-      active: interactionMode === 'view',
-      hidden: viewMode !== 'graphical',
-      reserveSpace: true,
-      ariaLabel: t('fields:graphical.modeAriaLabel'),
-      groupId: 'fields-interaction-mode',
-    },
-    {
-      id: 'fields-interaction-mode-edit',
-      label: t('fields:graphical.editModeOption'),
-      onClick: () => {
-        setInteractionMode('edit');
-      },
-      active: interactionMode === 'edit',
-      hidden: viewMode !== 'graphical',
-      reserveSpace: true,
-      ariaLabel: t('fields:graphical.modeAriaLabel'),
-      groupId: 'fields-interaction-mode',
-    },
-    {
-      id: 'fields-view-mode-list',
-      label: t('fields:representation.table'),
-      onClick: () => {
-        setViewMode('table');
-      },
-      active: viewMode === 'table',
-      ariaLabel: t('fields:representation.ariaLabel'),
-      groupId: 'fields-view-mode',
-    },
-    {
-      id: 'fields-view-mode-graphical',
-      label: t('fields:representation.graphical'),
-      onClick: () => {
-        setViewMode('graphical');
-      },
-      active: viewMode === 'graphical',
-      ariaLabel: t('fields:representation.ariaLabel'),
-      groupId: 'fields-view-mode',
-    },
-  ], [handleGlobalAddField, interactionMode, locations.length, shouldShowProjectRequiredState, t, viewMode]);
+  const contextActions = useMemo<TopbarContextAction[]>(() => (
+    locations.length === 1 && !shouldShowProjectRequiredState
+      ? [{
+        id: 'fields-global-add-field',
+        label: 'Parzelle hinzufügen',
+        onClick: handleGlobalAddField,
+        ariaLabel: 'Parzelle hinzufügen',
+      }]
+      : []
+  ), [handleGlobalAddField, locations.length, shouldShowProjectRequiredState]);
 
   useTopbarContextActions(setTopbarContextActions, contextActions);
 
@@ -290,6 +249,28 @@ export default function FieldsBedsPage(): React.ReactElement {
       </PageContainer>
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
+        {!shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 1.5 }}>
+            <ModeToggle
+              label={t('fields:representation.label')}
+              ariaLabel={t('fields:representation.ariaLabel')}
+              viewLabel={t('fields:representation.table')}
+              editLabel={t('fields:representation.graphical')}
+              value={viewMode === 'table' ? 'view' : 'edit'}
+              onChange={(nextMode) => setViewMode(nextMode === 'view' ? 'table' : 'graphical')}
+            />
+            {viewMode === 'graphical' ? (
+              <ModeToggle
+                label={t('fields:graphical.viewMode')}
+                ariaLabel={t('fields:graphical.modeAriaLabel')}
+                viewLabel={t('fields:graphical.viewModeOption')}
+                editLabel={t('fields:graphical.editModeOption')}
+                value={interactionMode}
+                onChange={setInteractionMode}
+              />
+            ) : null}
+          </Box>
+        ) : null}
         {!shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState && viewMode === 'graphical' ? (
           <GraphicalFields
             showTitle={false}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -35,7 +35,6 @@ import GanttChart, { ViewMode } from 'react-modern-gantt';
 import 'react-modern-gantt/dist/index.css';
 import './GanttChart.css';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
-import { useOutletContext } from 'react-router-dom';
 import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
@@ -58,8 +57,6 @@ import {
   getSegmentedActionButtonSx,
   segmentedButtonGroupSx,
 } from '../components/buttons/segmentedControlStyles';
-import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
-import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 
 interface WeeklyYieldCultureMeta {
   id: number;
@@ -121,8 +118,6 @@ function formatIsoWeek(date: Date): string {
 function GanttChartPage(): React.ReactElement {
   const { t, i18n } = useTranslation(['ganttChart', 'common']);
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
-  const outletContext = useOutletContext<RootLayoutOutletContext | null>();
-  const setTopbarContextActions = outletContext?.setTopbarContextActions ?? (() => undefined);
   useCommandContextTag('calendar');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -426,33 +421,6 @@ function GanttChartPage(): React.ReactElement {
     });
   }, [maxTotalYield]);
 
-
-  const topbarActions = useMemo<TopbarContextAction[]>(() => [
-    {
-      id: 'calendar-mode-view',
-      label: t('ganttChart:modeViewOption'),
-      onClick: () => setEditMode(false),
-      active: !editMode,
-      hidden: calendarMode !== 'occupancy',
-      reserveSpace: true,
-      groupId: 'calendar-interaction-mode',
-      ariaLabel: t('ganttChart:modeAriaLabel'),
-      tooltip: t('ganttChart:modeViewTooltip'),
-    },
-    {
-      id: 'calendar-mode-edit',
-      label: t('ganttChart:modeEditOption'),
-      onClick: () => setEditMode(true),
-      active: editMode,
-      hidden: calendarMode !== 'occupancy',
-      reserveSpace: true,
-      groupId: 'calendar-interaction-mode',
-      ariaLabel: t('ganttChart:modeAriaLabel'),
-      tooltip: t('ganttChart:modeEditTooltip'),
-    },
-  ], [calendarMode, editMode, t]);
-
-  useTopbarContextActions(setTopbarContextActions, topbarActions);
 
   if (loading) {
     return (

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import {
   Alert,
@@ -42,6 +43,7 @@ import type { CommandSpec } from '../commands/types';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import { extractApiErrorMessage } from '../api/errors';
 import EmptyStateCard from '../components/project/EmptyStateCard';
+import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import {
   buildFieldOccupancyTaskGroups,
   buildOccupancyTooltipDetails,
@@ -73,6 +75,7 @@ interface WeeklyYieldChartColumn {
 }
 
 type CalendarMode = 'occupancy' | 'seedlings';
+const NOOP_SET_TOPBAR_ACTIONS = (_actions: TopbarContextAction[]): void => undefined;
 
 class GanttRenderBoundary extends React.Component<
   { fallback: React.ReactNode; children: React.ReactNode },
@@ -132,6 +135,11 @@ function GanttChartPage(): React.ReactElement {
 
   const [calendarMode, setCalendarMode] = useState<CalendarMode>('occupancy');
   const [editMode, setEditMode] = useState(false);
+  const outletContext = useOutletContext<RootLayoutOutletContext | null>();
+  const setTopbarContextActions = useCallback((actions: TopbarContextAction[]): void => {
+    const setter = outletContext?.setTopbarContextActions ?? NOOP_SET_TOPBAR_ACTIONS;
+    setter(actions);
+  }, [outletContext]);
 
   const calendarCommands = useMemo<CommandSpec[]>(() => [
     {
@@ -148,6 +156,39 @@ function GanttChartPage(): React.ReactElement {
   ], [calendarMode, editMode]);
 
   useRegisterCommands('calendar-page', calendarCommands);
+
+  const topbarActions = useMemo<TopbarContextAction[]>(() => [
+    {
+      id: 'calendar-mode-view',
+      label: t('ganttChart:viewMode.view'),
+      icon: '👁️',
+      active: calendarMode === 'occupancy' && !editMode,
+      hidden: calendarMode !== 'occupancy',
+      tooltip: 'Ansichtsmodus: Kalender ansehen und navigieren. Keine Änderungen per Drag & Drop.',
+      onClick: () => {
+        setCalendarMode('occupancy');
+        setEditMode(false);
+      },
+    },
+    {
+      id: 'calendar-mode-edit',
+      label: t('ganttChart:viewMode.edit'),
+      icon: '✏️',
+      active: calendarMode === 'occupancy' && editMode,
+      hidden: calendarMode !== 'occupancy',
+      tooltip: 'Bearbeitungsmodus: Anbaupläne können per Drag & Drop direkt im Kalender verschoben und angepasst werden.',
+      onClick: () => {
+        setCalendarMode('occupancy');
+        setEditMode(true);
+      },
+    },
+  ], [calendarMode, editMode, t]);
+  useEffect(() => {
+    setTopbarContextActions(topbarActions);
+    return () => {
+      setTopbarContextActions([]);
+    };
+  }, [setTopbarContextActions, topbarActions]);
 
   const currentYear = new Date().getFullYear();
   const [displayYear] = useState(currentYear);

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1177,14 +1177,19 @@ export default function GraphicalFields({
 
   if (loading) {
     return (
-      <Box p={3}>
+      <Box sx={{ p: { xs: 0, sm: 3 } }}>
         <CircularProgress />
       </Box>
     );
   }
 
   return (
-    <Box p={3} ref={containerRef}>
+    <Box
+      ref={containerRef}
+      // This wrapper was the real xs gutter source on Anbauflächen mobile.
+      // Keep edge-aligned content on xs and preserve current spacing on sm+.
+      sx={{ p: { xs: 0, sm: 3 } }}
+    >
       <Stack
         direction={{ xs: "column", sm: "row" }}
         justifyContent="space-between"

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -337,22 +337,6 @@ export default function GraphicalFields({
     });
   };
 
-  const getContentBoundsForLocation = useCallback((locationId: number): ContentBounds => {
-    const layout = locationLayouts.find((item) => item.location.id === locationId);
-    if (!layout) {
-      return toContentBounds({ width: stageWidth, height: stageHeight });
-    }
-
-    const fieldBounds = getContentBoundsFromRects(layout.fieldViewModels);
-    return (
-      fieldBounds ??
-      toContentBounds({
-        width: layout.contentWidth,
-        height: layout.contentHeight,
-      })
-    );
-  }, [locationLayouts, stageHeight, stageWidth]);
-
   useEffect(() => {
     const handleResize = (): void => {
       const fullscreenContainer =
@@ -625,6 +609,22 @@ export default function GraphicalFields({
     });
   }, [fieldsByLocation, layoutsByField, locations]);
 
+  const getContentBoundsForLocation = useCallback((locationId: number): ContentBounds => {
+    const layout = locationLayouts.find((item) => item.location.id === locationId);
+    if (!layout) {
+      return toContentBounds({ width: stageWidth, height: stageHeight });
+    }
+
+    const fieldBounds = getContentBoundsFromRects(layout.fieldViewModels);
+    return (
+      fieldBounds ??
+      toContentBounds({
+        width: layout.contentWidth,
+        height: layout.contentHeight,
+      })
+    );
+  }, [locationLayouts, stageHeight, stageWidth]);
+
   useEffect(() => {
     if (!import.meta.env.DEV || import.meta.env.MODE === 'test') {
       return;
@@ -663,7 +663,7 @@ export default function GraphicalFields({
         sampleRects,
       });
     });
-  }, [locationLayouts, viewportByLocation, stageWidth, stageHeight]);
+  }, [getContentBoundsForLocation, locationLayouts, viewportByLocation, stageWidth, stageHeight]);
 
   const resetViewport = (locationId: number): void => {
     setViewportByLocation((prev) => {

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -440,8 +440,9 @@ export default function GraphicalFields({
   }, [locations]);
 
   useEffect(() => {
+    const timers = saveTimers.current;
     return () => {
-      Object.values(saveTimers.current).forEach((timer) => {
+      Object.values(timers).forEach((timer) => {
         window.clearTimeout(timer);
       });
     };
@@ -680,7 +681,7 @@ export default function GraphicalFields({
     });
   };
 
-  const updateViewport = (
+  const updateViewport = useCallback((
     locationId: number,
     updater: (current: ViewportState) => ViewportState,
   ): void => {
@@ -702,7 +703,7 @@ export default function GraphicalFields({
       );
       return { ...prev, [locationId]: nextClamped };
     });
-  };
+  }, [getContentBoundsForLocation, stageHeight, stageWidth]);
 
   const handleZoom = (locationId: number, factor: number): void => {
     updateViewport(locationId, (current) =>
@@ -713,7 +714,7 @@ export default function GraphicalFields({
     );
   };
 
-  const handlePanByOffset = (
+  const handlePanByOffset = useCallback((
     locationId: number,
     deltaX: number,
     deltaY: number,
@@ -723,7 +724,7 @@ export default function GraphicalFields({
       x: current.x + deltaX,
       y: current.y + deltaY,
     }));
-  };
+  }, [updateViewport]);
 
   const handleStageWheel = (
     locationId: number,

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Accordion,
   AccordionDetails,

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -337,6 +337,22 @@ export default function GraphicalFields({
     });
   };
 
+  const getContentBoundsForLocation = useCallback((locationId: number): ContentBounds => {
+    const layout = locationLayouts.find((item) => item.location.id === locationId);
+    if (!layout) {
+      return toContentBounds({ width: stageWidth, height: stageHeight });
+    }
+
+    const fieldBounds = getContentBoundsFromRects(layout.fieldViewModels);
+    return (
+      fieldBounds ??
+      toContentBounds({
+        width: layout.contentWidth,
+        height: layout.contentHeight,
+      })
+    );
+  }, [locationLayouts, stageHeight, stageWidth]);
+
   useEffect(() => {
     const handleResize = (): void => {
       const fullscreenContainer =
@@ -648,22 +664,6 @@ export default function GraphicalFields({
       });
     });
   }, [locationLayouts, viewportByLocation, stageWidth, stageHeight]);
-
-  function getContentBoundsForLocation(locationId: number): ContentBounds {
-    const layout = locationLayouts.find((item) => item.location.id === locationId);
-    if (!layout) {
-      return toContentBounds({ width: stageWidth, height: stageHeight });
-    }
-
-    const fieldBounds = getContentBoundsFromRects(layout.fieldViewModels);
-    return (
-      fieldBounds ??
-      toContentBounds({
-        width: layout.contentWidth,
-        height: layout.contentHeight,
-      })
-    );
-  }
 
   const resetViewport = (locationId: number): void => {
     setViewportByLocation((prev) => {

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -649,7 +649,7 @@ export default function GraphicalFields({
     });
   }, [locationLayouts, viewportByLocation, stageWidth, stageHeight]);
 
-  const getContentBoundsForLocation = (locationId: number): ContentBounds => {
+  function getContentBoundsForLocation(locationId: number): ContentBounds {
     const layout = locationLayouts.find((item) => item.location.id === locationId);
     if (!layout) {
       return toContentBounds({ width: stageWidth, height: stageHeight });
@@ -663,7 +663,7 @@ export default function GraphicalFields({
         height: layout.contentHeight,
       })
     );
-  };
+  }
 
   const resetViewport = (locationId: number): void => {
     setViewportByLocation((prev) => {

--- a/frontend/src/pages/fieldsBedsEvents.ts
+++ b/frontend/src/pages/fieldsBedsEvents.ts
@@ -1,0 +1,1 @@
+export const OPEN_ADD_BED_EVENT = 'openfarmplanner:areas:add-bed';

--- a/frontend/src/pages/fieldsBedsEvents.ts
+++ b/frontend/src/pages/fieldsBedsEvents.ts
@@ -1,1 +1,0 @@
-export const OPEN_ADD_BED_EVENT = 'openfarmplanner:areas:add-bed';


### PR DESCRIPTION
### Motivation
- Prevent multi-line mobile topbars and eliminate layout jumping by enforcing a single-line primary topbar on all mobile pages.
- Reduce persistent horizontal pressure from the project switcher by moving project-related controls into an overflow menu on mobile.
- Provide a compact, scrollable place for page-specific actions that is stable, thumb-friendly, and reusable across pages.

### Description
- Enforce single-row mobile primary topbar by setting `flexWrap: 'nowrap'` and separating mobile vs desktop rendering paths in `frontend/src/App.tsx`.
- Move project switching and related project entries into the global overflow menu on mobile by extending `GlobalMenu` with a mobile-mode project section and wiring `onSwitchProject`/settings/members entries (`frontend/src/App.tsx`).
- Add a dedicated secondary mobile action row rendered below the AppBar that is single-line, horizontally scrollable and holds compact/segmented page actions and the primary add action (`frontend/src/App.tsx`).
- Add centralized CSS `.mobile-action-scroll` to `frontend/src/App.css` with `overflow-x: auto`, `white-space: nowrap`, hidden scrollbar and touch-friendly scrolling to ensure consistent behavior across pages.

### Testing
- No automated tests were run for this change (per the request not to run tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04135749d083229b75ca459690cbae)