### PR TITLE
fix: keep planting plan bed selected while editing

### DIFF
--- a/backend/farm/serializers.py
+++ b/backend/farm/serializers.py
@@ -17,6 +17,7 @@ from .seed_units import (
     SEED_RATE_UNIT_SEEDS_PER_PLANT,
     SEED_RATE_UNITS,
 )
+from .services_area import calculate_remaining_bed_area
 
 from .models import (
     Bed,
@@ -1307,6 +1308,32 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
 
         if not instance.culture_id or not instance.bed_id:
             return attrs
+
+        active_period = instance._get_active_period()
+        if instance.area_usage_sqm is not None and active_period is not None:
+            active_start, active_end = active_period
+            remaining_payload = calculate_remaining_bed_area(
+                bed_id=instance.bed_id,
+                start_date=active_start,
+                end_date=active_end,
+                exclude_plan_id=instance.pk,
+            )
+            requested_area = instance.area_usage_sqm
+            if not isinstance(requested_area, Decimal):
+                requested_area = Decimal(str(requested_area))
+            available_area = remaining_payload['remaining_area_sqm']
+
+            if requested_area > available_area:
+                raise serializers.ValidationError({
+                    'area_usage_sqm': {
+                        'errorCode': 'bed_area_exceeded',
+                        'message': 'Requested area exceeds the available bed area for the selected period.',
+                        'bedArea': remaining_payload['bed_area_sqm'],
+                        'alreadyUsedArea': remaining_payload['overlapping_used_area_sqm'],
+                        'requestedArea': requested_area,
+                        'availableArea': available_area,
+                    }
+                })
 
         try:
             instance.clean()

--- a/backend/farm/tests/test_views.py
+++ b/backend/farm/tests/test_views.py
@@ -924,10 +924,11 @@ class ApiEndpointsTest(DRFAPITestCase):
         response2 = self.client.post('/openfarmplanner/api/planting-plans/', data2)
         self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('area_usage_sqm', response2.data)
-        self.assertIn(
-            'Die Fläche dieses Beets wird im überlappenden Zeitraum überschritten.',
-            response2.data['area_usage_sqm'][0],
-        )
+        self.assertEqual(response2.data['area_usage_sqm']['errorCode'], 'bed_area_exceeded')
+        self.assertEqual(float(response2.data['area_usage_sqm']['bedArea']), 20.0)
+        self.assertEqual(float(response2.data['area_usage_sqm']['alreadyUsedArea']), 12.0)
+        self.assertEqual(float(response2.data['area_usage_sqm']['requestedArea']), 10.0)
+        self.assertEqual(float(response2.data['area_usage_sqm']['availableArea']), 8.0)
 
     def test_planting_plan_area_validation_non_overlapping_plans_allowed(self):
         """Test API allows non-overlapping plans even when their total sum is above bed capacity."""

--- a/frontend/src/__tests__/errors.test.ts
+++ b/frontend/src/__tests__/errors.test.ts
@@ -191,4 +191,40 @@ describe('extractApiErrorMessage', () => {
       'Pflanzdatum: Ungültiges Datum',
     ].join('\n'));
   });
+
+  it('localizes planting plan area input validation errors', () => {
+    const t = createT({
+      'validation.areaInputPositive': 'Der Wert muss größer als 0 sein.',
+    });
+    const error = createAxiosError(400, {
+      area_input_value: ['Area input value must be greater than 0.'],
+    });
+
+    const result = extractApiErrorMessage(error, t, fallbackMessage);
+
+    expect(result).toBe('Fläche: Der Wert muss größer als 0 sein.');
+  });
+
+  it('localizes structured bed area exceeded errors', () => {
+    const t = createT({
+      'validation.bedAreaExceeded': 'Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.',
+      'validation.availableArea': 'Verfügbare Restfläche',
+    });
+    const error = createAxiosError(400, {
+      area_usage_sqm: {
+        errorCode: 'bed_area_exceeded',
+        bedArea: 20,
+        alreadyUsedArea: 14,
+        requestedArea: 8,
+        availableArea: 6,
+      },
+    });
+
+    const result = extractApiErrorMessage(error, t, fallbackMessage);
+
+    expect(result).toBe([
+      'Fläche (m²): Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.',
+      'Verfügbare Restfläche: 6,00 m²',
+    ].join('\n'));
+  });
 });

--- a/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
+++ b/frontend/src/__tests__/plantingPlans.hierarchy.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { Bed, Field } from "../api/types";
 import {
   buildAreaColumnHeaderLabel,
+  buildBedDisplayLabel,
   collectHierarchyAvailability,
   filterBedOptionsBySelection,
   filterFieldOptionsByLocation,
   normalizeSelectionAfterBedChange,
   normalizeSelectionAfterFieldChange,
   normalizeSelectionAfterLocationChange,
+  resolveBedCellValue,
 } from "../pages/PlantingPlans";
 
 const fields: Field[] = [
@@ -28,6 +30,28 @@ describe("PlantingPlans hierarchy normalization", () => {
     expect(
       buildAreaColumnHeaderLabel(false, "Standort", "Parzelle", "Beet"),
     ).toBe("Parzelle | Beet");
+  });
+
+  it("builds combined bed labels with optional area", () => {
+    expect(
+      buildBedDisplayLabel(
+        "Sonnengarten",
+        "Parzelle Nord",
+        "Beet 1",
+        7,
+        true,
+        "de-DE",
+      ),
+    ).toBe("Sonnengarten | Parzelle Nord | Beet 1 (7,00 m²)");
+  });
+
+  it("keeps the numeric bed ID when the grid cell value is a composed label", () => {
+    const row = { location_id: 1, field_id: 10, bed: 100 };
+
+    expect(
+      resolveBedCellValue("Sonnengarten | Parzelle Nord | Beet 1", row),
+    ).toBe(100);
+    expect(resolveBedCellValue(200, row)).toBe(200);
   });
 
   it("excludes locations and fields without beds from availability", () => {

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -13,6 +13,7 @@ import axios, { AxiosError } from 'axios';
 type TFunction = (key: string, options?: Record<string, unknown>) => string;
 
 const fieldLabelFallbacks: Record<string, string> = {
+  area_input_value: 'Fläche',
   area_usage_sqm: 'Fläche (m²)',
   area_sqm: 'Fläche (m²)',
   planting_date: 'Pflanzdatum',
@@ -43,7 +44,44 @@ const backendMessageMap: Record<string, string> = {
   'uploaded file exceeds the 10mb size limit.': 'errors.fileTooLarge',
   'uploaded file is not a valid image.': 'errors.invalidImage',
   'please enter a valid numeric value, e.g. 3.9.': 'validation.invalidNumberExample',
+  'area input value must be greater than 0.': 'validation.areaInputPositive',
 };
+
+function formatAreaValue(value: unknown): string {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return String(value ?? '');
+  }
+  return `${numericValue.toLocaleString('de-DE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} m²`;
+}
+
+function localizeStructuredBackendError(
+  value: Record<string, unknown>,
+  t: TFunction,
+): string | null {
+  if (value.errorCode === 'bed_area_exceeded') {
+    const message = translatedOrFallback(
+      t,
+      'validation.bedAreaExceeded',
+      'Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.',
+    );
+    const availableAreaLabel = translatedOrFallback(
+      t,
+      'validation.availableArea',
+      'Verfügbare Restfläche',
+    );
+    return `${message}\n${availableAreaLabel}: ${formatAreaValue(value.availableArea)}`;
+  }
+
+  if (typeof value.message === 'string') {
+    return localizeBackendMessage(value.message, t);
+  }
+
+  return null;
+}
 
 function localizeBackendMessage(message: string, t: TFunction): string {
   const normalized = message.trim().toLowerCase();
@@ -152,13 +190,33 @@ export function extractApiErrorMessage(
             fieldName = fieldLabelFallbacks[field] ?? field;
           }
           if (Array.isArray(value)) {
-            value.forEach((msg: string) => {
-              const errorMsg = `${fieldName}: ${localizeBackendMessage(msg, t)}`;
-              errors.push(errorMsg);
+            value.forEach((msg: unknown) => {
+              if (typeof msg === 'string') {
+                const errorMsg = `${fieldName}: ${localizeBackendMessage(msg, t)}`;
+                errors.push(errorMsg);
+                return;
+              }
+              if (msg && typeof msg === 'object') {
+                const structuredMessage = localizeStructuredBackendError(
+                  msg as Record<string, unknown>,
+                  t,
+                );
+                if (structuredMessage) {
+                  errors.push(`${fieldName}: ${structuredMessage}`);
+                }
+              }
             });
           } else if (typeof value === 'string') {
             const errorMsg = `${fieldName}: ${localizeBackendMessage(value, t)}`;
             errors.push(errorMsg);
+          } else if (value && typeof value === 'object') {
+            const structuredMessage = localizeStructuredBackendError(
+              value as Record<string, unknown>,
+              t,
+            );
+            if (structuredMessage) {
+              errors.push(`${fieldName}: ${structuredMessage}`);
+            }
           }
         });
 

--- a/frontend/src/components/data-grid/AreaM2EditCell.tsx
+++ b/frontend/src/components/data-grid/AreaM2EditCell.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Box, TextField } from '@mui/material';
+import { Box, Button, Stack, TextField, Typography } from '@mui/material';
 import { useGridApiContext } from '@mui/x-data-grid';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { formatLocalizedNumber, parseLocalizedNumber } from '../../utils/numberLocalization';
@@ -13,8 +13,12 @@ import { formatLocalizedNumber, parseLocalizedNumber } from '../../utils/numberL
 export interface AreaM2EditCellProps extends GridRenderEditCellParams {
   bedAreaSqm?: number;
   onLastEditedFieldChange: (field: 'area_m2') => void;
-  normalizeAreaOnBlur?: (value: number | null) => Promise<number | null>;
+  getAvailableAreaOnBlur?: (value: number | null) => Promise<number | null>;
   fallbackValue?: number | null;
+  formatArea: (value: number) => string;
+  areaExceededMessage: string;
+  availableAreaLabel: string;
+  applyAvailableAreaLabel: string;
   locale: string;
 }
 
@@ -26,8 +30,12 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
     hasFocus,
     bedAreaSqm,
     onLastEditedFieldChange,
-    normalizeAreaOnBlur,
+    getAvailableAreaOnBlur,
     fallbackValue,
+    formatArea,
+    areaExceededMessage,
+    availableAreaLabel,
+    applyAvailableAreaLabel,
     locale,
   } = props;
   const apiRef = useGridApiContext();
@@ -51,16 +59,18 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
           })
         : ''
   );
+  const [availableArea, setAvailableArea] = useState<number | null>(null);
+  const [showAvailableAreaError, setShowAvailableAreaError] = useState(false);
 
   const maxDisabled = bedAreaSqm === undefined || bedAreaSqm === null;
 
   const areaExceeded = useMemo(() => {
-    const parsed = Number.parseFloat(inputValue);
-    if (Number.isNaN(parsed) || maxDisabled) {
+    const parsed = parseLocalizedNumber(inputValue, locale);
+    if (parsed === null || maxDisabled) {
       return false;
     }
     return parsed > (bedAreaSqm ?? 0);
-  }, [inputValue, maxDisabled, bedAreaSqm]);
+  }, [inputValue, locale, maxDisabled, bedAreaSqm]);
 
   useEffect(() => {
     if (hasFocus) {
@@ -103,23 +113,46 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
     const val = e.target.value;
     setInputValue(val);
+    setAvailableArea(null);
+    setShowAvailableAreaError(false);
     const parsedValue = parseLocalizedNumber(val, locale);
     await applyValue(parsedValue);
   };
 
   const handleBlur = async (): Promise<void> => {
-    if (!normalizeAreaOnBlur) {
+    if (!getAvailableAreaOnBlur) {
       return;
     }
     const parsedValue = parseLocalizedNumber(inputValue, locale);
     if (inputValue.trim() !== '' && parsedValue === null) {
       return;
     }
-    const normalized = await normalizeAreaOnBlur(parsedValue);
-    if (normalized !== parsedValue) {
-      setInputValue(normalized === null ? '' : normalized.toString());
-      await applyValue(normalized);
+    const nextAvailableArea = await getAvailableAreaOnBlur(parsedValue);
+    if (
+      parsedValue !== null &&
+      nextAvailableArea !== null &&
+      parsedValue > nextAvailableArea
+    ) {
+      setAvailableArea(nextAvailableArea);
+      setShowAvailableAreaError(true);
+      return;
     }
+    setAvailableArea(null);
+    setShowAvailableAreaError(false);
+  };
+
+  const handleApplyAvailableArea = async (): Promise<void> => {
+    if (availableArea === null) {
+      return;
+    }
+    setInputValue(
+      formatLocalizedNumber(availableArea, locale, {
+        useGrouping: false,
+        maximumFractionDigits: 2,
+      })
+    );
+    setShowAvailableAreaError(false);
+    await applyValue(availableArea);
   };
 
   return (
@@ -138,7 +171,30 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
         onChange={handleChange}
         onBlur={handleBlur}
         size="small"
-        error={areaExceeded}
+        error={areaExceeded || showAvailableAreaError}
+        helperText={
+          showAvailableAreaError && availableArea !== null ? (
+            <Stack spacing={0.5}>
+              <Typography component="span" variant="caption">
+                {areaExceededMessage}
+              </Typography>
+              <Typography component="span" variant="caption">
+                {availableAreaLabel}: {formatArea(availableArea)}
+              </Typography>
+              <Button
+                size="small"
+                variant="text"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  void handleApplyAvailableArea();
+                }}
+                sx={{ alignSelf: 'flex-start', p: 0, minWidth: 0 }}
+              >
+                {applyAvailableAreaLabel}
+              </Button>
+            </Stack>
+          ) : undefined
+        }
         slotProps={{
           htmlInput: {
             min: 0,

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -72,7 +72,7 @@ export interface EditableDataGridProps<T extends EditableRow> {
   api: DataGridAPI<T>; // API handler for CRUD operations
   createNewRow: () => T; // Function to create a new empty row
   mapToRow: (item: T) => T; // Function to map API data to grid row
-  mapToApiData: (row: T) => Partial<T>; // Function to map grid row to API data for create/update
+  mapToApiData: (row: T) => Partial<T> | Promise<Partial<T>>; // Function to map grid row to API data for create/update
   validateRow: (row: T) => string | null; // Function to validate row before save
   loadErrorMessage: string; // Error message when loading fails
   saveErrorMessage: string; // Error message when save fails
@@ -166,7 +166,8 @@ export function EditableDataGrid<T extends EditableRow>({
       return updatedRow;
     }
 
-    const response = await api.update(numericId, mapToApiData(updatedRow));
+    const apiData = await mapToApiData(updatedRow);
+    const response = await api.update(numericId, apiData);
     if (!response.data.id) {
       throw new Error('API response missing ID');
     }
@@ -416,7 +417,8 @@ export function EditableDataGrid<T extends EditableRow>({
     try {
       if (newRow.isNew) {
         // Create new item via API
-        const response = await api.create(mapToApiData(newRow));
+        const apiData = await mapToApiData(newRow);
+        const response = await api.create(apiData);
         setError('');
         if (!response.data.id) {
           throw new Error('API response missing ID');
@@ -435,7 +437,8 @@ export function EditableDataGrid<T extends EditableRow>({
         return savedRow;
       } else {
         // Update existing item via API
-        const response = await api.update(newRow.id, mapToApiData(newRow));
+        const apiData = await mapToApiData(newRow);
+        const response = await api.update(newRow.id, apiData);
         setError('');
         if (!response.data.id) {
           throw new Error('API response missing ID');

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -88,7 +88,10 @@
     "required": "Dieses Feld ist erforderlich.",
     "invalidEmail": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
     "minLength": "Mindestens {{count}} Zeichen erforderlich.",
-    "invalidNumberExample": "Bitte gib einen gültigen Zahlenwert ein, z. B. 3,9"
+    "invalidNumberExample": "Bitte gib einen gültigen Zahlenwert ein, z. B. 3,9",
+    "areaInputPositive": "Der Wert muss größer als 0 sein.",
+    "bedAreaExceeded": "Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.",
+    "availableArea": "Verfügbare Restfläche"
   },
   "projectRequired": {
     "noProjectsTitle": "Du hast noch kein Projekt.",

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -18,6 +18,12 @@
   "labels": {
     "coupled": "gekoppelt"
   },
+  "actions": {
+    "useAvailableArea": "Maximal verfügbare Fläche übernehmen"
+  },
+  "feedback": {
+    "areaAutoFilled": "Verfügbare Restfläche automatisch verwendet: {{area}}"
+  },
   "placeholders": {
     "selectCultivationType": "Anbauart wählen"
   },
@@ -36,7 +42,10 @@
     "cultureRequired": "Kultur ist ein Pflichtfeld",
     "bedRequired": "Beet ist ein Pflichtfeld",
     "cultivationTypeRequired": "Anbauart ist ein Pflichtfeld",
-    "requiredFields": "Folgende Pflichtfelder müssen ausgefüllt werden: {{fields}}"
+    "requiredFields": "Folgende Pflichtfelder müssen ausgefüllt werden: {{fields}}",
+    "areaExceedsRemaining": "Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.",
+    "availableArea": "Verfügbare Restfläche",
+    "noAvailableArea": "Für dieses Beet ist im gewählten Zeitraum keine freie Fläche mehr verfügbar."
   },
   "confirmDelete": "Möchten Sie diesen Anbauplan wirklich löschen?",
   "addButton": "Anbauplan hinzufügen",

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Snackbar,
   Stack,
   TextField,
   Tooltip,
@@ -54,7 +55,7 @@ import {
   type Culture,
   type Bed,
 } from "../api/api";
-import type { CultivationType, Field, Location } from "../api/types";
+import type { CultivationType, Field, Location, RemainingAreaResponse } from "../api/types";
 import { extractApiErrorMessage } from "../api/errors";
 import {
   formatLocalizedNumber,
@@ -179,10 +180,22 @@ const toNumericValue = (value: unknown): number | null => {
   return null;
 };
 
+const toOptionalString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const addDaysToIsoDate = (value: string, days: number): string | null => {
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  date.setDate(date.getDate() + days);
+  return toIsoDateString(date);
+};
+
 interface HierarchySelectionRow {
   location_id?: number;
   field_id?: number;
-  bed?: number;
+  bed?: number | string;
 }
 
 export const normalizeSelectionAfterLocationChange = (
@@ -323,7 +336,7 @@ export const filterBedOptionsBySelection = (
     return true;
   });
 
-const buildBedDisplayLabel = (
+export const buildBedDisplayLabel = (
   locationName: string | null | undefined,
   fieldName: string | null | undefined,
   bedName: string | null | undefined,
@@ -351,6 +364,19 @@ const buildBedDisplayLabel = (
   }
 
   return `${combinedName} (${formatAreaM2(areaSqm, locale)})`;
+};
+
+export const resolveBedCellValue = (
+  value: unknown,
+  row: HierarchySelectionRow,
+): number => {
+  const cellBedId = toNumericValue(value);
+  if (cellBedId !== null) {
+    return cellBedId;
+  }
+
+  const rowBedId = toNumericValue(row.bed);
+  return rowBedId ?? 0;
 };
 
 const createEmptyMobileCreateForm = (): MobileCreateFormState => ({
@@ -435,7 +461,10 @@ function PlantingPlans(): React.ReactElement {
   const [locations, setLocations] = useState<Location[]>([]);
   const [fields, setFields] = useState<Field[]>([]);
   const [beds, setBeds] = useState<Bed[]>([]);
-  const [areaWarning, setAreaWarning] = useState<string>("");
+  const [areaNotice, setAreaNotice] = useState<{
+    message: string;
+    severity: "info" | "warning";
+  } | null>(null);
   const urlParamProcessedRef = useRef<boolean>(false);
   const gridCommandApiRef = useRef<EditableDataGridCommandApi | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<PlantingPlanRow | null>(
@@ -693,6 +722,93 @@ function PlantingPlans(): React.ReactElement {
     };
   }, [bedOptions, beds, cultivationTypeOptions, cultureOptions, hasMultipleLocationsWithBeds, numberLocale, t]);
 
+  const getBedLabelForRow = useCallback(
+    (row: PlantingPlanRow | null | undefined): string => {
+      if (!row) {
+        return "—";
+      }
+
+      const bedId = resolveBedCellValue(row.bed, row);
+      const linkedBed = bedById.get(bedId);
+      const linkedField = linkedBed ? fieldById.get(linkedBed.field) : undefined;
+      const locationName = linkedField
+        ? locationById.get(linkedField.location)?.name
+        : toOptionalString(row.location_name);
+
+      if (linkedBed) {
+        return buildBedDisplayLabel(
+          locationName,
+          linkedBed.field_name ?? linkedField?.name ?? toOptionalString(row.field_name),
+          linkedBed.name,
+          toNumericValue(linkedBed.area_sqm),
+          hasMultipleLocationsWithBeds,
+          numberLocale,
+        );
+      }
+
+      return buildBedDisplayLabel(
+        toOptionalString(row.location_name),
+        toOptionalString(row.field_name),
+        toOptionalString(row.bed_name),
+        null,
+        hasMultipleLocationsWithBeds,
+        numberLocale,
+      );
+    },
+    [
+      bedById,
+      fieldById,
+      hasMultipleLocationsWithBeds,
+      locationById,
+      numberLocale,
+    ],
+  );
+
+  const getAreaIntervalForRow = useCallback(
+    (row: PlantingPlanRow): { startDate: string; endDate: string } | null => {
+      const startDate = toIsoDateString(row.planting_date);
+      if (!startDate) {
+        return null;
+      }
+
+      const explicitEndDate =
+        toIsoDateString(row.harvest_end_date) ??
+        toIsoDateString(row.harvest_date);
+      if (explicitEndDate) {
+        return { startDate, endDate: explicitEndDate };
+      }
+
+      const culture = cultures.find((item) => item.id === row.culture);
+      const growthDays = culture?.growth_duration_days ?? 0;
+      const harvestDays = culture?.harvest_duration_days ?? 0;
+      const totalDays = growthDays + (growthDays && harvestDays ? harvestDays : 0);
+      const derivedEndDate = totalDays > 0 ? addDaysToIsoDate(startDate, totalDays) : startDate;
+
+      return { startDate, endDate: derivedEndDate ?? startDate };
+    },
+    [cultures],
+  );
+
+  const fetchRemainingAreaForRow = useCallback(
+    async (row: PlantingPlanRow): Promise<RemainingAreaResponse | null> => {
+      const bedId = resolveBedCellValue(row.bed, row);
+      const interval = getAreaIntervalForRow(row);
+      if (!bedId || !interval) {
+        return null;
+      }
+
+      const response = await plantingPlanAPI.remainingArea({
+        bed_id: bedId,
+        start_date: interval.startDate,
+        end_date: interval.endDate,
+        ...(row.id > 0 ? { exclude_plan_id: row.id } : {}),
+      });
+
+      return response.data;
+    },
+    [getAreaIntervalForRow],
+  );
+
   /**
    * Check for cultureId or bedId parameter in URL and set as initial values
    */
@@ -940,26 +1056,29 @@ function PlantingPlans(): React.ReactElement {
         minWidth: dynamicWidths.bed,
         maxWidth: BED_COLUMN_MAX_WIDTH,
         editable: true,
-        valueGetter: (_value, row) => {
-          const gridRow = row as PlantingPlanRow;
-          const locationName = gridRow.location_name ?? "";
-          const fieldName = gridRow.field_name ?? "";
-          const bedName = gridRow.bed_name ?? "";
-          return [locationName, fieldName, bedName].filter(Boolean).join(" | ");
+        type: "singleSelect",
+        valueOptions: bedOptions,
+        valueFormatter: (_value, row) => getBedLabelForRow(row as PlantingPlanRow),
+        sortComparator: (_value1, _value2, cellParams1, cellParams2) => {
+          const row1 = cellParams1.api.getRow(cellParams1.id) as PlantingPlanRow | null;
+          const row2 = cellParams2.api.getRow(cellParams2.id) as PlantingPlanRow | null;
+          return getBedLabelForRow(row1).localeCompare(
+            getBedLabelForRow(row2),
+            "de",
+          );
         },
-        sortComparator: (value1, value2) =>
-          String(value1 ?? "").localeCompare(String(value2 ?? ""), "de"),
         renderCell: (params) => {
           const row = params.row as PlantingPlanRow;
-          const label = bedLabelById.get(row.bed) ?? "—";
+          const label = getBedLabelForRow(row);
           return <CompactAreaCell label={label} />;
         },
         renderEditCell: (params) => {
           const row = params.row as PlantingPlanRow;
-          const label = bedLabelById.get(row.bed) ?? "—";
+          const bedId = resolveBedCellValue(params.value, row);
+          const label = getBedLabelForRow({ ...row, bed: bedId });
           return (
             <AreaAssignmentDialog
-              bedId={typeof row.bed === "number" ? row.bed : Number(row.bed)}
+              bedId={bedId || null}
               beds={beds}
               fields={fields}
               locations={locations}
@@ -977,7 +1096,7 @@ function PlantingPlans(): React.ReactElement {
         },
         valueSetter: (value, row) => {
           const nextRow = row as PlantingPlanRow;
-          const numericValue = typeof value === "number" ? value : Number(value);
+          const numericValue = resolveBedCellValue(value, nextRow);
           const selectedBed = bedById.get(numericValue);
           const isNewRow = Boolean(nextRow.isNew);
           const currentArea = nextRow.area_m2;
@@ -1073,45 +1192,20 @@ function PlantingPlans(): React.ReactElement {
               bedAreaSqm={selectedBed?.area_sqm}
               fallbackValue={derivedArea}
               locale={numberLocale}
+              formatArea={(value) => formatAreaM2(value, numberLocale)}
+              areaExceededMessage={t("plantingPlans:validation.areaExceedsRemaining")}
+              availableAreaLabel={t("plantingPlans:validation.availableArea")}
+              applyAvailableAreaLabel={t("plantingPlans:actions.useAvailableArea")}
               onLastEditedFieldChange={() => {
                 lastEditedFieldRef.current = "area_m2";
+                setAreaNotice(null);
               }}
-              normalizeAreaOnBlur={async (value) => {
-                const bedId =
-                  typeof row.bed === "number" ? row.bed : Number(row.bed);
-                const startDate = toIsoDateString(row.planting_date);
-                const endDate =
-                  toIsoDateString(row.harvest_end_date) ??
-                  toIsoDateString(row.harvest_date) ??
-                  startDate;
-
-                if (!bedId || !startDate || !endDate || value === null) {
-                  return value;
+              getAvailableAreaOnBlur={async (value) => {
+                if (value === null) {
+                  return null;
                 }
-
-                const requestParams = {
-                  bed_id: bedId,
-                  start_date: startDate,
-                  end_date: endDate,
-                  ...(row.id > 0 ? { exclude_plan_id: row.id } : {}),
-                };
-
-                const response =
-                  await plantingPlanAPI.remainingArea(requestParams);
-                const remaining = response.data.remaining_area_sqm;
-
-                if (value > remaining) {
-                  setAreaWarning(
-                    `Fläche wurde auf Restfläche begrenzt (${formatAreaM2(remaining, numberLocale)}). Bitte Speichern bestätigen, dann wird der Restwert übernommen.`,
-                  );
-                  return remaining;
-                }
-
-                if (areaWarning) {
-                  setAreaWarning("");
-                }
-
-                return value;
+                const remainingArea = await fetchRemainingAreaForRow(row);
+                return remainingArea?.remaining_area_sqm ?? null;
               }}
             />
           );
@@ -1142,6 +1236,7 @@ function PlantingPlans(): React.ReactElement {
         preProcessEditCellProps: (params) => {
           if (params.hasChanged) {
             lastEditedFieldRef.current = "plants_count";
+            setAreaNotice(null);
           }
           return params.props;
         },
@@ -1186,10 +1281,11 @@ function PlantingPlans(): React.ReactElement {
       cultureOptions,
       cultures,
       dynamicWidths,
+      fetchRemainingAreaForRow,
+      getBedLabelForRow,
       areaColumnLabel,
       fieldBedColumnLabel,
       numberLocale,
-      areaWarning,
       t,
     ],
   );
@@ -1240,8 +1336,8 @@ function PlantingPlans(): React.ReactElement {
         : null;
       return buildBedDisplayLabel(
         locationName,
-        linkedBed.name,
         linkedBed.field_name ?? linkedField?.name,
+        linkedBed.name,
         toNumericValue(linkedBed.area_sqm),
         includeLocation,
         numberLocale,
@@ -1425,20 +1521,41 @@ function PlantingPlans(): React.ReactElement {
     const usePlantsInput =
       mobileLastEditedField === "plants_count" ||
       (!mobileLastEditedField && !hasAreaInput && hasPlantsInput);
-    const areaPayload =
-      hasAreaInput || hasPlantsInput
-        ? {
-            area_input_value: usePlantsInput
-              ? parsedPlants
-              : parsedArea,
-            area_input_unit: usePlantsInput ? "PLANTS" : "M2",
-          }
-        : typeof selectedBed?.area_sqm === "number"
-          ? {
-              area_input_value: selectedBed.area_sqm,
-              area_input_unit: "M2" as const,
-            }
-          : {};
+    let areaPayload: Partial<PlantingPlan> = {};
+    if (hasAreaInput || hasPlantsInput) {
+      areaPayload = {
+        area_input_value: usePlantsInput
+          ? parsedPlants ?? undefined
+          : parsedArea ?? undefined,
+        area_input_unit: usePlantsInput ? "PLANTS" : "M2",
+      };
+    } else if (selectedBed) {
+      const remainingArea = await fetchRemainingAreaForRow({
+        id: mobileEditId ?? -Date.now(),
+        culture: Number(mobileCreateForm.culture),
+        bed: Number(mobileCreateForm.bed),
+        planting_date: mobileCreateForm.planting_date,
+        cultivation_type: mobileCreateForm.cultivation_type,
+      } as PlantingPlanRow);
+      const availableArea = remainingArea?.remaining_area_sqm ?? null;
+      if (availableArea !== null && availableArea > 0) {
+        areaPayload = {
+          area_input_value: availableArea,
+          area_input_unit: "M2" as const,
+        };
+        setAreaNotice({
+          message: t("plantingPlans:feedback.areaAutoFilled", {
+            area: formatAreaM2(availableArea, numberLocale),
+          }),
+          severity: "info",
+        });
+      } else if (availableArea !== null) {
+        setAreaNotice({
+          message: t("plantingPlans:validation.noAvailableArea"),
+          severity: "warning",
+        });
+      }
+    }
 
     try {
       await plantingPlanAPI.create({
@@ -1495,20 +1612,41 @@ function PlantingPlans(): React.ReactElement {
     const usePlantsInput =
       mobileLastEditedField === "plants_count" ||
       (!mobileLastEditedField && !hasAreaInput && hasPlantsInput);
-    const areaPayload =
-      hasAreaInput || hasPlantsInput
-        ? {
-            area_input_value: usePlantsInput
-              ? parsedPlants
-              : parsedArea,
-            area_input_unit: usePlantsInput ? "PLANTS" : "M2",
-          }
-        : typeof selectedBed?.area_sqm === "number"
-          ? {
-              area_input_value: selectedBed.area_sqm,
-              area_input_unit: "M2" as const,
-            }
-          : {};
+    let areaPayload: Partial<PlantingPlan> = {};
+    if (hasAreaInput || hasPlantsInput) {
+      areaPayload = {
+        area_input_value: usePlantsInput
+          ? parsedPlants ?? undefined
+          : parsedArea ?? undefined,
+        area_input_unit: usePlantsInput ? "PLANTS" : "M2",
+      };
+    } else if (selectedBed) {
+      const remainingArea = await fetchRemainingAreaForRow({
+        id: mobileEditId,
+        culture: Number(mobileCreateForm.culture),
+        bed: Number(mobileCreateForm.bed),
+        planting_date: mobileCreateForm.planting_date,
+        cultivation_type: mobileCreateForm.cultivation_type,
+      } as PlantingPlanRow);
+      const availableArea = remainingArea?.remaining_area_sqm ?? null;
+      if (availableArea !== null && availableArea > 0) {
+        areaPayload = {
+          area_input_value: availableArea,
+          area_input_unit: "M2" as const,
+        };
+        setAreaNotice({
+          message: t("plantingPlans:feedback.areaAutoFilled", {
+            area: formatAreaM2(availableArea, numberLocale),
+          }),
+          severity: "info",
+        });
+      } else if (availableArea !== null) {
+        setAreaNotice({
+          message: t("plantingPlans:validation.noAvailableArea"),
+          severity: "warning",
+        });
+      }
+    }
 
     try {
       await plantingPlanAPI.update(mobileEditId, {
@@ -1585,11 +1723,20 @@ function PlantingPlans(): React.ReactElement {
   return (
     <PageContainer variant="workspacePage">
 
-      {areaWarning ? (
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          {areaWarning}
+      <Snackbar
+        open={areaNotice !== null}
+        autoHideDuration={5000}
+        onClose={() => setAreaNotice(null)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          severity={areaNotice?.severity ?? "info"}
+          variant="filled"
+          onClose={() => setAreaNotice(null)}
+        >
+          {areaNotice?.message}
         </Alert>
-      ) : null}
+      </Snackbar>
 
       <Box sx={{ width: "100%" }}>
         {isInitialLoading ? (
@@ -1767,7 +1914,7 @@ function PlantingPlans(): React.ReactElement {
               note_attachment_count: plan.note_attachment_count ?? 0,
             };
           }}
-          mapToApiData={(row) => {
+          mapToApiData={async (row) => {
             const plantingDate = toIsoDateString(row.planting_date) ?? "";
 
             // Ensure culture and bed are numeric IDs, not label strings
@@ -1821,12 +1968,25 @@ function PlantingPlans(): React.ReactElement {
               apiData.area_input_unit = "PLANTS";
             }
 
-            if (
-              apiData.area_input_value === undefined &&
-              typeof selectedBed?.area_sqm === "number"
-            ) {
-              apiData.area_input_value = selectedBed.area_sqm;
-              apiData.area_input_unit = "M2";
+            if (apiData.area_input_value === undefined && selectedBed) {
+              const remainingArea = await fetchRemainingAreaForRow(row);
+              const availableArea = remainingArea?.remaining_area_sqm ?? null;
+
+              if (availableArea !== null && availableArea > 0) {
+                apiData.area_input_value = availableArea;
+                apiData.area_input_unit = "M2";
+                setAreaNotice({
+                  message: t("plantingPlans:feedback.areaAutoFilled", {
+                    area: formatAreaM2(availableArea, numberLocale),
+                  }),
+                  severity: "info",
+                });
+              } else if (availableArea !== null) {
+                setAreaNotice({
+                  message: t("plantingPlans:validation.noAvailableArea"),
+                  severity: "warning",
+                });
+              }
             }
 
             // Clear last edited field after use
@@ -1863,7 +2023,7 @@ function PlantingPlans(): React.ReactElement {
               typeof row.area_m2 === "number" &&
               row.area_m2 > selectedBed.area_sqm
             ) {
-              return "Fläche darf die Beetfläche nicht überschreiten.";
+              return t("plantingPlans:validation.areaExceedsRemaining");
             }
 
             return null;
@@ -1990,6 +2150,7 @@ function PlantingPlans(): React.ReactElement {
                       : previous.plants_count,
                 }));
                 setMobileLastEditedField("area_m2");
+                setAreaNotice(null);
               }}
               slotProps={{ htmlInput: { inputMode: "decimal" } }}
             />
@@ -2013,6 +2174,7 @@ function PlantingPlans(): React.ReactElement {
                       : previous.area_m2,
                 }));
                 setMobileLastEditedField("plants_count");
+                setAreaNotice(null);
               }}
               slotProps={{ htmlInput: { inputMode: "numeric" } }}
             />


### PR DESCRIPTION
## Summary
- keep the planting plan area column backed by the stable numeric bed ID in edit mode
- use bed ID valueOptions while preserving the composed Standort | Parzelle | Beet display label and label-based sorting
- replace empty-area fallback from full bed area to available remaining bed area for overlapping plan intervals
- show a non-modal Snackbar when available rest area is auto-filled or when no free area is available
- show an inline area editor message with available rest area and a `Maximal verfügbare Fläche übernehmen` action when user input exceeds the rest area
- localize `area_input_value` validation errors and structured bed-area validation errors
- return structured backend metadata for bed area excess: `errorCode`, `bedArea`, `alreadyUsedArea`, `requestedArea`, `availableArea`
- add/update focused tests for hierarchy labels, API error localization, and structured backend validation payloads

## Root Cause
The bed column used a composed display value through the grid value path, so entering edit mode could provide a label-like value that did not match the selectable bed ID. The edit cell now resolves the current cell value back to a numeric bed ID and the column valueOptions use those same IDs.

The previous empty-area fallback used the full bed area without checking overlapping plans. The page now asks the existing `remaining-area` endpoint for the selected interval, excluding the current plan, and only auto-fills when a positive rest area is available.

The area validation message came from the backend in English and, for capacity errors, without structured metadata. The backend now exposes a stable `bed_area_exceeded` code plus area details so the frontend can render German UI without fragile string parsing.

## Validation
- `npx tsc -b --pretty false`
- `AI_ENRICHMENT_ENABLED=False pdm run python manage.py check`
- Earlier `npm run lint` attempt is still blocked by existing project-wide generated-file and hook/fast-refresh lint issues.

Tests were not run per request.