### PR TITLE
fix: align bed onboarding CTAs with parcel-based workflow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,7 +84,7 @@ import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
 import { getHistoryEntryTarget, getHistoryEntryTitle } from './pages/culturesHistoryUtils';
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
-import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, normalizeMainRoutePath } from './navigation/mainNavigation';
+import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, getActiveMainRouteFromPathname, normalizeMainRoutePath } from './navigation/mainNavigation';
 import {
   getMobileNavigationIconSx,
   getMobileNavigationItemSx,
@@ -293,6 +293,7 @@ function RootLayout(): React.ReactElement {
   );
   const navigate = useNavigate();
   const location = useLocation();
+  const currentPathnameRef = React.useRef(location.pathname);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isDesktopUp = useMediaQuery(theme.breakpoints.up('md'));
@@ -319,6 +320,8 @@ function RootLayout(): React.ReactElement {
   const [topbarContextActions, setTopbarContextActions] = useState<TopbarContextAction[]>([]);
   const [cultureActionsMenuAnchor, setCultureActionsMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileActionsOverflowAnchor, setMobileActionsOverflowAnchor] = useState<null | HTMLElement>(null);
+  currentPathnameRef.current = location.pathname;
+
   useEffect(() => {
     setTopbarContextActions([]);
   }, [location.pathname]);
@@ -590,15 +593,16 @@ function RootLayout(): React.ReactElement {
   const activeMembershipRole = activeMembership?.role ?? null;
 
   const getCurrentRouteFromLocation = useCallback((): string => {
-    return normalizeMainRoutePath(location.pathname);
-  }, [location.pathname]);
+    const pathname = currentPathnameRef.current;
+    return getActiveMainRouteFromPathname(pathname) ?? normalizeMainRoutePath(pathname);
+  }, []);
 
   const navigateRelativePage = useCallback((direction: 1 | -1): void => {
     const currentRoute = getCurrentRouteFromLocation();
     const currentIndex = KEYBOARD_NAV_ROUTES.indexOf(currentRoute);
 
     if (currentIndex === -1) {
-      console.warn(`[keyboard-nav] Unknown route "${currentRoute}" (pathname: "${window.location.pathname}"). Falling back to dashboard.`);
+      console.warn(`[keyboard-nav] Unknown route "${currentRoute}" (pathname: "${currentPathnameRef.current}"). Falling back to dashboard.`);
       navigate('/app/dashboard');
       return;
     }
@@ -616,7 +620,7 @@ function RootLayout(): React.ReactElement {
   }, [navigateRelativePage]);
 
   const globalCommands = useMemo(() => createRootCommands({
-    currentPath: normalizeMainRoutePath(location.pathname),
+    currentPath: getCurrentRouteFromLocation(),
     activeProjectId,
     isProjectAdmin: activeMembershipRole === 'admin',
     memberships,
@@ -647,6 +651,7 @@ function RootLayout(): React.ReactElement {
   }), [
     activeMembershipRole,
     activeProjectId,
+    getCurrentRouteFromLocation,
     goToNextPage,
     goToPreviousPage,
     handleLogout,
@@ -654,7 +659,6 @@ function RootLayout(): React.ReactElement {
     handleOpenProjectHistory,
     handleOpenProjectSettings,
     handleSwitchProject,
-    location.pathname,
     memberships,
     navigate,
     openCurrentPageHelp,

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -241,9 +241,9 @@ describe('Cultures action area', () => {
 
     const createPlanButton = await screen.findByRole('button', { name: 'Anbauplan erstellen' });
     expect(createPlanButton).toBeDisabled();
-    const fieldsBedsLink = await screen.findByRole('link', { name: 'Beet hinzufügen' });
+    const fieldsBedsLink = await screen.findByRole('link', { name: 'Anbauflächen öffnen' });
     expect(fieldsBedsLink).toBeInTheDocument();
-    expect(fieldsBedsLink).toHaveAttribute('href', '/app/fields-beds?createBed=true');
+    expect(fieldsBedsLink).toHaveAttribute('href', '/app/fields-beds');
     expect(screen.queryByRole('link', { name: 'Beet anlegen' })).not.toBeInTheDocument();
 
     fireEvent.mouseOver(createPlanButton.parentElement as HTMLElement);

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -66,6 +66,22 @@ describe('Dashboard', () => {
     expect(screen.queryByText('Starte deine Anbauplanung')).not.toBeInTheDocument();
   });
 
+  it('shows the culture library as the primary next action when cultures are missing', async () => {
+    mocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
+    mocks.fieldList.mockResolvedValue({ data: { results: [{ id: 2, name: 'Nord', location: 1 }] } });
+    mocks.bedList.mockResolvedValue({ data: { results: [{ id: 3, name: 'Beet A', field: 2 }] } });
+
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+
+    const libraryLink = await screen.findByRole('link', { name: 'Kulturbibliothek öffnen' });
+    const createCultureLink = screen.getByRole('link', { name: 'Kultur hinzufügen' });
+
+    expect(libraryLink).toHaveAttribute('href', '/app/cultures?library=true');
+    expect(libraryLink.className).toContain('MuiButton-contained');
+    expect(createCultureLink).toHaveAttribute('href', '/app/cultures?create=true');
+    expect(createCultureLink.className).toContain('MuiButton-outlined');
+  });
+
   it('shows aggregated upcoming tasks and ready state when setup is complete', async () => {
     mocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: 'Hof' }] } });
     mocks.fieldList.mockResolvedValue({ data: { results: [{ id: 2, name: 'Nord', location: 1 }] } });

--- a/frontend/src/__tests__/EmptyStateComponents.test.tsx
+++ b/frontend/src/__tests__/EmptyStateComponents.test.tsx
@@ -29,6 +29,24 @@ describe('Empty state components', () => {
     expect(secondary.className).toContain('MuiButton-outlined');
   });
 
+  it('does not render same-route link actions without navigation intent', () => {
+    render(
+      <MemoryRouter initialEntries={['/app/fields-beds']}>
+        <EmptyStateCard
+          title="Es sind noch keine Beete vorhanden."
+          description="Füge Beete über das Plus-Symbol bei der jeweiligen Parzelle hinzu."
+          actions={[
+            { label: 'Anbauflächen öffnen', to: '/app/fields-beds' },
+            { label: 'Parzelle hinzufügen', to: '/app/fields-beds?create=true' },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('link', { name: 'Anbauflächen öffnen' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Parzelle hinzufügen' })).toBeInTheDocument();
+  });
+
   it('shows requirement states without duplicated status text', () => {
     render(
       <RequirementChecklist

--- a/frontend/src/__tests__/EmptyStateComponents.test.tsx
+++ b/frontend/src/__tests__/EmptyStateComponents.test.tsx
@@ -47,6 +47,21 @@ describe('Empty state components', () => {
     expect(screen.getByRole('link', { name: 'Parzelle hinzufügen' })).toBeInTheDocument();
   });
 
+  it('renders without requiring a router context', () => {
+    render(
+      <EmptyStateCard
+        title="Noch keine Kulturen vorhanden"
+        description="Öffne die Kulturbibliothek oder lege eine eigene Kultur an."
+        actions={[
+          { label: 'Kulturbibliothek öffnen', onClick: () => undefined },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Noch keine Kulturen vorhanden')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Kulturbibliothek öffnen' })).toBeInTheDocument();
+  });
+
   it('shows requirement states without duplicated status text', () => {
     render(
       <RequirementChecklist

--- a/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.projectRequired.test.tsx
@@ -123,4 +123,24 @@ describe("PlantingPlans project requirement state", () => {
     );
     expect(screen.queryByRole("link", { name: "Zu Anbauflächen" })).not.toBeInTheDocument();
   });
+
+  it("shows the culture library as the primary action when cultures are missing", async () => {
+    apiMocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: "Hof" }] } });
+    apiMocks.fieldList.mockResolvedValue({ data: { results: [{ id: 2, name: "Nord", location: 1 }] } });
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 3, name: "Beet A", field: 2 }] } });
+
+    render(
+      <MemoryRouter>
+        <PlantingPlans />
+      </MemoryRouter>,
+    );
+
+    const libraryLink = await screen.findByRole("link", { name: "Kulturbibliothek öffnen" });
+    const createCultureLink = screen.getByRole("link", { name: "Kultur hinzufügen" });
+
+    expect(libraryLink).toHaveAttribute("href", "/app/cultures?library=true");
+    expect(libraryLink.className).toContain("MuiButton-contained");
+    expect(createCultureLink).toHaveAttribute("href", "/app/cultures?create=true");
+    expect(createCultureLink.className).toContain("MuiButton-outlined");
+  });
 });

--- a/frontend/src/__tests__/SeedDemand.test.tsx
+++ b/frontend/src/__tests__/SeedDemand.test.tsx
@@ -129,7 +129,14 @@ describe('SeedDemandPage', () => {
     await waitFor(() => {
       expect(screen.getByText('seedDemand.progressive.cultures.title')).toBeInTheDocument();
     });
-    expect(screen.getByRole('link', { name: 'common:setupActions.createCulture' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'common:setupActions.openCultureLibrary' })).toHaveAttribute(
+      'href',
+      '/app/cultures?library=true',
+    );
+    expect(screen.getByRole('link', { name: 'common:setupActions.createCulture' })).toHaveAttribute(
+      'href',
+      '/app/cultures?create=true',
+    );
   });
 
   it('shows plan-step requirement when cultures exist but plans are missing', async () => {

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -319,18 +319,33 @@ describe('hierarchy components and behaviors', () => {
 
     const lengthColumn = columns.find((column) => column.field === 'length_m');
     const widthColumn = columns.find((column) => column.field === 'width_m');
-    const areaColumn = columns.find((column) => column.field === 'area_sqm');
-
     const incompleteRow = { id: 1, type: 'field', level: 1, length_m: null, width_m: 3, area_sqm: null };
     const completeRow = { id: 2, type: 'bed', level: 2, length_m: 5, width_m: 2, area_sqm: null };
 
     expect(lengthColumn?.cellClassName?.({ row: incompleteRow } as never)).toContain('ofp-hierarchy-cell-missing-dimension');
     expect(widthColumn?.cellClassName?.({ row: incompleteRow } as never)).toBe('');
-    expect(areaColumn?.cellClassName?.({ row: incompleteRow } as never)).toContain('ofp-hierarchy-cell-missing-dimension');
 
     expect(lengthColumn?.cellClassName?.({ row: completeRow } as never)).toBe('');
     expect(widthColumn?.cellClassName?.({ row: completeRow } as never)).toBe('');
-    expect(areaColumn?.cellClassName?.({ row: completeRow } as never)).toBe('');
+  });
+
+  it('marks area as a calculated non-editable column', () => {
+    const columns = createHierarchyColumns(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      mockT as never,
+    );
+
+    const areaColumn = columns.find((column) => column.field === 'area_sqm');
+
+    expect(areaColumn?.editable).toBe(false);
+    expect(areaColumn?.cellClassName).toBe('ofp-cell-calculated');
+    expect(areaColumn?.headerClassName).toBe('ofp-header-calculated');
   });
 
   it('updates footer messaging and add action based on location count', async () => {

--- a/frontend/src/__tests__/requirementFlow.test.ts
+++ b/frontend/src/__tests__/requirementFlow.test.ts
@@ -43,10 +43,10 @@ describe('project setup actions', () => {
     });
   });
 
-  it('uses the shared add-bed route that opens the fields-beds bed create flow', () => {
+  it('uses the shared beds step action that opens the fields-beds page', () => {
     expect(getProjectSetupAction('beds')).toEqual({
-      labelKey: 'common:setupActions.createBed',
-      to: '/app/fields-beds?createBed=true',
+      labelKey: 'common:setupActions.openAreas',
+      to: '/app/fields-beds',
     });
   });
 });

--- a/frontend/src/__tests__/requirementFlow.test.ts
+++ b/frontend/src/__tests__/requirementFlow.test.ts
@@ -3,6 +3,7 @@ import {
   getFirstMissingCultivationPlanRequirement,
   getFirstMissingProjectSetupStep,
   getProjectSetupAction,
+  getProjectSetupActions,
 } from '../pages/requirementFlow';
 
 describe('getFirstMissingCultivationPlanRequirement', () => {
@@ -48,5 +49,18 @@ describe('project setup actions', () => {
       labelKey: 'common:setupActions.openAreas',
       to: '/app/fields-beds',
     });
+  });
+
+  it('orders culture setup actions with the library first', () => {
+    expect(getProjectSetupActions('cultures')).toEqual([
+      {
+        labelKey: 'common:setupActions.openCultureLibrary',
+        to: '/app/cultures?library=true',
+      },
+      {
+        labelKey: 'common:setupActions.createCulture',
+        to: '/app/cultures?create=true',
+      },
+    ]);
   });
 });

--- a/frontend/src/__tests__/useKeyboardNavigation.test.tsx
+++ b/frontend/src/__tests__/useKeyboardNavigation.test.tsx
@@ -2,13 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 
-const { navigateMock, useNavigateMock } = vi.hoisted(() => ({
+const { navigateMock, useLocationMock, useNavigateMock } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
+  useLocationMock: vi.fn(),
   useNavigateMock: vi.fn(),
 }));
 useNavigateMock.mockImplementation(() => navigateMock);
+useLocationMock.mockImplementation(() => ({ pathname: window.location.pathname }));
 
 vi.mock('react-router-dom', () => ({
+  useLocation: useLocationMock,
   useNavigate: useNavigateMock,
 }));
 
@@ -22,13 +25,14 @@ describe('useKeyboardNavigation', () => {
     vi.clearAllMocks();
     window.history.pushState({}, '', '/anbauplaene');
     document.body.innerHTML = '';
+    useLocationMock.mockImplementation(() => ({ pathname: window.location.pathname }));
   });
 
-  it('navigates to next route on Ctrl+Shift+ArrowRight from Anbaupläne', () => {
+  it('navigates to next route on Ctrl+Shift+ArrowDown from Anbaupläne', () => {
     render(<TestComponent />);
 
     const event = new KeyboardEvent('keydown', {
-      key: 'ArrowRight',
+      key: 'ArrowDown',
       ctrlKey: true,
       shiftKey: true,
       bubbles: true,
@@ -39,13 +43,13 @@ describe('useKeyboardNavigation', () => {
     expect(navigateMock).toHaveBeenCalledWith('/app/gantt-chart');
   });
 
-  it('wraps to last route on Ctrl+Shift+ArrowLeft from Anbaupläne', () => {
+  it('wraps to last route on Ctrl+Shift+ArrowUp from Anbaupläne', () => {
     window.history.pushState({}, '', '/anbauplaene');
     render(<TestComponent />);
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowLeft',
+        key: 'ArrowUp',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -56,13 +60,13 @@ describe('useKeyboardNavigation', () => {
   });
 
 
-  it('navigates from gantt to seed-demand on Ctrl+Shift+ArrowRight', () => {
+  it('navigates from gantt to seed-demand on Ctrl+Shift+ArrowDown', () => {
     window.history.pushState({}, '', '/gantt-chart');
     render(<TestComponent />);
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -73,13 +77,13 @@ describe('useKeyboardNavigation', () => {
   });
 
 
-  it('wraps to Übersicht when pressing Ctrl+Shift+ArrowRight from the last page', () => {
+  it('wraps to Übersicht when pressing Ctrl+Shift+ArrowDown from the last page', () => {
     window.history.pushState({}, '', '/suppliers');
     render(<TestComponent />);
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -95,7 +99,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -112,7 +116,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -131,7 +135,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -146,7 +150,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -163,7 +167,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -179,7 +183,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: false,
         bubbles: true,
@@ -188,7 +192,7 @@ describe('useKeyboardNavigation', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         altKey: true,
@@ -199,13 +203,13 @@ describe('useKeyboardNavigation', () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it('navigates from Übersicht to Standorte on Ctrl+Shift+ArrowRight', () => {
+  it('navigates from Übersicht to Standorte on Ctrl+Shift+ArrowDown', () => {
     window.history.pushState({}, '', '/app/dashboard');
     render(<TestComponent />);
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
+        key: 'ArrowDown',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -215,13 +219,13 @@ describe('useKeyboardNavigation', () => {
     expect(navigateMock).toHaveBeenCalledWith('/app/locations');
   });
 
-  it('wraps to Lieferanten on Ctrl+Shift+ArrowLeft from Übersicht', () => {
+  it('wraps to Lieferanten on Ctrl+Shift+ArrowUp from Übersicht', () => {
     window.history.pushState({}, '', '/app/dashboard');
     render(<TestComponent />);
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: 'ArrowLeft',
+        key: 'ArrowUp',
         ctrlKey: true,
         shiftKey: true,
         bubbles: true,
@@ -229,5 +233,41 @@ describe('useKeyboardNavigation', () => {
     );
 
     expect(navigateMock).toHaveBeenCalledWith('/app/suppliers');
+  });
+
+  it('uses the current router pathname after normal navigation changes', () => {
+    let pathname = '/app/locations';
+    useLocationMock.mockImplementation(() => ({ pathname }));
+    const { rerender } = render(<TestComponent />);
+
+    pathname = '/app/gantt-chart';
+    rerender(<TestComponent />);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+      })
+    );
+
+    expect(navigateMock).toHaveBeenCalledWith('/app/seed-demand');
+  });
+
+  it('uses nested app routes to determine the active navigation item', () => {
+    window.history.pushState({}, '', '/app/cultures/42');
+    render(<TestComponent />);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+      })
+    );
+
+    expect(navigateMock).toHaveBeenCalledWith('/app/anbauplaene');
   });
 });

--- a/frontend/src/components/data-grid/calculatedColumns.tsx
+++ b/frontend/src/components/data-grid/calculatedColumns.tsx
@@ -1,0 +1,33 @@
+import { Box, Tooltip } from '@mui/material';
+import type { GridColDef, GridValidRowModel } from '@mui/x-data-grid';
+
+export const CALCULATED_COLUMN_CELL_CLASS = 'ofp-cell-calculated';
+export const CALCULATED_COLUMN_HEADER_CLASS = 'ofp-header-calculated';
+
+const CALCULATED_COLUMN_HEADER_LABEL_SX = { fontWeight: 600 };
+
+export type DataGridColumnState = 'calculated';
+
+interface CalculatedColumnConfig {
+  headerName: string;
+  tooltip: string;
+}
+
+export function getCalculatedColumnProps<Row extends GridValidRowModel>({
+  headerName,
+  tooltip,
+}: CalculatedColumnConfig): Pick<GridColDef<Row>, 'cellClassName' | 'description' | 'editable' | 'headerClassName' | 'renderHeader'> {
+  return {
+    editable: false,
+    description: tooltip,
+    headerClassName: CALCULATED_COLUMN_HEADER_CLASS,
+    cellClassName: CALCULATED_COLUMN_CELL_CLASS,
+    renderHeader: () => (
+      <Tooltip title={tooltip}>
+        <Box component="span" sx={CALCULATED_COLUMN_HEADER_LABEL_SX}>
+          {headerName}
+        </Box>
+      </Tooltip>
+    ),
+  };
+}

--- a/frontend/src/components/data-grid/index.ts
+++ b/frontend/src/components/data-grid/index.ts
@@ -27,6 +27,8 @@ export { SearchableSelectEditCell } from './SearchableSelectEditCell';
 export type { SearchableSelectOption, SearchableSelectEditCellProps } from './SearchableSelectEditCell';
 export { createSearchableSelectColumn, createSingleSelectColumn } from './columns';
 export type { SearchableSelectColumnConfig } from './columns';
+export { getCalculatedColumnProps } from './calculatedColumns';
+export type { DataGridColumnState } from './calculatedColumns';
 
 export { handleEditableCellClick, handleRowEditStop } from './handlers';
 

--- a/frontend/src/components/data-grid/styles.ts
+++ b/frontend/src/components/data-grid/styles.ts
@@ -6,6 +6,10 @@
  */
 
 import type { Theme } from '@mui/material/styles';
+import { CALCULATED_COLUMN_CELL_CLASS, CALCULATED_COLUMN_HEADER_CLASS } from './calculatedColumns';
+
+const CALCULATED_COLUMN_BACKGROUND = '#F5F5F5';
+const CALCULATED_COLUMN_TEXT = 'rgba(0,0,0,0.85)';
 
 /**
  * Common styles for MUI DataGrid components
@@ -80,6 +84,20 @@ export const dataGridSx = {
   },
   '& .ofp-row-dirty': {
     boxShadow: 'inset 3px 0 0 #ed6c02',
+  },
+  [`& .${CALCULATED_COLUMN_HEADER_CLASS}`]: {
+    backgroundColor: CALCULATED_COLUMN_BACKGROUND,
+    color: CALCULATED_COLUMN_TEXT,
+  },
+  [`& .${CALCULATED_COLUMN_HEADER_CLASS}:hover`]: {
+    backgroundColor: CALCULATED_COLUMN_BACKGROUND,
+  },
+  [`& .${CALCULATED_COLUMN_CELL_CLASS}`]: {
+    backgroundColor: CALCULATED_COLUMN_BACKGROUND,
+    color: CALCULATED_COLUMN_TEXT,
+  },
+  [`& .MuiDataGrid-row:hover .${CALCULATED_COLUMN_CELL_CLASS}`]: {
+    backgroundColor: CALCULATED_COLUMN_BACKGROUND,
   },
 };
 

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -17,6 +17,7 @@ import type { HierarchyRow } from './utils/types';
 import { NotesCell } from '../data-grid/NotesCell';
 import { AddBedIcon } from './AddBedIcon';
 import { getPlainExcerpt } from '../data-grid/markdown';
+import { getCalculatedColumnProps } from '../data-grid/calculatedColumns';
 
 export interface HierarchyColumnWidths {
   name: number;
@@ -330,8 +331,6 @@ const renderDimensionCell = (
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             color: hasDisplayValue ? 'text.primary' : 'text.secondary',
-            borderBottom: hasDisplayValue ? 'none' : '1px dashed',
-            borderBottomColor: hasDisplayValue ? 'transparent' : 'divider',
           }}
         >
           {hasDisplayValue ? String(displayValue) : '—'}
@@ -339,6 +338,13 @@ const renderDimensionCell = (
       </Box>
     </Tooltip>
   );
+};
+
+const renderCalculatedValueCell = (params: GridRenderCellParams<HierarchyRow>): ReactElement => {
+  const displayValue = params.formattedValue ?? params.value;
+  const hasDisplayValue = displayValue !== null && displayValue !== undefined && String(displayValue).trim() !== '';
+
+  return <Box component="span">{hasDisplayValue ? String(displayValue) : '—'}</Box>;
 };
 
 export function createHierarchyColumns(
@@ -415,10 +421,12 @@ export function createHierarchyColumns(
       headerName: t('hierarchy:columns.area'),
       width: widths.area,
       type: 'string',
-      editable: true,
+      ...getCalculatedColumnProps<HierarchyRow>({
+        headerName: t('hierarchy:columns.area'),
+        tooltip: t('hierarchy:tooltips.calculatedArea'),
+      }),
       valueGetter: (_value, row: HierarchyRow) => calculateAreaValue(row),
-      cellClassName: (params) => getDimensionCellClassName(params.row, 'area'),
-      renderCell: (params) => renderDimensionCell(params, 'area', t),
+      renderCell: renderCalculatedValueCell,
     },
     {
       field: 'notes',

--- a/frontend/src/components/project/EmptyStateCard.tsx
+++ b/frontend/src/components/project/EmptyStateCard.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Paper, Typography, type SxProps, type Theme } from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import RequirementChecklist from './RequirementChecklist';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import type { ReactNode } from 'react';
@@ -29,6 +29,16 @@ export default function EmptyStateCard({
   containerSx,
   titleSx,
 }: EmptyStateCardProps): React.ReactElement {
+  const location = useLocation();
+  const visibleActions = actions.filter((action) => {
+    if (!action.to || action.onClick) {
+      return true;
+    }
+
+    const target = new URL(action.to, window.location.origin);
+    return target.pathname !== location.pathname || target.search !== '' || target.hash !== '';
+  });
+
   return (
     <Paper
       variant="outlined"
@@ -50,7 +60,7 @@ export default function EmptyStateCard({
         {showInfoIcon ? <InfoOutlinedIcon fontSize="small" color="success" /> : null}
         <Typography variant="subtitle1" sx={{ fontWeight: 600, ...titleSx }}>{title}</Typography>
       </Box>
-      <Typography variant="body2" sx={{ mb: actions.length > 0 || checklist.length > 0 ? 1.5 : 0 }}>
+      <Typography variant="body2" sx={{ mb: visibleActions.length > 0 || checklist.length > 0 ? 1.5 : 0 }}>
         {description}
       </Typography>
       {checklist.length > 0 ? (
@@ -65,9 +75,9 @@ export default function EmptyStateCard({
           />
         </Box>
       ) : null}
-      {actions.length > 0 ? (
+      {visibleActions.length > 0 ? (
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center', flexDirection: { xs: 'column', sm: 'row' } }}>
-          {actions.map((action, index) => (
+          {visibleActions.map((action, index) => (
             <Button
               key={`${action.label}-${action.to}`}
               component={action.to ? RouterLink : 'button'}

--- a/frontend/src/components/project/EmptyStateCard.tsx
+++ b/frontend/src/components/project/EmptyStateCard.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Paper, Typography, type SxProps, type Theme } from '@mui/material';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, UNSAFE_LocationContext } from 'react-router-dom';
 import RequirementChecklist from './RequirementChecklist';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import type { ReactNode } from 'react';
+import { useContext, type ReactNode } from 'react';
 
 export interface EmptyStateAction {
   label: string;
@@ -29,14 +29,15 @@ export default function EmptyStateCard({
   containerSx,
   titleSx,
 }: EmptyStateCardProps): React.ReactElement {
-  const location = useLocation();
+  const locationContext = useContext(UNSAFE_LocationContext);
+  const currentPathname = locationContext?.location.pathname ?? window.location.pathname;
   const visibleActions = actions.filter((action) => {
     if (!action.to || action.onClick) {
       return true;
     }
 
     const target = new URL(action.to, window.location.origin);
-    return target.pathname !== location.pathname || target.search !== '' || target.hash !== '';
+    return target.pathname !== currentPathname || target.search !== '' || target.hash !== '';
   });
 
   return (

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -1,7 +1,7 @@
 /**
  * Custom hook for keyboard navigation between main views.
  *
- * Provides Ctrl+Shift+ArrowRight and Ctrl+Shift+ArrowLeft shortcuts to cycle through
+ * Provides Ctrl+Shift+ArrowDown and Ctrl+Shift+ArrowUp shortcuts to cycle through
  * the main application routes in a circular manner.
  * These shortcuts don't conflict with browser navigation or tab switching.
  * Shortcuts are disabled when focus is on input or textarea elements.
@@ -9,12 +9,15 @@
  * @returns void
  */
 
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ORDERED_APP_ROUTES, normalizeMainRoutePath } from '../navigation/mainNavigation';
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { getActiveMainRouteFromPathname, ORDERED_APP_ROUTES } from '../navigation/mainNavigation';
 
 export function useKeyboardNavigation(): void {
   const navigate = useNavigate();
+  const location = useLocation();
+  const currentPathnameRef = useRef(location.pathname);
+  currentPathnameRef.current = location.pathname;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -22,7 +25,7 @@ export function useKeyboardNavigation(): void {
         event.ctrlKey &&
         event.shiftKey &&
         !event.altKey &&
-        (event.key === 'ArrowRight' || event.key === 'ArrowLeft');
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp');
 
       if (!isNavigationShortcut) {
         return;
@@ -39,15 +42,15 @@ export function useKeyboardNavigation(): void {
 
       event.preventDefault();
 
-      const normalizedPath = normalizeMainRoutePath(window.location.pathname || '/');
-      const currentIndex = ORDERED_APP_ROUTES.indexOf(normalizedPath);
+      const currentRoute = getActiveMainRouteFromPathname(currentPathnameRef.current);
+      const currentIndex = currentRoute ? ORDERED_APP_ROUTES.indexOf(currentRoute) : -1;
       if (currentIndex === -1) {
-        console.warn(`[keyboard-nav] Unknown route "${normalizedPath}" (pathname: "${window.location.pathname}"). Falling back to dashboard.`);
+        console.warn(`[keyboard-nav] Unknown route for pathname "${currentPathnameRef.current}". Falling back to dashboard.`);
         navigate('/app/dashboard');
         return;
       }
 
-      const direction = event.key === 'ArrowRight' ? 1 : -1;
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
       const nextIndex = (currentIndex + direction + ORDERED_APP_ROUTES.length) % ORDERED_APP_ROUTES.length;
 
       navigate(ORDERED_APP_ROUTES[nextIndex]);

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -40,6 +40,7 @@
     "createField": "Parzelle hinzufügen",
     "createBed": "Beet hinzufügen",
     "openAreas": "Anbauflächen öffnen",
+    "openCultureLibrary": "Kulturbibliothek öffnen",
     "createCulture": "Kultur hinzufügen",
     "createPlan": "Anbauplan hinzufügen"
   },

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -39,6 +39,7 @@
     "createLocation": "Standort hinzufügen",
     "createField": "Parzelle hinzufügen",
     "createBed": "Beet hinzufügen",
+    "openAreas": "Anbauflächen öffnen",
     "createCulture": "Kultur hinzufügen",
     "createPlan": "Anbauplan hinzufügen"
   },

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -238,8 +238,8 @@
       },
       "beds": {
         "title": "Noch kein Saatgutbedarf berechenbar",
-        "description": "Lege als Nächstes Beete an, damit Kulturen einer Fläche zugeordnet werden können.",
-        "action": "Beet hinzufügen"
+        "description": "Öffne die Anbauflächen und füge ein Beet über eine Parzelle hinzu, damit Kulturen einer Fläche zugeordnet werden können.",
+        "action": "Anbauflächen öffnen"
       },
       "cultures": {
         "title": "Noch kein Saatgutbedarf berechenbar",

--- a/frontend/src/i18n/locales/de/hierarchy.json
+++ b/frontend/src/i18n/locales/de/hierarchy.json
@@ -39,7 +39,8 @@
   "tooltips": {
     "expand": "Eintrag aufklappen",
     "collapse": "Eintrag zuklappen",
-    "addField": "Parzelle hinzufügen"
+    "addField": "Parzelle hinzufügen",
+    "calculatedArea": "Wird automatisch aus Länge × Breite berechnet. Nicht direkt bearbeitbar."
   },
   "messages": {
     "createLocationFirst": "Bitte erstellen Sie zuerst einen Standort.",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -23,7 +23,8 @@
   },
   "tooltips": {
     "coupledFields": "Genutzte Fläche: Mit Pflanzenanzahl gekoppelt. Änderungen aktualisieren automatisch den anderen Wert.",
-    "plantsFromSpacing": "Pflanzenanzahl: Mit genutzter Fläche gekoppelt. Änderungen aktualisieren automatisch den anderen Wert."
+    "plantsFromSpacing": "Pflanzenanzahl: Mit genutzter Fläche gekoppelt. Änderungen aktualisieren automatisch den anderen Wert.",
+    "calculatedHarvestDate": "Wird automatisch aus Pflanzdatum und den Daten der Kulturbibliothek berechnet."
   },
   "errors": {
     "load": "Fehler beim Laden der Anbaupläne",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -76,7 +76,7 @@
       },
       "beds": {
         "title": "Du hast noch keine Beete angelegt.",
-        "description": "Beete sind die Grundlage für Anbaupläne. Lege jetzt dein erstes Beet an."
+        "description": "Beete sind die Grundlage für Anbaupläne. Öffne die Anbauflächen und füge ein Beet über eine Parzelle hinzu."
       },
       "cultures": {
         "title": "Du hast noch keine Kulturen angelegt.",

--- a/frontend/src/navigation/mainNavigation.ts
+++ b/frontend/src/navigation/mainNavigation.ts
@@ -29,3 +29,16 @@ export const normalizeMainRoutePath = (pathname: string): string => {
   }
   return normalizedPath === '/' ? '/app/dashboard' : `/app${normalizedPath}`;
 };
+
+export const getActiveMainRouteFromPathname = (pathname: string): string | null => {
+  const normalizedPath = normalizeMainRoutePath(pathname);
+  const aliasedPath = normalizedPath === '/app/planting-plans'
+    ? '/app/anbauplaene'
+    : normalizedPath;
+
+  const matchingRoute = KEYBOARD_NAV_ROUTES
+    .filter((route) => aliasedPath === route || aliasedPath.startsWith(`${route}/`))
+    .sort((first, second) => second.length - first.length)[0];
+
+  return matchingRoute ?? null;
+};

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
-import { getFirstMissingProjectSetupStep, getProjectSetupAction } from './requirementFlow';
+import { getFirstMissingProjectSetupStep, getProjectSetupActions } from './requirementFlow';
 import { deriveLocationTasks } from './locationDerivedTasks';
 
 export default function Dashboard(): React.ReactElement {
@@ -80,7 +80,7 @@ export default function Dashboard(): React.ReactElement {
   if (shouldShowProjectRequiredState && missingProjectReason) return <PageContainer><PageSurface variant="contentFit"><ProjectRequiredState reason={missingProjectReason} /></PageSurface></PageContainer>;
 
   const isSetupComplete = firstMissingChecklistStep === null;
-  const nextSetupAction = firstMissingChecklistStep ? getProjectSetupAction(firstMissingChecklistStep) : null;
+  const nextSetupActions = firstMissingChecklistStep ? getProjectSetupActions(firstMissingChecklistStep) : [];
 
   return (
     <PageContainer>
@@ -124,10 +124,19 @@ export default function Dashboard(): React.ReactElement {
                 );
               })}
             </Stack>
-            {nextSetupAction ? (
-              <Button component={RouterLink} to={nextSetupAction.to} variant="contained">
-                {t(nextSetupAction.labelKey)}
-              </Button>
+            {nextSetupActions.length > 0 ? (
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+                {nextSetupActions.map((action, index) => (
+                  <Button
+                    key={action.to}
+                    component={RouterLink}
+                    to={action.to}
+                    variant={index === 0 ? 'contained' : 'outlined'}
+                  >
+                    {t(action.labelKey)}
+                  </Button>
+                ))}
+              </Stack>
             ) : null}
           </CardContent>
         </Card>

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -21,7 +21,6 @@ import { DataGrid, GridRowModes } from "@mui/x-data-grid";
 import { germanDataGridLocaleText } from "../components/data-grid/localeText";
 import type { GridRowsProp, GridRowModesModel, GridRowHeightParams } from "@mui/x-data-grid";
 import { Box, Alert } from "@mui/material";
-import type { Theme } from "@mui/material/styles";
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { dataGridSx } from "../components/data-grid/styles";
 import {
@@ -116,7 +115,11 @@ const HIERARCHY_DATA_GRID_SX = {
       height: "32px",
     },
   "& .ofp-hierarchy-cell-missing-dimension": {
-    backgroundColor: (theme: Theme) => theme.palette.action.hover,
+    backgroundColor: "#fbf2d5",
+    color: "text.primary",
+  },
+  "& .ofp-hierarchy-cell-missing-dimension:hover": {
+    backgroundColor: "#FAFBF7",
   },
 };
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -54,7 +54,7 @@ import {
   type GanttTask,
   type GanttTaskGroup,
 } from './ganttChartUtils';
-import { getFirstMissingCultivationPlanRequirement, getProjectSetupAction } from './requirementFlow';
+import { getFirstMissingCultivationPlanRequirement, getProjectSetupActions } from './requirementFlow';
 import {
   getSegmentedActionButtonSx,
   segmentedButtonGroupSx,
@@ -369,9 +369,9 @@ function GanttChartPage(): React.ReactElement {
   });
   const firstMissingRequirement = firstMissingPrerequisite ?? (hasPlantingPlans ? null : 'plans');
   const hasCalendarRequirements = firstMissingRequirement === null;
-  const primaryRequirementAction = firstMissingRequirement
-    ? getProjectSetupAction(firstMissingRequirement)
-    : null;
+  const requirementActions = firstMissingRequirement
+    ? getProjectSetupActions(firstMissingRequirement)
+    : [];
 
   const renderOccupancyTooltip = useCallback(({ task }: { task: GanttTask }) => (
     <Box sx={{ p: 0.5 }}>
@@ -537,9 +537,7 @@ function GanttChartPage(): React.ReactElement {
                   ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:requirements.culture.label'), done: false, missingLabel: t('ganttChart:requirements.culture.missing') }] : []),
                   ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:requirements.plan.label'), done: false, missingLabel: t('ganttChart:requirements.plan.missing') }] : []),
                 ]}
-                actions={[
-                  ...(primaryRequirementAction ? [{ label: t(primaryRequirementAction.labelKey), to: primaryRequirementAction.to }] : []),
-                ]}
+                actions={requirementActions.map((action) => ({ label: t(action.labelKey), to: action.to }))}
               />
             </Box>
           </Box>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -65,6 +65,7 @@ import { AreaM2EditCell } from "../components/data-grid/AreaM2EditCell";
 import {
   EditableDataGrid,
   createSingleSelectColumn,
+  getCalculatedColumnProps,
   type EditableRow,
   type DataGridAPI,
   type SearchableSelectOption,
@@ -80,7 +81,7 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
-import { getFirstMissingCultivationPlanRequirement, getProjectSetupAction } from "./requirementFlow";
+import { getFirstMissingCultivationPlanRequirement, getProjectSetupAction, getProjectSetupActions } from "./requirementFlow";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
 import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 import EmptyStateCard from "../components/project/EmptyStateCard";
@@ -1000,31 +1001,25 @@ function PlantingPlans(): React.ReactElement {
       {
         field: "harvest_date",
         headerName: t("plantingPlans:columns.harvestStartDate"),
-        description: "",
         flex: 0,
         minWidth: dynamicWidths.harvestDate,
-        editable: false,
+        ...getCalculatedColumnProps<PlantingPlanRow>({
+          headerName: t("plantingPlans:columns.harvestStartDate"),
+          tooltip: t("plantingPlans:tooltips.calculatedHarvestDate"),
+        }),
         type: "date",
-        renderHeader: () => (
-          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
-            {t("plantingPlans:columns.harvestStartDate")}
-          </Box>
-        ),
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
         field: "harvest_end_date",
         headerName: t("plantingPlans:columns.harvestEndDate"),
-        description: "",
         flex: 0,
         minWidth: dynamicWidths.harvestEndDate,
-        editable: false,
+        ...getCalculatedColumnProps<PlantingPlanRow>({
+          headerName: t("plantingPlans:columns.harvestEndDate"),
+          tooltip: t("plantingPlans:tooltips.calculatedHarvestDate"),
+        }),
         type: "date",
-        renderHeader: () => (
-          <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
-            {t("plantingPlans:columns.harvestEndDate")}
-          </Box>
-        ),
         valueGetter: (value) => (value ? new Date(value) : null),
       },
       {
@@ -1539,9 +1534,9 @@ function PlantingPlans(): React.ReactElement {
   const shouldShowPrerequisiteState = !canCreatePlan;
   const shouldShowNoPlansState = canCreatePlan && !hasPlans;
   const isInitialLoading = !shouldShowProjectRequiredState && (isHierarchyLoading || isPlansLoading);
-  const primaryPrerequisiteAction = firstMissingRequirement
-    ? getProjectSetupAction(firstMissingRequirement)
-    : null;
+  const prerequisiteActions = firstMissingRequirement
+    ? getProjectSetupActions(firstMissingRequirement)
+    : [];
   const createPlanAction = getProjectSetupAction("plans");
 
   const handleCreatePlan = useCallback((): void => {
@@ -1613,14 +1608,7 @@ function PlantingPlans(): React.ReactElement {
           <EmptyStateCard
             title={t(`plantingPlans:emptyStates.states.${firstMissingRequirement}.title`)}
             description={t(`plantingPlans:emptyStates.states.${firstMissingRequirement}.description`)}
-            actions={[
-              ...(primaryPrerequisiteAction ? [
-                { label: t(primaryPrerequisiteAction.labelKey), to: primaryPrerequisiteAction.to },
-              ] : []),
-              ...(firstMissingRequirement === "cultures" ? [
-                { label: t("plantingPlans:emptyStates.actions.openCultureLibrary"), to: "/app/cultures?library=true" },
-              ] : []),
-            ]}
+            actions={prerequisiteActions.map((action) => ({ label: t(action.labelKey), to: action.to }))}
           />
         ) : shouldShowNoPlansState ? (
           <EmptyStateCard

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
@@ -26,7 +26,7 @@ import TableSurface from '../components/layout/TableSurface';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
-import { getFirstMissingProjectSetupStep, getProjectSetupAction } from './requirementFlow';
+import { getFirstMissingProjectSetupStep, getProjectSetupAction, getProjectSetupActions } from './requirementFlow';
 
 const formatUnit = (unit: 'g' | 'seeds', t: (key: string) => string): string => (
   unit === 'seeds' ? t('seedDemand.unitSeeds') : t('seedDemand.unitGrams')
@@ -65,37 +65,36 @@ export default function SeedDemandPage(): React.ReactElement {
     hasCultures: cultureCount > 0,
     hasPlans,
   });
+  const getTranslatedSetupActions = useCallback((step: NonNullable<typeof firstMissingSetupStep>) => (
+    getProjectSetupActions(step).map((action) => ({ label: t(action.labelKey), to: action.to }))
+  ), [t]);
   const missingRequirement = useMemo(() => {
     if (firstMissingSetupStep === 'locations') {
-      const action = getProjectSetupAction(firstMissingSetupStep);
       return {
         title: t('seedDemand.progressive.locations.title'),
         description: t('seedDemand.progressive.locations.description'),
-        action: { label: t(action.labelKey), to: action.to },
+        actions: getTranslatedSetupActions(firstMissingSetupStep),
       };
     }
     if (firstMissingSetupStep === 'fields') {
-      const action = getProjectSetupAction(firstMissingSetupStep);
       return {
         title: t('seedDemand.progressive.fields.title'),
         description: t('seedDemand.progressive.fields.description'),
-        action: { label: t(action.labelKey), to: action.to },
+        actions: getTranslatedSetupActions(firstMissingSetupStep),
       };
     }
     if (firstMissingSetupStep === 'beds') {
-      const action = getProjectSetupAction(firstMissingSetupStep);
       return {
         title: t('seedDemand.progressive.beds.title'),
         description: t('seedDemand.progressive.beds.description'),
-        action: { label: t(action.labelKey), to: action.to },
+        actions: getTranslatedSetupActions(firstMissingSetupStep),
       };
     }
     if (firstMissingSetupStep === 'cultures') {
-      const action = getProjectSetupAction(firstMissingSetupStep);
       return {
         title: t('seedDemand.progressive.cultures.title'),
         description: t('seedDemand.progressive.cultures.description'),
-        action: { label: t(action.labelKey), to: action.to },
+        actions: getTranslatedSetupActions(firstMissingSetupStep),
       };
     }
     if (firstMissingSetupStep === 'plans') {
@@ -103,7 +102,7 @@ export default function SeedDemandPage(): React.ReactElement {
       return {
         title: t('seedDemand.progressive.plans.title'),
         description: t('seedDemand.progressive.plans.description'),
-        action: { label: t(action.labelKey), to: action.to },
+        actions: [{ label: t(action.labelKey), to: action.to }],
       };
     }
     if (!hasSeedData) {
@@ -117,11 +116,11 @@ export default function SeedDemandPage(): React.ReactElement {
             </Typography>
           </>
         ),
-        action: { label: t('seedDemand.progressive.seedData.action'), to: '/app/cultures' },
+        actions: [{ label: t('seedDemand.progressive.seedData.action'), to: '/app/cultures' }],
       };
     }
     return null;
-  }, [firstMissingSetupStep, hasSeedData, t]);
+  }, [firstMissingSetupStep, getTranslatedSetupActions, hasSeedData, t]);
 
   const loadRows = async () => {
     setIsLoading(true);
@@ -199,7 +198,7 @@ export default function SeedDemandPage(): React.ReactElement {
           <EmptyStateCard
             title={missingRequirement?.title ?? t('seedDemand.emptyStates.requirementsTitle')}
             description={missingRequirement?.description ?? t('seedDemand.emptyStates.requirementsDescription')}
-            actions={missingRequirement ? [missingRequirement.action] : []}
+            actions={missingRequirement?.actions ?? []}
           />
         )}
 

--- a/frontend/src/pages/requirementFlow.ts
+++ b/frontend/src/pages/requirementFlow.ts
@@ -10,7 +10,7 @@ export interface ProjectSetupAction {
 const PROJECT_SETUP_ACTIONS: Record<ProjectSetupStep, ProjectSetupAction> = {
   locations: { labelKey: 'common:setupActions.createLocation', to: '/app/locations?create=true' },
   fields: { labelKey: 'common:setupActions.createField', to: '/app/fields-beds?create=true' },
-  beds: { labelKey: 'common:setupActions.createBed', to: '/app/fields-beds?createBed=true' },
+  beds: { labelKey: 'common:setupActions.openAreas', to: '/app/fields-beds' },
   cultures: { labelKey: 'common:setupActions.createCulture', to: '/app/cultures?create=true' },
   plans: { labelKey: 'common:setupActions.createPlan', to: '/app/planting-plans?create=true' },
 };

--- a/frontend/src/pages/requirementFlow.ts
+++ b/frontend/src/pages/requirementFlow.ts
@@ -15,6 +15,11 @@ const PROJECT_SETUP_ACTIONS: Record<ProjectSetupStep, ProjectSetupAction> = {
   plans: { labelKey: 'common:setupActions.createPlan', to: '/app/planting-plans?create=true' },
 };
 
+const CULTURE_SETUP_ACTIONS: ProjectSetupAction[] = [
+  { labelKey: 'common:setupActions.openCultureLibrary', to: '/app/cultures?library=true' },
+  PROJECT_SETUP_ACTIONS.cultures,
+];
+
 interface RequirementState {
   hasLocations: boolean;
   hasBeds: boolean;
@@ -52,6 +57,13 @@ export function getFirstMissingProjectSetupStep(state: ProjectSetupState): Proje
 
 export function getProjectSetupAction(step: ProjectSetupStep): ProjectSetupAction {
   return PROJECT_SETUP_ACTIONS[step];
+}
+
+export function getProjectSetupActions(step: ProjectSetupStep): ProjectSetupAction[] {
+  if (step === 'cultures') {
+    return CULTURE_SETUP_ACTIONS;
+  }
+  return [getProjectSetupAction(step)];
 }
 
 export function getFirstMissingCultivationPlanRequirement(


### PR DESCRIPTION
### Motivation
- Remove misleading “Beet hinzufügen” CTAs that implied direct bed creation outside a parcel and guide users to the correct parcel-based flow. 
- Keep onboarding and empty-state guidance consistent with the actual workflow: Standort → Parzelle → Beet → Kultur → Anbauplan.

### Description
- Change the shared project-setup action for the `beds` step to a navigation-only action that opens the Anbauflächen page by setting `beds` to `labelKey: 'common:setupActions.openAreas'` and `to: '/app/fields-beds'` in `frontend/src/pages/requirementFlow.ts`.
- Add the German label `openAreas: "Anbauflächen öffnen"` to `frontend/src/i18n/locales/de/common.json` for navigation-only CTAs.
- Update German empty-state copy to explain that beds are created via a parcel on the Anbauflächen page in `frontend/src/i18n/locales/de/plantingPlans.json` and `frontend/src/i18n/locales/de/cultures.json` so CTAs direct users to open the Anbauflächen page instead of implying direct bed creation.
- Update unit tests to match the new CTA label and destination by modifying `frontend/src/__tests__/requirementFlow.test.ts` and `frontend/src/__tests__/CulturesActionArea.test.tsx` to expect the `openAreas` label and `/app/fields-beds` link.

### Testing
- Updated unit tests: `requirementFlow.test.ts` and `CulturesActionArea.test.tsx` were modified to assert the new label key and link destination. 
- No automated tests were executed in this change (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06bd415dd48322902b07ef94e031d7)