### PR TITLE
fix: simplify planting area validation on save

### DIFF
--- a/docs/keyboard-edit-analysis.md
+++ b/docs/keyboard-edit-analysis.md
@@ -1,0 +1,416 @@
+# Keyboard & Edit Flow Analysis — PlantingPlans DataGrid
+
+> **Scope:** `frontend/src/components/data-grid/DataGrid.tsx` and
+> `frontend/src/pages/PlantingPlans.tsx`.  
+> **Analysed at commit:** `c192054`  
+> **Purpose:** Pure architecture analysis. No code was changed.
+
+---
+
+## 1. Grundprinzip: Row Editing
+
+Der Grid verwendet `editMode="row"` (DataGrid.tsx:1241). MUI behandelt **immer
+eine ganze Zeile** als editierbare Einheit — es gibt keinen separaten
+cell-editing-Modus. Die einzige maßgebliche Edit-Zustandsquelle ist daher
+`rowModesModel` (kein `cellModesModel`).
+
+---
+
+## 2. Eintritt in den Edit-Modus
+
+Es gibt vier unabhängige Eintrittspfade.
+
+### 2.1 Mausklick auf eine bearbeitbare Zelle
+
+```
+onCellClick (DataGrid.tsx:1288)
+  → setDirtyRowIds
+  → handleEditableCellClick (handlers.ts:23)
+       Bedingung: params.isEditable && rowModesModel[id]?.mode !== Edit
+       → setRowModesModel({ [id]: { mode: Edit, fieldToFocus: field } })
+```
+
+Gleichzeitig wird der Snapshot der Originalzeile in `rowSnapshotRef` gespeichert
+(DataGrid.tsx:1290-1294).
+
+### 2.2 Enter-Taste auf einer View-Zeile
+
+```
+onCellKeyDown (DataGrid.tsx:1314)
+  Bedingung: Enter && editable && mode !== Edit
+  → event.preventDefault() + defaultMuiPrevented = true
+  → handleStartCellEditFromKeyboard (DataGrid.tsx:782)
+       → api.setCellFocus(id, field)
+       → setRowModesModel({ [id]: { mode: Edit, fieldToFocus: field } })
+```
+
+Snapshot wird ebenfalls angelegt (DataGrid.tsx:788-793).
+
+### 2.3 Neue Zeile hinzufügen
+
+```
+handleAddClick (DataGrid.tsx:504)
+  → createNewRow()
+  → setRows([newRow, ...oldRows])
+  → setRowModesModel({ [newRow.id]: { mode: Edit, fieldToFocus: columns[0].field } })
+```
+
+### 2.4 Keyboard-Navigation aus einer anderen Zeile (horizontale Pfeile/Tab)
+
+Wird über `focusKeyboardNavigableCell` gestartet (DataGrid.tsx:348):
+
+```
+focusKeyboardNavigableCell(rowId, field, { startEdit: true })
+  → api.scrollToIndexes(...)
+  → api.setCellFocus(rowId, field)
+  → setRowModesModel({ [rowId]: { mode: Edit, fieldToFocus: field } })
+```
+
+Gilt nur für horizontale Navigation (Tab, ArrowLeft, ArrowRight) auf
+nicht-Notes-Spalten — Details in Abschnitt 5.
+
+---
+
+## 3. Austritt aus dem Edit-Modus
+
+### 3.1 Speichern (normale Pfade)
+
+Alle drei Speicherpfade setzen die Zeile auf `View`, was MUI's
+`processRowUpdate` auslöst:
+
+| Auslöser | Codestelle |
+|---|---|
+| Enter-Taste während Edit | DataGrid.tsx:1336 → `handleSaveRow` |
+| Speichern-Button (Footer/Zeile) | DataGrid.tsx:1012 / 1104 → `handleSaveAllDirtyRows` / `handleSaveRow` |
+| Keyboard-Navigation weg von der Zeile | DataGrid.tsx:662 in `navigateFromEditedCell` |
+| Natürlicher Fokusverlust (Blur) | `onRowEditStop` / `rowFocusOut` → MUI's default |
+
+```
+handleSaveRow (DataGrid.tsx:751)
+  → shouldSaveRow(rowId)
+       → onBeforeSaveRow(draftRow)   // PlantingPlans: Flächenvalidierung
+       → applyDraftValues(...)       // bei Partial<T>-Rückgabe
+  → setRowModesModel({ [rowId]: { mode: View } })
+       → MUI: processRowUpdate(newRow)
+            → validateRow(newRow)
+            → mapToApiData(row)
+            → api.create / api.update
+            → mapToRow(response)
+            → setRows(...)
+```
+
+### 3.2 Abbrechen (Escape)
+
+```
+onCellKeyDown: event.key === 'Escape' (DataGrid.tsx:1342)
+  → event.preventDefault()
+  → handleDiscardRowChanges (DataGrid.tsx:513)
+       → Snapshot wiederherstellen  (oder Zeile löschen wenn isNew)
+       → setDirtyRowIds.delete(rowId)
+       → setActiveValidationErrors.delete(rowId)
+       → setRowModesModel({ [rowId]: { mode: View, ignoreModifications: true } })
+```
+
+`ignoreModifications: true` teilt MUI mit, dass kein `processRowUpdate`
+aufgerufen werden soll → kein API-Aufruf.
+
+Ergänzend: `handleRowEditStop` (handlers.ts:47) setzt
+`event.defaultMuiPrevented = true` für `escapeKeyDown`, damit MUI's eigener
+Escape-Handler nicht doppelt feuert.
+
+### 3.3 Natürlicher Fokusverlust
+
+Wenn der Fokus die Zeile ohne expliziten Tastendruck verlässt, feuert MUI den
+`rowFocusOut`-Grund in `onRowEditStop`. `handleRowEditStop` lässt diesen Grund
+ungehindert durch → MUI ruft `processRowUpdate` auf (Autosave on Blur).
+
+---
+
+## 4. `rowModesModel` — Lebenszyklus
+
+```
+{}
+ ↓ addRow / click / Enter / keyboard-navigate-into
+{ [rowId]: { mode: Edit, fieldToFocus?: string } }
+ ↓ Enter-Save / Save-Button / navigate-away
+{ [rowId]: { mode: View } }                        → processRowUpdate
+ ↓ Escape
+{ [rowId]: { mode: View, ignoreModifications: true } }  → kein processRowUpdate
+```
+
+**Schreiborte:**
+
+| Funktion | Auswirkung |
+|---|---|
+| `handleAddClick` | setzt Edit + fieldToFocus |
+| `handleEditableCellClick` | setzt Edit + fieldToFocus |
+| `handleStartCellEditFromKeyboard` | setzt Edit + fieldToFocus |
+| `focusKeyboardNavigableCell` | setzt Edit + fieldToFocus (bei `startEdit: true`) |
+| `navigateFromEditedCell` | setzt View für aktuelle Zeile |
+| `handleSaveRow` / `handleSaveAllDirtyRows` | setzt View |
+| `handleDiscardRowChanges` | setzt View + ignoreModifications |
+| `setDraftValues` (commandApi) | stellt Edit sicher (damit Werte nicht verworfen werden) |
+| `onRowModesModelChange={setRowModesModel}` | MUI kann das Modell extern überschreiben |
+
+Das Modell wird als React-State gehalten (`useState`, DataGrid.tsx:223) und ist
+vollständig im `EditableDataGrid`-Wrapper gekapselt. `PlantingPlans.tsx` greift
+nicht direkt auf `rowModesModel` zu, sondern ausschließlich über die
+`commandApiRef`-Schnittstelle.
+
+---
+
+## 5. `setCellFocus` — Flow
+
+`api.setCellFocus(rowId, field)` ist ein MUI DataGrid API-Aufruf, der:
+
+1. den internen Fokuszustand (`gridApiRef.current.state.focus.cell`) setzt,
+2. das DOM-Element der Zelle fokussiert,
+3. ggf. scrollt (DataGrid.tsx:360-363 scrollt vorher explizit via
+   `api.scrollToIndexes`).
+
+`setCellFocus` wird aus zwei Stellen aufgerufen:
+
+| Funktion | Bedingung |
+|---|---|
+| `focusKeyboardNavigableCell` (DataGrid.tsx:363) | Keyboard-Navigation zu einer Zielzelle |
+| `handleStartCellEditFromKeyboard` (DataGrid.tsx:800) | Enter auf View-Zeile |
+
+**Verhältnis zu Edit-Modus:** `setCellFocus` allein startet den Edit-Modus
+*nicht*. Der Edit-Modus wird immer durch ein separates `setRowModesModel(...Edit)`
+gestartet, das direkt nach `setCellFocus` aufgerufen wird.
+
+**Fokus in Custom Renderers:** Edit-Zellen wie `AreaM2EditCell`,
+`SearchableSelectEditCell`, `PlantsCountEditCell` prüfen `params.hasFocus` und
+rufen bei `true` ihre innere Input-Referenz via `useEffect` auf. Das stellt
+sicher, dass der DOM-Fokus innerhalb der Zelle landet, sobald MUI `hasFocus`
+auf `true` setzt (was nach dem `setCellFocus`-Aufruf und dem nächsten Render
+passiert).
+
+---
+
+## 6. Verhalten Enter
+
+Enter ist dreifach belegt (geprüft in der Reihenfolge unten):
+
+### 6.1 Notes-Spalte
+
+```
+Bedingung: notesFieldNames.includes(field) && key === 'Enter'
+→ event.preventDefault() + defaultMuiPrevented = true
+→ notesEditor.handleOpen(id, field)   // öffnet Notes-Drawer
+```
+
+### 6.2 Editierbare Zelle, Zeile im View-Modus
+
+```
+Bedingung: key === 'Enter' && isEditable && mode !== Edit
+→ event.preventDefault() + defaultMuiPrevented = true
+→ handleStartCellEditFromKeyboard(params)
+     → api.setCellFocus(id, field)
+     → setRowModesModel(Edit + fieldToFocus)
+```
+
+### 6.3 Zelle, Zeile im Edit-Modus
+
+```
+Bedingung: key === 'Enter' && mode === Edit
+→ event.preventDefault() + defaultMuiPrevented = true
+→ handleSaveRow(id)
+     → shouldSaveRow → onBeforeSaveRow → (ggf. applyDraftValues)
+     → setRowModesModel(View)
+     → MUI: processRowUpdate → API-Aufruf
+```
+
+MUI's Standard-Enter-Verhalten (Zeile speichern) wird in allen drei Fällen via
+`defaultMuiPrevented = true` unterdrückt.
+
+---
+
+## 7. Verhalten Pfeiltasten
+
+### 7.1 Gemeinsame Eingangsbedingung
+
+Der Capture-Handler `handleGridEditNavigation` (DataGrid.tsx:678) wird über
+`onKeyDownCapture` ausgelöst — d.h. **bevor** jeder innere Handler eine Chance
+bekommt. Er greift ein, wenn:
+
+- Die Taste in `gridNavigationKeys` ist (`Tab`, `ArrowLeft`, `ArrowRight`,
+  `ArrowUp`, `ArrowDown`),
+- kein Alt/Ctrl/Meta/Composing,
+- die fokussierte Zelle **im Edit-Modus** ist,
+- für ArrowUp/ArrowDown: kein aufgeklapptes Dropdown offen ist
+  (`isDropdownUsingArrowKey`, DataGrid.tsx:174).
+
+Wenn diese Bedingungen nicht alle zutreffen, passiert nichts — der Event
+propagiert normal durch MUI.
+
+### 7.2 ArrowRight / ArrowLeft
+
+```
+Ziel:   getHorizontalNavigationTarget(rowId, field, ±1)
+         → liefert { id: rowId, field: nächstesEditierbaresField }
+         → gibt null zurück, wenn kein weiteres Feld in der Richtung existiert
+
+Wenn Ziel vorhanden:
+  event.preventDefault() + stopPropagation()
+  navigateFromEditedCell(current, target, { startTargetEdit: true })
+    → canLeaveEditedRowForKeyboardNavigation(current.id)
+    → blurActiveElementInCell(current)
+    → setRowModesModel({ [current.id]: View })          ← Zeile verlässt Edit
+    → requestAnimationFrame():
+         focusKeyboardNavigableCell(target.id, target.field, { startEdit: true })
+           → api.setCellFocus(target)
+           → setRowModesModel({ [target.id]: Edit })    ← Zeile tritt wieder in Edit
+```
+
+**Wenn Ziel nicht vorhanden** (erstes/letztes Feld): `null` wird zurückgegeben,
+`preventDefault` wird nicht aufgerufen, MUI erhält das Event unverändert.
+
+### 7.3 ArrowUp / ArrowDown
+
+```
+Ziel:   getVerticalNavigationTarget(rowId, field, ±1)
+         → andere Zeile, selbes Feld (oder Fallback-Feld)
+         → gibt null zurück, wenn keine weitere Zeile vorhanden
+
+Wenn Ziel vorhanden:
+  event.preventDefault() + stopPropagation()
+  navigateFromEditedCell(current, target, { startTargetEdit: false })
+    → (gleicher Pfad wie horizontal)
+    → ABER startTargetEdit: false
+    → focusKeyboardNavigableCell(target, { startEdit: false })
+         → api.setCellFocus(target)
+         → KEIN setRowModesModel → Zielzeile startet NICHT im Edit-Modus
+```
+
+ArrowUp/ArrowDown verlassen die aktuelle Zeile (Save), fokussieren die nächste,
+starten die nächste Zeile aber **nicht automatisch** im Edit-Modus. Ein
+weiterer Klick oder Enter ist nötig, um die Zielzeile zu editieren.
+
+### 7.4 Übersicht
+
+| Taste | Richtung | Ziel | startTargetEdit |
+|---|---|---|---|
+| ArrowLeft | horizontal −1 | gleiche Zeile, voriges Feld | **true** |
+| ArrowRight | horizontal +1 | gleiche Zeile, nächstes Feld | **true** |
+| ArrowUp | vertikal −1 | vorige Zeile, gleiches Feld | **false** |
+| ArrowDown | vertikal +1 | nächste Zeile, gleiches Feld | **false** |
+| Tab | horizontal +1 | gleiche Zeile, nächstes Feld | **true** |
+| Shift+Tab | horizontal −1 | gleiche Zeile, voriges Feld | **true** |
+
+---
+
+## 8. Unterschiede Zeilen-/Zellmodus
+
+Diese Anwendung nutzt ausschließlich `editMode="row"`. Der MUI
+cell-editing-Modus ist nicht aktiviert und wird nirgendwo verwendet.
+
+Konsequenzen aus dem Row-Modus:
+
+| Aspekt | Row-Modus (aktiv) | Cell-Modus (nicht verwendet) |
+|---|---|---|
+| Edit-Zustandsträger | `rowModesModel` | `cellModesModel` |
+| Granularität | gesamte Zeile tritt in/aus Edit | einzelne Zelle |
+| `processRowUpdate` | feuert beim Verlassen der gesamten Zeile | feuert beim Verlassen der einzelnen Zelle |
+| Mehrere Felder gleichzeitig editierbar | ja, alle Felder der Zeile | nein, nur ein Feld |
+| `fieldToFocus` | kann angegeben werden, um initiales Fokusfeld zu steuern | nicht relevant |
+
+Da alle Felder einer Zeile gleichzeitig im Edit-Modus sind, ist der Fokussprung
+zwischen ArrowLeft/ArrowRight innerhalb einer Zeile ein reiner Fokus-Wechsel —
+**der Edit-Modus der Zeile muss dabei technisch nicht beendet werden**. Die
+aktuelle Implementierung tut dies trotzdem (Details in Abschnitt 9).
+
+---
+
+## 9. Ursache: Warum ArrowLeft/ArrowRight den Edit-Modus verliert
+
+### 9.1 Beobachtung
+
+Beim Navigieren von Feld A nach Feld B innerhalb derselben Zeile mit ArrowLeft
+oder ArrowRight durchläuft die Zeile folgende Zustandssequenz:
+
+```
+[Zeile im Edit-Modus, Feld A fokussiert]
+  ↓ ArrowRight
+setRowModesModel({ [rowId]: View })         → Zeile verlässt Edit
+  ↓ (synchron, gleicher React-Render-Zyklus)
+MUI: rowFocusOut → processRowUpdate         → API-Aufruf wird ausgelöst
+  ↓ requestAnimationFrame (nächster Frame)
+setRowModesModel({ [rowId]: Edit, fieldToFocus: B })  → Zeile tritt wieder in Edit
+```
+
+### 9.2 Ursache im Code
+
+`navigateFromEditedCell` (DataGrid.tsx:645) wurde als **allgemeiner**
+Navigationsmechanismus entworfen, der immer folgende Schritte ausführt:
+
+1. Validation / `onBeforeSaveRow` prüfen
+2. Aktuelle Zeile auf `View` setzen (=Speichern auslösen)
+3. Per `requestAnimationFrame` zur Zielzelle wechseln
+
+Dieser Ablauf ist korrekt für **zeilenübergreifende Navigation** (ArrowUp/Down,
+Tab bis Ende der Zeile). Für **zellinterne Navigation** (ArrowLeft/Right
+innerhalb einer Zeile) ist der Umweg über `View` jedoch unnötig, weil die Zeile
+im Edit-Modus bleibt und kein Speichern erforderlich wäre.
+
+Da `navigateFromEditedCell` ohne Fallunterscheidung (gleiche vs. andere Zeile)
+aufgerufen wird, tritt derselbe Save-Zyklus auch für Intrazeilen-Navigation auf:
+
+```js
+// DataGrid.tsx:714 — kein Unterschied ob gleiche oder andere Zeile
+void navigateFromEditedCell(focusedCell, target, {
+  startTargetEdit: isHorizontalNavigation && !notesFieldNames.includes(target.field),
+});
+```
+
+### 9.3 Konkrete Nebeneffekte
+
+| Nebeneffekt | Beschreibung |
+|---|---|
+| Unnötiger API-Aufruf | Jedes ArrowLeft/ArrowRight innerhalb einer Zeile löst `processRowUpdate` und damit `api.update(...)` aus — auch wenn der Nutzer noch weiter editieren wollte. |
+| Kurzzeitiges View-State | Zwischen View und dem nächsten Edit-Eintritt über `requestAnimationFrame` befindet sich die Zeile einen Frame lang im View-Modus; React re-rendert die Zeile ohne Edit-Input. |
+| Race Condition bei Validierung | Wenn `canLeaveEditedRowForKeyboardNavigation` (wegen `onBeforeSaveRow`) `false` zurückgibt (z.B. Flächenvalidierungsdialog öffnet sich), wird die Navigation abgebrochen. Der Cursor bleibt auf Feld A, obwohl der Nutzer nur zu Feld B wollte. |
+| rAF-Timing | `setRowModesModel(View)` ist synchron; das erneute `setRowModesModel(Edit)` liegt im nächsten Animationsframe. Wenn zwischen diesen beiden Frames ein externer State-Update eintrifft (z.B. aus dem async `processRowUpdate`-Promise), kann die zweite `setRowModesModel`-Änderung überschrieben werden. |
+
+### 9.4 Warum ArrowUp/ArrowDown dieses Problem *nicht* in gleicher Weise zeigt
+
+Bei vertikaler Navigation ist `startTargetEdit: false`, d.h. die Zielzeile tritt
+nach dem Speichern der aktuellen Zeile **nicht automatisch** in den Edit-Modus.
+Der Nutzer bemerkt daher nur das Speichern der alten Zeile — dieses Verhalten
+ist gewollt (Autosave on Navigate).
+
+Bei horizontaler Navigation hingegen erwartet der Nutzer, weiterhin in der
+gleichen Zeile zu editieren. Der `View → Edit`-Übergang ist für ihn unsichtbar,
+solange kein Validierungsfehler oder API-Fehler eintritt.
+
+---
+
+## 10. Zusammenfassung Speicherfluss
+
+```
+[Auslöser: Enter / Save-Button / Keyboard-Navigate-Away / Blur]
+  ↓
+shouldSaveRow(rowId)
+  ↓
+onBeforeSaveRow(draftRow)           [optional, z.B. Flächenvalidierung]
+  ├─ false   → Abbruch, ggf. Dialog
+  ├─ Partial → applyDraftValues → Draft-Werte korrigieren
+  └─ true    → weiter
+  ↓
+setRowModesModel({ [rowId]: View })
+  ↓
+MUI: processRowUpdate(newRow)
+  ├─ validateRow(newRow)            [Pflichtfelder]
+  ├─ mapToApiData(row)
+  ├─ api.create / api.update
+  ├─ mapToRow(response)
+  └─ setRows(...)
+
+[Abbruch via Escape]
+  ↓
+handleDiscardRowChanges(rowId)
+  ├─ Snapshot wiederherstellen
+  ├─ dirtyRowIds / validationErrors bereinigen
+  └─ setRowModesModel({ mode: View, ignoreModifications: true })
+     → kein processRowUpdate, kein API-Aufruf
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gemüse-Anbauplaner für CSA, Solawi und Marktgärtnerei | OpenFarmPlanner</title>
+    <title>OpenFarmPlanner</title>
     <meta name="description" content="OpenFarmPlanner ist ein Open-Source Gemüse-Anbauplaner für CSA, Solawi und kleinteiligen Gemüsebau. Plane Kulturen, Beete, Anbauflächen und Saattermine einfach online." />
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -300,6 +300,10 @@ function RootLayout(): React.ReactElement {
     () => i18n.getFixedT(i18n.resolvedLanguage ?? i18n.language ?? 'de', 'cultures'),
     [i18n],
   );
+  const tCommon = useMemo(
+    () => i18n.getFixedT(i18n.resolvedLanguage ?? i18n.language ?? 'de', 'common'),
+    [i18n],
+  );
   const navigate = useNavigate();
   const location = useLocation();
   const currentPathnameRef = React.useRef(location.pathname);
@@ -751,6 +755,13 @@ function RootLayout(): React.ReactElement {
     }
     return activeItem?.label ?? '';
   }, [location.pathname, navItems, t]);
+  useEffect(() => {
+    const appName = tCommon('appName');
+    document.title = currentPageTitle ? `${currentPageTitle} – ${appName}` : appName;
+    return () => {
+      document.title = appName;
+    };
+  }, [currentPageTitle, tCommon]);
   const topbarHelpConfig = useMemo(() => {
     if (location.pathname.startsWith('/app/dashboard')) return { pageKey: 'dashboard' as const, label: 'Hilfe zu Übersicht' };
     if (location.pathname.startsWith('/app/locations')) return { pageKey: 'locations' as const, label: 'Hilfe zu Standorte' };

--- a/frontend/src/__tests__/CompactAreaCell.test.tsx
+++ b/frontend/src/__tests__/CompactAreaCell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CompactAreaCell, shouldShowAreaTooltip } from '../components/planting-plans/CompactAreaCell';
 
@@ -15,16 +15,22 @@ describe('CompactAreaCell', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent(label);
   });
 
-  it('is keyboard focusable with full accessible text for long values', async () => {
-    const user = userEvent.setup();
+  it('is keyboard focusable with full accessible text when the grid cell has focus', async () => {
+    const label = 'Regenbogenland · 8 Karotte + Zwiebel · Beet 5 (10,00 m²)';
+
+    render(<CompactAreaCell label={label} hasFocus />);
+
+    const focusTarget = screen.getByLabelText(label);
+    expect(focusTarget).toHaveAttribute('tabindex', '0');
+    await waitFor(() => expect(focusTarget).toHaveFocus());
+  });
+
+  it('stays out of the tab order when the grid cell does not have focus', () => {
     const label = 'Regenbogenland · 8 Karotte + Zwiebel · Beet 5 (10,00 m²)';
 
     render(<CompactAreaCell label={label} />);
 
-    await user.tab();
-
-    const focusTarget = screen.getByLabelText(label);
-    expect(focusTarget).toHaveFocus();
+    expect(screen.getByLabelText(label)).toHaveAttribute('tabindex', '-1');
   });
 
   it('keeps short values compact without tooltip interaction', async () => {

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -31,6 +31,12 @@ vi.mock('@mui/x-data-grid', async () => {
     tabKeyDown: 'tabKeyDown',
     escapeKeyDown: 'escapeKeyDown',
   };
+  const getMockFilterOperators = () => [
+    {
+      value: 'contains',
+      getApplyFilterFn: () => () => true,
+    },
+  ];
 
   const DataGrid = ({
     rows,
@@ -106,7 +112,17 @@ vi.mock('@mui/x-data-grid', async () => {
     );
   };
 
-  return { DataGrid, GridRowModes, GridRowEditStopReasons, useGridApiRef };
+  return {
+    DataGrid,
+    GridRowModes,
+    GridRowEditStopReasons,
+    getGridBooleanOperators: getMockFilterOperators,
+    getGridDateOperators: getMockFilterOperators,
+    getGridNumericOperators: getMockFilterOperators,
+    getGridSingleSelectOperators: getMockFilterOperators,
+    getGridStringOperators: getMockFilterOperators,
+    useGridApiRef,
+  };
 });
 
 describe('EditableDataGrid', () => {
@@ -301,8 +317,3 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(updateSpy).toHaveBeenCalled());
   });
 });
-  const useGridApiRef = () => ({
-    current: {
-      setEditCellValue: vi.fn().mockResolvedValue(undefined),
-    },
-  });

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -62,14 +62,24 @@ vi.mock("../components/data-grid", async () => {
         };
       }
       return (
-        <button
-          type="button"
-          onClick={() => {
-            onBeforeSaveRow?.(mockGridRowState.row);
-          }}
-        >
-          Zeile speichern
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              onBeforeSaveRow?.(mockGridRowState.row);
+            }}
+          >
+            Zeile speichern
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onBeforeSaveRow?.(mockGridRowState.row);
+            }}
+          >
+            Speichern mit Enter
+          </button>
+        </>
       );
     },
   };
@@ -125,6 +135,16 @@ describe("PlantingPlans save-time area validation", () => {
     expect(screen.getByRole("button", { name: "Beetfläche übernehmen" })).toBeInTheDocument();
   });
 
+  it("shows bed-limit dialog when saving via Enter flow", async () => {
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die Größe dieses Beets.")).toBeInTheDocument();
+  });
+
   it("applies bed area when clicking 'Beetfläche übernehmen'", async () => {
     mockGridRowState.row = {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
@@ -157,6 +177,38 @@ describe("PlantingPlans save-time area validation", () => {
     expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
     expect(screen.getByText("Verfügbare Restfläche: 3,00 m²")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restfläche übernehmen" })).toBeInTheDocument();
+  });
+
+  it("shows remaining-area dialog when saving via Enter flow", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet A", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [{
+          id: 9, bed: 101, culture: 2, planting_date: "2026-04-01", harvest_date: "2026-05-01", area_usage_sqm: 4,
+        }],
+      },
+    });
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "5",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
+  });
+
+  it("shows identical dialog details for click-save and enter-save", async () => {
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
+    };
+    const { unmount } = render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+    expect(await screen.findByText("Übernommen wird: 1,00 m²")).toBeInTheDocument();
+    unmount();
+
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
+    expect(await screen.findByText("Übernommen wird: 1,00 m²")).toBeInTheDocument();
   });
 
   it("applies available area and shows snackbar for empty or max input", async () => {

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -19,6 +19,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const commandApiSpies = vi.hoisted(() => ({
   setDraftValues: vi.fn(),
+  saveAttemptResult: vi.fn(),
 }));
 
 vi.mock("../hooks/useProjectRequirement", () => ({
@@ -44,13 +45,21 @@ vi.mock("../hooks/useNavigationBlocker", () => ({
 }));
 
 vi.mock("../components/data-grid", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
   const actual = await vi.importActual<typeof import("../components/data-grid")>("../components/data-grid");
+  type MockGridProps = {
+    api?: {
+      list?: () => Promise<{ data: { results: Record<string, unknown>[] } }>;
+    };
+    mapToRow?: (row: Record<string, unknown>) => Record<string, unknown>;
+    onRowsStateChange?: (rows: Record<string, unknown>[]) => void;
+    onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean }) => void;
+    onBeforeSaveRow?: (row: Record<string, unknown>) => boolean;
+    commandApiRef?: { current: EditableDataGridCommandApi | null };
+  };
   return {
     ...actual,
-    EditableDataGrid: ({ onBeforeSaveRow, commandApiRef }: {
-      onBeforeSaveRow?: (row: Record<string, unknown>) => boolean;
-      commandApiRef?: { current: EditableDataGridCommandApi | null };
-    }) => {
+    EditableDataGrid: ({ api, mapToRow, onRowsStateChange, onLoadStateChange, onBeforeSaveRow, commandApiRef }: MockGridProps) => {
       if (commandApiRef) {
         commandApiRef.current = {
           addRow: vi.fn(),
@@ -61,12 +70,30 @@ vi.mock("../components/data-grid", async () => {
           setDraftValues: commandApiSpies.setDraftValues,
         };
       }
+      const latestPropsRef = React.useRef({ api, mapToRow, onRowsStateChange, onLoadStateChange });
+      latestPropsRef.current = { api, mapToRow, onRowsStateChange, onLoadStateChange };
+      React.useEffect(() => {
+        let isMounted = true;
+        const { api: currentApi, mapToRow: currentMapToRow, onRowsStateChange: currentOnRowsStateChange, onLoadStateChange: currentOnLoadStateChange } = latestPropsRef.current;
+        currentOnLoadStateChange?.({ loading: true, dataFetched: false });
+        void currentApi?.list?.().then((response) => {
+          if (!isMounted) {
+            return;
+          }
+          const rows = response.data.results.map((row) => currentMapToRow?.(row) ?? row);
+          currentOnRowsStateChange?.(rows);
+          currentOnLoadStateChange?.({ loading: false, dataFetched: true });
+        });
+        return () => {
+          isMounted = false;
+        };
+      }, []);
       return (
         <>
           <button
             type="button"
             onClick={() => {
-              onBeforeSaveRow?.(mockGridRowState.row);
+              commandApiSpies.saveAttemptResult(onBeforeSaveRow?.(mockGridRowState.row) ?? true);
             }}
           >
             Zeile speichern
@@ -74,7 +101,7 @@ vi.mock("../components/data-grid", async () => {
           <button
             type="button"
             onClick={() => {
-              onBeforeSaveRow?.(mockGridRowState.row);
+              commandApiSpies.saveAttemptResult(onBeforeSaveRow?.(mockGridRowState.row) ?? true);
             }}
           >
             Speichern mit Enter
@@ -84,6 +111,15 @@ vi.mock("../components/data-grid", async () => {
     },
   };
 });
+
+const areaText = (label: string, value: string): RegExp =>
+  new RegExp(`${label}:\\s*${value}\\s*m²`);
+
+const waitForPlansToLoad = async (callCount = 1): Promise<void> => {
+  await waitFor(() => {
+    expect(apiMocks.planList).toHaveBeenCalledTimes(callCount);
+  });
+};
 
 vi.mock("../api/api", async () => {
   const actual = await vi.importActual<typeof import("../api/api")>("../api/api");
@@ -127,11 +163,12 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
 
     expect(await screen.findByText("Die angegebene Fläche überschreitet die Größe dieses Beets.")).toBeInTheDocument();
-    expect(screen.getByText("Beetfläche: 1,00 m²")).toBeInTheDocument();
-    expect(screen.getByText("Angefragt: 99,00 m²")).toBeInTheDocument();
+    expect(screen.getByText(areaText("Beetfläche", "1,00"))).toBeInTheDocument();
+    expect(screen.getByText(areaText("Angefragt", "99,00"))).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Beetfläche übernehmen" })).toBeInTheDocument();
   });
 
@@ -140,6 +177,7 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
 
     expect(await screen.findByText("Die angegebene Fläche überschreitet die Größe dieses Beets.")).toBeInTheDocument();
@@ -150,6 +188,7 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
     await userEvent.click(await screen.findByRole("button", { name: "Beetfläche übernehmen" }));
 
@@ -172,10 +211,11 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "5",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
 
     expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
-    expect(screen.getByText("Verfügbare Restfläche: 3,00 m²")).toBeInTheDocument();
+    expect(screen.getByText(areaText("Verfügbare Restfläche", "3,00"))).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restfläche übernehmen" })).toBeInTheDocument();
   });
 
@@ -192,6 +232,7 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "5",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
 
     expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
@@ -202,13 +243,15 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
     };
     const { unmount } = render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
-    expect(await screen.findByText("Übernommen wird: 1,00 m²")).toBeInTheDocument();
+    expect(await screen.findByText(areaText("Übernommen wird", "1,00"))).toBeInTheDocument();
     unmount();
 
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad(2);
     await userEvent.click(await screen.findByRole("button", { name: "Speichern mit Enter" }));
-    expect(await screen.findByText("Übernommen wird: 1,00 m²")).toBeInTheDocument();
+    expect(await screen.findByText(areaText("Übernommen wird", "1,00"))).toBeInTheDocument();
   });
 
   it("applies available area and shows snackbar for empty or max input", async () => {
@@ -224,10 +267,192 @@ describe("PlantingPlans save-time area validation", () => {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "max",
     };
     render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
 
     expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 3, plants_count: 30 }));
     expect(await screen.findByText("Maximal verfügbare Fläche übernommen: 3,00 m²")).toBeInTheDocument();
+    expect(screen.queryByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).not.toBeInTheDocument();
+  });
+
+  it("does not count same-bed rows whose German date ranges do not overlap", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet 1", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 21,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.9.2026",
+            harvest_end_date: "2.2.2027",
+            area_usage_sqm: 7,
+          },
+          {
+            id: 22,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.2.2026",
+            harvest_end_date: "18.9.2026",
+            area_usage_sqm: 1,
+          },
+        ],
+      },
+    });
+    mockGridRowState.row = {
+      id: 22,
+      bed: 101,
+      culture: 2,
+      planting_date: "20.2.2026",
+      harvest_end_date: "18.9.2026",
+      area_m2: "7",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(true);
+    expect(screen.queryByText("Für dieses Beet ist im gewählten Zeitraum keine freie Fläche verfügbar.")).not.toBeInTheDocument();
+  });
+
+  it("counts same-bed rows whose German date ranges overlap", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet 1", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 23,
+            bed: 101,
+            culture: 2,
+            planting_date: "2.2.2026",
+            harvest_end_date: "2.6.2026",
+            area_usage_sqm: 3,
+          },
+          {
+            id: 22,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.2.2026",
+            harvest_end_date: "18.9.2026",
+            area_usage_sqm: 1,
+          },
+        ],
+      },
+    });
+    mockGridRowState.row = {
+      id: 22,
+      bed: 101,
+      culture: 2,
+      planting_date: "20.2.2026",
+      harvest_end_date: "18.9.2026",
+      area_m2: "5",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
+    expect(screen.getByText(areaText("Bereits belegt", "3,00"))).toBeInTheDocument();
+    expect(screen.getByText(areaText("Verfügbare Restfläche", "4,00"))).toBeInTheDocument();
+  });
+
+  it("shows the corrected remaining-area values for the Majoran overlap scenario", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "1", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 21,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.9.2026",
+            harvest_end_date: "2.2.2027",
+            area_usage_sqm: 7,
+          },
+          {
+            id: 23,
+            bed: 101,
+            culture: 2,
+            planting_date: "2.2.2026",
+            harvest_end_date: "2.6.2026",
+            area_usage_sqm: 3,
+          },
+          {
+            id: 22,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.2.2026",
+            harvest_end_date: "18.9.2026",
+            area_usage_sqm: 1,
+          },
+        ],
+      },
+    });
+    mockGridRowState.row = {
+      id: 22,
+      bed: 101,
+      culture: 2,
+      planting_date: "20.2.2026",
+      harvest_end_date: "18.9.2026",
+      area_m2: "5",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
+    expect(screen.getByText(areaText("Beetfläche", "7,00"))).toBeInTheDocument();
+    expect(screen.getByText(areaText("Bereits belegt", "3,00"))).toBeInTheDocument();
+    expect(screen.getByText(areaText("Verfügbare Restfläche", "4,00"))).toBeInTheDocument();
+    expect(screen.getByText(areaText("Übernommen wird", "4,00"))).toBeInTheDocument();
+    expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(false);
+  });
+
+  it("allows saving the Majoran row when the requested area fits the corrected remaining area", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "1", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 21,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.9.2026",
+            harvest_end_date: "2.2.2027",
+            area_usage_sqm: 7,
+          },
+          {
+            id: 23,
+            bed: 101,
+            culture: 2,
+            planting_date: "2.2.2026",
+            harvest_end_date: "2.6.2026",
+            area_usage_sqm: 3,
+          },
+          {
+            id: 22,
+            bed: 101,
+            culture: 2,
+            planting_date: "20.2.2026",
+            harvest_end_date: "18.9.2026",
+            area_usage_sqm: 1,
+          },
+        ],
+      },
+    });
+    mockGridRowState.row = {
+      id: 22,
+      bed: 101,
+      culture: 2,
+      planting_date: "20.2.2026",
+      harvest_end_date: "18.9.2026",
+      area_m2: "4",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(true);
     expect(screen.queryByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PlantingPlans from "../pages/PlantingPlans";
+import type { EditableDataGridCommandApi } from "../components/data-grid";
+
+const mockGridRowState = vi.hoisted(() => ({
+  row: {} as Record<string, unknown>,
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  cultureList: vi.fn(),
+  locationList: vi.fn(),
+  fieldList: vi.fn(),
+  bedList: vi.fn(),
+  planList: vi.fn(),
+}));
+
+const commandApiSpies = vi.hoisted(() => ({
+  setDraftValues: vi.fn(),
+}));
+
+vi.mock("../hooks/useProjectRequirement", () => ({
+  useProjectRequirement: () => ({
+    shouldShowProjectRequiredState: false,
+    missingProjectReason: null,
+  }),
+}));
+
+vi.mock("../commands/useCommandContext", () => ({
+  useCommandContextTag: vi.fn(),
+  useRegisterCommands: vi.fn(),
+  useRegisterCreateActions: vi.fn(),
+}));
+
+vi.mock("../hooks/useNavigationBlocker", () => ({
+  useNavigationBlocker: () => ({
+    isBlocked: false,
+    proceed: vi.fn(),
+    reset: vi.fn(),
+    destination: null,
+  }),
+}));
+
+vi.mock("../components/data-grid", async () => {
+  const actual = await vi.importActual<typeof import("../components/data-grid")>("../components/data-grid");
+  return {
+    ...actual,
+    EditableDataGrid: ({ onBeforeSaveRow, commandApiRef }: {
+      onBeforeSaveRow?: (row: Record<string, unknown>) => boolean;
+      commandApiRef?: { current: EditableDataGridCommandApi | null };
+    }) => {
+      if (commandApiRef) {
+        commandApiRef.current = {
+          addRow: vi.fn(),
+          editSelectedRow: vi.fn(),
+          deleteSelectedRow: vi.fn(),
+          getSelectedRowId: vi.fn(),
+          reload: vi.fn(),
+          setDraftValues: commandApiSpies.setDraftValues,
+        };
+      }
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            onBeforeSaveRow?.(mockGridRowState.row);
+          }}
+        >
+          Zeile speichern
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock("../api/api", async () => {
+  const actual = await vi.importActual<typeof import("../api/api")>("../api/api");
+  return {
+    ...actual,
+    cultureAPI: {
+      ...actual.cultureAPI,
+      list: apiMocks.cultureList,
+    },
+    locationAPI: {
+      ...actual.locationAPI,
+      list: apiMocks.locationList,
+    },
+    fieldAPI: {
+      ...actual.fieldAPI,
+      list: apiMocks.fieldList,
+    },
+    bedAPI: {
+      ...actual.bedAPI,
+      list: apiMocks.bedList,
+    },
+    plantingPlanAPI: {
+      ...actual.plantingPlanAPI,
+      list: apiMocks.planList,
+    },
+  };
+});
+
+describe("PlantingPlans save-time area validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.cultureList.mockResolvedValue({ data: { results: [{ id: 2, name: "Möhre", plants_per_m2: 10 }] } });
+    apiMocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: "Hof" }] } });
+    apiMocks.fieldList.mockResolvedValue({ data: { results: [{ id: 11, name: "Parzelle 1", location: 1 }] } });
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet A", field: 11, area_sqm: 1 }] } });
+    apiMocks.planList.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it("shows bed-limit dialog when requested area exceeds bed area", async () => {
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die Größe dieses Beets.")).toBeInTheDocument();
+    expect(screen.getByText("Beetfläche: 1,00 m²")).toBeInTheDocument();
+    expect(screen.getByText("Angefragt: 99,00 m²")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Beetfläche übernehmen" })).toBeInTheDocument();
+  });
+
+  it("applies bed area when clicking 'Beetfläche übernehmen'", async () => {
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99,00",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Beetfläche übernehmen" }));
+
+    expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 1, plants_count: 10 }));
+    await waitFor(() => {
+      expect(screen.queryByText("Die angegebene Fläche überschreitet die Größe dieses Beets.")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows remaining-area dialog when request exceeds available area", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet A", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [{
+          id: 9, bed: 101, culture: 2, planting_date: "2026-04-01", harvest_date: "2026-05-01", area_usage_sqm: 4,
+        }],
+      },
+    });
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "5",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(await screen.findByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).toBeInTheDocument();
+    expect(screen.getByText("Verfügbare Restfläche: 3,00 m²")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restfläche übernehmen" })).toBeInTheDocument();
+  });
+
+  it("applies available area and shows snackbar for empty or max input", async () => {
+    apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet A", field: 11, area_sqm: 7 }] } });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [{
+          id: 9, bed: 101, culture: 2, planting_date: "2026-04-01", harvest_date: "2026-05-01", area_usage_sqm: 4,
+        }],
+      },
+    });
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "max",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 3, plants_count: 30 }));
+    expect(await screen.findByText("Maximal verfügbare Fläche übernommen: 3,00 m²")).toBeInTheDocument();
+    expect(screen.queryByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -54,7 +54,7 @@ vi.mock("../components/data-grid", async () => {
     mapToRow?: (row: Record<string, unknown>) => Record<string, unknown>;
     onRowsStateChange?: (rows: Record<string, unknown>[]) => void;
     onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean }) => void;
-    onBeforeSaveRow?: (row: Record<string, unknown>) => boolean;
+    onBeforeSaveRow?: (row: Record<string, unknown>) => boolean | Record<string, unknown>;
     commandApiRef?: { current: EditableDataGridCommandApi | null };
   };
   return {
@@ -88,21 +88,26 @@ vi.mock("../components/data-grid", async () => {
           isMounted = false;
         };
       }, []);
+      const handleSaveAttempt = (): void => {
+        const result = onBeforeSaveRow?.(mockGridRowState.row) ?? true;
+        if (result !== true && result !== false) {
+          commandApiSpies.setDraftValues(mockGridRowState.row.id, result);
+          commandApiSpies.saveAttemptResult(true);
+          return;
+        }
+        commandApiSpies.saveAttemptResult(result);
+      };
       return (
         <>
           <button
             type="button"
-            onClick={() => {
-              commandApiSpies.saveAttemptResult(onBeforeSaveRow?.(mockGridRowState.row) ?? true);
-            }}
+            onClick={handleSaveAttempt}
           >
             Zeile speichern
           </button>
           <button
             type="button"
-            onClick={() => {
-              commandApiSpies.saveAttemptResult(onBeforeSaveRow?.(mockGridRowState.row) ?? true);
-            }}
+            onClick={handleSaveAttempt}
           >
             Speichern mit Enter
           </button>
@@ -119,6 +124,24 @@ const waitForPlansToLoad = async (callCount = 1): Promise<void> => {
   await waitFor(() => {
     expect(apiMocks.planList).toHaveBeenCalledTimes(callCount);
   });
+};
+
+const mockRemainingAreaScenario = (): void => {
+  apiMocks.bedList.mockResolvedValue({ data: { results: [{ id: 101, name: "Beet A", field: 11, area_sqm: 7 }] } });
+  apiMocks.planList.mockResolvedValue({
+    data: {
+      results: [{
+        id: 9, bed: 101, culture: 2, planting_date: "2026-04-01", harvest_date: "2026-05-01", area_usage_sqm: 3,
+      }],
+    },
+  });
+};
+
+const expectMaxAreaApplied = async (): Promise<void> => {
+  expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(true);
+  expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 4, plants_count: 40 }));
+  expect(screen.queryByText("Der Wert muss größer als 0 sein.")).not.toBeInTheDocument();
+  expect(await screen.findByText(areaText("Maximal verfügbare Fläche übernommen", "4,00"))).toBeInTheDocument();
 };
 
 vi.mock("../api/api", async () => {
@@ -273,6 +296,42 @@ describe("PlantingPlans save-time area validation", () => {
     expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 3, plants_count: 30 }));
     expect(await screen.findByText("Maximal verfügbare Fläche übernommen: 3,00 m²")).toBeInTheDocument();
     expect(screen.queryByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).not.toBeInTheDocument();
+  });
+
+  it("applies the remaining area for max input without positive-number validation", async () => {
+    mockRemainingAreaScenario();
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "max",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    await expectMaxAreaApplied();
+  });
+
+  it("applies the remaining area for trimmed uppercase max input", async () => {
+    mockRemainingAreaScenario();
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: " MAX ",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    await expectMaxAreaApplied();
+  });
+
+  it("applies the remaining area for empty area input", async () => {
+    mockRemainingAreaScenario();
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-10", harvest_date: "2026-05-10", area_m2: "",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    await expectMaxAreaApplied();
   });
 
   it("does not count same-bed rows whose German date ranges do not overlap", async () => {

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -20,6 +20,7 @@ const apiMocks = vi.hoisted(() => ({
 const commandApiSpies = vi.hoisted(() => ({
   setDraftValues: vi.fn(),
   saveAttemptResult: vi.fn(),
+  apiPayload: vi.fn(),
 }));
 
 vi.mock("../hooks/useProjectRequirement", () => ({
@@ -52,6 +53,7 @@ vi.mock("../components/data-grid", async () => {
       list?: () => Promise<{ data: { results: Record<string, unknown>[] } }>;
     };
     mapToRow?: (row: Record<string, unknown>) => Record<string, unknown>;
+    mapToApiData?: (row: Record<string, unknown>) => Partial<Record<string, unknown>> | Promise<Partial<Record<string, unknown>>>;
     onRowsStateChange?: (rows: Record<string, unknown>[]) => void;
     onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean }) => void;
     onBeforeSaveRow?: (row: Record<string, unknown>) => boolean | Record<string, unknown>;
@@ -59,7 +61,7 @@ vi.mock("../components/data-grid", async () => {
   };
   return {
     ...actual,
-    EditableDataGrid: ({ api, mapToRow, onRowsStateChange, onLoadStateChange, onBeforeSaveRow, commandApiRef }: MockGridProps) => {
+    EditableDataGrid: ({ api, mapToRow, mapToApiData, onRowsStateChange, onLoadStateChange, onBeforeSaveRow, commandApiRef }: MockGridProps) => {
       if (commandApiRef) {
         commandApiRef.current = {
           addRow: vi.fn(),
@@ -93,9 +95,17 @@ vi.mock("../components/data-grid", async () => {
         if (result !== true && result !== false) {
           commandApiSpies.setDraftValues(mockGridRowState.row.id, result);
           commandApiSpies.saveAttemptResult(true);
+          void Promise.resolve(mapToApiData?.({ ...mockGridRowState.row, ...result })).then((payload) => {
+            commandApiSpies.apiPayload(payload);
+          });
           return;
         }
         commandApiSpies.saveAttemptResult(result);
+        if (result) {
+          void Promise.resolve(mapToApiData?.(mockGridRowState.row)).then((payload) => {
+            commandApiSpies.apiPayload(payload);
+          });
+        }
       };
       return (
         <>
@@ -140,6 +150,9 @@ const mockRemainingAreaScenario = (): void => {
 const expectMaxAreaApplied = async (): Promise<void> => {
   expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(true);
   expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 4, plants_count: 40 }));
+  await waitFor(() => {
+    expect(commandApiSpies.apiPayload).toHaveBeenCalledWith(expect.objectContaining({ area_input_value: 4, area_input_unit: "M2" }));
+  });
   expect(screen.queryByText("Der Wert muss größer als 0 sein.")).not.toBeInTheDocument();
   expect(await screen.findByText(areaText("Maximal verfügbare Fläche übernommen", "4,00"))).toBeInTheDocument();
 };

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -307,7 +307,7 @@ describe("PlantingPlans save-time area validation", () => {
     await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
 
     expect(commandApiSpies.setDraftValues).toHaveBeenCalledWith(1, expect.objectContaining({ area_m2: 3, plants_count: 30 }));
-    expect(await screen.findByText("Maximal verfügbare Fläche übernommen: 3,00 m²")).toBeInTheDocument();
+    expect(await screen.findByText(areaText("Maximal verfügbare Fläche übernommen", "3,00"))).toBeInTheDocument();
     expect(screen.queryByText("Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/data-grid/AreaM2EditCell.tsx
+++ b/frontend/src/components/data-grid/AreaM2EditCell.tsx
@@ -120,6 +120,7 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
         htmlInput: {
           min: 0,
           step: 0.01,
+          tabIndex: hasFocus ? 0 : -1,
         },
       }}
       sx={{

--- a/frontend/src/components/data-grid/AreaM2EditCell.tsx
+++ b/frontend/src/components/data-grid/AreaM2EditCell.tsx
@@ -10,15 +10,49 @@ import { useGridApiContext } from '@mui/x-data-grid';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { formatLocalizedNumber, parseLocalizedNumber } from '../../utils/numberLocalization';
 
-function parseAreaInput(value: string, locale: string, maxKeyword: string): number | null {
+function isMaxAreaKeyword(value: string, maxKeyword: string): boolean {
   const normalized = value.trim().toLowerCase();
+  return [maxKeyword.trim().toLowerCase(), 'maximum'].includes(normalized);
+}
+
+function parseAreaInput(value: string, locale: string, maxKeyword: string): number | string | null {
+  const normalized = value.trim();
   if (normalized === '') {
     return null;
   }
-  if (normalized === maxKeyword.trim().toLowerCase()) {
-    return null;
+  if (isMaxAreaKeyword(normalized, maxKeyword)) {
+    return normalized;
   }
-  return parseLocalizedNumber(value, locale);
+  return parseLocalizedNumber(value, locale) ?? value;
+}
+
+function getInitialInputValue(
+  value: unknown,
+  fallbackValue: number | null | undefined,
+  locale: string,
+): string {
+  if (typeof value === 'string' && value.trim() !== '' && Number.isNaN(Number(value))) {
+    return value;
+  }
+  const normalizedValue =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : null;
+  if (typeof normalizedValue === 'number' && !Number.isNaN(normalizedValue)) {
+    return formatLocalizedNumber(normalizedValue, locale, {
+      useGrouping: false,
+      maximumFractionDigits: 2,
+    });
+  }
+  if (typeof fallbackValue === 'number' && !Number.isNaN(fallbackValue)) {
+    return formatLocalizedNumber(fallbackValue, locale, {
+      useGrouping: false,
+      maximumFractionDigits: 2,
+    });
+  }
+  return '';
 }
 
 
@@ -44,24 +78,8 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
   } = props;
   const apiRef = useGridApiContext();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const normalizedValue =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'string' && value.trim() !== ''
-        ? Number(value)
-        : null;
   const [inputValue, setInputValue] = useState<string>(
-    typeof normalizedValue === 'number' && !Number.isNaN(normalizedValue)
-      ? formatLocalizedNumber(normalizedValue, locale, {
-          useGrouping: false,
-          maximumFractionDigits: 2,
-        })
-      : typeof fallbackValue === 'number' && !Number.isNaN(fallbackValue)
-        ? formatLocalizedNumber(fallbackValue, locale, {
-            useGrouping: false,
-            maximumFractionDigits: 2,
-          })
-        : ''
+    () => getInitialInputValue(value, fallbackValue, locale)
   );
 
 
@@ -72,29 +90,7 @@ export function AreaM2EditCell(props: AreaM2EditCellProps): React.ReactElement {
     }
   }, [hasFocus]);
 
-  useEffect(() => {
-    if (typeof normalizedValue === 'number' && !Number.isNaN(normalizedValue)) {
-      setInputValue(
-        formatLocalizedNumber(normalizedValue, locale, {
-          useGrouping: false,
-          maximumFractionDigits: 2,
-        })
-      );
-      return;
-    }
-    if (typeof fallbackValue === 'number' && !Number.isNaN(fallbackValue)) {
-      setInputValue(
-        formatLocalizedNumber(fallbackValue, locale, {
-          useGrouping: false,
-          maximumFractionDigits: 2,
-        })
-      );
-      return;
-    }
-    setInputValue('');
-  }, [normalizedValue, fallbackValue, locale]);
-
-  const applyValue = async (nextValue: number | null): Promise<void> => {
+  const applyValue = async (nextValue: number | string | null): Promise<void> => {
     onLastEditedFieldChange('area_m2');
     await apiRef.current.setEditCellValue({
       id,

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -279,6 +279,10 @@ export function EditableDataGrid<T extends EditableRow>({
     (mode) => mode.mode === GridRowModes.Edit
   );
   const hasUnsavedChanges = hasRowsInEditMode || dirtyRowIds.size > 0;
+  const notesFieldNames = useMemo(
+    () => notes?.fields.map((fieldConfig) => fieldConfig.field) ?? [],
+    [notes],
+  );
 
   // Check if there's a validation error (indicating incomplete/invalid data)
   const hasValidationError = Boolean(error);
@@ -315,10 +319,14 @@ export function EditableDataGrid<T extends EditableRow>({
     };
   }, [gridApiRef]);
 
-  const getEditableFieldsForRow = useCallback((rowId: GridRowId): string[] => {
+  const getKeyboardNavigableFieldsForRow = useCallback((rowId: GridRowId): string[] => {
     const api = gridApiRef.current;
     return api.getVisibleColumns()
       .filter((column) => {
+        if (notesFieldNames.includes(column.field)) {
+          return true;
+        }
+
         if (!column.editable) {
           return false;
         }
@@ -330,14 +338,14 @@ export function EditableDataGrid<T extends EditableRow>({
         }
       })
       .map((column) => column.field);
-  }, [gridApiRef]);
+  }, [gridApiRef, notesFieldNames]);
 
   const getVisibleSortedRowIds = useCallback((): GridRowId[] => {
     const api = gridApiRef.current;
     return api.getSortedRowIds().filter((rowId) => api.state.visibleRowsLookup[rowId] !== false);
   }, [gridApiRef]);
 
-  const focusEditableCell = useCallback((rowId: GridRowId, field: string): void => {
+  const focusKeyboardNavigableCell = useCallback((rowId: GridRowId, field: string): void => {
     const api = gridApiRef.current;
     const rowKey = String(rowId);
     const row = rowsById.get(rowKey);
@@ -349,11 +357,16 @@ export function EditableDataGrid<T extends EditableRow>({
     const colIndex = api.getColumnIndexRelativeToVisibleColumns(field);
     api.scrollToIndexes({ rowIndex, colIndex });
     api.setCellFocus(rowId, field);
+
+    if (notesFieldNames.includes(field)) {
+      return;
+    }
+
     setRowModesModel((oldModel) => ({
       ...oldModel,
       [rowId]: { mode: GridRowModes.Edit, fieldToFocus: field },
     }));
-  }, [gridApiRef, rowsById]);
+  }, [gridApiRef, notesFieldNames, rowsById]);
 
   const getHorizontalNavigationTarget = useCallback((
     rowId: GridRowId,
@@ -366,7 +379,7 @@ export function EditableDataGrid<T extends EditableRow>({
       return null;
     }
 
-    const editableFields = getEditableFieldsForRow(rowId);
+    const editableFields = getKeyboardNavigableFieldsForRow(rowId);
     const fieldIndex = editableFields.indexOf(field);
     if (fieldIndex === -1) {
       return null;
@@ -382,13 +395,13 @@ export function EditableDataGrid<T extends EditableRow>({
       return null;
     }
 
-    const nextRowEditableFields = getEditableFieldsForRow(nextRowId);
+    const nextRowEditableFields = getKeyboardNavigableFieldsForRow(nextRowId);
     const nextRowField = direction > 0
       ? nextRowEditableFields[0]
       : nextRowEditableFields[nextRowEditableFields.length - 1];
 
     return nextRowField ? { id: nextRowId, field: nextRowField } : null;
-  }, [getEditableFieldsForRow, getVisibleSortedRowIds]);
+  }, [getKeyboardNavigableFieldsForRow, getVisibleSortedRowIds]);
 
   const getVerticalNavigationTarget = useCallback((
     rowId: GridRowId,
@@ -402,16 +415,16 @@ export function EditableDataGrid<T extends EditableRow>({
       return null;
     }
 
-    const nextRowEditableFields = getEditableFieldsForRow(nextRowId);
+    const nextRowEditableFields = getKeyboardNavigableFieldsForRow(nextRowId);
     if (nextRowEditableFields.includes(field)) {
       return { id: nextRowId, field };
     }
 
-    const currentFields = getEditableFieldsForRow(rowId);
+    const currentFields = getKeyboardNavigableFieldsForRow(rowId);
     const currentFieldIndex = currentFields.indexOf(field);
     const fallbackField = nextRowEditableFields[currentFieldIndex] ?? nextRowEditableFields[0];
     return fallbackField ? { id: nextRowId, field: fallbackField } : null;
-  }, [getEditableFieldsForRow, getVisibleSortedRowIds]);
+  }, [getKeyboardNavigableFieldsForRow, getVisibleSortedRowIds]);
 
   const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
     if (
@@ -447,9 +460,9 @@ export function EditableDataGrid<T extends EditableRow>({
 
     event.preventDefault();
     event.stopPropagation();
-    focusEditableCell(target.id, target.field);
+    focusKeyboardNavigableCell(target.id, target.field);
   }, [
-    focusEditableCell,
+    focusKeyboardNavigableCell,
     getFocusedCellFromEvent,
     getHorizontalNavigationTarget,
     getVerticalNavigationTarget,
@@ -960,8 +973,6 @@ export function EditableDataGrid<T extends EditableRow>({
       return columns.map((col) => keepDraftRowsVisibleForColumnFilters(col));
     }
 
-    const notesFieldNames = notes.fields.map((f) => f.field);
-
     return columns.map((col) => {
       if (!notesFieldNames.includes(col.field)) {
         return keepDraftRowsVisibleForColumnFilters(col);
@@ -996,12 +1007,13 @@ export function EditableDataGrid<T extends EditableRow>({
                 event.stopPropagation();
                 notesEditor.handleOpen(params.id, col.field, { focusAttachments: true });
               }}
+              hasFocus={params.hasFocus}
             />
           );
         },
       });
     });
-  }, [columns, notes, notesEditor]);
+  }, [columns, notes, notesEditor, notesFieldNames]);
 
   const columnsWithActions: GridColDef[] = [
     ...processedColumns,
@@ -1218,6 +1230,20 @@ export function EditableDataGrid<T extends EditableRow>({
             handleEditableCellClick(params, rowModesModel, setRowModesModel);
           }}
           onCellKeyDown={(params: GridCellParams<T>, event) => {
+            const shouldOpenNotes =
+              notesFieldNames.includes(params.field) &&
+              (event.key === 'Enter' || event.key === ' ') &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey;
+
+            if (shouldOpenNotes) {
+              event.preventDefault();
+              event.defaultMuiPrevented = true;
+              notesEditor.handleOpen(params.id, params.field);
+              return;
+            }
+
             const shouldStartCellEdit =
               event.key === 'Enter' &&
               !event.ctrlKey &&

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -18,10 +18,19 @@
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo, type MutableRefObject } from 'react';
-import { DataGrid, GridRowModes, useGridApiRef } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridRowModes,
+  getGridBooleanOperators,
+  getGridDateOperators,
+  getGridNumericOperators,
+  getGridSingleSelectOperators,
+  getGridStringOperators,
+  useGridApiRef,
+} from '@mui/x-data-grid';
 import { dataGridSx, dataGridFooterSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
-import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridCellParams, GridRowParams } from '@mui/x-data-grid';
+import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridCellParams, GridRowParams, GridFilterOperator } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
@@ -40,6 +49,7 @@ import { germanDataGridLocaleText } from './localeText';
 export interface EditableRow {
   id: number;
   isNew?: boolean;
+  __draft?: boolean;
   [key: string]: unknown;
 }
 
@@ -106,6 +116,58 @@ export interface EditableDataGridProps<T extends EditableRow> {
    */
   surfaceSizing?: 'contentFit' | 'fullWorkspace' | 'compact';
 }
+
+const isUnsavedDraftRow = (row: EditableRow): boolean =>
+  Boolean(row.isNew || row.__draft || Number(row.id) < 0);
+
+const getDefaultFilterOperators = (column: GridColDef): GridFilterOperator[] => {
+  switch (column.type) {
+    case 'boolean':
+      return getGridBooleanOperators();
+    case 'date':
+      return getGridDateOperators();
+    case 'dateTime':
+      return getGridDateOperators(true);
+    case 'number':
+      return getGridNumericOperators();
+    case 'singleSelect':
+      return getGridSingleSelectOperators();
+    default:
+      return getGridStringOperators();
+  }
+};
+
+const keepDraftRowsVisibleForFilterOperators = (operators: GridFilterOperator[]): GridFilterOperator[] =>
+  operators.map((operator) => ({
+    ...operator,
+    getApplyFilterFn: (filterItem, column) => {
+      const applyFilter = operator.getApplyFilterFn(filterItem, column);
+      if (!applyFilter) {
+        return null;
+      }
+
+      return (value, row, filterColumn, apiRef) => {
+        if (isUnsavedDraftRow(row as EditableRow)) {
+          return true;
+        }
+
+        return applyFilter(value, row, filterColumn, apiRef);
+      };
+    },
+  }));
+
+const keepDraftRowsVisibleForColumnFilters = (column: GridColDef): GridColDef => {
+  if (column.filterable === false) {
+    return column;
+  }
+
+  return {
+    ...column,
+    filterOperators: keepDraftRowsVisibleForFilterOperators(
+      column.filterOperators ?? getDefaultFilterOperators(column),
+    ),
+  };
+};
 
 export function EditableDataGrid<T extends EditableRow>({
   columns,
@@ -713,19 +775,19 @@ export function EditableDataGrid<T extends EditableRow>({
    */
   const processedColumns: GridColDef[] = useMemo(() => {
     if (!notes || !notes.fields || notes.fields.length === 0) {
-      return columns;
+      return columns.map((col) => keepDraftRowsVisibleForColumnFilters(col));
     }
 
     const notesFieldNames = notes.fields.map((f) => f.field);
 
     return columns.map((col) => {
       if (!notesFieldNames.includes(col.field)) {
-        return col;
+        return keepDraftRowsVisibleForColumnFilters(col);
       }
 
       const fieldConfig = notes.fields.find((f) => f.field === col.field);
 
-      return {
+      return keepDraftRowsVisibleForColumnFilters({
         ...col,
         editable: false,
         renderCell: (params) => {
@@ -755,7 +817,7 @@ export function EditableDataGrid<T extends EditableRow>({
             />
           );
         },
-      };
+      });
     });
   }, [columns, notes, notesEditor]);
 

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -345,7 +345,11 @@ export function EditableDataGrid<T extends EditableRow>({
     return api.getSortedRowIds().filter((rowId) => api.state.visibleRowsLookup[rowId] !== false);
   }, [gridApiRef]);
 
-  const focusKeyboardNavigableCell = useCallback((rowId: GridRowId, field: string): void => {
+  const focusKeyboardNavigableCell = useCallback((
+    rowId: GridRowId,
+    field: string,
+    options: { startEdit: boolean },
+  ): void => {
     const api = gridApiRef.current;
     const rowKey = String(rowId);
     const row = rowsById.get(rowKey);
@@ -358,7 +362,7 @@ export function EditableDataGrid<T extends EditableRow>({
     api.scrollToIndexes({ rowIndex, colIndex });
     api.setCellFocus(rowId, field);
 
-    if (notesFieldNames.includes(field)) {
+    if (!options.startEdit || notesFieldNames.includes(field)) {
       return;
     }
 
@@ -373,12 +377,6 @@ export function EditableDataGrid<T extends EditableRow>({
     field: string,
     direction: 1 | -1,
   ): { id: GridRowId; field: string } | null => {
-    const visibleRowIds = getVisibleSortedRowIds();
-    const rowIndex = visibleRowIds.findIndex((visibleRowId) => String(visibleRowId) === String(rowId));
-    if (rowIndex === -1) {
-      return null;
-    }
-
     const editableFields = getKeyboardNavigableFieldsForRow(rowId);
     const fieldIndex = editableFields.indexOf(field);
     if (fieldIndex === -1) {
@@ -390,18 +388,8 @@ export function EditableDataGrid<T extends EditableRow>({
       return { id: rowId, field: nextField };
     }
 
-    const nextRowId = visibleRowIds[rowIndex + direction];
-    if (nextRowId === undefined) {
-      return null;
-    }
-
-    const nextRowEditableFields = getKeyboardNavigableFieldsForRow(nextRowId);
-    const nextRowField = direction > 0
-      ? nextRowEditableFields[0]
-      : nextRowEditableFields[nextRowEditableFields.length - 1];
-
-    return nextRowField ? { id: nextRowId, field: nextRowField } : null;
-  }, [getKeyboardNavigableFieldsForRow, getVisibleSortedRowIds]);
+    return null;
+  }, [getKeyboardNavigableFieldsForRow]);
 
   const getVerticalNavigationTarget = useCallback((
     rowId: GridRowId,
@@ -657,6 +645,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const navigateFromEditedCell = useCallback(async (
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
+    options: { startTargetEdit: boolean },
   ): Promise<void> => {
     if (current.id === target.id && current.field === target.field) {
       return;
@@ -677,7 +666,7 @@ export function EditableDataGrid<T extends EditableRow>({
     }
 
     requestAnimationFrame(() => {
-      focusKeyboardNavigableCell(target.id, target.field);
+      focusKeyboardNavigableCell(target.id, target.field, { startEdit: options.startTargetEdit });
     });
   }, [
     blurActiveElementInCell,
@@ -703,6 +692,8 @@ export function EditableDataGrid<T extends EditableRow>({
       return;
     }
 
+    const isHorizontalNavigation =
+      event.key === 'Tab' || event.key === 'ArrowRight' || event.key === 'ArrowLeft';
     const target =
       event.key === 'Tab'
         ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1)
@@ -720,12 +711,15 @@ export function EditableDataGrid<T extends EditableRow>({
 
     event.preventDefault();
     event.stopPropagation();
-    void navigateFromEditedCell(focusedCell, target);
+    void navigateFromEditedCell(focusedCell, target, {
+      startTargetEdit: isHorizontalNavigation && !notesFieldNames.includes(target.field),
+    });
   }, [
     getFocusedCellFromEvent,
     getHorizontalNavigationTarget,
     getVerticalNavigationTarget,
     navigateFromEditedCell,
+    notesFieldNames,
     rowModesModel,
   ]);
 

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -96,7 +96,7 @@ export interface EditableDataGridProps<T extends EditableRow> {
   showRowEditActions?: boolean;
   onRowsStateChange?: (rows: T[]) => void;
   onLoadStateChange?: (state: { loading: boolean; dataFetched: boolean; error: string }) => void;
-  onBeforeSaveRow?: (row: T) => boolean;
+  onBeforeSaveRow?: (row: T) => boolean | Partial<T>;
   isSaveErrorHandled?: (error: unknown) => boolean;
   /**
    * Controls how the grid surface uses available page/workspace width:
@@ -341,7 +341,47 @@ export function EditableDataGrid<T extends EditableRow>({
     return api.getRowWithUpdatedValues(rowId, '') as T | null;
   }, [gridApiRef]);
 
-  const shouldSaveRow = useCallback((rowId: GridRowId): boolean => {
+  const applyDraftValues = useCallback(async (rowId: GridRowId, values: Partial<T>): Promise<void> => {
+    const rowKey = String(rowId);
+    const targetRow = rowsById.get(rowKey);
+    const api = gridApiRef.current;
+    if (api) {
+      const editUpdates = Object.entries(values).flatMap(([fieldKey, fieldValue]) => {
+        if (fieldValue === undefined) {
+          return [];
+        }
+        return [
+          api.setEditCellValue({
+            id: rowId,
+            field: fieldKey,
+            value: fieldValue,
+          }),
+        ];
+      });
+      await Promise.allSettled(editUpdates);
+    }
+
+    setRows((previousRows) =>
+      previousRows.map((row) =>
+        String(row.id) === rowKey ? ({ ...row, ...values } as T) : row,
+      ),
+    );
+    if (targetRow) {
+      const nextRow = { ...targetRow, ...values } as T;
+      const fieldErrors = getRowValidationErrors?.(nextRow) ?? {};
+      setActiveValidationErrors((prev) => ({
+        ...prev,
+        [rowKey]: fieldErrors,
+      }));
+    }
+    setDirtyRowIds((previous) => {
+      const next = new Set(previous);
+      next.add(rowKey);
+      return next;
+    });
+  }, [getRowValidationErrors, gridApiRef, rowsById]);
+
+  const shouldSaveRow = useCallback(async (rowId: GridRowId): Promise<boolean> => {
     if (!onBeforeSaveRow) {
       return true;
     }
@@ -349,17 +389,29 @@ export function EditableDataGrid<T extends EditableRow>({
     if (!draftRow) {
       return true;
     }
-    return onBeforeSaveRow(draftRow);
-  }, [getDraftRow, onBeforeSaveRow]);
+    const saveDecision = onBeforeSaveRow(draftRow);
+    if (saveDecision === false) {
+      return false;
+    }
+    if (saveDecision !== true && saveDecision !== null && typeof saveDecision === 'object') {
+      await applyDraftValues(rowId, saveDecision);
+    }
+    return true;
+  }, [applyDraftValues, getDraftRow, onBeforeSaveRow]);
 
-  const handleSaveAllDirtyRows = useCallback((): void => {
+  const handleSaveAllDirtyRows = useCallback(async (): Promise<void> => {
     const editingRowIds = Object.entries(rowModesModel)
       .filter(([, mode]) => mode.mode === GridRowModes.Edit)
       .map(([id]) => id);
     if (editingRowIds.length === 0) {
       return;
     }
-    const saveableRowIds = editingRowIds.filter((rowId) => shouldSaveRow(rowId));
+    const saveableRowIds: GridRowId[] = [];
+    for (const rowId of editingRowIds) {
+      if (await shouldSaveRow(rowId)) {
+        saveableRowIds.push(rowId);
+      }
+    }
     if (saveableRowIds.length === 0) {
       return;
     }
@@ -372,8 +424,8 @@ export function EditableDataGrid<T extends EditableRow>({
     });
   }, [rowModesModel, shouldSaveRow]);
 
-  const handleSaveRow = useCallback((rowId: GridRowId): void => {
-    if (!shouldSaveRow(rowId)) {
+  const handleSaveRow = useCallback(async (rowId: GridRowId): Promise<void> => {
+    if (!(await shouldSaveRow(rowId))) {
       return;
     }
     setRowModesModel((oldModel) => ({
@@ -633,7 +685,7 @@ export function EditableDataGrid<T extends EditableRow>({
         )}
         {showFooterEditControls && hasUnsavedChanges && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: showAddAction ? 1 : 0 }}>
-            <Button size="small" variant="contained" onClick={handleSaveAllDirtyRows}>
+            <Button size="small" variant="contained" onClick={() => void handleSaveAllDirtyRows()}>
               {t('actions.save')}
             </Button>
             <Button
@@ -727,7 +779,7 @@ export function EditableDataGrid<T extends EditableRow>({
                   {isEditing && (
                     <>
                       <Tooltip title={t('actions.saveRow')} arrow>
-                        <IconButton size="small" color="primary" aria-label={t('actions.save')} onClick={() => handleSaveRow(rowId)}>
+                        <IconButton size="small" color="primary" aria-label={t('actions.save')} onClick={() => void handleSaveRow(rowId)}>
                           <CheckIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
@@ -946,7 +998,7 @@ export function EditableDataGrid<T extends EditableRow>({
             if (shouldSaveEditedRowWithEnter) {
               event.preventDefault();
               event.defaultMuiPrevented = true;
-              handleSaveRow(params.id);
+              void handleSaveRow(params.id);
               return;
             }
             if (event.key === 'Escape') {
@@ -956,7 +1008,7 @@ export function EditableDataGrid<T extends EditableRow>({
             }
             if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
               event.preventDefault();
-              handleSaveRow(params.id);
+              void handleSaveRow(params.id);
             }
           }}
           localeText={germanDataGridLocaleText}

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -426,49 +426,6 @@ export function EditableDataGrid<T extends EditableRow>({
     return fallbackField ? { id: nextRowId, field: fallbackField } : null;
   }, [getKeyboardNavigableFieldsForRow, getVisibleSortedRowIds]);
 
-  const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
-    if (
-      !gridNavigationKeys.has(event.key)
-      || event.altKey
-      || event.ctrlKey
-      || event.metaKey
-      || event.nativeEvent.isComposing
-      || isDropdownUsingArrowKey(event)
-    ) {
-      return;
-    }
-
-    const focusedCell = getFocusedCellFromEvent(event);
-    if (!focusedCell || rowModesModel[focusedCell.id]?.mode !== GridRowModes.Edit) {
-      return;
-    }
-
-    const target =
-      event.key === 'Tab'
-        ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1)
-        : event.key === 'ArrowRight'
-          ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, 1)
-          : event.key === 'ArrowLeft'
-            ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, -1)
-            : event.key === 'ArrowDown'
-              ? getVerticalNavigationTarget(focusedCell.id, focusedCell.field, 1)
-              : getVerticalNavigationTarget(focusedCell.id, focusedCell.field, -1);
-
-    if (!target) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    focusKeyboardNavigableCell(target.id, target.field);
-  }, [
-    focusKeyboardNavigableCell,
-    getFocusedCellFromEvent,
-    getHorizontalNavigationTarget,
-    getVerticalNavigationTarget,
-    rowModesModel,
-  ]);
-
   const hasInvalidRowInEditMode = useMemo(() => {
     if (!hasRowsInEditMode) return false;
     
@@ -655,6 +612,122 @@ export function EditableDataGrid<T extends EditableRow>({
     }
     return true;
   }, [applyDraftValues, getDraftRow, onBeforeSaveRow]);
+
+  const blurActiveElementInCell = useCallback((cell: { id: GridRowId; field: string }): void => {
+    const activeElement = document.activeElement;
+    if (!(activeElement instanceof HTMLElement)) {
+      return;
+    }
+
+    const cellElement = activeElement.closest<HTMLElement>('[role="gridcell"][data-field]');
+    const rowElement = activeElement.closest<HTMLElement>('[role="row"][data-id]');
+    if (cellElement?.dataset.field !== cell.field || rowElement?.dataset.id !== String(cell.id)) {
+      return;
+    }
+
+    activeElement.blur();
+  }, []);
+
+  const canLeaveEditedRowForKeyboardNavigation = useCallback(async (rowId: GridRowId): Promise<boolean> => {
+    if (rowModesModel[rowId]?.mode !== GridRowModes.Edit) {
+      return true;
+    }
+
+    const draftRow = getDraftRow(rowId);
+    if (draftRow) {
+      const validationError = validateRow(draftRow);
+      if (validationError) {
+        setError(validationError);
+        return false;
+      }
+
+      const fieldErrors = getRowValidationErrors?.(draftRow) ?? {};
+      if (Object.keys(fieldErrors).length > 0) {
+        setActiveValidationErrors((prev) => ({
+          ...prev,
+          [String(rowId)]: fieldErrors,
+        }));
+        return false;
+      }
+    }
+
+    return shouldSaveRow(rowId);
+  }, [getDraftRow, getRowValidationErrors, rowModesModel, shouldSaveRow, validateRow]);
+
+  const navigateFromEditedCell = useCallback(async (
+    current: { id: GridRowId; field: string },
+    target: { id: GridRowId; field: string },
+  ): Promise<void> => {
+    if (current.id === target.id && current.field === target.field) {
+      return;
+    }
+
+    const canLeaveCurrentCell = await canLeaveEditedRowForKeyboardNavigation(current.id);
+    if (!canLeaveCurrentCell) {
+      return;
+    }
+
+    blurActiveElementInCell(current);
+
+    if (rowModesModel[current.id]?.mode === GridRowModes.Edit) {
+      setRowModesModel((oldModel) => ({
+        ...oldModel,
+        [current.id]: { mode: GridRowModes.View },
+      }));
+    }
+
+    requestAnimationFrame(() => {
+      focusKeyboardNavigableCell(target.id, target.field);
+    });
+  }, [
+    blurActiveElementInCell,
+    canLeaveEditedRowForKeyboardNavigation,
+    focusKeyboardNavigableCell,
+    rowModesModel,
+  ]);
+
+  const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
+    if (
+      !gridNavigationKeys.has(event.key)
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+      || event.nativeEvent.isComposing
+      || isDropdownUsingArrowKey(event)
+    ) {
+      return;
+    }
+
+    const focusedCell = getFocusedCellFromEvent(event);
+    if (!focusedCell || rowModesModel[focusedCell.id]?.mode !== GridRowModes.Edit) {
+      return;
+    }
+
+    const target =
+      event.key === 'Tab'
+        ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1)
+        : event.key === 'ArrowRight'
+          ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, 1)
+          : event.key === 'ArrowLeft'
+            ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, -1)
+            : event.key === 'ArrowDown'
+              ? getVerticalNavigationTarget(focusedCell.id, focusedCell.field, 1)
+              : getVerticalNavigationTarget(focusedCell.id, focusedCell.field, -1);
+
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    void navigateFromEditedCell(focusedCell, target);
+  }, [
+    getFocusedCellFromEvent,
+    getHorizontalNavigationTarget,
+    getVerticalNavigationTarget,
+    navigateFromEditedCell,
+    rowModesModel,
+  ]);
 
   const handleSaveAllDirtyRows = useCallback(async (): Promise<void> => {
     const editingRowIds = Object.entries(rowModesModel)

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -167,20 +167,7 @@ const keepDraftRowsVisibleForColumnFilters = (column: GridColDef): GridColDef =>
   };
 };
 
-const gridNavigationKeys = new Set(['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
-
-const isDropdownUsingArrowKey = (event: KeyboardEvent): boolean => {
-  if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
-    return false;
-  }
-
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  return Boolean(target.closest('[aria-expanded="true"]'));
-};
+const editModeEditorArrowKeys = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
 
 export function EditableDataGrid<T extends EditableRow>({
   columns,
@@ -338,11 +325,6 @@ export function EditableDataGrid<T extends EditableRow>({
       .map((column) => column.field);
   }, [gridApiRef, notesFieldNames]);
 
-  const getVisibleSortedRowIds = useCallback((): GridRowId[] => {
-    const api = gridApiRef.current;
-    return api.getSortedRowIds().filter((rowId) => api.state.visibleRowsLookup[rowId] !== false);
-  }, [gridApiRef]);
-
   const focusKeyboardNavigableCell = useCallback((
     rowId: GridRowId,
     field: string,
@@ -388,29 +370,6 @@ export function EditableDataGrid<T extends EditableRow>({
 
     return null;
   }, [getKeyboardNavigableFieldsForRow]);
-
-  const getVerticalNavigationTarget = useCallback((
-    rowId: GridRowId,
-    field: string,
-    direction: 1 | -1,
-  ): { id: GridRowId; field: string } | null => {
-    const visibleRowIds = getVisibleSortedRowIds();
-    const rowIndex = visibleRowIds.findIndex((visibleRowId) => String(visibleRowId) === String(rowId));
-    const nextRowId = rowIndex === -1 ? undefined : visibleRowIds[rowIndex + direction];
-    if (nextRowId === undefined) {
-      return null;
-    }
-
-    const nextRowEditableFields = getKeyboardNavigableFieldsForRow(nextRowId);
-    if (nextRowEditableFields.includes(field)) {
-      return { id: nextRowId, field };
-    }
-
-    const currentFields = getKeyboardNavigableFieldsForRow(rowId);
-    const currentFieldIndex = currentFields.indexOf(field);
-    const fallbackField = nextRowEditableFields[currentFieldIndex] ?? nextRowEditableFields[0];
-    return fallbackField ? { id: nextRowId, field: fallbackField } : null;
-  }, [getKeyboardNavigableFieldsForRow, getVisibleSortedRowIds]);
 
   const hasInvalidRowInEditMode = useMemo(() => {
     if (!hasRowsInEditMode) return false;
@@ -675,12 +634,11 @@ export function EditableDataGrid<T extends EditableRow>({
 
   const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
     if (
-      !gridNavigationKeys.has(event.key)
+      event.key !== 'Tab'
       || event.altKey
       || event.ctrlKey
       || event.metaKey
       || event.nativeEvent.isComposing
-      || isDropdownUsingArrowKey(event)
     ) {
       return;
     }
@@ -690,18 +648,7 @@ export function EditableDataGrid<T extends EditableRow>({
       return;
     }
 
-    const isHorizontalNavigation =
-      event.key === 'Tab' || event.key === 'ArrowRight' || event.key === 'ArrowLeft';
-    const target =
-      event.key === 'Tab'
-        ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1)
-        : event.key === 'ArrowRight'
-          ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, 1)
-          : event.key === 'ArrowLeft'
-            ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, -1)
-            : event.key === 'ArrowDown'
-              ? getVerticalNavigationTarget(focusedCell.id, focusedCell.field, 1)
-              : getVerticalNavigationTarget(focusedCell.id, focusedCell.field, -1);
+    const target = getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1);
 
     if (!target) {
       return;
@@ -710,12 +657,11 @@ export function EditableDataGrid<T extends EditableRow>({
     event.preventDefault();
     event.stopPropagation();
     navigateFromEditedCell(focusedCell, target, {
-      startTargetEdit: isHorizontalNavigation && !notesFieldNames.includes(target.field),
+      startTargetEdit: !notesFieldNames.includes(target.field),
     });
   }, [
     getFocusedCellFromEvent,
     getHorizontalNavigationTarget,
-    getVerticalNavigationTarget,
     navigateFromEditedCell,
     notesFieldNames,
     rowModesModel,
@@ -1359,6 +1305,16 @@ export function EditableDataGrid<T extends EditableRow>({
               event.preventDefault();
               event.defaultMuiPrevented = true;
               handleStartCellEditFromKeyboard(params);
+              return;
+            }
+            if (
+              rowModesModel[params.id]?.mode === GridRowModes.Edit &&
+              editModeEditorArrowKeys.has(event.key) &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey
+            ) {
+              event.defaultMuiPrevented = true;
               return;
             }
             const shouldKeepEnterFromSavingEditedRow =

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -28,7 +28,7 @@ import {
 } from '@mui/x-data-grid';
 import { dataGridSx, dataGridFooterSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
-import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridCellParams, GridRowParams, GridFilterOperator } from '@mui/x-data-grid';
+import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRowParams, GridFilterOperator } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
@@ -169,6 +169,83 @@ const keepDraftRowsVisibleForColumnFilters = (column: GridColDef): GridColDef =>
 
 const editModeEditorArrowKeys = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
 
+const isComboboxInteractionTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest('[role="combobox"], [aria-haspopup="listbox"], [aria-haspopup="menu"]'),
+  );
+};
+
+const isEnterSaveInputTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLInputElement && !isComboboxInteractionTarget(target);
+
+const getSortableValue = (row: EditableRow, field: string): unknown => row[field];
+
+const compareSortableValues = (leftValue: unknown, rightValue: unknown): number => {
+  if (leftValue === rightValue) {
+    return 0;
+  }
+  if (leftValue === null || leftValue === undefined || leftValue === '') {
+    return 1;
+  }
+  if (rightValue === null || rightValue === undefined || rightValue === '') {
+    return -1;
+  }
+  if (leftValue instanceof Date || rightValue instanceof Date) {
+    const leftTime = leftValue instanceof Date ? leftValue.getTime() : new Date(String(leftValue)).getTime();
+    const rightTime = rightValue instanceof Date ? rightValue.getTime() : new Date(String(rightValue)).getTime();
+    if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {
+      return leftTime - rightTime;
+    }
+  }
+  if (typeof leftValue === 'number' && typeof rightValue === 'number') {
+    return leftValue - rightValue;
+  }
+  if (typeof leftValue === 'boolean' && typeof rightValue === 'boolean') {
+    return Number(leftValue) - Number(rightValue);
+  }
+  return String(leftValue).localeCompare(String(rightValue), undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+};
+
+const getSortedRowIds = <T extends EditableRow>(sourceRows: readonly T[], model: GridSortModel): GridRowId[] => {
+  const [sortItem] = model;
+  if (!sortItem?.field || !sortItem.sort) {
+    return sourceRows.map((row) => row.id);
+  }
+
+  const direction = sortItem.sort === 'desc' ? -1 : 1;
+  return sourceRows
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      const comparison = compareSortableValues(
+        getSortableValue(left.row, sortItem.field),
+        getSortableValue(right.row, sortItem.field),
+      );
+      return comparison === 0 ? left.index - right.index : comparison * direction;
+    })
+    .map(({ row }) => row.id);
+};
+
+const orderRowsByStableIds = <T extends EditableRow>(sourceRows: readonly T[], orderedIds: readonly GridRowId[]): T[] => {
+  if (orderedIds.length === 0) {
+    return [...sourceRows];
+  }
+
+  const rowsById = new Map(sourceRows.map((row) => [String(row.id), row]));
+  const orderedRows = orderedIds
+    .map((rowId) => rowsById.get(String(rowId)))
+    .filter((row): row is T => row !== undefined);
+  const orderedIdKeys = new Set(orderedIds.map(String));
+  const missingRows = sourceRows.filter((row) => !orderedIdKeys.has(String(row.id)));
+  return [...orderedRows, ...missingRows];
+};
+
 export function EditableDataGrid<T extends EditableRow>({
   columns,
   api,
@@ -205,6 +282,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const shouldUseCompactContainer = resolvedSurfaceSizing === 'compact';
   const shouldDisableTrailingFiller = isContentSizedSurface;
   const [rows, setRows] = useState<GridRowsProp<T>>([]);
+  const [stableRowOrder, setStableRowOrder] = useState<GridRowId[]>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
@@ -224,6 +302,13 @@ export function EditableDataGrid<T extends EditableRow>({
     allowedFields: columns.map((column) => column.field),
     persistInUrl: persistSortInUrl,
   });
+  const rowsForGrid = useMemo(
+    () => orderRowsByStableIds(rows as T[], stableRowOrder),
+    [rows, stableRowOrder],
+  );
+  const refreshStableRowOrder = useCallback((sourceRows: readonly T[], model: GridSortModel = sortModel): void => {
+    setStableRowOrder(getSortedRowIds(sourceRows, model));
+  }, [sortModel]);
 
   const saveUpdatedRow = useCallback(async (updatedRow: T): Promise<T> => {
     const numericId = Number(updatedRow.id);
@@ -277,6 +362,14 @@ export function EditableDataGrid<T extends EditableRow>({
   const rowsById = useMemo(() => {
     return new Map(rows.map((row) => [String(row.id), row]));
   }, [rows]);
+  const handleSortModelChange = useCallback((nextSortModel: GridSortModel): void => {
+    setSortModel(nextSortModel);
+    refreshStableRowOrder(rows as T[], nextSortModel);
+  }, [refreshStableRowOrder, rows, setSortModel]);
+  const handleFilterModelChange = useCallback((nextFilterModel: GridFilterModel): void => {
+    setFilterModel(nextFilterModel);
+    refreshStableRowOrder(rows as T[]);
+  }, [refreshStableRowOrder, rows, setFilterModel]);
 
   const getFocusedCellFromEvent = useCallback((event: KeyboardEvent): { id: GridRowId; field: string } | null => {
     const focusedCell = gridApiRef.current.state.focus.cell;
@@ -417,6 +510,7 @@ export function EditableDataGrid<T extends EditableRow>({
         .filter((item): item is T & { id: number } => item.id !== undefined)
         .map(mapToRow);
       setRows(dataRows);
+      refreshStableRowOrder(dataRows);
       setError('');
       setDataFetched(true);
     } catch (err) {
@@ -426,7 +520,7 @@ export function EditableDataGrid<T extends EditableRow>({
     } finally {
       setLoading(false);
     }
-  }, [api, mapToRow, loadErrorMessage]);
+  }, [api, mapToRow, loadErrorMessage, refreshStableRowOrder]);
 
   useEffect(() => {
     // Only fetch on initial mount
@@ -445,6 +539,7 @@ export function EditableDataGrid<T extends EditableRow>({
       initialRowProcessedRef.current = true;
       const newRow = { ...createNewRow(), ...initialRow };
       setRows((oldRows) => [newRow, ...oldRows]);
+      setStableRowOrder((previousOrder) => [newRow.id, ...previousOrder]);
       // Set row to edit mode after a small delay to ensure row is added first
       setTimeout(() => {
         setRowModesModel((oldModel) => ({
@@ -461,6 +556,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const handleAddClick = (): void => {
     const newRow = createNewRow();
     setRows((oldRows) => [newRow, ...oldRows]);
+    setStableRowOrder((previousOrder) => [newRow.id, ...previousOrder]);
     setRowModesModel((oldModel) => ({
       ...oldModel,
       [newRow.id]: { mode: GridRowModes.Edit, fieldToFocus: columns[0]?.field },
@@ -474,6 +570,7 @@ export function EditableDataGrid<T extends EditableRow>({
       setRows((prevRows) => prevRows.map((row) => (String(row.id) === rowKey ? snapshot : row)));
     } else if (Number(rowId) < 0) {
       setRows((prevRows) => prevRows.filter((row) => String(row.id) !== rowKey));
+      setStableRowOrder((previousOrder) => previousOrder.filter((orderedId) => String(orderedId) !== rowKey));
     }
 
     setDirtyRowIds((prev) => {
@@ -707,6 +804,9 @@ export function EditableDataGrid<T extends EditableRow>({
           // Add the saved row at the beginning
           return [savedRow, ...filteredRows];
         });
+        setStableRowOrder((previousOrder) =>
+          previousOrder.map((orderedId) => (String(orderedId) === rowKey ? savedRow.id : orderedId)),
+        );
         setDirtyRowIds((prev) => {
           const next = new Set(prev);
           next.delete(rowKey);
@@ -953,6 +1053,7 @@ export function EditableDataGrid<T extends EditableRow>({
     if (numericId < 0) {
       // If it's a new unsaved row, just remove it from the grid
       setRows((prevRows) => prevRows.filter((row) => row.id !== id));
+      setStableRowOrder((previousOrder) => previousOrder.filter((orderedId) => String(orderedId) !== String(id)));
       return;
     }
 
@@ -960,6 +1061,7 @@ export function EditableDataGrid<T extends EditableRow>({
     api.delete(numericId)
       .then(() => {
         setRows((prevRows) => prevRows.filter((row) => row.id !== id));
+        setStableRowOrder((previousOrder) => previousOrder.filter((orderedId) => String(orderedId) !== String(id)));
         setError('');
       })
       .catch((err) => {
@@ -1211,7 +1313,7 @@ export function EditableDataGrid<T extends EditableRow>({
           }}
         >
           <DataGrid
-          rows={rows}
+          rows={rowsForGrid}
           columns={columnsWithActions}
           rowModesModel={rowModesModel}
           onRowModesModelChange={setRowModesModel}
@@ -1224,9 +1326,10 @@ export function EditableDataGrid<T extends EditableRow>({
           autoHeight
           hideFooter={false}
           sortModel={sortModel}
-          onSortModelChange={setSortModel}
+          onSortModelChange={handleSortModelChange}
+          sortingMode="server"
           filterModel={filterModel}
-          onFilterModelChange={setFilterModel}
+          onFilterModelChange={handleFilterModelChange}
           rowSelectionModel={{ type: "include", ids: new Set(selectedRowIds) }}
           onRowSelectionModelChange={(nextModel) => setSelectedRowIds(Array.from(nextModel.ids))}
           slots={{
@@ -1317,15 +1420,19 @@ export function EditableDataGrid<T extends EditableRow>({
               event.defaultMuiPrevented = true;
               return;
             }
-            const shouldKeepEnterFromSavingEditedRow =
+            const shouldHandleEnterInEditedRow =
               event.key === 'Enter' &&
               !event.shiftKey &&
               !event.ctrlKey &&
               !event.metaKey &&
               !event.altKey &&
               rowModesModel[params.id]?.mode === GridRowModes.Edit;
-            if (shouldKeepEnterFromSavingEditedRow) {
+            if (shouldHandleEnterInEditedRow) {
               event.defaultMuiPrevented = true;
+              if (isEnterSaveInputTarget(event.target)) {
+                event.preventDefault();
+                void handleSaveRow(params.id);
+              }
               return;
             }
             if (event.key === 'Escape') {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -10,10 +10,8 @@
  * @returns A configurable editable data grid component
  * 
  * @remarks
- * Changes are automatically saved when you:
- * - Click outside the row (blur)
- * - Press Tab to move to another field
- * - Click on a different row
+ * Changes are saved through the row save action.
+ * Keyboard navigation commits edit values locally without calling the API.
  * Navigation is blocked if there are unsaved changes (row in edit mode).
  */
 
@@ -601,67 +599,68 @@ export function EditableDataGrid<T extends EditableRow>({
     return true;
   }, [applyDraftValues, getDraftRow, onBeforeSaveRow]);
 
-  const blurActiveElementInCell = useCallback((cell: { id: GridRowId; field: string }): void => {
-    const activeElement = document.activeElement;
-    if (!(activeElement instanceof HTMLElement)) {
-      return;
-    }
-
-    const cellElement = activeElement.closest<HTMLElement>('[role="gridcell"][data-field]');
-    const rowElement = activeElement.closest<HTMLElement>('[role="row"][data-id]');
-    if (cellElement?.dataset.field !== cell.field || rowElement?.dataset.id !== String(cell.id)) {
-      return;
-    }
-
-    activeElement.blur();
-  }, []);
-
-  const canLeaveEditedRowForKeyboardNavigation = useCallback(async (rowId: GridRowId): Promise<boolean> => {
-    if (rowModesModel[rowId]?.mode !== GridRowModes.Edit) {
+  const commitEditedRowDraftForKeyboardNavigation = useCallback((rowId: GridRowId): boolean => {
+    const draftRow = getDraftRow(rowId);
+    if (!draftRow) {
       return true;
     }
 
-    const draftRow = getDraftRow(rowId);
-    if (draftRow) {
-      const validationError = validateRow(draftRow);
+    const validationError = validateRow(draftRow);
+    const rowKey = String(rowId);
+    const fieldErrors = getRowValidationErrors?.(draftRow) ?? {};
+    setActiveValidationErrors((prev) => ({
+      ...prev,
+      [rowKey]: fieldErrors,
+    }));
+
+    if (validationError || Object.keys(fieldErrors).length > 0) {
       if (validationError) {
         setError(validationError);
-        return false;
       }
-
-      const fieldErrors = getRowValidationErrors?.(draftRow) ?? {};
-      if (Object.keys(fieldErrors).length > 0) {
-        setActiveValidationErrors((prev) => ({
-          ...prev,
-          [String(rowId)]: fieldErrors,
-        }));
-        return false;
-      }
+      return false;
     }
 
-    return shouldSaveRow(rowId);
-  }, [getDraftRow, getRowValidationErrors, rowModesModel, shouldSaveRow, validateRow]);
+    setError('');
+    setRows((prevRows) =>
+      prevRows.map((row) => (String(row.id) === rowKey ? draftRow : row)),
+    );
+    setDirtyRowIds((prev) => {
+      const next = new Set(prev);
+      next.add(rowKey);
+      return next;
+    });
+    return true;
+  }, [getDraftRow, getRowValidationErrors, validateRow]);
 
-  const navigateFromEditedCell = useCallback(async (
+  const navigateFromEditedCell = useCallback((
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
     options: { startTargetEdit: boolean },
-  ): Promise<void> => {
+  ): void => {
     if (current.id === target.id && current.field === target.field) {
       return;
     }
 
-    const canLeaveCurrentCell = await canLeaveEditedRowForKeyboardNavigation(current.id);
-    if (!canLeaveCurrentCell) {
+    const canCommitCurrentDraft = commitEditedRowDraftForKeyboardNavigation(current.id);
+    if (!canCommitCurrentDraft) {
       return;
     }
 
-    blurActiveElementInCell(current);
+    const isSameRow = String(current.id) === String(target.id);
+
+    if (isSameRow) {
+      requestAnimationFrame(() => {
+        focusKeyboardNavigableCell(target.id, target.field, {
+          startEdit: options.startTargetEdit,
+        });
+      });
+      return;
+    }
 
     if (rowModesModel[current.id]?.mode === GridRowModes.Edit) {
       setRowModesModel((oldModel) => ({
         ...oldModel,
-        [current.id]: { mode: GridRowModes.View },
+        [current.id]: { mode: GridRowModes.View, ignoreModifications: true },
       }));
     }
 
@@ -669,8 +668,7 @@ export function EditableDataGrid<T extends EditableRow>({
       focusKeyboardNavigableCell(target.id, target.field, { startEdit: options.startTargetEdit });
     });
   }, [
-    blurActiveElementInCell,
-    canLeaveEditedRowForKeyboardNavigation,
+    commitEditedRowDraftForKeyboardNavigation,
     focusKeyboardNavigableCell,
     rowModesModel,
   ]);
@@ -711,7 +709,7 @@ export function EditableDataGrid<T extends EditableRow>({
 
     event.preventDefault();
     event.stopPropagation();
-    void navigateFromEditedCell(focusedCell, target, {
+    navigateFromEditedCell(focusedCell, target, {
       startTargetEdit: isHorizontalNavigation && !notesFieldNames.includes(target.field),
     });
   }, [
@@ -723,40 +721,169 @@ export function EditableDataGrid<T extends EditableRow>({
     rowModesModel,
   ]);
 
+  const processRowUpdate = useCallback(async (newRow: T): Promise<T> => {
+    // Clear previous error before validating
+    // This ensures dropdown selections and other changes trigger fresh validation
+    setError('');
+
+    // Validate required fields
+    const validationError = validateRow(newRow);
+    const rowKey = String(newRow.id);
+    const fieldErrors = getRowValidationErrors?.(newRow) ?? {};
+    setActiveValidationErrors((prev) => ({
+      ...prev,
+      [rowKey]: fieldErrors,
+    }));
+    if (validationError) {
+      if (newRow.isNew) {
+        throw new Error(validationError);
+      }
+      setError(validationError);
+      throw new Error(validationError);
+    }
+
+    try {
+      if (newRow.isNew) {
+        // Create new item via API
+        const apiData = await mapToApiData(newRow);
+        const response = await api.create(apiData);
+        setError('');
+        if (!response.data.id) {
+          throw new Error('API response missing ID');
+        }
+
+        // Remove the temporary row and add the saved row
+        const savedRow = mapToRow(response.data as T);
+        rowSnapshotRef.current.set(String(savedRow.id), savedRow);
+        setRows((prevRows) => {
+          // Remove the temporary row with negative ID
+          const filteredRows = prevRows.filter(row => row.id !== newRow.id);
+          // Add the saved row at the beginning
+          return [savedRow, ...filteredRows];
+        });
+        setDirtyRowIds((prev) => {
+          const next = new Set(prev);
+          next.delete(rowKey);
+          return next;
+        });
+
+        return savedRow;
+      } else {
+        // Update existing item via API
+        const apiData = await mapToApiData(newRow);
+        const response = await api.update(newRow.id, apiData);
+        setError('');
+        if (!response.data.id) {
+          throw new Error('API response missing ID');
+        }
+        // Map the response through mapToRow to ensure all fields are properly formatted
+        // This is important for auto-calculated fields like harvest dates
+        const mappedRow = mapToRow(response.data as T);
+        rowSnapshotRef.current.set(String(mappedRow.id), mappedRow);
+        setDirtyRowIds((prev) => {
+          const next = new Set(prev);
+          next.delete(rowKey);
+          return next;
+        });
+        return mappedRow;
+      }
+    } catch (err) {
+      if (isSaveErrorHandled?.(err)) {
+        console.error('Error saving data:', err);
+        throw err;
+      }
+      // Extract user-friendly error message
+      const errorMessage = extractApiErrorMessage(err, t, saveErrorMessage);
+      setError(errorMessage);
+      console.error('Error saving data:', err);
+      throw new Error(errorMessage);
+    }
+  }, [
+    api,
+    getRowValidationErrors,
+    isSaveErrorHandled,
+    mapToApiData,
+    mapToRow,
+    saveErrorMessage,
+    t,
+    validateRow,
+  ]);
+
+  const handleProcessRowUpdateError = useCallback((error: unknown): void => {
+    console.error('Row update error:', error);
+    if (isSaveErrorHandled?.(error)) {
+      return;
+    }
+    if (error instanceof Error && error.message) {
+      setError(error.message);
+      return;
+    }
+    const errorMessage = extractApiErrorMessage(error, t, saveErrorMessage);
+    setError(errorMessage);
+  }, [isSaveErrorHandled, saveErrorMessage, t]);
+
+  const handleSaveRow = useCallback(async (rowId: GridRowId): Promise<void> => {
+    if (!(await shouldSaveRow(rowId))) {
+      return;
+    }
+
+    if (rowModesModel[rowId]?.mode === GridRowModes.Edit) {
+      setRowModesModel((oldModel) => ({
+        ...oldModel,
+        [rowId]: { mode: GridRowModes.View },
+      }));
+      return;
+    }
+
+    const row = rowsById.get(String(rowId)) as T | undefined;
+    if (!row) {
+      return;
+    }
+
+    try {
+      const savedRow = await processRowUpdate(row);
+      setRows((prevRows) =>
+        prevRows.map((currentRow) =>
+          String(currentRow.id) === String(rowId) ? savedRow : currentRow,
+        ),
+      );
+    } catch (error) {
+      handleProcessRowUpdateError(error);
+    }
+  }, [
+    handleProcessRowUpdateError,
+    processRowUpdate,
+    rowModesModel,
+    rowsById,
+    shouldSaveRow,
+  ]);
+
   const handleSaveAllDirtyRows = useCallback(async (): Promise<void> => {
     const editingRowIds = Object.entries(rowModesModel)
       .filter(([, mode]) => mode.mode === GridRowModes.Edit)
       .map(([id]) => id);
-    if (editingRowIds.length === 0) {
-      return;
-    }
     const saveableRowIds: GridRowId[] = [];
     for (const rowId of editingRowIds) {
       if (await shouldSaveRow(rowId)) {
         saveableRowIds.push(rowId);
       }
     }
-    if (saveableRowIds.length === 0) {
-      return;
+    if (saveableRowIds.length > 0) {
+      setRowModesModel((oldModel) => {
+        const nextModel = { ...oldModel };
+        for (const rowId of saveableRowIds) {
+          nextModel[rowId] = { mode: GridRowModes.View };
+        }
+        return nextModel;
+      });
     }
-    setRowModesModel((oldModel) => {
-      const nextModel = { ...oldModel };
-      for (const rowId of saveableRowIds) {
-        nextModel[rowId] = { mode: GridRowModes.View };
+    const editingRowIdKeys = new Set(editingRowIds.map(String));
+    for (const rowKey of dirtyRowIds) {
+      if (!editingRowIdKeys.has(rowKey)) {
+        await handleSaveRow(rowKey);
       }
-      return nextModel;
-    });
-  }, [rowModesModel, shouldSaveRow]);
-
-  const handleSaveRow = useCallback(async (rowId: GridRowId): Promise<void> => {
-    if (!(await shouldSaveRow(rowId))) {
-      return;
     }
-    setRowModesModel((oldModel) => ({
-      ...oldModel,
-      [rowId]: { mode: GridRowModes.View },
-    }));
-  }, [shouldSaveRow]);
+  }, [dirtyRowIds, handleSaveRow, rowModesModel, shouldSaveRow]);
 
   const handleEditSelectedRow = (): void => {
     const selectedRowId = selectedRowIds[0];
@@ -869,100 +996,6 @@ export function EditableDataGrid<T extends EditableRow>({
       commandApiRef.current = null;
     };
   }, [commandApiRef, fetchData, getRowValidationErrors, gridApiRef, rowModesModel, rowsById, selectedRowIds]);
-
-
-  /**
-   * Process row update - save to API
-   */
-  const processRowUpdate = async (newRow: T): Promise<T> => {
-    // Clear previous error before validating
-    // This ensures dropdown selections and other changes trigger fresh validation
-    setError('');
-    
-    // Validate required fields
-    const validationError = validateRow(newRow);
-    const rowKey = String(newRow.id);
-    const fieldErrors = getRowValidationErrors?.(newRow) ?? {};
-    setActiveValidationErrors((prev) => ({
-      ...prev,
-      [rowKey]: fieldErrors,
-    }));
-    if (validationError) {
-      if (newRow.isNew) {
-        throw new Error(validationError);
-      }
-      setError(validationError);
-      throw new Error(validationError);
-    }
-
-    try {
-      if (newRow.isNew) {
-        // Create new item via API
-        const apiData = await mapToApiData(newRow);
-        const response = await api.create(apiData);
-        setError('');
-        if (!response.data.id) {
-          throw new Error('API response missing ID');
-        }
-        
-        // Remove the temporary row and add the saved row
-        const savedRow = mapToRow(response.data as T);
-        rowSnapshotRef.current.set(String(savedRow.id), savedRow);
-        setRows((prevRows) => {
-          // Remove the temporary row with negative ID
-          const filteredRows = prevRows.filter(row => row.id !== newRow.id);
-          // Add the saved row at the beginning
-          return [savedRow, ...filteredRows];
-        });
-        
-        return savedRow;
-      } else {
-        // Update existing item via API
-        const apiData = await mapToApiData(newRow);
-        const response = await api.update(newRow.id, apiData);
-        setError('');
-        if (!response.data.id) {
-          throw new Error('API response missing ID');
-        }
-        // Map the response through mapToRow to ensure all fields are properly formatted
-        // This is important for auto-calculated fields like harvest dates
-        const mappedRow = mapToRow(response.data as T);
-        rowSnapshotRef.current.set(String(mappedRow.id), mappedRow);
-        setDirtyRowIds((prev) => {
-          const next = new Set(prev);
-          next.delete(rowKey);
-          return next;
-        });
-        return mappedRow;
-      }
-    } catch (err) {
-      if (isSaveErrorHandled?.(err)) {
-        console.error('Error saving data:', err);
-        throw err;
-      }
-      // Extract user-friendly error message
-      const errorMessage = extractApiErrorMessage(err, t, saveErrorMessage);
-      setError(errorMessage);
-      console.error('Error saving data:', err);
-      throw new Error(errorMessage);
-    }
-  };
-
-  /**
-   * Handle row update errors
-   */
-  const handleProcessRowUpdateError = (error: unknown): void => {
-    console.error('Row update error:', error);
-    if (isSaveErrorHandled?.(error)) {
-      return;
-    }
-    if (error instanceof Error && error.message) {
-      setError(error.message);
-      return;
-    }
-    const errorMessage = extractApiErrorMessage(error, t, saveErrorMessage);
-    setError(errorMessage);
-  };
 
   /**
    * Handle row deletion
@@ -1095,11 +1128,13 @@ export function EditableDataGrid<T extends EditableRow>({
             align: 'right' as const,
             renderCell: (params: GridCellParams<T>) => {
               const rowId = params.id;
+              const rowKey = String(rowId);
               const isEditing = rowModesModel[rowId]?.mode === GridRowModes.Edit;
+              const hasLocalDraft = dirtyRowIds.has(rowKey);
 
               return (
                 <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, width: '100%', justifyContent: 'flex-end' }}>
-                  {isEditing && (
+                  {(isEditing || hasLocalDraft) && (
                     <>
                       <Tooltip title={t('actions.saveRow')} arrow>
                         <IconButton size="small" color="primary" aria-label={t('actions.save')} onClick={() => void handleSaveRow(rowId)}>
@@ -1326,17 +1361,15 @@ export function EditableDataGrid<T extends EditableRow>({
               handleStartCellEditFromKeyboard(params);
               return;
             }
-            const shouldSaveEditedRowWithEnter =
+            const shouldKeepEnterFromSavingEditedRow =
               event.key === 'Enter' &&
               !event.shiftKey &&
               !event.ctrlKey &&
               !event.metaKey &&
               !event.altKey &&
               rowModesModel[params.id]?.mode === GridRowModes.Edit;
-            if (shouldSaveEditedRowWithEnter) {
-              event.preventDefault();
+            if (shouldKeepEnterFromSavingEditedRow) {
               event.defaultMuiPrevented = true;
-              void handleSaveRow(params.id);
               return;
             }
             if (event.key === 'Escape') {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -936,6 +936,19 @@ export function EditableDataGrid<T extends EditableRow>({
               handleStartCellEditFromKeyboard(params);
               return;
             }
+            const shouldSaveEditedRowWithEnter =
+              event.key === 'Enter' &&
+              !event.shiftKey &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey &&
+              rowModesModel[params.id]?.mode === GridRowModes.Edit;
+            if (shouldSaveEditedRowWithEnter) {
+              event.preventDefault();
+              event.defaultMuiPrevented = true;
+              handleSaveRow(params.id);
+              return;
+            }
             if (event.key === 'Escape') {
               event.preventDefault();
               handleDiscardRowChanges(params.id);

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -17,7 +17,7 @@
  * Navigation is blocked if there are unsaved changes (row in edit mode).
  */
 
-import { useState, useEffect, useCallback, useRef, useMemo, type MutableRefObject } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo, type KeyboardEvent, type MutableRefObject } from 'react';
 import {
   DataGrid,
   GridRowModes,
@@ -169,6 +169,21 @@ const keepDraftRowsVisibleForColumnFilters = (column: GridColDef): GridColDef =>
   };
 };
 
+const gridNavigationKeys = new Set(['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
+
+const isDropdownUsingArrowKey = (event: KeyboardEvent): boolean => {
+  if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+    return false;
+  }
+
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return Boolean(target.closest('[aria-expanded="true"]'));
+};
+
 export function EditableDataGrid<T extends EditableRow>({
   columns,
   api,
@@ -273,6 +288,173 @@ export function EditableDataGrid<T extends EditableRow>({
   const rowsById = useMemo(() => {
     return new Map(rows.map((row) => [String(row.id), row]));
   }, [rows]);
+
+  const getFocusedCellFromEvent = useCallback((event: KeyboardEvent): { id: GridRowId; field: string } | null => {
+    const focusedCell = gridApiRef.current.state.focus.cell;
+    if (focusedCell) {
+      return focusedCell;
+    }
+
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return null;
+    }
+
+    const cellElement = target.closest<HTMLElement>('[role="gridcell"][data-field]');
+    const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
+    const field = cellElement?.dataset.field;
+    const id = rowElement?.dataset.id;
+    if (!field || id === undefined) {
+      return null;
+    }
+
+    const numericId = Number(id);
+    return {
+      id: Number.isNaN(numericId) ? id : numericId,
+      field,
+    };
+  }, [gridApiRef]);
+
+  const getEditableFieldsForRow = useCallback((rowId: GridRowId): string[] => {
+    const api = gridApiRef.current;
+    return api.getVisibleColumns()
+      .filter((column) => {
+        if (!column.editable) {
+          return false;
+        }
+
+        try {
+          return api.isCellEditable(api.getCellParams(rowId, column.field));
+        } catch {
+          return false;
+        }
+      })
+      .map((column) => column.field);
+  }, [gridApiRef]);
+
+  const getVisibleSortedRowIds = useCallback((): GridRowId[] => {
+    const api = gridApiRef.current;
+    return api.getSortedRowIds().filter((rowId) => api.state.visibleRowsLookup[rowId] !== false);
+  }, [gridApiRef]);
+
+  const focusEditableCell = useCallback((rowId: GridRowId, field: string): void => {
+    const api = gridApiRef.current;
+    const rowKey = String(rowId);
+    const row = rowsById.get(rowKey);
+    if (row && !rowSnapshotRef.current.has(rowKey)) {
+      rowSnapshotRef.current.set(rowKey, row as T);
+    }
+
+    const rowIndex = api.getRowIndexRelativeToVisibleRows(rowId);
+    const colIndex = api.getColumnIndexRelativeToVisibleColumns(field);
+    api.scrollToIndexes({ rowIndex, colIndex });
+    api.setCellFocus(rowId, field);
+    setRowModesModel((oldModel) => ({
+      ...oldModel,
+      [rowId]: { mode: GridRowModes.Edit, fieldToFocus: field },
+    }));
+  }, [gridApiRef, rowsById]);
+
+  const getHorizontalNavigationTarget = useCallback((
+    rowId: GridRowId,
+    field: string,
+    direction: 1 | -1,
+  ): { id: GridRowId; field: string } | null => {
+    const visibleRowIds = getVisibleSortedRowIds();
+    const rowIndex = visibleRowIds.findIndex((visibleRowId) => String(visibleRowId) === String(rowId));
+    if (rowIndex === -1) {
+      return null;
+    }
+
+    const editableFields = getEditableFieldsForRow(rowId);
+    const fieldIndex = editableFields.indexOf(field);
+    if (fieldIndex === -1) {
+      return null;
+    }
+
+    const nextField = editableFields[fieldIndex + direction];
+    if (nextField) {
+      return { id: rowId, field: nextField };
+    }
+
+    const nextRowId = visibleRowIds[rowIndex + direction];
+    if (nextRowId === undefined) {
+      return null;
+    }
+
+    const nextRowEditableFields = getEditableFieldsForRow(nextRowId);
+    const nextRowField = direction > 0
+      ? nextRowEditableFields[0]
+      : nextRowEditableFields[nextRowEditableFields.length - 1];
+
+    return nextRowField ? { id: nextRowId, field: nextRowField } : null;
+  }, [getEditableFieldsForRow, getVisibleSortedRowIds]);
+
+  const getVerticalNavigationTarget = useCallback((
+    rowId: GridRowId,
+    field: string,
+    direction: 1 | -1,
+  ): { id: GridRowId; field: string } | null => {
+    const visibleRowIds = getVisibleSortedRowIds();
+    const rowIndex = visibleRowIds.findIndex((visibleRowId) => String(visibleRowId) === String(rowId));
+    const nextRowId = rowIndex === -1 ? undefined : visibleRowIds[rowIndex + direction];
+    if (nextRowId === undefined) {
+      return null;
+    }
+
+    const nextRowEditableFields = getEditableFieldsForRow(nextRowId);
+    if (nextRowEditableFields.includes(field)) {
+      return { id: nextRowId, field };
+    }
+
+    const currentFields = getEditableFieldsForRow(rowId);
+    const currentFieldIndex = currentFields.indexOf(field);
+    const fallbackField = nextRowEditableFields[currentFieldIndex] ?? nextRowEditableFields[0];
+    return fallbackField ? { id: nextRowId, field: fallbackField } : null;
+  }, [getEditableFieldsForRow, getVisibleSortedRowIds]);
+
+  const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
+    if (
+      !gridNavigationKeys.has(event.key)
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+      || event.nativeEvent.isComposing
+      || isDropdownUsingArrowKey(event)
+    ) {
+      return;
+    }
+
+    const focusedCell = getFocusedCellFromEvent(event);
+    if (!focusedCell || rowModesModel[focusedCell.id]?.mode !== GridRowModes.Edit) {
+      return;
+    }
+
+    const target =
+      event.key === 'Tab'
+        ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, event.shiftKey ? -1 : 1)
+        : event.key === 'ArrowRight'
+          ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, 1)
+          : event.key === 'ArrowLeft'
+            ? getHorizontalNavigationTarget(focusedCell.id, focusedCell.field, -1)
+            : event.key === 'ArrowDown'
+              ? getVerticalNavigationTarget(focusedCell.id, focusedCell.field, 1)
+              : getVerticalNavigationTarget(focusedCell.id, focusedCell.field, -1);
+
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    focusEditableCell(target.id, target.field);
+  }, [
+    focusEditableCell,
+    getFocusedCellFromEvent,
+    getHorizontalNavigationTarget,
+    getVerticalNavigationTarget,
+    rowModesModel,
+  ]);
 
   const hasInvalidRowInEditMode = useMemo(() => {
     if (!hasRowsInEditMode) return false;
@@ -950,6 +1132,7 @@ export function EditableDataGrid<T extends EditableRow>({
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       
       <Box
+        onKeyDownCapture={handleGridEditNavigation}
         sx={{
           width: '100%',
           maxWidth: '100%',

--- a/frontend/src/components/data-grid/NotesCell.tsx
+++ b/frontend/src/components/data-grid/NotesCell.tsx
@@ -2,7 +2,7 @@
  * NotesCell component for rendering notes field in DataGrid.
  */
 
-import type { MouseEvent } from 'react';
+import { useEffect, useRef, type MouseEvent } from 'react';
 import { Badge, Box, IconButton, Tooltip, Typography } from '@mui/material';
 import NotesIcon from '@mui/icons-material/Notes';
 import NotesOutlinedIcon from '@mui/icons-material/NotesOutlined';
@@ -19,6 +19,7 @@ export interface NotesCellProps {
   attachmentCount?: number;
   compactIndicator?: boolean;
   onOpenAttachments?: (event: MouseEvent<HTMLButtonElement>) => void;
+  hasFocus?: boolean;
 }
 
 export function NotesCell({
@@ -29,8 +30,11 @@ export function NotesCell({
   attachmentCount = 0,
   compactIndicator = false,
   onOpenAttachments,
+  hasFocus = false,
 }: NotesCellProps): React.ReactElement {
   const { t } = useTranslation('common');
+  const compactTriggerRef = useRef<HTMLDivElement | null>(null);
+  const notesButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const firstLine = excerpt.split('\n')[0];
   const displayText = firstLine.length > 40 ? `${firstLine.substring(0, 37)}...` : firstLine;
@@ -71,6 +75,16 @@ export function NotesCell({
   const notesAria = hasValue ? t('notes.editWithContent') : t('notes.editEmpty');
   const attachmentTooltip = t('notes.attachmentsCount', { count: attachmentCount });
   const hasAttachments = attachmentCount > 0;
+  useEffect(() => {
+    if (!hasFocus) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      (compactIndicator ? compactTriggerRef.current : notesButtonRef.current)?.focus();
+    });
+  }, [compactIndicator, hasFocus]);
+
   const compactAriaLabel = hasValue && hasAttachments
     ? 'Notiz und Bilder vorhanden'
     : hasValue
@@ -90,13 +104,15 @@ export function NotesCell({
     return (
       <Tooltip title={hasValue || hasAttachments ? compactTooltip : '—'} arrow>
         <Box
+          ref={compactTriggerRef}
           role="button"
-          tabIndex={0}
+          tabIndex={hasFocus ? 0 : -1}
           aria-label={compactAriaLabel}
           onClick={onOpen}
           onKeyDown={(event) => {
             if (event.key === 'Enter' || event.key === ' ') {
               event.preventDefault();
+              event.stopPropagation();
               onOpen();
             }
           }}
@@ -145,12 +161,13 @@ export function NotesCell({
     >
       <Box
         role="button"
-        tabIndex={0}
+        tabIndex={-1}
         aria-label={notesAria}
         onClick={onOpen}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
+            event.stopPropagation();
             onOpen();
           }
         }}
@@ -166,12 +183,21 @@ export function NotesCell({
         }}
       >
         <IconButton
+          ref={notesButtonRef}
           size="small"
           onClick={(event) => {
             event.stopPropagation();
             onOpen();
           }}
           aria-label={notesAria}
+          tabIndex={hasFocus ? 0 : -1}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpen();
+            }
+          }}
           sx={{ p: 0.5 }}
         >
           {hasValue ? (
@@ -203,6 +229,7 @@ export function NotesCell({
               size="small"
               onClick={(event) => { event.stopPropagation(); event.preventDefault(); onOpenAttachments(event); }}
               aria-label={attachmentTooltip}
+              tabIndex={-1}
               sx={{
                 position: 'absolute',
                 top: 2,

--- a/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
@@ -28,6 +28,7 @@ export function SearchableSelectEditCell({
   options,
   onValueChange,
   placeholder,
+  hasFocus,
 }: SearchableSelectEditCellProps): React.ReactElement {
   const apiRef = useGridApiContext();
   const [inputValue, setInputValue] = useState('');
@@ -70,6 +71,7 @@ export function SearchableSelectEditCell({
       }}
       placeholder={placeholder}
       size="small"
+      autoFocus={hasFocus}
       textFieldSx={{ '& .MuiInputBase-root': { height: '100%' } }}
     />
   );

--- a/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
@@ -72,6 +72,7 @@ export function SearchableSelectEditCell({
       placeholder={placeholder}
       size="small"
       autoFocus={hasFocus}
+      inputTabIndex={hasFocus ? 0 : -1}
       textFieldSx={{ '& .MuiInputBase-root': { height: '100%' } }}
     />
   );

--- a/frontend/src/components/data-grid/columns.tsx
+++ b/frontend/src/components/data-grid/columns.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { GridColDef } from '@mui/x-data-grid';
-import { Box, Tooltip } from '@mui/material';
+import { Box, MenuItem, TextField, Tooltip } from '@mui/material';
 import { SearchableSelectEditCell } from './SearchableSelectEditCell';
 import type { SearchableSelectOption } from './SearchableSelectEditCell';
 
@@ -148,6 +148,33 @@ export const createSingleSelectColumn = <Row extends { [key: string]: unknown }>
         </Tooltip>
       );
     },
+    renderEditCell: (params) => (
+      <TextField
+        select
+        fullWidth
+        size="small"
+        autoFocus={params.hasFocus}
+        value={params.value ?? ''}
+        slotProps={{
+          htmlInput: {
+            tabIndex: params.hasFocus ? 0 : -1,
+          },
+        }}
+        onChange={async (event) => {
+          await params.api.setEditCellValue({
+            id: params.id,
+            field: params.field,
+            value: event.target.value,
+          });
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    ),
     valueSetter: (value, row) => {
       const numericValue = typeof value === 'number' ? value : Number(value);
       return { ...row, [field]: numericValue } as Row;

--- a/frontend/src/components/inputs/SearchableSelect.tsx
+++ b/frontend/src/components/inputs/SearchableSelect.tsx
@@ -39,6 +39,7 @@ export interface SearchableSelectProps<T = unknown> {
   size?: 'small' | 'medium';
   fullWidth?: boolean;
   autoFocus?: boolean;
+  inputTabIndex?: number;
   textFieldSx?: SxProps<Theme>;
   inputValue?: string;
   onInputChange?: (value: string) => void;
@@ -55,6 +56,7 @@ export function SearchableSelect<T = unknown>({
   size = 'medium',
   fullWidth = true,
   autoFocus = false,
+  inputTabIndex,
   textFieldSx,
   inputValue,
   onInputChange,
@@ -98,6 +100,10 @@ export function SearchableSelect<T = unknown>({
           placeholder={placeholder}
           autoFocus={autoFocus}
           sx={textFieldSx}
+          inputProps={{
+            ...params.inputProps,
+            tabIndex: inputTabIndex,
+          }}
           InputProps={{
             ...params.InputProps,
             endAdornment: (

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -29,6 +29,7 @@ interface AreaAssignmentDialogProps {
   locale: string;
   onApply: (bedId: number) => Promise<void> | void;
   compactLabel: string;
+  hasFocus?: boolean;
 }
 
 interface AssignmentState {
@@ -75,6 +76,7 @@ export function AreaAssignmentDialog({
   locale,
   onApply,
   compactLabel,
+  hasFocus = false,
 }: AreaAssignmentDialogProps): React.ReactElement {
   const { t } = useTranslation('plantingPlans');
   const [isOpen, setIsOpen] = useState(false);
@@ -82,12 +84,23 @@ export function AreaAssignmentDialog({
   const locationSelectRef = useRef<HTMLDivElement | null>(null);
   const fieldSelectRef = useRef<HTMLDivElement | null>(null);
   const bedSelectRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
 
   const stopGridEnterPropagation = (event: KeyboardEvent): void => {
     if (event.key === 'Enter' || event.key === 'Escape') {
       event.stopPropagation();
     }
   };
+
+  useEffect(() => {
+    if (!hasFocus || isOpen) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, [hasFocus, isOpen]);
 
   const fieldsById = useMemo(() => new Map(fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item])), [fields]);
 
@@ -227,13 +240,15 @@ export function AreaAssignmentDialog({
   return (
     <>
       <Box
+        ref={triggerRef}
         role="button"
-        tabIndex={0}
+        tabIndex={hasFocus ? 0 : -1}
         aria-label={t('areaAssignment.editButton')}
         onClick={() => setIsOpen(true)}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
+            event.stopPropagation();
             setIsOpen(true);
           }
         }}

--- a/frontend/src/components/planting-plans/CompactAreaCell.tsx
+++ b/frontend/src/components/planting-plans/CompactAreaCell.tsx
@@ -3,6 +3,7 @@ import { Box, Tooltip, Typography } from '@mui/material';
 
 interface CompactAreaCellProps {
   label: string;
+  hasFocus?: boolean;
 }
 
 const TOOLTIP_TEXT_LENGTH_THRESHOLD = 40;
@@ -11,8 +12,9 @@ export function shouldShowAreaTooltip(label: string, isOverflowing: boolean): bo
   return isOverflowing || label.length > TOOLTIP_TEXT_LENGTH_THRESHOLD;
 }
 
-export function CompactAreaCell({ label }: CompactAreaCellProps): React.ReactElement {
+export function CompactAreaCell({ label, hasFocus = false }: CompactAreaCellProps): React.ReactElement {
   const textRef = useRef<HTMLParagraphElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
 
   useEffect(() => {
@@ -37,6 +39,16 @@ export function CompactAreaCell({ label }: CompactAreaCellProps): React.ReactEle
     [isOverflowing, label],
   );
 
+  useEffect(() => {
+    if (!hasFocus || !showTooltip) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, [hasFocus, showTooltip]);
+
   return (
     <Tooltip
       title={showTooltip ? label : ''}
@@ -46,8 +58,9 @@ export function CompactAreaCell({ label }: CompactAreaCellProps): React.ReactEle
       enterTouchDelay={450}
     >
       <Box
+        ref={triggerRef}
         sx={{ width: '100%', minWidth: 0, overflow: 'hidden', display: 'flex', alignItems: 'center', height: '100%' }}
-        tabIndex={showTooltip ? 0 : -1}
+        tabIndex={hasFocus && showTooltip ? 0 : -1}
         aria-label={showTooltip ? label : undefined}
       >
         <Typography

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -25,6 +25,18 @@
   "feedback": {
     "areaAutoFilled": "Verfügbare Restfläche automatisch verwendet: {{area}}"
   },
+  "areaValidation": {
+    "maxAreaApplied": "Maximal verfügbare Fläche übernommen: {{area}}",
+    "remainingLimitTitle": "Die angegebene Fläche überschreitet die verfügbare Restfläche dieses Beets.",
+    "noRemainingTitle": "Für dieses Beet ist im gewählten Zeitraum keine freie Fläche verfügbar.",
+    "bedLimitTitle": "Die angegebene Fläche überschreitet die Größe dieses Beets.",
+    "availableArea": "Verfügbare Restfläche: {{area}}",
+    "bedArea": "Beetfläche: {{area}}",
+    "occupiedArea": "Bereits belegt: {{area}}",
+    "requestedArea": "Angefragt: {{area}}",
+    "applyRemainingArea": "Restfläche übernehmen",
+    "applyBedArea": "Beetfläche übernehmen"
+  },
   "placeholders": {
     "selectCultivationType": "Anbauart wählen",
     "maxKeyword": "max"

--- a/frontend/src/i18n/locales/de/plantingPlans.json
+++ b/frontend/src/i18n/locales/de/plantingPlans.json
@@ -34,6 +34,7 @@
     "bedArea": "Beetfläche: {{area}}",
     "occupiedArea": "Bereits belegt: {{area}}",
     "requestedArea": "Angefragt: {{area}}",
+    "acceptedArea": "Übernommen wird: {{area}}",
     "applyRemainingArea": "Restfläche übernehmen",
     "applyBedArea": "Beetfläche übernehmen"
   },

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -1455,11 +1455,6 @@ function Cultures(): React.ReactElement {
             width: '100%',
             alignItems: 'center',
             fontWeight: 500,
-            bgcolor: snackbar.severity === 'info' ? 'rgba(37, 111, 42, 0.96)' : undefined,
-            color: snackbar.severity === 'info' ? '#ffffff' : undefined,
-            '& .MuiAlert-icon': {
-              color: snackbar.severity === 'info' ? '#ffffff' : undefined,
-            },
           }}
         >
           {snackbar.message}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -128,6 +128,8 @@ interface AreaValidationDialogState {
   availableArea: number;
   bedArea: number;
   occupiedArea: number;
+  cultureId?: number;
+  plantsCount?: number | null;
   mode: "bedLimit" | "remainingLimit" | "noRemainingArea";
 }
 
@@ -177,6 +179,42 @@ const toIsoDateString = (value: unknown): string | null => {
   return null;
 };
 
+const toDateKey = (value: unknown): number | null => {
+  const buildDateKey = (year: number, month: number, day: number): number | null => {
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day
+    ) {
+      return null;
+    }
+    return date.getTime();
+  };
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return Date.UTC(value.getFullYear(), value.getMonth(), value.getDate());
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  const isoMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(trimmed);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    return buildDateKey(Number(year), Number(month), Number(day));
+  }
+  const germanMatch = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/.exec(trimmed);
+  if (germanMatch) {
+    const [, day, month, year] = germanMatch;
+    return buildDateKey(Number(year), Number(month), Number(day));
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+};
+
 const toNumericValue = (value: unknown): number | null => {
   if (typeof value === "number") {
     return Number.isNaN(value) ? null : value;
@@ -208,6 +246,16 @@ const toAreaNumericValue = (value: unknown, locale: string): number | null => {
 
 const toOptionalString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
+
+const toOptionalNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    return Number(value.trim());
+  }
+  return undefined;
+};
 
 interface HierarchySelectionRow {
   location_id?: number;
@@ -1433,14 +1481,41 @@ function PlantingPlans(): React.ReactElement {
     }
     return Number((row.plants_count / plantsPerSqm).toFixed(2));
   };
+
+  const getPlanBedId = (row: PlantingPlanRow): number | null => {
+    const rowRecord = row as PlantingPlanRow & {
+      bed_id?: unknown;
+      bed?: unknown;
+    };
+    const directBedId = toOptionalNumber(rowRecord.bed);
+    if (directBedId !== undefined) {
+      return directBedId;
+    }
+    const apiBedId = toOptionalNumber(rowRecord.bed_id);
+    if (apiBedId !== undefined) {
+      return apiBedId;
+    }
+    if (
+      rowRecord.bed &&
+      typeof rowRecord.bed === "object" &&
+      "id" in rowRecord.bed
+    ) {
+      return toOptionalNumber(rowRecord.bed.id) ?? null;
+    }
+    return null;
+  };
+
+  const isSamePlanRow = (rowA: PlantingPlanRow, rowB: PlantingPlanRow): boolean =>
+    rowA === rowB || (typeof rowA.id === "number" && typeof rowB.id === "number" && rowA.id === rowB.id);
+
   const datesOverlap = (rowA: PlantingPlanRow, rowB: PlantingPlanRow): boolean => {
-    const startA = toIsoDateString(rowA.planting_date);
-    const startB = toIsoDateString(rowB.planting_date);
-    if (!startA || !startB) {
+    const startA = toDateKey(rowA.planting_date);
+    const startB = toDateKey(rowB.planting_date);
+    if (startA === null || startB === null) {
       return false;
     }
-    const endA = toIsoDateString(rowA.harvest_end_date) ?? toIsoDateString(rowA.harvest_date) ?? "9999-12-31";
-    const endB = toIsoDateString(rowB.harvest_end_date) ?? toIsoDateString(rowB.harvest_date) ?? "9999-12-31";
+    const endA = toDateKey(rowA.harvest_end_date) ?? toDateKey(rowA.harvest_date) ?? Number.MAX_SAFE_INTEGER;
+    const endB = toDateKey(rowB.harvest_end_date) ?? toDateKey(rowB.harvest_date) ?? Number.MAX_SAFE_INTEGER;
     return startA <= endB && startB <= endA;
   };
 
@@ -1449,17 +1524,18 @@ function PlantingPlans(): React.ReactElement {
     occupiedArea: number;
     availableArea: number;
   } | null => {
-    if (typeof row.bed !== "number") {
+    const rowBedId = getPlanBedId(row);
+    if (rowBedId === null) {
       return null;
     }
-    const selectedBed = bedById.get(row.bed);
+    const selectedBed = bedById.get(rowBedId);
     const bedArea = toNumericValue(selectedBed?.area_sqm);
     if (bedArea === null) {
       return null;
     }
     const occupiedArea = mobileRows
-      .filter((item) => item.id !== row.id && item.bed === row.bed && datesOverlap(item, row))
-      .reduce((total, item) => total + Math.max(0, toAreaNumericValue(item.area_m2, numberLocale) ?? 0), 0);
+      .filter((item) => getPlanBedId(item) === rowBedId && !isSamePlanRow(item, row) && datesOverlap(item, row))
+      .reduce((total, item) => total + Math.max(0, toAreaNumericValue(item.area_m2 ?? item.area_usage_sqm, numberLocale) ?? 0), 0);
     return {
       bedArea,
       occupiedArea,
@@ -1467,14 +1543,20 @@ function PlantingPlans(): React.ReactElement {
     };
   };
 
-  const applyAreaAndPlants = (rowId: number, nextArea: number): void => {
+  const applyAreaAndPlants = (
+    rowId: number,
+    nextArea: number,
+    fallbackCultureId?: number,
+    fallbackPlantsCount?: number | null,
+  ): void => {
     const normalizedArea = Number(nextArea.toFixed(2));
     const row = mobileRows.find((item) => item.id === rowId);
-    const culture = cultures.find((item) => item.id === row?.culture);
+    const cultureId = row?.culture ?? fallbackCultureId;
+    const culture = cultures.find((item) => item.id === cultureId);
     const plantsPerSqm = culture?.plants_per_m2;
     gridCommandApiRef.current?.setDraftValues(rowId, {
       area_m2: normalizedArea,
-      plants_count: plantsPerSqm && plantsPerSqm > 0 ? Math.round(normalizedArea * plantsPerSqm) : row?.plants_count,
+      plants_count: plantsPerSqm && plantsPerSqm > 0 ? Math.round(normalizedArea * plantsPerSqm) : row?.plants_count ?? fallbackPlantsCount,
     });
     lastEditedFieldRef.current = "area_m2";
   };
@@ -1969,7 +2051,7 @@ function PlantingPlans(): React.ReactElement {
             const requestedArea = toAreaNumericValue(row.area_m2, numberLocale);
             if (requestedArea === null) {
               if (capacity.availableArea > 0) {
-                applyAreaAndPlants(row.id, capacity.availableArea);
+                applyAreaAndPlants(row.id, capacity.availableArea, row.culture, row.plants_count);
                 setAreaNotice({
                   severity: "info",
                   message: t("plantingPlans:areaValidation.maxAreaApplied", { area: formatAreaM2(capacity.availableArea, numberLocale) }),
@@ -1984,6 +2066,8 @@ function PlantingPlans(): React.ReactElement {
                 availableArea: capacity.availableArea,
                 bedArea: capacity.bedArea,
                 occupiedArea: capacity.occupiedArea,
+                cultureId: row.culture,
+                plantsCount: row.plants_count,
                 mode: "bedLimit",
               });
               return false;
@@ -1995,6 +2079,8 @@ function PlantingPlans(): React.ReactElement {
                 availableArea: capacity.availableArea,
                 bedArea: capacity.bedArea,
                 occupiedArea: capacity.occupiedArea,
+                cultureId: row.culture,
+                plantsCount: row.plants_count,
                 mode: "noRemainingArea",
               });
               return false;
@@ -2006,6 +2092,8 @@ function PlantingPlans(): React.ReactElement {
                 availableArea: capacity.availableArea,
                 bedArea: capacity.bedArea,
                 occupiedArea: capacity.occupiedArea,
+                cultureId: row.culture,
+                plantsCount: row.plants_count,
                 mode: "remainingLimit",
               });
               return false;
@@ -2219,6 +2307,8 @@ function PlantingPlans(): React.ReactElement {
                   areaValidationDialog.mode === "bedLimit"
                     ? areaValidationDialog.bedArea
                     : areaValidationDialog.availableArea,
+                  areaValidationDialog.cultureId,
+                  areaValidationDialog.plantsCount,
                 );
                 setAreaValidationDialog(null);
               }}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -244,6 +244,17 @@ const toAreaNumericValue = (value: unknown, locale: string): number | null => {
   return localized === null ? null : localized;
 };
 
+const isAutoAreaRequest = (value: unknown, maxKeyword: string): boolean => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (typeof value !== "string") {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "" || normalized === maxKeyword.trim().toLowerCase() || normalized === "maximum";
+};
+
 const toOptionalString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
 
@@ -1543,20 +1554,31 @@ function PlantingPlans(): React.ReactElement {
     };
   };
 
+  const buildAreaAndPlantsDraft = (
+    row: Pick<PlantingPlanRow, "culture" | "plants_count"> | undefined,
+    nextArea: number,
+    fallbackCultureId?: number,
+    fallbackPlantsCount?: number | null,
+  ): Pick<PlantingPlanRow, "area_m2" | "plants_count"> => {
+    const normalizedArea = Number(nextArea.toFixed(2));
+    const cultureId = row?.culture ?? fallbackCultureId;
+    const culture = cultures.find((item) => item.id === cultureId);
+    const plantsPerSqm = culture?.plants_per_m2;
+    return {
+      area_m2: normalizedArea,
+      plants_count: plantsPerSqm && plantsPerSqm > 0 ? Math.round(normalizedArea * plantsPerSqm) : row?.plants_count ?? fallbackPlantsCount,
+    };
+  };
+
   const applyAreaAndPlants = (
     rowId: number,
     nextArea: number,
     fallbackCultureId?: number,
     fallbackPlantsCount?: number | null,
   ): void => {
-    const normalizedArea = Number(nextArea.toFixed(2));
     const row = mobileRows.find((item) => item.id === rowId);
-    const cultureId = row?.culture ?? fallbackCultureId;
-    const culture = cultures.find((item) => item.id === cultureId);
-    const plantsPerSqm = culture?.plants_per_m2;
     gridCommandApiRef.current?.setDraftValues(rowId, {
-      area_m2: normalizedArea,
-      plants_count: plantsPerSqm && plantsPerSqm > 0 ? Math.round(normalizedArea * plantsPerSqm) : row?.plants_count ?? fallbackPlantsCount,
+      ...buildAreaAndPlantsDraft(row, nextArea, fallbackCultureId, fallbackPlantsCount),
     });
     lastEditedFieldRef.current = "area_m2";
   };
@@ -2048,16 +2070,21 @@ function PlantingPlans(): React.ReactElement {
             if (!capacity) {
               return true;
             }
-            const requestedArea = toAreaNumericValue(row.area_m2, numberLocale);
-            if (requestedArea === null) {
+            const maxKeyword = t("plantingPlans:placeholders.maxKeyword");
+            if (isAutoAreaRequest(row.area_m2, maxKeyword)) {
               if (capacity.availableArea > 0) {
-                applyAreaAndPlants(row.id, capacity.availableArea, row.culture, row.plants_count);
                 setAreaNotice({
                   severity: "info",
                   message: t("plantingPlans:areaValidation.maxAreaApplied", { area: formatAreaM2(capacity.availableArea, numberLocale) }),
                 });
+                lastEditedFieldRef.current = "area_m2";
+                return buildAreaAndPlantsDraft(row, capacity.availableArea);
               }
               return false;
+            }
+            const requestedArea = toAreaNumericValue(row.area_m2, numberLocale);
+            if (requestedArea === null) {
+              return true;
             }
             if (requestedArea > capacity.bedArea) {
               setAreaValidationDialog({

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -2189,6 +2189,18 @@ function PlantingPlans(): React.ReactElement {
               {areaValidationDialog.mode !== "noRemainingArea" && (
                 <Typography sx={{ whiteSpace: "nowrap" }}>{t("plantingPlans:areaValidation.requestedArea", { area: formatAreaM2(areaValidationDialog.requestedArea, numberLocale) })}</Typography>
               )}
+              {areaValidationDialog.mode !== "noRemainingArea" && (
+                <Typography sx={{ whiteSpace: "nowrap", fontWeight: 700 }}>
+                  {t("plantingPlans:areaValidation.acceptedArea", {
+                    area: formatAreaM2(
+                      areaValidationDialog.mode === "bedLimit"
+                        ? areaValidationDialog.bedArea
+                        : areaValidationDialog.availableArea,
+                      numberLocale,
+                    ),
+                  })}
+                </Typography>
+              )}
             </Stack>
           )}
         </DialogContent>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -187,6 +187,24 @@ const toNumericValue = (value: unknown): number | null => {
   }
   return null;
 };
+const toAreaNumericValue = (value: unknown, locale: string): number | null => {
+  const directNumeric = toNumericValue(value);
+  if (directNumeric !== null) {
+    return directNumeric;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value
+    .replace("m²", "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+  const localized = parseLocalizedNumber(normalized, locale);
+  return localized === null ? null : localized;
+};
 
 const toOptionalString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
@@ -1441,7 +1459,7 @@ function PlantingPlans(): React.ReactElement {
     }
     const occupiedArea = mobileRows
       .filter((item) => item.id !== row.id && item.bed === row.bed && datesOverlap(item, row))
-      .reduce((total, item) => total + Math.max(0, toNumericValue(item.area_m2) ?? 0), 0);
+      .reduce((total, item) => total + Math.max(0, toAreaNumericValue(item.area_m2, numberLocale) ?? 0), 0);
     return {
       bedArea,
       occupiedArea,
@@ -1948,7 +1966,7 @@ function PlantingPlans(): React.ReactElement {
             if (!capacity) {
               return true;
             }
-            const requestedArea = toNumericValue(row.area_m2);
+            const requestedArea = toAreaNumericValue(row.area_m2, numberLocale);
             if (requestedArea === null) {
               if (capacity.availableArea > 0) {
                 applyAreaAndPlants(row.id, capacity.availableArea);

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -12,6 +12,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import type {
   GridCellParams,
   GridColDef,
+  GridRenderEditCellParams,
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
@@ -178,6 +179,46 @@ const toIsoDateString = (value: unknown): string | null => {
   }
   return null;
 };
+
+function PlantingDateEditCell(params: GridRenderEditCellParams): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputValue = toIsoDateString(params.value) ?? "";
+
+  useEffect(() => {
+    if (!params.hasFocus) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, [params.hasFocus]);
+
+  return (
+    <TextField
+      type="date"
+      fullWidth
+      size="small"
+      inputRef={inputRef}
+      value={inputValue}
+      slotProps={{
+        htmlInput: {
+          tabIndex: params.hasFocus ? 0 : -1,
+        },
+      }}
+      onChange={async (event) => {
+        const nextValue = event.target.value
+          ? new Date(`${event.target.value}T00:00:00`)
+          : null;
+        await params.api.setEditCellValue({
+          id: params.id,
+          field: params.field,
+          value: nextValue,
+        });
+      }}
+    />
+  );
+}
 
 const toDateKey = (value: unknown): number | null => {
   const buildDateKey = (year: number, month: number, day: number): number | null => {
@@ -1161,34 +1202,7 @@ function PlantingPlans(): React.ReactElement {
         type: "date",
         editable: true,
         valueGetter: (value) => (value ? new Date(value) : null),
-        renderEditCell: (params) => {
-          const inputValue = toIsoDateString(params.value) ?? "";
-
-          return (
-            <TextField
-              type="date"
-              fullWidth
-              size="small"
-              autoFocus={params.hasFocus}
-              value={inputValue}
-              slotProps={{
-                htmlInput: {
-                  tabIndex: params.hasFocus ? 0 : -1,
-                },
-              }}
-              onChange={async (event) => {
-                const nextValue = event.target.value
-                  ? new Date(`${event.target.value}T00:00:00`)
-                  : null;
-                await params.api.setEditCellValue({
-                  id: params.id,
-                  field: params.field,
-                  value: nextValue,
-                });
-              }}
-            />
-          );
-        },
+        renderEditCell: (params) => <PlantingDateEditCell {...params} />,
         preProcessEditCellProps: (params) => {
           const hasError = !params.props.value;
           return { ...params.props, error: hasError };

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1044,6 +1044,11 @@ function PlantingPlans(): React.ReactElement {
               size="small"
               autoFocus={params.hasFocus}
               value={selectedValue}
+              slotProps={{
+                htmlInput: {
+                  tabIndex: params.hasFocus ? 0 : -1,
+                },
+              }}
               onChange={async (event) => {
                 await params.api.setEditCellValue({
                   id: params.id,
@@ -1156,6 +1161,34 @@ function PlantingPlans(): React.ReactElement {
         type: "date",
         editable: true,
         valueGetter: (value) => (value ? new Date(value) : null),
+        renderEditCell: (params) => {
+          const inputValue = toIsoDateString(params.value) ?? "";
+
+          return (
+            <TextField
+              type="date"
+              fullWidth
+              size="small"
+              autoFocus={params.hasFocus}
+              value={inputValue}
+              slotProps={{
+                htmlInput: {
+                  tabIndex: params.hasFocus ? 0 : -1,
+                },
+              }}
+              onChange={async (event) => {
+                const nextValue = event.target.value
+                  ? new Date(`${event.target.value}T00:00:00`)
+                  : null;
+                await params.api.setEditCellValue({
+                  id: params.id,
+                  field: params.field,
+                  value: nextValue,
+                });
+              }}
+            />
+          );
+        },
         preProcessEditCellProps: (params) => {
           const hasError = !params.props.value;
           return { ...params.props, error: hasError };

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -122,6 +122,14 @@ interface MobileCreateFormState {
   plants_count: string;
   notes: string;
 }
+interface AreaValidationDialogState {
+  rowId: number;
+  requestedArea: number;
+  availableArea: number;
+  bedArea: number;
+  occupiedArea: number;
+  mode: "bedLimit" | "remainingLimit" | "noRemainingArea";
+}
 
 const CULTIVATION_TYPE_OPTIONS = [
   {
@@ -456,6 +464,7 @@ function PlantingPlans(): React.ReactElement {
     message: string;
     severity: "info" | "warning";
   } | null>(null);
+  const [areaValidationDialog, setAreaValidationDialog] = useState<AreaValidationDialogState | null>(null);
   const urlParamProcessedRef = useRef<boolean>(false);
   const gridCommandApiRef = useRef<EditableDataGridCommandApi | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<PlantingPlanRow | null>(
@@ -1406,6 +1415,51 @@ function PlantingPlans(): React.ReactElement {
     }
     return Number((row.plants_count / plantsPerSqm).toFixed(2));
   };
+  const datesOverlap = (rowA: PlantingPlanRow, rowB: PlantingPlanRow): boolean => {
+    const startA = toIsoDateString(rowA.planting_date);
+    const startB = toIsoDateString(rowB.planting_date);
+    if (!startA || !startB) {
+      return false;
+    }
+    const endA = toIsoDateString(rowA.harvest_end_date) ?? toIsoDateString(rowA.harvest_date) ?? "9999-12-31";
+    const endB = toIsoDateString(rowB.harvest_end_date) ?? toIsoDateString(rowB.harvest_date) ?? "9999-12-31";
+    return startA <= endB && startB <= endA;
+  };
+
+  const getCapacityForRow = (row: PlantingPlanRow): {
+    bedArea: number;
+    occupiedArea: number;
+    availableArea: number;
+  } | null => {
+    if (typeof row.bed !== "number") {
+      return null;
+    }
+    const selectedBed = bedById.get(row.bed);
+    const bedArea = toNumericValue(selectedBed?.area_sqm);
+    if (bedArea === null) {
+      return null;
+    }
+    const occupiedArea = mobileRows
+      .filter((item) => item.id !== row.id && item.bed === row.bed && datesOverlap(item, row))
+      .reduce((total, item) => total + Math.max(0, toNumericValue(item.area_m2) ?? 0), 0);
+    return {
+      bedArea,
+      occupiedArea,
+      availableArea: Math.max(0, bedArea - occupiedArea),
+    };
+  };
+
+  const applyAreaAndPlants = (rowId: number, nextArea: number): void => {
+    const normalizedArea = Number(nextArea.toFixed(2));
+    const row = mobileRows.find((item) => item.id === rowId);
+    const culture = cultures.find((item) => item.id === row?.culture);
+    const plantsPerSqm = culture?.plants_per_m2;
+    gridCommandApiRef.current?.setDraftValues(rowId, {
+      area_m2: normalizedArea,
+      plants_count: plantsPerSqm && plantsPerSqm > 0 ? Math.round(normalizedArea * plantsPerSqm) : row?.plants_count,
+    });
+    lastEditedFieldRef.current = "area_m2";
+  };
 
   const validateMobileForm = (): boolean => {
     if (!mobileCreateForm.culture || !mobileCreateForm.bed || !mobileCreateForm.planting_date) {
@@ -1889,6 +1943,57 @@ function PlantingPlans(): React.ReactElement {
             }
             return errors;
           }}
+          onBeforeSaveRow={(row) => {
+            const capacity = getCapacityForRow(row);
+            if (!capacity) {
+              return true;
+            }
+            const requestedArea = toNumericValue(row.area_m2);
+            if (requestedArea === null) {
+              if (capacity.availableArea > 0) {
+                applyAreaAndPlants(row.id, capacity.availableArea);
+                setAreaNotice({
+                  severity: "info",
+                  message: t("plantingPlans:areaValidation.maxAreaApplied", { area: formatAreaM2(capacity.availableArea, numberLocale) }),
+                });
+              }
+              return false;
+            }
+            if (requestedArea > capacity.bedArea) {
+              setAreaValidationDialog({
+                rowId: row.id,
+                requestedArea,
+                availableArea: capacity.availableArea,
+                bedArea: capacity.bedArea,
+                occupiedArea: capacity.occupiedArea,
+                mode: "bedLimit",
+              });
+              return false;
+            }
+            if (capacity.availableArea <= 0) {
+              setAreaValidationDialog({
+                rowId: row.id,
+                requestedArea,
+                availableArea: capacity.availableArea,
+                bedArea: capacity.bedArea,
+                occupiedArea: capacity.occupiedArea,
+                mode: "noRemainingArea",
+              });
+              return false;
+            }
+            if (requestedArea > capacity.availableArea) {
+              setAreaValidationDialog({
+                rowId: row.id,
+                requestedArea,
+                availableArea: capacity.availableArea,
+                bedArea: capacity.bedArea,
+                occupiedArea: capacity.occupiedArea,
+                mode: "remainingLimit",
+              });
+              return false;
+            }
+            return true;
+          }}
           loadErrorMessage={t("plantingPlans:errors.load")}
           saveErrorMessage={t("plantingPlans:errors.save")}
           deleteErrorMessage={t("plantingPlans:errors.delete")}
@@ -2043,6 +2148,56 @@ function PlantingPlans(): React.ReactElement {
           <Button onClick={() => void (mobileEditId ? handleMobileUpdate() : handleMobileCreate())} variant="contained">
             {mobileEditId ? t("common:actions.save") : t("common:actions.add")}
           </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog open={areaValidationDialog !== null} onClose={() => setAreaValidationDialog(null)} fullWidth maxWidth="xs">
+        <DialogTitle>
+          {areaValidationDialog?.mode === "bedLimit"
+            ? t("plantingPlans:areaValidation.bedLimitTitle")
+            : areaValidationDialog?.mode === "noRemainingArea"
+              ? t("plantingPlans:areaValidation.noRemainingTitle")
+              : t("plantingPlans:areaValidation.remainingLimitTitle")}
+        </DialogTitle>
+        <DialogContent>
+          {areaValidationDialog && (
+            <Stack spacing={1}>
+              {areaValidationDialog.mode !== "bedLimit" && (
+                <Typography sx={{ whiteSpace: "nowrap" }}>{t("plantingPlans:areaValidation.availableArea", { area: formatAreaM2(areaValidationDialog.availableArea, numberLocale) })}</Typography>
+              )}
+              <Typography sx={{ whiteSpace: "nowrap" }}>{t("plantingPlans:areaValidation.bedArea", { area: formatAreaM2(areaValidationDialog.bedArea, numberLocale) })}</Typography>
+              {areaValidationDialog.mode !== "bedLimit" && (
+                <Typography sx={{ whiteSpace: "nowrap" }}>{t("plantingPlans:areaValidation.occupiedArea", { area: formatAreaM2(areaValidationDialog.occupiedArea, numberLocale) })}</Typography>
+              )}
+              {areaValidationDialog.mode !== "noRemainingArea" && (
+                <Typography sx={{ whiteSpace: "nowrap" }}>{t("plantingPlans:areaValidation.requestedArea", { area: formatAreaM2(areaValidationDialog.requestedArea, numberLocale) })}</Typography>
+              )}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAreaValidationDialog(null)}>{t("common:actions.cancel")}</Button>
+          {areaValidationDialog?.mode !== "noRemainingArea" && (
+            <Button
+              variant="contained"
+              color="success"
+              onClick={() => {
+                if (!areaValidationDialog) {
+                  return;
+                }
+                applyAreaAndPlants(
+                  areaValidationDialog.rowId,
+                  areaValidationDialog.mode === "bedLimit"
+                    ? areaValidationDialog.bedArea
+                    : areaValidationDialog.availableArea,
+                );
+                setAreaValidationDialog(null);
+              }}
+            >
+              {areaValidationDialog?.mode === "bedLimit"
+                ? t("plantingPlans:areaValidation.applyBedArea")
+                : t("plantingPlans:areaValidation.applyRemainingArea")}
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1191,7 +1191,6 @@ function PlantingPlans(): React.ReactElement {
         width: dynamicWidths.area,
         maxWidth: dynamicWidths.area,
         editable: true,
-        type: "number",
         renderHeader: () => (
           <Tooltip title={t("plantingPlans:tooltips.areaInput")}>
             <Box component="span" sx={DATA_GRID_HEADER_LABEL_SX}>
@@ -2007,7 +2006,13 @@ function PlantingPlans(): React.ReactElement {
             // Determine which field to send based on last edit
             const source = lastEditedFieldRef.current || "area_m2";
 
-            if (source === "area_m2" && typeof row.area_m2 === "number") {
+            if (source === "area_m2" && isAutoAreaRequest(row.area_m2, t("plantingPlans:placeholders.maxKeyword"))) {
+              const capacity = getCapacityForRow(row);
+              if (capacity && capacity.availableArea > 0) {
+                apiData.area_input_value = Number(capacity.availableArea.toFixed(2));
+                apiData.area_input_unit = "M2";
+              }
+            } else if (source === "area_m2" && typeof row.area_m2 === "number") {
               // User edited area directly - send as M2
               apiData.area_input_value = row.area_m2;
               apiData.area_input_unit = "M2";

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1042,6 +1042,7 @@ function PlantingPlans(): React.ReactElement {
               select
               fullWidth
               size="small"
+              autoFocus={params.hasFocus}
               value={selectedValue}
               onChange={async (event) => {
                 await params.api.setEditCellValue({
@@ -1104,7 +1105,7 @@ function PlantingPlans(): React.ReactElement {
         renderCell: (params) => {
           const row = params.row as PlantingPlanRow;
           const label = getBedLabelForRow(row);
-          return <CompactAreaCell label={label} />;
+          return <CompactAreaCell label={label} hasFocus={params.hasFocus} />;
         },
         renderEditCell: (params) => {
           const row = params.row as PlantingPlanRow;
@@ -1118,6 +1119,7 @@ function PlantingPlans(): React.ReactElement {
               locations={locations}
               locale={numberLocale}
               compactLabel={label}
+              hasFocus={params.hasFocus}
               onApply={async (nextBedId) => {
                 await params.api.setEditCellValue({
                   id: params.id,

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,6 +1,7 @@
 // Central MUI theme configuration
 // Controls colors, shapes, and component style overrides.
 import { alpha, createTheme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
 const surfaceColors = {
@@ -14,6 +15,23 @@ const surfaceColors = {
   surfaceBorder: '#e7e1d6',
   surfaceSoftBorder: '#ece8df',
 } as const;
+
+const createPositiveFilledAlertStyles = (theme: Theme) => ({
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.primary.contrastText,
+  '& .MuiAlert-icon': {
+    color: theme.palette.primary.contrastText,
+  },
+  '& .MuiAlert-action': {
+    color: theme.palette.primary.contrastText,
+  },
+  '& .MuiIconButton-root': {
+    color: theme.palette.primary.contrastText,
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.contrastText, 0.12),
+    },
+  },
+});
 
 declare module '@mui/material/styles' {
   interface SurfacePalette {
@@ -289,6 +307,8 @@ const theme = createTheme({
     },
     MuiAlert: {
       styleOverrides: {
+        filledInfo: ({ theme }) => createPositiveFilledAlertStyles(theme),
+        filledSuccess: ({ theme }) => createPositiveFilledAlertStyles(theme),
         standardInfo: {
           backgroundColor: 'rgba(33, 150, 243, 0.08)',
           color: '#24435f',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
     },
   },
   server: {
+    watch: {
+      ignored: ['**/coverage/**'],
+    },
     proxy: {
       '/admin': {
         target: 'http://localhost:8000',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,12 @@ export default defineConfig({
   },
   server: {
     watch: {
-      ignored: ['**/coverage/**'],
+      ignored: [
+        '**/coverage/**',
+        '**/dist/**',
+        '**/.git/**',
+        '**/node_modules/.cache/**',
+      ],
     },
     proxy: {
       '/admin': {


### PR DESCRIPTION
### Motivation

- Reintroduce a simple, low-friction area validation that runs primarily at save time instead of restoring the previous live per-keystroke complexity.

### Description

- Added save-time capacity checks via `onBeforeSaveRow` in `frontend/src/pages/PlantingPlans.tsx` that compute bed capacity and remaining area before allowing a row save.
- Implemented overlap-aware helpers `datesOverlap` and `getCapacityForRow` to calculate `availableArea = max(0, bedArea - occupiedArea)` while excluding the currently edited row, and kept plants↔area coupling by using `applyAreaAndPlants` to set draft values via the grid command API (`setDraftValues`).
- Implemented three dialog flows and a subtle snackbar for the requested UX cases: empty/`max` input applies available area, requested area > remaining opens a dialog to apply remaining area, requested area > bed area opens a dialog to apply full bed area, and no remaining area opens an informational dialog; UI strings were added to `frontend/src/i18n/locales/de/plantingPlans.json`.
- Kept changes localized to the inline edit/save flow without introducing persistent live validation, avoided showing errors inside cells, and used MUI dialogs/snackbar to match existing styling and interaction patterns.

### Testing

- No automated tests were run (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd3e557b8832297b638a4224ec00a)