### PR TITLE
fix: handle stale Vite chunks after deploy

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -50,6 +50,12 @@ npm run test:e2e:headed
 - UI strings are managed through i18n resource files under `src/i18n/locales/`.
 - Keep UI text in translation resources rather than inline strings whenever practical.
 
+## Deployment Notes
+
+The app uses Vite code splitting and hashed frontend assets. When a new build is deployed, existing browser sessions can still reference chunk URLs from the previous build. The runtime handler in `src/runtime/chunkLoadErrors.ts` catches missing dynamic imports, reloads once per session window, and then shows a manual reload action if the chunk is still unavailable.
+
+Vite clears the build output directory by default before writing a new build unless `emptyOutDir` is changed. Deployment details live in the separate ops repository, but if production deployment removes old hashed assets immediately, the runtime handler is still required. Keeping old `assets/` files available for a short grace period during deploys further reduces missing-chunk errors for active sessions.
+
 ## End-to-End Tests
 
 See [`e2e/README.md`](./e2e/README.md) for Playwright-specific details.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@
  * @returns The main App component with routing
  */
 
-import { createBrowserRouter, RouterProvider, Outlet, Link as RouterLink, redirect, useLocation, useNavigate, Navigate } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Outlet, Link as RouterLink, redirect, useLocation, useNavigate, Navigate, useRouteError } from 'react-router-dom';
 import {
   Alert,
   AppBar,
@@ -101,6 +101,8 @@ import {
   navigationTooltipSx,
 } from './navigation/navigationStyles';
 import { PanelLeft } from 'lucide-react';
+import RuntimeErrorState from './components/runtime/RuntimeErrorState';
+import { isDynamicImportLoadError, reloadOnceForDynamicImportError } from './runtime/chunkLoadErrors';
 
 const CONTENT_ALIGNMENT_MODE = 'centered';
 const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
@@ -1734,84 +1736,167 @@ function withLazyFallback(element: React.ReactElement): React.ReactElement {
   return <Suspense fallback={null}>{element}</Suspense>;
 }
 
+function RouteErrorBoundary() {
+  const error = useRouteError();
+  const isApplicationUpdateError = isDynamicImportLoadError(error);
+
+  useEffect(() => {
+    if (isApplicationUpdateError) {
+      reloadOnceForDynamicImportError(error);
+    }
+  }, [error, isApplicationUpdateError]);
+
+  return <RuntimeErrorState variant={isApplicationUpdateError ? 'applicationUpdated' : 'routeError'} />;
+}
+
+interface GlobalRuntimeErrorHandlerProps {
+  children: React.ReactNode;
+}
+
+function GlobalRuntimeErrorHandler({ children }: GlobalRuntimeErrorHandlerProps) {
+  const [hasApplicationUpdateError, setHasApplicationUpdateError] = useState(false);
+
+  const handleDynamicImportError = useCallback((error: unknown) => {
+    if (!isDynamicImportLoadError(error)) {
+      return;
+    }
+
+    if (!reloadOnceForDynamicImportError(error)) {
+      setHasApplicationUpdateError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleError = (event: ErrorEvent) => {
+      const error = event.error ?? event.message;
+      if (!isDynamicImportLoadError(error)) {
+        return;
+      }
+
+      event.preventDefault();
+      handleDynamicImportError(error);
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (!isDynamicImportLoadError(event.reason)) {
+        return;
+      }
+
+      event.preventDefault();
+      handleDynamicImportError(event.reason);
+    };
+
+    const handleVitePreloadError = (event: Event) => {
+      event.preventDefault();
+      const payload = (event as CustomEvent<unknown>).detail
+        ?? (event as Event & { payload?: unknown }).payload
+        ?? 'vite:preloadError';
+      handleDynamicImportError(payload);
+    };
+
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    window.addEventListener('vite:preloadError', handleVitePreloadError);
+
+    return () => {
+      window.removeEventListener('error', handleError);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      window.removeEventListener('vite:preloadError', handleVitePreloadError);
+    };
+  }, [handleDynamicImportError]);
+
+  if (hasApplicationUpdateError) {
+    return <RuntimeErrorState variant="applicationUpdated" />;
+  }
+
+  return children;
+}
+
 function createAppRouter(basename: string) {
   return createBrowserRouter([
     {
       path: '/',
-      element: withLazyFallback(<HomePage />),
-    },
-    {
-      path: '/impressum',
-      element: withLazyFallback(<ImprintPage />),
-    },
-    {
-      path: '/datenschutz',
-      element: withLazyFallback(<PrivacyPolicyPage />),
-    },
-    {
-      path: '/login',
-      element: withLazyFallback(<LoginPage />),
-    },
-    {
-      path: '/register',
-      element: withLazyFallback(<RegisterPage />),
-    },
-    {
-      path: '/activate',
-      element: withLazyFallback(<ActivatePage />),
-    },
-    {
-      path: '/activate/:uid/:token',
-      element: withLazyFallback(<ActivatePage />),
-    },
-    {
-      path: '/forgot-password',
-      element: withLazyFallback(<ForgotPasswordPage />),
-    },
-    {
-      path: '/reset-password',
-      element: withLazyFallback(<ResetPasswordPage />),
-    },
-    {
-      path: '/confirm-email-change',
-      element: withLazyFallback(<ConfirmEmailChangePage />),
-    },
-    {
-      path: '/invitation',
-      element: <LegacyInvitationRedirect />,
-    },
-    {
-      path: '/invite/accept',
-      element: withLazyFallback(<InvitationAcceptPage />),
-    },
-    {
-      path: '/invite/:token',
-      element: <TokenInvitationRedirect />,
-    },
-    {
-      path: '/app',
-      element: <ProtectedRoute />,
+      element: <Outlet />,
+      errorElement: <RouteErrorBoundary />,
       children: [
         {
-          path: '',
-          element: <RootLayout />,
+          index: true,
+          element: withLazyFallback(<HomePage />),
+        },
+        {
+          path: 'impressum',
+          element: withLazyFallback(<ImprintPage />),
+        },
+        {
+          path: 'datenschutz',
+          element: withLazyFallback(<PrivacyPolicyPage />),
+        },
+        {
+          path: 'login',
+          element: withLazyFallback(<LoginPage />),
+        },
+        {
+          path: 'register',
+          element: withLazyFallback(<RegisterPage />),
+        },
+        {
+          path: 'activate',
+          element: withLazyFallback(<ActivatePage />),
+        },
+        {
+          path: 'activate/:uid/:token',
+          element: withLazyFallback(<ActivatePage />),
+        },
+        {
+          path: 'forgot-password',
+          element: withLazyFallback(<ForgotPasswordPage />),
+        },
+        {
+          path: 'reset-password',
+          element: withLazyFallback(<ResetPasswordPage />),
+        },
+        {
+          path: 'confirm-email-change',
+          element: withLazyFallback(<ConfirmEmailChangePage />),
+        },
+        {
+          path: 'invitation',
+          element: <LegacyInvitationRedirect />,
+        },
+        {
+          path: 'invite/accept',
+          element: withLazyFallback(<InvitationAcceptPage />),
+        },
+        {
+          path: 'invite/:token',
+          element: <TokenInvitationRedirect />,
+        },
+        {
+          path: 'app',
+          element: <ProtectedRoute />,
           children: [
             {
-              index: true,
-              loader: () => redirect('/app/dashboard'),
+              path: '',
+              element: <RootLayout />,
+              children: [
+                {
+                  index: true,
+                  loader: () => redirect('/app/dashboard'),
+                },
+                { path: 'dashboard', element: withLazyFallback(<Dashboard />) },
+                { path: 'locations', element: withLazyFallback(<Locations />) },
+                { path: 'fields-beds', element: withLazyFallback(<FieldsBedsPage />) },
+                { path: 'cultures', element: withLazyFallback(<Cultures />) },
+                { path: 'anbauplaene', element: withLazyFallback(<PlantingPlans />) },
+                { path: 'suppliers', element: withLazyFallback(<Suppliers />) },
+                { path: 'planting-plans', element: withLazyFallback(<PlantingPlans />) },
+                { path: 'gantt-chart', element: withLazyFallback(<GanttChart />) },
+                { path: 'seed-demand', element: withLazyFallback(<SeedDemandPage />) },
+                { path: 'project-selection', element: withLazyFallback(<ProjectSelectionPage />) },
+                { path: 'account-settings', element: withLazyFallback(<AccountSettingsPage />) },
+                { path: 'project-settings', element: withLazyFallback(<ProjectSettingsPage />) },
+              ],
             },
-            { path: 'dashboard', element: withLazyFallback(<Dashboard />) },
-            { path: 'locations', element: withLazyFallback(<Locations />) },
-            { path: 'fields-beds', element: withLazyFallback(<FieldsBedsPage />) },
-            { path: 'cultures', element: withLazyFallback(<Cultures />) },
-            { path: 'anbauplaene', element: withLazyFallback(<PlantingPlans />) },
-            { path: 'suppliers', element: withLazyFallback(<Suppliers />) },
-            { path: 'planting-plans', element: withLazyFallback(<PlantingPlans />) },
-            { path: 'gantt-chart', element: withLazyFallback(<GanttChart />) },
-            { path: 'seed-demand', element: withLazyFallback(<SeedDemandPage />) },
-            { path: 'project-selection', element: withLazyFallback(<ProjectSelectionPage />) },
-            { path: 'account-settings', element: withLazyFallback(<AccountSettingsPage />) },
-            { path: 'project-settings', element: withLazyFallback(<ProjectSettingsPage />) },
           ],
         },
       ],
@@ -1829,7 +1914,11 @@ function App() {
 
   const router = useMemo(() => createAppRouter(basename), [basename]);
 
-  return <RouterProvider router={router} />;
+  return (
+    <GlobalRuntimeErrorHandler>
+      <RouterProvider router={router} />
+    </GlobalRuntimeErrorHandler>
+  );
 }
 
 export default App;

--- a/frontend/src/components/runtime/RuntimeErrorState.tsx
+++ b/frontend/src/components/runtime/RuntimeErrorState.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@mui/material';
+import EmptyStateCard from '../project/EmptyStateCard';
+import { useTranslation } from '../../i18n';
+import { reloadPage } from '../../runtime/chunkLoadErrors';
+
+interface RuntimeErrorStateProps {
+  variant: 'applicationUpdated' | 'routeError';
+}
+
+export default function RuntimeErrorState({ variant }: RuntimeErrorStateProps) {
+  const { t } = useTranslation('common');
+  const isApplicationUpdated = variant === 'applicationUpdated';
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center', p: 2 }}>
+      <EmptyStateCard
+        title={t(isApplicationUpdated ? 'runtime.applicationUpdatedTitle' : 'runtime.routeErrorTitle')}
+        description={t(isApplicationUpdated ? 'runtime.applicationUpdatedDescription' : 'runtime.routeErrorDescription')}
+        actions={[{ label: t('runtime.reloadPage'), onClick: reloadPage }]}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -133,5 +133,12 @@
     "createProjectAction": "Erstes Projekt anlegen",
     "createFirstProjectAction": "Erstes Projekt anlegen",
     "selectProjectAction": "Projekt auswählen"
+  },
+  "runtime": {
+    "applicationUpdatedTitle": "Die Anwendung wurde aktualisiert.",
+    "applicationUpdatedDescription": "Bitte lade die Seite neu.",
+    "routeErrorTitle": "Die Seite konnte nicht geladen werden.",
+    "routeErrorDescription": "Bitte lade die Seite neu. Wenn der Fehler bestehen bleibt, versuche es später erneut.",
+    "reloadPage": "Seite neu laden"
   }
 }

--- a/frontend/src/runtime/chunkLoadErrors.ts
+++ b/frontend/src/runtime/chunkLoadErrors.ts
@@ -1,0 +1,73 @@
+const CHUNK_RELOAD_STORAGE_KEY = 'openFarmPlanner.lastChunkReloadAt';
+const CHUNK_RELOAD_WINDOW_MS = 60_000;
+
+const DYNAMIC_IMPORT_ERROR_PATTERNS = [
+  'failed to fetch dynamically imported module',
+  'importing a module script failed',
+  'error loading dynamically imported module',
+  'chunkloaderror',
+  'loading chunk',
+  'loading css chunk',
+  'unable to preload css',
+  'vite:preloaderror',
+];
+
+function getErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name} ${error.message}`.toLowerCase();
+  }
+
+  if (typeof error === 'string') {
+    return error.toLowerCase();
+  }
+
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    const parts = [record.name, record.message, record.type, record.reason, record.payload]
+      .filter((value): value is string => typeof value === 'string');
+    return parts.join(' ').toLowerCase();
+  }
+
+  return '';
+}
+
+function getSessionStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function isDynamicImportLoadError(error: unknown): boolean {
+  const errorText = getErrorText(error);
+  return DYNAMIC_IMPORT_ERROR_PATTERNS.some((pattern) => errorText.includes(pattern));
+}
+
+export function shouldAutomaticallyReloadForChunkError(now = Date.now()): boolean {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return false;
+  }
+
+  const previousReloadAt = Number(storage.getItem(CHUNK_RELOAD_STORAGE_KEY));
+  if (Number.isFinite(previousReloadAt) && now - previousReloadAt < CHUNK_RELOAD_WINDOW_MS) {
+    return false;
+  }
+
+  storage.setItem(CHUNK_RELOAD_STORAGE_KEY, String(now));
+  return true;
+}
+
+export function reloadPage(): void {
+  window.location.reload();
+}
+
+export function reloadOnceForDynamicImportError(error: unknown): boolean {
+  if (!isDynamicImportLoadError(error) || !shouldAutomaticallyReloadForChunkError()) {
+    return false;
+  }
+
+  reloadPage();
+  return true;
+}


### PR DESCRIPTION
## Summary
- add centralized detection for failed dynamic imports, Vite preload failures, and common chunk load errors
- show a German runtime fallback with a visible "Seite neu laden" action instead of React Router's default error page
- reload automatically at most once per short session window before falling back to the manual reload state
- add a frontend deployment note explaining why the runtime handler remains necessary and why keeping old hashed assets briefly can reduce the issue

## Deployment note
The app repo does not contain production deployment scripts; deployment operations are documented as living in `OpenFarmPlanner-ops`. The local Vite config does not override `emptyOutDir`, so Vite's default build behavior clears the build output before writing the new hashed assets. If the production deploy then replaces or deletes old `assets/` immediately, active browser sessions can still request now-missing chunks. This PR handles that runtime failure; keeping old hashed assets available for a short grace period would further reduce it.

## Validation
- npx tsc -b --pretty false

Tests were not run per request.