### PR TITLE
Refactor topbar/toolbar responsiveness, add ContentViewControls, and update Fields/Gantt actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -899,7 +899,7 @@ function RootLayout(): React.ReactElement {
           </Box>
           {!isPhone ? (
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, maxWidth: '100%', flex: 1, overflow: 'hidden' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flex: 1, overflow: 'hidden', pr: 0.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flex: 1, justifyContent: 'flex-end', overflow: 'hidden', pr: 0.5 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction && !showDesktopCultureActionsOverflow ? (
@@ -911,7 +911,7 @@ function RootLayout(): React.ReactElement {
                       onClick={() => cultureLibraryAction.onClick()}
                       aria-label="Kulturbibliothek öffnen"
                       startIcon={<PublicIcon fontSize="small" />}
-                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: showIconOnlyCultureLibrary ? 36 : 0, maxWidth: 170, px: showIconOnlyCultureLibrary ? 0.75 : 1.25, overflow: 'hidden', textOverflow: 'ellipsis' }}
+                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: showIconOnlyCultureLibrary ? 36 : 'auto', px: showIconOnlyCultureLibrary ? 0.75 : 1.25, flexShrink: 0 }}
                       disabled={cultureLibraryAction.disabled}
                     >
                       {!showIconOnlyCultureLibrary ? (showCompactCultureLibrary ? 'Bibliothek' : 'Kulturbibliothek') : null}
@@ -929,7 +929,7 @@ function RootLayout(): React.ReactElement {
                   aria-expanded={Boolean(cultureActionsMenuAnchor)}
                   onClick={handleCultureActionsMenuOpen}
                   endIcon={!isPhone ? <KeyboardArrowDownIcon fontSize="small" /> : undefined}
-                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, maxWidth: 150, px: isPhone ? 0.75 : 1.25, overflow: 'hidden', textOverflow: 'ellipsis', flexShrink: 0 }}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.25, flexShrink: 0 }}
                 >
                   {isPhone ? '⋯' : 'Import/Export'}
                 </Button>
@@ -1043,7 +1043,7 @@ function RootLayout(): React.ReactElement {
                 onClick={handleTopbarPrimaryAction}
                 aria-label={topbarPrimaryAction.label}
                 startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
-                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, maxWidth: 180, px: isPhone ? 0.75 : 1.25, flexShrink: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.25, flexShrink: 0 }}
               >
                 {isPhone ? <AddIcon fontSize="small" /> : topbarPrimaryAction.label}
               </Button>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1194,6 +1194,26 @@ function RootLayout(): React.ReactElement {
                       Import/Export
                     </Button>
                   ) : null}
+                  <Menu
+                    id="culture-actions-menu-mobile"
+                    anchorEl={cultureActionsMenuAnchor}
+                    open={Boolean(cultureActionsMenuAnchor)}
+                    onClose={handleCultureActionsMenuClose}
+                  >
+                    {cultureImportExportActions.map((action) => (
+                      <MenuItem
+                        key={`mobile-${action.id}`}
+                        aria-label={action.ariaLabel ?? action.label}
+                        onClick={() => {
+                          action.onClick();
+                          handleCultureActionsMenuClose();
+                        }}
+                        disabled={action.disabled}
+                      >
+                        <ListItemText primary={action.label} secondary={action.shortcutHint} />
+                      </MenuItem>
+                    ))}
+                  </Menu>
                 </>
               ) : null}
               {(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -897,10 +897,9 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
-          {!isPhone ? <Box sx={{ flex: 1, minWidth: 0 }} /> : null}
           {!isPhone ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0, maxWidth: '100%', flex: 1, justifyContent: 'flex-end', overflow: 'hidden' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, maxWidth: '100%', flex: 1, justifyContent: 'flex-end', overflow: 'hidden', pr: 0.25 }}>
+          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, maxWidth: '100%', flex: 1, overflow: 'hidden' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flex: 1, overflow: 'hidden', pr: 0.5 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction && !showDesktopCultureActionsOverflow ? (
@@ -1051,7 +1050,7 @@ function RootLayout(): React.ReactElement {
             </Tooltip>
           ) : null}
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 1.5, flexShrink: 0 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 1, flexShrink: 0 }}>
           <Button
             aria-label={t('projectSwitcher.ariaLabel')}
             aria-controls={projectMenuAnchor ? 'project-switcher-menu' : undefined}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -868,9 +868,9 @@ function RootLayout(): React.ReactElement {
         elevation={0}
         sx={{ borderBottom: '1px solid', borderColor: '#e4dfd4', bgcolor: '#f7f4ed', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
-        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 0, sm: 2, md: 3 }, flexWrap: 'nowrap' }}>
+        <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 0, sm: 2, md: 3 }, flexWrap: 'nowrap', minWidth: 0, maxWidth: '100%', overflow: 'hidden' }}>
           {!isDesktopUp ? <IconButton aria-label="Menü öffnen" onClick={() => setMobileNavOpen(true)} size="small"><MenuIcon fontSize="small" /></IconButton> : null}
-          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1 }}>
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflow: 'hidden' }}>
             {!isDesktopUp ? (
               <Typography
                 component="h1"
@@ -896,9 +896,10 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
+          {!isPhone ? <Box sx={{ flex: 1, minWidth: 0 }} /> : null}
           {!isPhone ? (
-          <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, flex: 1 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, overflowX: 'auto', overflowY: 'hidden', pr: 0.5, scrollbarWidth: 'thin' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0, maxWidth: '100%', flex: 1, justifyContent: 'flex-end', overflow: 'hidden' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, maxWidth: '100%', flex: 1, justifyContent: 'flex-end', overflow: 'hidden', pr: 0.25 }}>
           {isCulturesPage ? (
             <>
               {cultureLibraryAction ? (
@@ -910,7 +911,7 @@ function RootLayout(): React.ReactElement {
                       onClick={() => cultureLibraryAction.onClick()}
                       aria-label="Kulturbibliothek öffnen"
                       startIcon={<PublicIcon fontSize="small" />}
-                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: showIconOnlyCultureLibrary ? 36 : 'auto', px: showIconOnlyCultureLibrary ? 0.75 : 1.25 }}
+                      sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: showIconOnlyCultureLibrary ? 36 : 0, maxWidth: 170, px: showIconOnlyCultureLibrary ? 0.75 : 1.25, overflow: 'hidden', textOverflow: 'ellipsis' }}
                       disabled={cultureLibraryAction.disabled}
                     >
                       {!showIconOnlyCultureLibrary ? (showCompactCultureLibrary ? 'Bibliothek' : 'Kulturbibliothek') : null}
@@ -928,7 +929,7 @@ function RootLayout(): React.ReactElement {
                   aria-expanded={Boolean(cultureActionsMenuAnchor)}
                   onClick={handleCultureActionsMenuOpen}
                   endIcon={!isPhone ? <KeyboardArrowDownIcon fontSize="small" /> : undefined}
-                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.25 }}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, px: isPhone ? 0.75 : 1.25 }}
                 >
                   {isPhone ? '⋯' : 'Import/Export'}
                 </Button>
@@ -1003,7 +1004,7 @@ function RootLayout(): React.ReactElement {
                   {content}
                 </ButtonGroup>
               ) : (
-                <Box key={`group-${index}`} sx={{ display: 'inline-flex', flexShrink: 0 }}>{content}</Box>
+                <Box key={`group-${index}`} sx={{ display: 'inline-flex', flexShrink: 1, minWidth: 0 }}>{content}</Box>
               );
             });
           })()}
@@ -1015,14 +1016,14 @@ function RootLayout(): React.ReactElement {
                 onClick={handleTopbarPrimaryAction}
                 aria-label={topbarPrimaryAction.label}
                 startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
-                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 'auto', px: isPhone ? 0.75 : 1.5 }}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, px: isPhone ? 0.75 : 1.25, flexShrink: 0 }}
               >
                 {isPhone ? <AddIcon fontSize="small" /> : topbarPrimaryAction.label}
               </Button>
             </Tooltip>
           ) : null}
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 1.5, flexShrink: 0 }}>
           <Button
             aria-label={t('projectSwitcher.ariaLabel')}
             aria-controls={projectMenuAnchor ? 'project-switcher-menu' : undefined}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -284,6 +284,8 @@ function RootLayout(): React.ReactElement {
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
   const isLargeDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
+  const isCoarseLowHeightViewport = useMediaQuery('(pointer: coarse) and (max-height: 500px)');
+  const isCompactTopbar = isPhone || isCoarseLowHeightViewport;
   const isVeryNarrowMobile = useMediaQuery('(max-width:360px)');
   const isPhonePortrait = useMediaQuery(`${theme.breakpoints.down('sm')} and (orientation: portrait)`);
   const isTabletOrNarrowDesktop = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
@@ -897,7 +899,7 @@ function RootLayout(): React.ReactElement {
             )}
             {topbarHelpConfig ? <PageHelp pageKey={topbarHelpConfig.pageKey} ariaLabel={`${topbarHelpConfig.label} öffnen`} tooltip={topbarHelpConfig.label} /> : null}
           </Box>
-          {!isPhone ? (
+          {!isCompactTopbar ? (
           <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', minWidth: 0, maxWidth: '100%', flex: 1, overflow: 'hidden' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flex: 1, justifyContent: 'flex-end', overflow: 'hidden', pr: 0.5 }}>
           {isCulturesPage ? (
@@ -1141,7 +1143,7 @@ function RootLayout(): React.ReactElement {
                 open={Boolean(globalMenuAnchor)}
                 historyLoading={historyLoading}
                 userLabel={user?.email ? `(${user.email})` : (user?.display_label ? `(${user.display_label})` : '')}
-                isMobile={isPhone}
+                isMobile={isCompactTopbar}
                 onClose={handleGlobalMenuClose}
                 onOpenProjectSwitcher={handleOpenMobileProjectSwitcher}
                 onOpenCreateProject={handleOpenCreateProject}
@@ -1157,7 +1159,7 @@ function RootLayout(): React.ReactElement {
             </Box>
           )}
         </Toolbar>
-        {isPhone && hasMobileSecondaryRow ? (
+        {isCompactTopbar && hasMobileSecondaryRow ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -517,6 +517,7 @@ function RootLayout(): React.ReactElement {
   const showCompactCultureLibrary = isCulturesPage && (isTabletOrNarrowDesktop || isPhone);
   const showIconOnlyCultureLibrary = isCulturesPage && (isPhone || isTabletOrNarrowDesktop);
   const showCultureImportExportButton = isCulturesPage;
+  const showDesktopCultureActionsOverflow = isCulturesPage && !isPhone && !isLargeDesktop;
   const hasVisibleMobileContextActions = useMemo(
     () => [...topbarModeControls, ...topbarOverflowActions].some((action) => !action.hidden),
     [topbarModeControls, topbarOverflowActions],
@@ -902,7 +903,7 @@ function RootLayout(): React.ReactElement {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, maxWidth: '100%', flex: 1, justifyContent: 'flex-end', overflow: 'hidden', pr: 0.25 }}>
           {isCulturesPage ? (
             <>
-              {cultureLibraryAction ? (
+              {cultureLibraryAction && !showDesktopCultureActionsOverflow ? (
                 <Tooltip title="Kulturbibliothek öffnen">
                   <span>
                     <Button
@@ -919,7 +920,7 @@ function RootLayout(): React.ReactElement {
                   </span>
                 </Tooltip>
               ) : null}
-              {showCultureImportExportButton || isMobile ? (
+              {(showCultureImportExportButton || isMobile) && !showDesktopCultureActionsOverflow ? (
                 <Button
                   size="small"
                   variant="outlined"
@@ -934,12 +935,39 @@ function RootLayout(): React.ReactElement {
                   {isPhone ? '⋯' : 'Import/Export'}
                 </Button>
               ) : null}
+              {showDesktopCultureActionsOverflow ? (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  aria-label="Kultur-Aktionen öffnen"
+                  aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu' : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={Boolean(cultureActionsMenuAnchor)}
+                  onClick={handleCultureActionsMenuOpen}
+                  endIcon={<KeyboardArrowDownIcon fontSize="small" />}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: 0, px: 1 }}
+                >
+                  Aktionen
+                </Button>
+              ) : null}
               <Menu
                 id="culture-actions-menu"
                 anchorEl={cultureActionsMenuAnchor}
                 open={Boolean(cultureActionsMenuAnchor)}
                 onClose={handleCultureActionsMenuClose}
               >
+                {showDesktopCultureActionsOverflow && cultureLibraryAction ? (
+                  <MenuItem
+                    aria-label={cultureLibraryAction.ariaLabel ?? cultureLibraryAction.label}
+                    onClick={() => {
+                      cultureLibraryAction.onClick();
+                      handleCultureActionsMenuClose();
+                    }}
+                    disabled={cultureLibraryAction.disabled}
+                  >
+                    <ListItemText primary={cultureLibraryAction.label} />
+                  </MenuItem>
+                ) : null}
                 {cultureImportExportActions.map((action) => (
                   <MenuItem
                     key={action.id}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -930,7 +930,7 @@ function RootLayout(): React.ReactElement {
                   aria-expanded={Boolean(cultureActionsMenuAnchor)}
                   onClick={handleCultureActionsMenuOpen}
                   endIcon={!isPhone ? <KeyboardArrowDownIcon fontSize="small" /> : undefined}
-                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, px: isPhone ? 0.75 : 1.25 }}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, maxWidth: 150, px: isPhone ? 0.75 : 1.25, overflow: 'hidden', textOverflow: 'ellipsis', flexShrink: 0 }}
                 >
                   {isPhone ? '⋯' : 'Import/Export'}
                 </Button>
@@ -945,7 +945,7 @@ function RootLayout(): React.ReactElement {
                   aria-expanded={Boolean(cultureActionsMenuAnchor)}
                   onClick={handleCultureActionsMenuOpen}
                   endIcon={<KeyboardArrowDownIcon fontSize="small" />}
-                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: 0, px: 1 }}
+                  sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: 0, px: 1, flexShrink: 0 }}
                 >
                   Aktionen
                 </Button>
@@ -1018,7 +1018,7 @@ function RootLayout(): React.ReactElement {
                 );
                 return action.tooltip ? (
                   <Tooltip key={action.id} title={action.tooltip}>
-                    <Box component="span" sx={{ display: 'inline-flex' }}>{button}</Box>
+                    <Box component="span" sx={{ display: 'inline-flex', minWidth: 0 }}>{button}</Box>
                   </Tooltip>
                 ) : React.cloneElement(button, { key: action.id });
               });
@@ -1027,7 +1027,7 @@ function RootLayout(): React.ReactElement {
                   key={`group-${group[0]?.groupId}-${index}`}
                   size="small"
                   variant="outlined"
-                  sx={{ ...segmentedButtonGroupSx, flexShrink: 0 }}
+                  sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}
                 >
                   {content}
                 </ButtonGroup>
@@ -1044,7 +1044,7 @@ function RootLayout(): React.ReactElement {
                 onClick={handleTopbarPrimaryAction}
                 aria-label={topbarPrimaryAction.label}
                 startIcon={!isPhone ? <AddIcon fontSize="small" /> : undefined}
-                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, px: isPhone ? 0.75 : 1.25, flexShrink: 0 }}
+                sx={{ textTransform: 'none', whiteSpace: 'nowrap', minWidth: isPhone ? 36 : 0, maxWidth: 180, px: isPhone ? 0.75 : 1.25, flexShrink: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}
               >
                 {isPhone ? <AddIcon fontSize="small" /> : topbarPrimaryAction.label}
               </Button>

--- a/frontend/src/components/layout/ContentViewControls.tsx
+++ b/frontend/src/components/layout/ContentViewControls.tsx
@@ -1,0 +1,41 @@
+import { Box } from '@mui/material';
+import type { ReactElement, ReactNode } from 'react';
+
+interface ContentViewControlsProps {
+  primaryControls?: ReactNode;
+  secondaryControls?: ReactNode;
+  actions?: ReactNode;
+  sx?: Record<string, unknown>;
+}
+
+export default function ContentViewControls({
+  primaryControls,
+  secondaryControls,
+  actions,
+  sx,
+}: ContentViewControlsProps): ReactElement | null {
+  if (!primaryControls && !secondaryControls && !actions) {
+    return null;
+  }
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.75,
+        mb: 1,
+        ...sx,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minHeight: 36, flexWrap: 'nowrap', overflowX: 'auto' }}>
+        {primaryControls}
+        {actions ? <Box sx={{ ml: 'auto', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>{actions}</Box> : null}
+      </Box>
+      {secondaryControls ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minHeight: 36, flexWrap: 'nowrap', overflowX: 'auto' }}>
+          {secondaryControls}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -14,9 +14,9 @@ import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
-import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
 import { getSegmentedActionButtonSx, segmentedButtonGroupSx } from '../components/buttons/segmentedControlStyles';
 import { useTheme } from '@mui/material/styles';
+import ContentViewControls from '../components/layout/ContentViewControls';
 
 const VIEW_MODE_STORAGE_KEY = 'fieldsBedsViewMode';
 const NOOP_SET_TOPBAR_ACTIONS = (): void => undefined;
@@ -28,7 +28,6 @@ export default function FieldsBedsPage(): React.ReactElement {
   const { t } = useTranslation(['fields', 'hierarchy']);
   const theme = useTheme();
   const isXs = useMediaQuery(theme.breakpoints.down('sm'));
-  const isVeryNarrowPhone = useMediaQuery('(max-width:360px)');
   const navigate = useNavigate();
   const location = useLocation();
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -194,6 +193,45 @@ export default function FieldsBedsPage(): React.ReactElement {
     }
   }, [viewMode]);
 
+  const viewModeActions = useMemo<TopbarContextAction[]>(() => ([
+    {
+      id: 'fields-view-mode-list',
+      label: t('fields:representation.table'),
+      onClick: () => setViewMode('table'),
+      active: viewMode === 'table',
+      ariaLabel: t('fields:representation.ariaLabel'),
+      groupId: 'fields-view-mode',
+    },
+    {
+      id: 'fields-view-mode-graphical',
+      label: t('fields:representation.graphical'),
+      onClick: () => setViewMode('graphical'),
+      active: viewMode === 'graphical',
+      ariaLabel: t('fields:representation.ariaLabel'),
+      groupId: 'fields-view-mode',
+    },
+  ]), [t, viewMode]);
+
+  const interactionModeActions = useMemo<TopbarContextAction[]>(() => ([
+    {
+      id: 'fields-interaction-mode-view',
+      label: t('fields:graphical.viewModeOption'),
+      onClick: () => setInteractionMode('view'),
+      active: interactionMode === 'view',
+      hidden: viewMode !== 'graphical',
+      ariaLabel: t('fields:graphical.modeAriaLabel'),
+      groupId: 'fields-interaction-mode',
+    },
+    {
+      id: 'fields-interaction-mode-edit',
+      label: t('fields:graphical.editModeOption'),
+      onClick: () => setInteractionMode('edit'),
+      active: interactionMode === 'edit',
+      hidden: viewMode !== 'graphical',
+      ariaLabel: t('fields:graphical.modeAriaLabel'),
+      groupId: 'fields-interaction-mode',
+    },
+  ]), [interactionMode, t, viewMode]);
 
   const contextActions = useMemo<TopbarContextAction[]>(() => {
     const globalActions: TopbarContextAction[] = locations.length === 1 && !shouldShowProjectRequiredState
@@ -207,48 +245,20 @@ export default function FieldsBedsPage(): React.ReactElement {
     if (isXs) {
       return globalActions;
     }
-    return [
-      ...globalActions,
-      {
-        id: 'fields-interaction-mode-view',
-        label: t('fields:graphical.viewModeOption'),
-        onClick: () => setInteractionMode('view'),
-        active: interactionMode === 'view',
-        hidden: viewMode !== 'graphical',
-        reserveSpace: true,
-        ariaLabel: t('fields:graphical.modeAriaLabel'),
-        groupId: 'fields-interaction-mode',
-      },
-      {
-        id: 'fields-interaction-mode-edit',
-        label: t('fields:graphical.editModeOption'),
-        onClick: () => setInteractionMode('edit'),
-        active: interactionMode === 'edit',
-        hidden: viewMode !== 'graphical',
-        reserveSpace: true,
-        ariaLabel: t('fields:graphical.modeAriaLabel'),
-        groupId: 'fields-interaction-mode',
-      },
-      {
-        id: 'fields-view-mode-list',
-        label: t('fields:representation.table'),
-        onClick: () => setViewMode('table'),
-        active: viewMode === 'table',
-        ariaLabel: t('fields:representation.ariaLabel'),
-        groupId: 'fields-view-mode',
-      },
-      {
-        id: 'fields-view-mode-graphical',
-        label: t('fields:representation.graphical'),
-        onClick: () => setViewMode('graphical'),
-        active: viewMode === 'graphical',
-        ariaLabel: t('fields:representation.ariaLabel'),
-        groupId: 'fields-view-mode',
-      },
-    ];
-  }, [handleGlobalAddField, interactionMode, isXs, locations.length, shouldShowProjectRequiredState, t, viewMode]);
+    return [...globalActions, ...interactionModeActions, ...viewModeActions];
+  }, [
+    handleGlobalAddField,
+    interactionModeActions,
+    isXs,
+    locations.length,
+    shouldShowProjectRequiredState,
+    viewModeActions,
+  ]);
 
-  useTopbarContextActions(setTopbarContextActions, contextActions);
+  useEffect(() => {
+    setTopbarContextActions(contextActions);
+    return () => setTopbarContextActions([]);
+  }, [contextActions, setTopbarContextActions]);
 
   return (
     <>
@@ -296,64 +306,68 @@ export default function FieldsBedsPage(): React.ReactElement {
 
       <PageContainer variant={viewMode === 'graphical' ? 'full' : 'standard'}>
         {isXs && !shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState ? (
-          <Box
+          <ContentViewControls
+            primaryControls={(
+              <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.375, flexWrap: 'nowrap', minWidth: 0, whiteSpace: 'nowrap' }}>
+                <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
+                  <Button
+                    aria-label={viewModeActions[0].ariaLabel ?? viewModeActions[0].label}
+                    aria-pressed={viewModeActions[0].active}
+                    variant={viewModeActions[0].active ? 'contained' : 'outlined'}
+                    color={viewModeActions[0].active ? 'success' : 'inherit'}
+                    onClick={viewModeActions[0].onClick}
+                    sx={{ ...getSegmentedActionButtonSx({ active: Boolean(viewModeActions[0].active) }), px: 0.875, minHeight: 40, fontSize: '0.8rem', whiteSpace: 'nowrap' }}
+                  >
+                    {viewModeActions[0].label}
+                  </Button>
+                  <Button
+                    aria-label={viewModeActions[1].ariaLabel ?? viewModeActions[1].label}
+                    aria-pressed={viewModeActions[1].active}
+                    variant={viewModeActions[1].active ? 'contained' : 'outlined'}
+                    color={viewModeActions[1].active ? 'success' : 'inherit'}
+                    onClick={viewModeActions[1].onClick}
+                    sx={{ ...getSegmentedActionButtonSx({ active: Boolean(viewModeActions[1].active) }), px: 0.875, minHeight: 40, fontSize: '0.8rem', whiteSpace: 'nowrap' }}
+                  >
+                    {viewModeActions[1].label}
+                  </Button>
+                </ButtonGroup>
+                {interactionModeActions.every((action) => !action.hidden) ? (
+                  <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
+                    <Button
+                      aria-label={interactionModeActions[0].ariaLabel ?? interactionModeActions[0].label}
+                      aria-pressed={interactionModeActions[0].active}
+                      variant={interactionModeActions[0].active ? 'contained' : 'outlined'}
+                      color={interactionModeActions[0].active ? 'success' : 'inherit'}
+                      onClick={interactionModeActions[0].onClick}
+                      sx={{ ...getSegmentedActionButtonSx({ active: Boolean(interactionModeActions[0].active) }), px: 0.875, minHeight: 40, fontSize: '0.8rem', whiteSpace: 'nowrap' }}
+                    >
+                      {interactionModeActions[0].label}
+                    </Button>
+                    <Button
+                      aria-label={interactionModeActions[1].ariaLabel ?? interactionModeActions[1].label}
+                      aria-pressed={interactionModeActions[1].active}
+                      variant={interactionModeActions[1].active ? 'contained' : 'outlined'}
+                      color={interactionModeActions[1].active ? 'success' : 'inherit'}
+                      onClick={interactionModeActions[1].onClick}
+                      sx={{ ...getSegmentedActionButtonSx({ active: Boolean(interactionModeActions[1].active) }), px: 0.875, minHeight: 40, fontSize: '0.8rem', whiteSpace: 'nowrap' }}
+                    >
+                      {interactionModeActions[1].label}
+                    </Button>
+                  </ButtonGroup>
+                ) : null}
+              </Box>
+            )}
             sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-              gap: 0.5,
-              flexWrap: isVeryNarrowPhone ? 'wrap' : 'nowrap',
-              minWidth: 0,
               mb: 0.75,
+              '& > div': {
+                flexWrap: 'nowrap',
+                minWidth: 0,
+                gap: 0.375,
+                overflowX: 'auto',
+                whiteSpace: 'nowrap',
+              },
             }}
-          >
-            <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
-              <Button
-                aria-label={t('fields:representation.table')}
-                aria-pressed={viewMode === 'table'}
-                variant={viewMode === 'table' ? 'contained' : 'outlined'}
-                color={viewMode === 'table' ? 'success' : 'inherit'}
-                onClick={() => setViewMode('table')}
-                sx={{ ...getSegmentedActionButtonSx({ active: viewMode === 'table' }), px: 1, minHeight: 30 }}
-              >
-                {t('fields:representation.table')}
-              </Button>
-              <Button
-                aria-label={t('fields:representation.graphical')}
-                aria-pressed={viewMode === 'graphical'}
-                variant={viewMode === 'graphical' ? 'contained' : 'outlined'}
-                color={viewMode === 'graphical' ? 'success' : 'inherit'}
-                onClick={() => setViewMode('graphical')}
-                sx={{ ...getSegmentedActionButtonSx({ active: viewMode === 'graphical' }), px: 1, minHeight: 30 }}
-              >
-                {t('fields:representation.graphical')}
-              </Button>
-            </ButtonGroup>
-            {viewMode === 'graphical' ? (
-              <ButtonGroup size="small" variant="outlined" sx={{ ...segmentedButtonGroupSx, flexShrink: 0, minWidth: 0 }}>
-                <Button
-                  aria-label={t('fields:graphical.viewModeOption')}
-                  aria-pressed={interactionMode === 'view'}
-                  variant={interactionMode === 'view' ? 'contained' : 'outlined'}
-                  color={interactionMode === 'view' ? 'success' : 'inherit'}
-                  onClick={() => setInteractionMode('view')}
-                  sx={{ ...getSegmentedActionButtonSx({ active: interactionMode === 'view' }), px: 1, minHeight: 30 }}
-                >
-                  {t('fields:graphical.viewModeOption')}
-                </Button>
-                <Button
-                  aria-label={t('fields:graphical.editModeOption')}
-                  aria-pressed={interactionMode === 'edit'}
-                  variant={interactionMode === 'edit' ? 'contained' : 'outlined'}
-                  color={interactionMode === 'edit' ? 'success' : 'inherit'}
-                  onClick={() => setInteractionMode('edit')}
-                  sx={{ ...getSegmentedActionButtonSx({ active: interactionMode === 'edit' }), px: 1, minHeight: 30 }}
-                >
-                  {t('fields:graphical.editModeOption')}
-                </Button>
-              </ButtonGroup>
-            ) : null}
-          </Box>
+          />
         ) : null}
         {!shouldShowProjectRequiredState && !isAreaDataLoading && !shouldShowAreasEmptyState && viewMode === 'graphical' ? (
           <GraphicalFields

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -160,7 +160,7 @@ function GanttChartPage(): React.ReactElement {
   const topbarActions = useMemo<TopbarContextAction[]>(() => [
     {
       id: 'calendar-mode-view',
-      label: t('ganttChart:viewMode.view'),
+      label: t('ganttChart:modeViewOption', { defaultValue: 'Ansicht' }),
       icon: '👁️',
       active: calendarMode === 'occupancy' && !editMode,
       hidden: calendarMode !== 'occupancy',
@@ -172,7 +172,7 @@ function GanttChartPage(): React.ReactElement {
     },
     {
       id: 'calendar-mode-edit',
-      label: t('ganttChart:viewMode.edit'),
+      label: t('ganttChart:modeEditOption', { defaultValue: 'Bearbeiten' }),
       icon: '✏️',
       active: calendarMode === 'occupancy' && editMode,
       hidden: calendarMode !== 'occupancy',


### PR DESCRIPTION
### Motivation

- Improve topbar and toolbar responsiveness to prevent overflow issues on narrow screens and provide a consistent control layout.
- Encapsulate repeated control layout into a reusable component for content view controls.
- Make fields and Gantt topbar actions more declarative and localizable.

### Description

- Adjust `App.tsx` toolbar layout and styles by adding `minWidth`, `maxWidth`, `overflow: 'hidden'` and related `sx` tweaks to prevent overflow and ensure consistent truncation of titles and controls. 
- Tweak topbar control containers and buttons (culture library, import/export, primary action, grouped controls) to use `minWidth: 0`, `maxWidth`, `overflow` and `flexShrink` for better responsive behavior. 
- Add new `ContentViewControls` component at `frontend/src/components/layout/ContentViewControls.tsx` to centralize primary/secondary/action control layout and horizontal scrolling behavior. 
- Refactor `FieldsBedsPage.tsx` to introduce `viewModeActions` and `interactionModeActions`, replace `useTopbarContextActions` usage with an explicit `useEffect` that calls `setTopbarContextActions`, and render the compact control UI for small screens using the new `ContentViewControls` component. 
- Update `GanttChart.tsx` topbar action labels to use different translation keys with `defaultValue` fallbacks (`t('ganttChart:modeViewOption', { defaultValue: 'Ansicht' })` and `t('ganttChart:modeEditOption', { defaultValue: 'Bearbeiten' })`).

### Testing

- Ran TypeScript type check / build which completed successfully. 
- Ran the automated unit test suite (`yarn test`) and the affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045e6ca63083229d70c743c1d049ad)