### PR TITLE
fix: enable sorting for location-field-bed column

### DIFF
--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -940,7 +940,15 @@ function PlantingPlans(): React.ReactElement {
         minWidth: dynamicWidths.bed,
         maxWidth: BED_COLUMN_MAX_WIDTH,
         editable: true,
-        sortable: false,
+        valueGetter: (_value, row) => {
+          const gridRow = row as PlantingPlanRow;
+          const locationName = gridRow.location_name ?? "";
+          const fieldName = gridRow.field_name ?? "";
+          const bedName = gridRow.bed_name ?? "";
+          return [locationName, fieldName, bedName].filter(Boolean).join(" | ");
+        },
+        sortComparator: (value1, value2) =>
+          String(value1 ?? "").localeCompare(String(value2 ?? ""), "de"),
         renderCell: (params) => {
           const row = params.row as PlantingPlanRow;
           const label = bedLabelById.get(row.bed) ?? "—";


### PR DESCRIPTION
## Summary
- Enable sorting for the composed location / field / bed column on the Planting Plans page.
- Add a stable DataGrid valueGetter built from location_name, field_name, and bed_name with empty-string fallbacks.
- Add a German locale-aware comparator while preserving the existing cell rendering.

## Validation
- Reviewed local and remote diffs against main.
- Confirmed the branch is one commit ahead of main and only changes frontend/src/pages/PlantingPlans.tsx.
- Tests not run per request.