### PR TITLE
[codex] fix MUI hierarchy grid build

### DIFF
--- a/backend/accounts/templates/accounts/emails/activation_email.html
+++ b/backend/accounts/templates/accounts/emails/activation_email.html
@@ -15,7 +15,7 @@
                 </p>
                 <p style="margin:0 0 8px 0;">Falls der Button nicht funktioniert, kopiere bitte diesen Link in deinen Browser:</p>
                 <p style="margin:0 0 16px 0; word-break:break-all;"><a href="{{ activation_link }}" style="color:#1d4ed8; text-decoration:underline;">{{ activation_link }}</a></p>
-                <p style="margin:0 0 16px 0;">OpenFarmPlanner ist eine Open-Source-Webanwendung zur Planung von Gemüsebau und CSA-Anbau.</p>
+                <p style="margin:0 0 16px 0;">OpenFarmPlanner ist eine Open-Source-Webanwendung für die Planung von Gemüseanbau.</p>
                 <p style="margin:0 0 24px 0;">Falls du kein Konto erstellt hast, kannst du diese E-Mail ignorieren.</p>
                 <hr style="border:none; border-top:1px solid #e5e7eb; margin:0 0 16px 0;">
                 <p style="margin:0; font-size:13px; color:#4b5563;">

--- a/backend/accounts/templates/accounts/emails/activation_email.txt
+++ b/backend/accounts/templates/accounts/emails/activation_email.txt
@@ -6,7 +6,7 @@ Bitte bestätige deine Registrierung über den folgenden Link:
 
 {{ activation_link|safe }}
 
-OpenFarmPlanner ist eine Open-Source-Webanwendung zur Planung von Gemüsebau und CSA-Anbau.
+OpenFarmPlanner ist eine Open-Source-Webanwendung für die Planung von Gemüseanbau.
 
 Falls du kein Konto erstellt hast, kannst du diese E-Mail ignorieren.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenFarmPlanner</title>
-    <meta name="description" content="OpenFarmPlanner ist ein Open-Source Gemüse-Anbauplaner für CSA, Solawi und kleinteiligen Gemüsebau. Plane Kulturen, Beete, Anbauflächen und Saattermine einfach online." />
+    <meta name="description" content="OpenFarmPlanner ist ein Open-Source-Anbauplaner für den Gemüsebau. Plane Kulturen, Anbauflächen und Anbauzeiträume an einem Ort." />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/__tests__/PageHelp.test.tsx
+++ b/frontend/src/__tests__/PageHelp.test.tsx
@@ -3,18 +3,111 @@ import { describe, expect, it } from 'vitest';
 import PageHelp from '../components/help/PageHelp';
 
 describe('PageHelp', () => {
-  it('renders the page introduction as body text before structured sections', async () => {
+  it('renders compact planting plans help without structured sections', async () => {
     render(<PageHelp pageKey="plantingPlans" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
 
-    const intro = await screen.findByText(
-      'Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet deine Anbauflächen mit den Kulturdaten und bildet die Grundlage für Anbaukalender und Saatgutbedarf.',
-    );
+    expect(await screen.findByText('Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet Anbauflächen und Kulturen und bildet die Grundlage für Anbaukalender und Saatgutbedarf.')).toBeInTheDocument();
+    expect(screen.getByText('Einträge können direkt in der Tabelle erstellt und bearbeitet werden.')).toBeInTheDocument();
+    expect(screen.getByText('Anbaukalender und Saatgutbedarf werden automatisch aus diesen Planungen berechnet.')).toBeInTheDocument();
 
-    expect(screen.queryByText('Was sehe ich hier?')).not.toBeInTheDocument();
-    expect(screen.queryByText(`• ${intro.textContent}`)).not.toBeInTheDocument();
-    expect(screen.getByText('Bedienung')).toBeInTheDocument();
-    expect(screen.getByText('Zusammenhang mit anderen Seiten')).toBeInTheDocument();
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zusammenhang mit anderen Seiten')).not.toBeInTheDocument();
+    expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();
+    expect(screen.queryByText('Anbauplan hinzufügen')).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders compact dashboard help without structured sections', async () => {
+    render(<PageHelp pageKey="dashboard" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Die Übersicht zeigt die nächsten wichtigen Aufgaben aus deiner Planung.')).toBeInTheDocument();
+    expect(screen.getByText('Sobald Anbaupläne vorhanden sind, erscheinen hier anstehende Termine für Aussaat, Pflanzung, Anzucht und Ernte.')).toBeInTheDocument();
+    expect(screen.getByText('Änderungen an den Daten erfolgen in den jeweiligen Bereichen wie Anbauflächen, Kulturen oder Anbaupläne.')).toBeInTheDocument();
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hinweis')).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders compact areas list help without obsolete symbol guidance', async () => {
+    render(<PageHelp pageKey="areas" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Hier verwaltest du die Flächenstruktur deines Betriebs – vom Standort über Parzellen bis zu einzelnen Beeten.')).toBeInTheDocument();
+    expect(screen.getByText('Neue Standorte, Parzellen und Beete können über das', { exact: false })).toBeInTheDocument();
+    expect(screen.getByTestId('AddIcon')).toBeInTheDocument();
+    expect(screen.getByText('hinzugefügt werden, das beim Überfahren eines Elements mit der Maus erscheint.', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Einträge können direkt in der Tabelle bearbeitet werden. Weitere Aktionen wie Umbenennen, Löschen oder das Anlegen von Anbauplänen findest du im Kontextmenü per Rechtsklick.')).toBeInTheDocument();
+    expect(screen.getByText('Die angelegten Flächen bilden die Grundlage für deine Anbauplanung.')).toBeInTheDocument();
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zusammenhang mit anderen Seiten')).not.toBeInTheDocument();
+    expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders cultures help with vertical more-actions icon and without separate delete symbol', async () => {
+    render(<PageHelp pageKey="cultures" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Weitere Aktionen öffnen')).toBeInTheDocument();
+    expect(screen.getAllByTestId('MoreVertIcon').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('Über', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('erreichst du weitere Aktionen wie Versionen, Veröffentlichung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.', { exact: false })).toBeInTheDocument();
+    expect(screen.queryByText(/⋯/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Kultur entfernen')).not.toBeInTheDocument();
+  });
+
+  it('renders compact calendar help without controls or icon guidance', async () => {
+    render(<PageHelp pageKey="calendar" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Der Anbaukalender visualisiert die zeitliche Planung deiner Anbaupläne. So erkennst du Belegungen, Anzuchtphasen, Erntezeiträume und mögliche Überschneidungen.')).toBeInTheDocument();
+    expect(screen.getByText('Fahre über Einträge, um weitere Details anzuzeigen.')).toBeInTheDocument();
+    expect(screen.getByText('Änderungen in den Anbauplänen werden hier automatisch übernommen.')).toBeInTheDocument();
+
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zusammenhang mit anderen Seiten')).not.toBeInTheDocument();
+    expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zwischen Ansichten wechseln')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Drag & Drop/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders compact seed demand help without supplier or package control guidance', async () => {
+    render(<PageHelp pageKey="seedDemand" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Hier siehst du den berechneten Saatgutbedarf deiner Anbaupläne.')).toBeInTheDocument();
+    expect(screen.getByText('Die Berechnung basiert auf den Kulturdaten und Anbauplänen. Änderungen werden automatisch übernommen.')).toBeInTheDocument();
+
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Zusammenhang mit anderen Seiten')).not.toBeInTheDocument();
+    expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lieferant pro Kultur festlegen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Empfohlene Packungskombinationen prüfen')).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders compact suppliers help without icon guidance', async () => {
+    render(<PageHelp pageKey="suppliers" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Hier verwaltest du deine Lieferanten.')).toBeInTheDocument();
+    expect(screen.getByText('Lieferanten können in Kulturen hinterlegt werden, um kulturspezifische Artikel- und Verpackungsinformationen zu erfassen. Diese Daten werden für Saatgutbedarf und Bestellvorschläge verwendet.')).toBeInTheDocument();
+
+    expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
+    expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lieferanten hinzufügen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lieferantendaten ändern')).not.toBeInTheDocument();
+    expect(screen.queryByText('Lieferanten entfernen')).not.toBeInTheDocument();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/hierarchyComponents.test.tsx
+++ b/frontend/src/__tests__/hierarchyComponents.test.tsx
@@ -201,7 +201,7 @@ describe('hierarchy components and behaviors', () => {
       openNotes,
       mockT as never,
       undefined,
-      { disablePlantingPlanHoverAction: true },
+      { disableInlineHoverActions: true },
     );
     const touchNameColumn = touchColumns.find((column) => column.field === 'name');
     rerender(
@@ -215,8 +215,21 @@ describe('hierarchy components and behaviors', () => {
       </>
     );
     expect(screen.queryByLabelText('Pflanzplan erstellen')).not.toBeInTheDocument();
+
+    rerender(
+      <>
+        {touchNameColumn?.renderCell?.({
+          id: 'field-10',
+          field: 'name',
+          value: 'Parzelle 10',
+          row: { id: 'field-10', type: 'field', fieldId: 10, level: 1 },
+        } as never)}
+      </>
+    );
+    expect(screen.queryByLabelText('Beet hinzufügen')).not.toBeInTheDocument();
+
     fireEvent.contextMenu(screen.getByTestId('hierarchy-name-text'));
-    expect(openContextMenu).toHaveBeenLastCalledWith(expect.any(Object), expect.objectContaining({ id: 101 }));
+    expect(openContextMenu).toHaveBeenLastCalledWith(expect.any(Object), expect.objectContaining({ id: 'field-10' }));
   }, 15000);
 
 

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -46,6 +46,7 @@ import { useTheme } from '@mui/material/styles';
 import { useEffect, useMemo, useRef, useState, type MouseEvent, type ReactElement } from 'react';
 import { useTranslation } from '../../i18n';
 import HelpIconRow from './HelpIconRow';
+import { HierarchyAddIcon } from '../hierarchy/HierarchyAddIcon';
 
 export type HelpPageKey =
   | 'dashboard'
@@ -245,15 +246,61 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
     setMobileOpen(false);
   };
 
+  const renderHelpTextContent = (text: string): ReactElement | string => {
+    const tokens = text.split(/({{addIcon}}|{{moreIcon}})/);
+    if (tokens.length === 1) {
+      return text;
+    }
+
+    return (
+      <>
+        {tokens.map((token, index) => {
+          if (token === '{{addIcon}}') {
+            return (
+              <HierarchyAddIcon
+                key={`${token}-${index}`}
+                interactive={false}
+                ariaHidden
+                sx={{
+                  mx: 0.25,
+                  verticalAlign: 'text-bottom',
+                }}
+              />
+            );
+          }
+          if (token === '{{moreIcon}}') {
+            return (
+              <MoreVertIcon
+                key={`${token}-${index}`}
+                aria-hidden
+                fontSize="small"
+                sx={{
+                  mx: 0.25,
+                  color: 'text.secondary',
+                  verticalAlign: 'text-bottom',
+                }}
+              />
+            );
+          }
+          return token;
+        })}
+      </>
+    );
+  };
+
   const renderIntro = (): ReactElement | null => {
     if (!intro) {
       return null;
     }
 
     return (
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-        {intro}
-      </Typography>
+      <Stack spacing={1} sx={{ mb: 1.5 }}>
+        {intro.split(/\n{2,}/).map((paragraph) => (
+          <Typography key={paragraph} variant="body2">
+            {renderHelpTextContent(paragraph)}
+          </Typography>
+        ))}
+      </Stack>
     );
   };
 
@@ -265,7 +312,15 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
       <List dense disablePadding>
         {section.points.map((point, pointIndex) => (
           <ListItem key={`${key}-${pointIndex}`} sx={{ py: 0.15, px: 0 }}>
-            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${point}`} />
+            <ListItemText
+              slotProps={{ primary: { variant: 'body2' } }}
+              primary={(
+                <>
+                  {'• '}
+                  {renderHelpTextContent(point)}
+                </>
+              )}
+            />
           </ListItem>
         ))}
       </List>

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -47,7 +47,7 @@ interface NameCellCallbacks {
 }
 
 interface HierarchyColumnOptions {
-  disablePlantingPlanHoverAction?: boolean;
+  disableInlineHoverActions?: boolean;
 }
 
 function renderHierarchyAddIconButton({
@@ -117,6 +117,10 @@ function renderInlineActions(
   t: TFunction,
   options: HierarchyColumnOptions,
 ): ReactElement | null {
+  if (options.disableInlineHoverActions) {
+    return null;
+  }
+
   if (row.type === 'location') {
     return (
       <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
@@ -140,10 +144,6 @@ function renderInlineActions(
   }
 
   if (row.type === 'bed') {
-    if (options.disablePlantingPlanHoverAction) {
-      return null;
-    }
-
     return (
       <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
         {renderPlantingPlanActionButton(row, callbacks, t)}

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -41,23 +41,7 @@
   "pages": {
     "dashboard": {
       "title": "Hilfe: Übersicht",
-      "intro": "Die Übersicht zeigt dir, was als Nächstes wichtig ist. Bei neuen Projekten führt sie dich mit einer Checkliste durch die ersten Schritte. Sobald Anbaupläne vorhanden sind, erscheinen hier die nächsten Aufgaben und Termine aus deiner Planung.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Nutze die Checkliste, um fehlende Grunddaten Schritt für Schritt anzulegen.",
-            "Öffne die jeweiligen Bereiche, um Anbauflächen, Kulturen oder Anbaupläne zu bearbeiten.",
-            "Prüfe die anstehenden Aufgaben, um Aussaat, Pflanzung, Anzucht und Ernte im Blick zu behalten."
-          ]
-        },
-        {
-          "title": "Hinweis",
-          "points": [
-            "Die Übersicht ist eine Zusammenfassung. Änderungen an den Daten machst du in den jeweiligen Fachseiten."
-          ]
-        }
-      ]
+      "intro": "Die Übersicht zeigt die nächsten wichtigen Aufgaben aus deiner Planung.\n\nSobald Anbaupläne vorhanden sind, erscheinen hier anstehende Termine für Aussaat, Pflanzung, Anzucht und Ernte.\n\nÄnderungen an den Daten erfolgen in den jeweiligen Bereichen wie Anbauflächen, Kulturen oder Anbaupläne."
     },
     "locations": {
       "title": "Hilfe: Standorte",
@@ -119,32 +103,7 @@
     },
     "areas": {
       "title": "Hilfe: Anbauflächen – Listenansicht",
-      "intro": "Hier verwaltest du deine Flächenstruktur vom Standort bis zum Beet. Die hierarchische Liste eignet sich besonders zum Anlegen und Bearbeiten von Flächen.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Klicke in eine Zelle, um Einträge direkt zu bearbeiten.",
-            "Klicke auf Tabellenüberschriften, um zu sortieren oder zu filtern."
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "Die Flächenstruktur bildet die Grundlage für deine weitere Planung.",
-            "In den Anbauplänen ordnest du Kulturen einzelnen Beeten zu.",
-            "In der grafischen Ansicht werden dieselben Flächen visuell dargestellt."
-          ]
-        }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "expandToggle": "Bereich ein- oder ausklappen",
-        "add": "Element hinzufügen",
-        "delete": "Element löschen",
-        "createPlan": "Anbauplan für dieses Beet hinzufügen",
-        "dimensions": "Ausrichtung von Länge und Breite für die grafische Ansicht"
-      }
+      "intro": "Hier verwaltest du die Flächenstruktur deines Betriebs – vom Standort über Parzellen bis zu einzelnen Beeten.\n\nNeue Standorte, Parzellen und Beete können über das {{addIcon}} hinzugefügt werden, das beim Überfahren eines Elements mit der Maus erscheint.\n\nEinträge können direkt in der Tabelle bearbeitet werden. Weitere Aktionen wie Umbenennen, Löschen oder das Anlegen von Anbauplänen findest du im Kontextmenü per Rechtsklick.\n\nDie angelegten Flächen bilden die Grundlage für deine Anbauplanung."
     },
     "cultures": {
       "title": "Hilfe: Kulturen",
@@ -154,7 +113,7 @@
           "title": "Bedienung",
           "points": [
             "Wähle eine Kultur aus, um Details anzuzeigen, zu bearbeiten oder Anbaupläne dafür zu erstellen.",
-            "Über ⋯ erreichst du weitere Aktionen wie Versionen, Veröffentlichung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.",
+            "Über {{moreIcon}} erreichst du weitere Aktionen wie Versionen, Veröffentlichung in der öffentlichen Kulturbibliothek oder das Löschen der ausgewählten Kultur.",
             "Nutze die öffentliche Kulturbibliothek, um Kulturen zu entdecken, zu verwenden oder zu veröffentlichen."
           ]
         },
@@ -172,107 +131,24 @@
         "library": "Kulturbibliothek öffnen",
         "createPlan": "Anbauplan für diese Kultur hinzufügen",
         "more": "Weitere Aktionen öffnen",
-        "edit": "Kulturdaten bearbeiten",
-        "delete": "Kultur entfernen"
+        "edit": "Kulturdaten bearbeiten"
       }
     },
     "plantingPlans": {
       "title": "Hilfe: Anbaupläne",
-      "intro": "Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet deine Anbauflächen mit den Kulturdaten und bildet die Grundlage für Anbaukalender und Saatgutbedarf.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Einträge direkt in der Tabelle erstellen und bearbeiten.",
-            "Mit „Neu“ einen zusätzlichen Plan anlegen.",
-            "Änderungen an Fläche, Zeitraum oder Kultur werden direkt in der Planung übernommen.",
-            "Auf Mobilgeräten neue Einträge über den schwebenden Plus-Button anlegen."
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "Anbaupläne nutzen die Flächenstruktur aus den Anbauflächen.",
-            "Im Anbaukalender wird daraus die zeitliche Abfolge sichtbar.",
-            "Der Saatgutbedarf wird aus diesen Planungen berechnet."
-          ]
-        }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "add": "Anbauplan hinzufügen",
-        "mobileAdd": "Auf Mobilgeräten schnell einen neuen Eintrag anlegen",
-        "notes": "Notizen und Anhänge pro Eintrag öffnen",
-        "edit": "Werte direkt in der Tabelle ändern"
-      }
+      "intro": "Hier planst du, welche Kultur wann auf welchem Beet angebaut wird. Die Seite verbindet Anbauflächen und Kulturen und bildet die Grundlage für Anbaukalender und Saatgutbedarf.\n\nEinträge können direkt in der Tabelle erstellt und bearbeitet werden.\n\nAnbaukalender und Saatgutbedarf werden automatisch aus diesen Planungen berechnet."
     },
     "calendar": {
       "title": "Hilfe: Anbaukalender",
-      "intro": "Der Anbaukalender zeigt die zeitliche Planung deiner Anbaupläne (Anzuchtzeitraum, Wachstumszeitraum und Erntezeitraum). So erkennst du Belegungen, Anzuchtphasen und mögliche Überschneidungen.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Fahre über Einträge, um Details im Tooltip zu sehen.",
-            "Im Bearbeitungsmodus kannst du Zeiträume direkt im Kalender per Drag & Drop anpassen."
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "Der Kalender basiert auf den Daten aus den Anbauplänen.",
-            "Änderungen an Zeiträumen in den Anbauplänen aktualisieren diese Ansicht."
-          ]
-        }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "tabs": "Zwischen Ansichten wechseln",
-        "switch": "Wöchentlichen Ertragskalender ein- oder ausblenden",
-        "tooltip": "Zusätzliche Details anzeigen"
-      }
+      "intro": "Der Anbaukalender visualisiert die zeitliche Planung deiner Anbaupläne. So erkennst du Belegungen, Anzuchtphasen, Erntezeiträume und mögliche Überschneidungen.\n\nFahre über Einträge, um weitere Details anzuzeigen.\n\nÄnderungen in den Anbauplänen werden hier automatisch übernommen."
     },
     "seedDemand": {
       "title": "Hilfe: Saatgutbedarf",
-      "intro": "Hier siehst du, wie viel Saatgut du für deine geplanten Anbaupläne benötigst. Die Mengen werden aus Kulturdaten, Flächen und Planungseinträgen berechnet.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Wähle pro Kultur einen Lieferanten aus, um passende Packungsvorschläge zu erhalten."
-          ]
-        },
-        {
-          "title": "Zusammenhang mit anderen Seiten",
-          "points": [
-            "Die Daten kommen aus den Anbauplänen und Kulturdaten.",
-            "Änderungen an Kultur oder Planung wirken sich direkt auf den Bedarf aus."
-          ]
-        }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "supplierSelect": "Lieferant pro Kultur festlegen",
-        "packageInfo": "Empfohlene Packungskombinationen prüfen"
-      }
+      "intro": "Hier siehst du den berechneten Saatgutbedarf deiner Anbaupläne.\n\nDie Berechnung basiert auf den Kulturdaten und Anbauplänen. Änderungen werden automatisch übernommen."
     },
     "suppliers": {
       "title": "Hilfe: Lieferanten",
-      "intro": "Hier verwaltest du Lieferanten-Stammdaten. Kulturspezifische Artikel- und Verpackungsinformationen ergänzt du in der jeweiligen Kultur.",
-      "sections": [
-        {
-          "title": "Bedienung",
-          "points": [
-            "Bearbeite bestehende Einträge direkt in der Liste."
-          ]
-        }
-      ],
-      "symbolsTitle": "Symbole und Bedienelemente",
-      "symbols": {
-        "add": "Lieferanten hinzufügen",
-        "edit": "Lieferantendaten ändern",
-        "delete": "Lieferanten entfernen"
-      }
+      "intro": "Hier verwaltest du deine Lieferanten.\n\nLieferanten können in Kulturen hinterlegt werden, um kulturspezifische Artikel- und Verpackungsinformationen zu erfassen. Diese Daten werden für Saatgutbedarf und Bestellvorschläge verwendet."
     },
     "graphical": {
       "title": "Hilfe: Anbauflächen – Grafische Ansicht",

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "OpenFarmPlanner",
     "betaBadge": "Beta",
-    "subtitle": "Gemüse-Anbauplaner für CSA (Community Supported Agriculture), Solidarische Landwirtschaften und Marktgärtnereien.",
+    "subtitle": "Open-Source-Anbauplaner für den Gemüsebau.",
     "description": "Verwalte Kulturen, Anbauflächen und Anbauzeiträume übersichtlich an einem Ort.",
     "actions": {
       "openApp": "Anmelden",

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -1725,7 +1725,7 @@ function FieldsBedsHierarchy({
         name: nameColumnWidth,
       },
       {
-        disablePlantingPlanHoverAction: isTouchLikePointer || isMobileViewport,
+        disableInlineHoverActions: isTouchLikePointer || isMobileViewport,
       },
     );
   }, [

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -31,6 +31,7 @@ import type {
   GridRowId,
   GridRowsProp,
   GridRowModesModel,
+  MuiEvent,
 } from "@mui/x-data-grid";
 import { Box, Alert, useMediaQuery } from "@mui/material";
 import Divider from "@mui/material/Divider";
@@ -1951,8 +1952,8 @@ function FieldsBedsHierarchy({
                 setTreeActive(true);
                 handleEditableCellClick(params, rowModesModel, setRowModesModel);
               }}
-              onCellKeyDown={(params: GridCellParams<HierarchyRow>, event: React.KeyboardEvent) => {
-                const keyboardEvent = event as React.KeyboardEvent & { defaultMuiPrevented?: boolean };
+              onCellKeyDown={(params: GridCellParams<HierarchyRow>, event) => {
+                const keyboardEvent = event as MuiEvent<React.KeyboardEvent>;
                 if (
                   keyboardEvent.key === "Escape" &&
                   rowModesModel[params.id]?.mode === GridRowModes.Edit

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -24,7 +24,6 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import { supplierAPI } from '../api/api';
@@ -605,7 +604,7 @@ export default function Suppliers() {
                         aria-label={t('deleteAction')}
                         onClick={() => void deleteSupplier(supplier)}
                       >
-                        <CloseIcon fontSize="small" />
+                        <DeleteIcon fontSize="small" />
                       </IconButton>
                       </Box>
                     </TableCell>

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,6 @@
-import { Alert, Box, Button, Container, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Container, IconButton, InputAdornment, Stack, TextField, Typography } from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link as RouterLink, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -17,6 +19,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [pendingDeletionAt, setPendingDeletionAt] = useState<string | null>(null);
   const [pendingInvitation, setPendingInvitation] = useState<InvitationPublicStatus | null>(null);
   const nextPath = getNextFromSearch(location.search);
@@ -98,7 +101,29 @@ export default function LoginPage() {
             </Alert>
           ) : null}
           <TextField label={t('auth:login.email')} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-          <TextField label={t('auth:login.password')} type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          <TextField
+            label={t('auth:login.password')}
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      edge="end"
+                      onClick={() => setShowPassword((current) => !current)}
+                      onMouseDown={(event) => event.preventDefault()}
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
           <Button type="submit" variant="contained" disabled={submitting}>{submitting ? t('auth:login.submitting') : t('auth:login.submit')}</Button>
           {pendingDeletionAt ? (
             <Button variant="outlined" disabled={submitting} onClick={() => void handleRestore()}>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -84,7 +84,8 @@ export default defineConfig({
       output: {
         manualChunks: {
           react: ['react', 'react-dom', 'react-router-dom'],
-          mui: ['@mui/material', '@mui/icons-material', '@mui/x-data-grid'],
+          mui: ['@mui/material'],
+          muiIcons: ['@mui/icons-material'],
           i18n: ['i18next', 'react-i18next'],
         },
       },


### PR DESCRIPTION
## Summary

Fix the hierarchy grid TypeScript build failure after the MUI DataGrid event type changes by using `MuiEvent<React.KeyboardEvent>` for the cell keydown handler.

## Root Cause

The handler writes to `defaultMuiPrevented`, which is provided by MUI's event wrapper but is not part of React's plain `KeyboardEvent` type. Current TypeScript settings reject the previous local event typing.

## Validation

- `npm run build -- --base /openfarmplanner/ --outDir dist-staging`

The build succeeds. The sandbox printed `Failed to create stream fd: Operation not permitted` warnings before the npm scripts, but TypeScript and Vite completed successfully.