### PR TITLE
fix: update calendar empty state for missing plans

### DIFF
--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -154,7 +154,7 @@ describe('GanttChartPage', () => {
     expect(screen.queryByTestId('mock-gantt')).not.toBeInTheDocument();
   });
 
-  it('shows "Anbauplan fehlt" when cultures and beds exist but no plan exists', async () => {
+  it('shows plan guidance without a redundant missing-plan badge when areas and cultures exist', async () => {
     mocks.planList.mockResolvedValue({ data: { results: [] } });
     mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
 
@@ -166,8 +166,11 @@ describe('GanttChartPage', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => expect(screen.getByText('Anbauplan fehlt')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Noch keine Anbaupläne vorhanden')).toBeInTheDocument());
+    expect(screen.getByText('Für die vorhandenen Anbauflächen wurden noch keine Anbaupläne erstellt. Lege einen Anbauplan an, um Kulturen und Termine im Anbaukalender darzustellen.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Anbauplan hinzufügen' })).toBeInTheDocument();
+    expect(screen.queryByText('Anbauplan fehlt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Öffne die Anbauflächen und füge dort eine Parzelle beim passenden Standort hinzu. Danach kannst du Beete, Kulturen und Anbaupläne erfassen.')).not.toBeInTheDocument();
   });
 
   it('shows culture-specific guidance when land hierarchy exists but no cultures exist', async () => {

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -123,6 +123,10 @@
       "cultures": {
         "title": "Noch keine Kulturen vorhanden",
         "description": "Lege jetzt deine erste Kultur an oder importiere eine Kultur aus der Kulturbibliothek. Danach kannst du Anbaupläne erstellen."
+      },
+      "plans": {
+        "title": "Noch keine Anbaupläne vorhanden",
+        "description": "Für die vorhandenen Anbauflächen wurden noch keine Anbaupläne erstellt. Lege einen Anbauplan an, um Kulturen und Termine im Anbaukalender darzustellen."
       }
     },
     "actions": {

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -454,10 +454,14 @@ function GanttChartPage() {
     : [];
   const requirementEmptyStateTitleKey = firstMissingRequirement === 'cultures'
     ? 'ganttChart:emptyStates.states.cultures.title'
-    : 'ganttChart:emptyStates.requirementsTitle';
+    : firstMissingRequirement === 'plans'
+      ? 'ganttChart:emptyStates.states.plans.title'
+      : 'ganttChart:emptyStates.requirementsTitle';
   const requirementEmptyStateDescriptionKey = firstMissingRequirement === 'cultures'
     ? 'ganttChart:emptyStates.states.cultures.description'
-    : 'ganttChart:emptyStates.requirementsDescription';
+    : firstMissingRequirement === 'plans'
+      ? 'ganttChart:emptyStates.states.plans.description'
+      : 'ganttChart:emptyStates.requirementsDescription';
 
   const renderOccupancyTooltip = useCallback(({ task }: { task: GanttTask }) => (
     <Box sx={{ p: 0.5 }}>
@@ -619,7 +623,6 @@ function GanttChartPage() {
                 checklist={[
                   ...(firstMissingRequirement === 'beds' ? [{ label: t('ganttChart:requirements.bed.label'), done: false, missingLabel: t('ganttChart:requirements.bed.missing') }] : []),
                   ...(firstMissingRequirement === 'cultures' ? [{ label: t('ganttChart:requirements.culture.label'), done: false, missingLabel: t('ganttChart:requirements.culture.missing') }] : []),
-                  ...(firstMissingRequirement === 'plans' ? [{ label: t('ganttChart:requirements.plan.label'), done: false, missingLabel: t('ganttChart:requirements.plan.missing') }] : []),
                 ]}
                 actions={requirementActions.map((action) => ({ label: t(action.labelKey), to: action.to }))}
               />


### PR DESCRIPTION
## Summary
- show a dedicated Anbaukalender empty state when areas and cultures exist but no planting plans exist
- remove the redundant "Anbauplan fehlt" checklist badge for that state
- cover the behavior in the existing Gantt chart test

## Tests
- npm run test -- GanttChart.test.tsx