### PR TITLE
fix: restore tree navigation after confirming an inline row edit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Warn when an unusually large number of files are being deleted in a single commit.
+# Catches the common mistake of silently losing files after a git stash pop during rebase.
+
+DELETED_FILES=$(git diff --cached --name-status | grep "^D")
+DELETED_COUNT=$(echo "$DELETED_FILES" | grep -c "^D" || true)
+
+if [ "$DELETED_COUNT" -gt 2 ]; then
+  echo ""
+  echo "⚠️  WARNING: $DELETED_COUNT files are staged for deletion:"
+  echo "$DELETED_FILES" | awk '{print "   - " $2}'
+  echo ""
+  echo "This can happen after 'git stash pop' silently drops files during a rebase."
+  echo "Verify these deletions are intentional before continuing."
+  echo ""
+  printf "Continue with commit? (y/N) "
+  read -r confirm </dev/tty
+  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Commit aborted."
+    exit 1
+  fi
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Initial setup
+
+After cloning the repo, run once to activate the project's git hooks:
+
+```bash
+make setup
+```
+
+This configures the pre-commit hook that warns you when an unusually large number of files are staged for deletion — which catches the common mistake of silently losing source files after a `git stash pop` conflict during a rebase.
+
 ## Conventional Commits
 
 This project uses Conventional Commits for automated versioning and releases.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: quality bump-version
+.PHONY: setup quality bump-version
+
+setup:
+	git config core.hooksPath .githooks
+	@echo "Git hooks configured. Pre-commit hook will warn on bulk file deletions."
 
 quality:
 	./scripts/quality.sh

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "react-markdown": "^10.1.0",
         "react-modern-gantt": "https://codeload.github.com/stipsitzm/React-Modern-Gantt/tar.gz/refs/heads/master",
         "react-router-dom": "^7.9.6",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3807,6 +3808,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4235,6 +4245,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -4364,6 +4387,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4484,6 +4516,18 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5736,6 +5780,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -9624,6 +9677,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10659,6 +10724,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10696,6 +10779,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,8 @@
     "react-markdown": "^10.1.0",
     "react-modern-gantt": "https://codeload.github.com/stipsitzm/React-Modern-Gantt/tar.gz/refs/heads/master",
     "react-router-dom": "^7.9.6",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -987,7 +987,7 @@ function RootLayout() {
         sx={{ borderBottom: '1px solid', borderColor: 'surface.surfaceBorder', bgcolor: 'surface.topbarBackground', backdropFilter: 'saturate(120%) blur(2px)' }}
       >
         <Toolbar variant="dense" sx={{ minHeight: 56, gap: 1, py: 0.5, px: { xs: 0, sm: 2, md: 3 }, flexWrap: 'nowrap', minWidth: 0, maxWidth: '100%', overflow: 'hidden' }}>
-          {!isDesktopUp ? <IconButton aria-label={t('globalMenu.openMobileMenu')} onClick={() => setMobileNavOpen(true)}><MenuIcon /></IconButton> : null}
+          {!isDesktopUp ? <IconButton aria-label={t('globalMenu.openMobileMenu')} onClick={() => setMobileNavOpen(true)} sx={{ width: COMPACT_TOPBAR_TOGGLE_SIZE, height: COMPACT_TOPBAR_TOGGLE_SIZE }}><MenuIcon /></IconButton> : null}
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0, flexShrink: 1, flexWrap: 'nowrap', overflow: 'hidden' }}>
             {!isDesktopUp ? (
               <Typography
@@ -1576,7 +1576,7 @@ function RootLayout() {
                     aria-controls={topbarPrimaryActionMenuAnchor ? 'topbar-primary-action-menu' : undefined}
                     aria-haspopup={topbarPrimaryAction.menuActions && topbarPrimaryAction.menuActions.length > 0 ? 'true' : undefined}
                     aria-expanded={Boolean(topbarPrimaryActionMenuAnchor)}
-                    sx={{ textTransform: 'none', minWidth: 32, px: 0.75, minHeight: 30 }}
+                    sx={{ textTransform: 'none', minWidth: COMPACT_TOPBAR_TOGGLE_SIZE, px: 0.75, minHeight: COMPACT_TOPBAR_TOGGLE_SIZE }}
                   >
                     <AddIcon fontSize="small" />
                   </Button>
@@ -1611,7 +1611,7 @@ function RootLayout() {
                 aria-controls={globalMenuAnchor ? 'global-actions-menu' : undefined}
                 aria-haspopup="true"
                 onClick={handleGlobalMenuOpen}
-                sx={{ color: 'text.primary' }}
+                sx={{ color: 'text.primary', width: COMPACT_TOPBAR_TOGGLE_SIZE, height: COMPACT_TOPBAR_TOGGLE_SIZE }}
               >
                 <MoreVertIcon />
               </IconButton>
@@ -1637,20 +1637,19 @@ function RootLayout() {
         </Toolbar>
         {isCompactTopbar && hasMobileSecondaryRow ? (
           <Box className="mobile-action-scroll" sx={{ px: 0, pb: 0.5 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: TOPBAR_ACTION_GROUP_GAP, minHeight: 36, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: TOPBAR_ACTION_GROUP_GAP, minHeight: COMPACT_TOPBAR_TOGGLE_SIZE, flexWrap: 'wrap', whiteSpace: 'normal', width: '100%' }}>
               {isCulturesPage ? (
                 <>
                   {cultureLibraryAction ? (
                     <Tooltip title={t('cultureActions.openLibrary')} enterTouchDelay={0}>
                       <span>
                         <IconButton
-                          size="small"
                           onClick={() => cultureLibraryAction.onClick()}
                           aria-label={t('cultureActions.openLibrary')}
-                          sx={{ color: 'text.primary' }}
+                          sx={{ color: 'text.primary', width: COMPACT_TOPBAR_TOGGLE_SIZE, height: COMPACT_TOPBAR_TOGGLE_SIZE }}
                           disabled={cultureLibraryAction.disabled}
                         >
-                          <PublicIcon fontSize="small" />
+                          <PublicIcon />
                         </IconButton>
                       </span>
                     </Tooltip>
@@ -1658,15 +1657,14 @@ function RootLayout() {
                   {showCultureImportExportButton || isMobile ? (
                     <Tooltip title={t('cultureActions.openImportExport')} enterTouchDelay={0}>
                       <IconButton
-                        size="small"
                         aria-label={t('cultureActions.openImportExport')}
                         aria-controls={cultureActionsMenuAnchor ? 'culture-actions-menu-mobile' : undefined}
                         aria-haspopup="true"
                         aria-expanded={Boolean(cultureActionsMenuAnchor)}
                         onClick={handleCultureActionsMenuOpen}
-                        sx={{ color: 'text.primary' }}
+                        sx={{ color: 'text.primary', width: COMPACT_TOPBAR_TOGGLE_SIZE, height: COMPACT_TOPBAR_TOGGLE_SIZE }}
                       >
-                        <FileExportIcon fontSize="small" />
+                        <FileExportIcon />
                       </IconButton>
                     </Tooltip>
                   ) : null}
@@ -1723,14 +1721,14 @@ function RootLayout() {
                           ? {
                             textTransform: 'none',
                             whiteSpace: 'nowrap',
-                            minWidth: isPhone ? 32 : 'auto',
+                            minWidth: isPhone ? COMPACT_TOPBAR_TOGGLE_SIZE : 'auto',
                             px: isPhone ? 0.75 : 1.25,
-                            minHeight: 30,
+                            minHeight: COMPACT_TOPBAR_TOGGLE_SIZE,
                             ...(action.hidden ? { display: 'none' } : {}),
                           }
                           : {
                             ...getSegmentedActionButtonSx({ active: Boolean(action.active), hidden: Boolean(action.hidden) }),
-                            minHeight: 30,
+                            minHeight: COMPACT_TOPBAR_TOGGLE_SIZE,
                             px: 1,
                           }}
                       >
@@ -1753,13 +1751,12 @@ function RootLayout() {
                   ...visibleNodes,
                   <IconButton
                     key="mobile-actions-overflow-trigger"
-                    size="small"
                     aria-label="Weitere Aktionen"
                     aria-controls={mobileActionsOverflowAnchor ? 'mobile-actions-overflow-menu' : undefined}
                     aria-haspopup="true"
                     aria-expanded={Boolean(mobileActionsOverflowAnchor)}
                     onClick={handleMobileActionsOverflowOpen}
-                    sx={{ border: '1px solid', borderColor: 'divider' }}
+                    sx={{ border: '1px solid', borderColor: 'divider', width: COMPACT_TOPBAR_TOGGLE_SIZE, height: COMPACT_TOPBAR_TOGGLE_SIZE }}
                   >
                     <MoreVertIcon fontSize="small" />
                   </IconButton>,

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -31,6 +31,9 @@ const {
   locationListMock,
   getCapturedOnCellKeyDown,
   setCapturedOnCellKeyDown,
+  getCapturedOnRowEditStop,
+  setCapturedOnRowEditStop,
+  getEditCellFocusMock,
   getCapturedProcessRowUpdate,
   setCapturedProcessRowUpdate,
   getSetCellFocusMock,
@@ -42,10 +45,12 @@ const {
   let capturedOnCellKeyDown: ((params: unknown, event: unknown) => void) | undefined;
   // capturedProcessRowUpdate lets tests simulate a row-save confirmation.
   let capturedProcessRowUpdate: ((row: unknown) => Promise<unknown>) | undefined;
+  let capturedOnRowEditStop: ((params: unknown, event: { defaultMuiPrevented: boolean }) => void) | undefined;
   // selectRowImpl bridges gridApiRef.current.selectRow() → DataGrid's React state.
   // It should stay unused for keyboard-only focus navigation.
   let selectRowImpl: ((id: string | number, isSelected: boolean, reset: boolean) => void) | undefined;
   const setCellFocusMock = vi.fn();
+  const editCellFocusMock = vi.fn();
   return {
     bedListMock: vi.fn(),
     fieldListMock: vi.fn(),
@@ -55,6 +60,11 @@ const {
     setCapturedOnCellKeyDown: (fn: ((params: unknown, event: unknown) => void) | undefined) => {
       capturedOnCellKeyDown = fn;
     },
+    getCapturedOnRowEditStop: () => capturedOnRowEditStop,
+    setCapturedOnRowEditStop: (fn: typeof capturedOnRowEditStop) => {
+      capturedOnRowEditStop = fn;
+    },
+    getEditCellFocusMock: () => editCellFocusMock,
     getCapturedProcessRowUpdate: () => capturedProcessRowUpdate,
     setCapturedProcessRowUpdate: (fn: typeof capturedProcessRowUpdate) => {
       capturedProcessRowUpdate = fn;
@@ -100,7 +110,13 @@ vi.mock('../api/api', async () => {
 vi.mock('@mui/x-data-grid', async () => {
   const ReactModule = await import('react');
   const GridRowModes = { Edit: 'edit', View: 'view' };
-  const GridRowEditStopReasons = { escapeKeyDown: 'escapeKeyDown', rowFocusOut: 'rowFocusOut' };
+  const GridRowEditStopReasons = {
+    escapeKeyDown: 'escapeKeyDown',
+    enterKeyDown: 'enterKeyDown',
+    rowFocusOut: 'rowFocusOut',
+    shiftTabKeyDown: 'shiftTabKeyDown',
+    tabKeyDown: 'tabKeyDown',
+  };
   // Mirror the real useGridApiRef which uses React.useRef internally, returning the
   // same ref object across re-renders. Without this, gridApiRef changes on every
   // render, which cascades through focusRow → focusSelectedCell → useLayoutEffect,
@@ -121,6 +137,7 @@ vi.mock('@mui/x-data-grid', async () => {
     isCellEditable,
     onCellClick,
     onCellKeyDown,
+    onRowEditStop,
     processRowUpdate,
     rowModesModel,
     rows,
@@ -132,6 +149,7 @@ vi.mock('@mui/x-data-grid', async () => {
     isCellEditable?: (p: { row: Record<string, unknown>; field: string }) => boolean;
     onCellClick?: (p: { id: string | number; field: string; isEditable: boolean; row: Record<string, unknown> }) => void;
     onCellKeyDown?: (params: unknown, event: unknown) => void;
+    onRowEditStop?: (params: unknown, event: { defaultMuiPrevented: boolean }) => void;
     processRowUpdate?: (row: unknown) => Promise<unknown>;
     rowModesModel: Record<string, { mode: string }>;
     rows: Array<Record<string, unknown> & { id: string | number }>;
@@ -150,6 +168,7 @@ vi.mock('@mui/x-data-grid', async () => {
     });
     // Capture so tests can invoke them directly.
     setCapturedOnCellKeyDown(onCellKeyDown);
+    setCapturedOnRowEditStop(onRowEditStop);
     setCapturedProcessRowUpdate(processRowUpdate);
     if (apiRef?.current) {
       apiRef.current.setCellFocus = (id: string | number, field: string) => {
@@ -171,6 +190,9 @@ vi.mock('@mui/x-data-grid', async () => {
         rows.findIndex((row) => String(row.id) === String(id));
       apiRef.current.getColumnIndexRelativeToVisibleColumns = (field: string) =>
         columns.findIndex((column) => column.field === field);
+      apiRef.current.getCellElement = () => ({
+        focus: getEditCellFocusMock(),
+      });
       apiRef.current.isCellEditable = (params: { row?: Record<string, unknown>; field: string }) =>
         params.row ? (isCellEditable?.({ row: params.row, field: params.field }) ?? true) : false;
       apiRef.current.scrollToIndexes = vi.fn();
@@ -272,6 +294,7 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSetCellFocusMock().mockClear();
+    getEditCellFocusMock().mockClear();
     window.sessionStorage.clear();
     vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
     // jsdom does not implement scrollIntoView
@@ -715,6 +738,30 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     const calls = getSetCellFocusMock().mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     expect(calls.every(([id]: [unknown]) => id === 'field-2')).toBe(true);
+  });
+
+  it('anchors focus on the edited cell before MUI stops row editing with Enter', async () => {
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-field-2')).toBeInTheDocument());
+
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-2-width_m')); });
+    expect(screen.getByTestId('mode-field-2')).toHaveTextContent('edit');
+
+    const onRowEditStop = getCapturedOnRowEditStop();
+    expect(onRowEditStop).toBeDefined();
+    getEditCellFocusMock().mockClear();
+
+    const event = { defaultMuiPrevented: false };
+    act(() => {
+      onRowEditStop!(
+        { id: 'field-2', reason: 'enterKeyDown' },
+        event,
+      );
+    });
+
+    expect(event.defaultMuiPrevented).toBe(false);
+    expect(getEditCellFocusMock()).toHaveBeenCalledWith({ preventScroll: true });
+    expect(getSetCellFocusMock()).not.toHaveBeenCalledWith('field-1', 'name');
   });
 
   it('pressing a printable key while a row is keyboard-focused does not start edit mode', async () => {

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -673,6 +673,50 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'false');
   });
 
+  it('focus does not flash to first row when confirming an inline edit on a non-first row', async () => {
+    // Regression: when a row exits edit mode the edit-cell input is removed from the DOM,
+    // which caused the browser to drop focus to the first focusable element (first row).
+    // The fix changed the focus-restoration effect from useEffect (async, after paint) to
+    // useLayoutEffect (synchronous, before paint) so the correct row is focused before the
+    // browser ever paints.  Here we verify setCellFocus is called with the edited row, not
+    // with the first row, immediately after the save completes.
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-field-2')).toBeInTheDocument());
+
+    // Click field-2 (not the first row) to select and start editing it.
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-2-name')); });
+    expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'true');
+    expect(screen.getByTestId('mode-field-2')).toHaveTextContent('edit');
+
+    fieldUpdateMock.mockResolvedValue({ data: { id: 2, name: 'Parzelle 2', location: 1, area_sqm: 20 } });
+
+    getSetCellFocusMock().mockClear();
+
+    const processRowUpdate = getCapturedProcessRowUpdate();
+    await act(async () => {
+      await processRowUpdate!({
+        id: 'field-2',
+        type: 'field',
+        name: 'Parzelle 2',
+        fieldId: 2,
+        locationId: 1,
+        area_sqm: 20,
+        level: 1,
+        parentId: 'location-1',
+        hasChildren: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('mode-field-2')).toHaveTextContent('view'),
+    );
+
+    // Every setCellFocus call after the save must target field-2, never field-1.
+    const calls = getSetCellFocusMock().mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every(([id]: [unknown]) => id === 'field-2')).toBe(true);
+  });
+
   it('pressing a printable key while a row is keyboard-focused does not start edit mode', async () => {
     renderHierarchy();
     await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -27,9 +27,12 @@ import { mockT } from './helpers/testI18n';
 const {
   bedListMock,
   fieldListMock,
+  fieldUpdateMock,
   locationListMock,
   getCapturedOnCellKeyDown,
   setCapturedOnCellKeyDown,
+  getCapturedProcessRowUpdate,
+  setCapturedProcessRowUpdate,
   getSetCellFocusMock,
   getSelectRowImpl,
   setSelectRowImpl,
@@ -37,6 +40,8 @@ const {
   // capturedOnCellKeyDown is set by the DataGrid mock each render so tests
   // can call the handler directly to verify blocking behaviour.
   let capturedOnCellKeyDown: ((params: unknown, event: unknown) => void) | undefined;
+  // capturedProcessRowUpdate lets tests simulate a row-save confirmation.
+  let capturedProcessRowUpdate: ((row: unknown) => Promise<unknown>) | undefined;
   // selectRowImpl bridges gridApiRef.current.selectRow() → DataGrid's React state.
   // It should stay unused for keyboard-only focus navigation.
   let selectRowImpl: ((id: string | number, isSelected: boolean, reset: boolean) => void) | undefined;
@@ -44,10 +49,15 @@ const {
   return {
     bedListMock: vi.fn(),
     fieldListMock: vi.fn(),
+    fieldUpdateMock: vi.fn(),
     locationListMock: vi.fn(),
     getCapturedOnCellKeyDown: () => capturedOnCellKeyDown,
     setCapturedOnCellKeyDown: (fn: ((params: unknown, event: unknown) => void) | undefined) => {
       capturedOnCellKeyDown = fn;
+    },
+    getCapturedProcessRowUpdate: () => capturedProcessRowUpdate,
+    setCapturedProcessRowUpdate: (fn: typeof capturedProcessRowUpdate) => {
+      capturedProcessRowUpdate = fn;
     },
     getSetCellFocusMock: () => setCellFocusMock,
     getSelectRowImpl: () => selectRowImpl,
@@ -76,7 +86,7 @@ vi.mock('../api/api', async () => {
       create: vi.fn(),
       delete: vi.fn(),
       list: fieldListMock,
-      update: vi.fn(),
+      update: fieldUpdateMock,
     },
     locationAPI: {
       create: vi.fn(),
@@ -111,6 +121,7 @@ vi.mock('@mui/x-data-grid', async () => {
     isCellEditable,
     onCellClick,
     onCellKeyDown,
+    processRowUpdate,
     rowModesModel,
     rows,
   }: {
@@ -121,6 +132,7 @@ vi.mock('@mui/x-data-grid', async () => {
     isCellEditable?: (p: { row: Record<string, unknown>; field: string }) => boolean;
     onCellClick?: (p: { id: string | number; field: string; isEditable: boolean; row: Record<string, unknown> }) => void;
     onCellKeyDown?: (params: unknown, event: unknown) => void;
+    processRowUpdate?: (row: unknown) => Promise<unknown>;
     rowModesModel: Record<string, { mode: string }>;
     rows: Array<Record<string, unknown> & { id: string | number }>;
   }) => {
@@ -136,8 +148,9 @@ vi.mock('@mui/x-data-grid', async () => {
         return next;
       });
     });
-    // Capture so tests can invoke it directly (e.g. letter-key guard test)
+    // Capture so tests can invoke them directly.
     setCapturedOnCellKeyDown(onCellKeyDown);
+    setCapturedProcessRowUpdate(processRowUpdate);
     if (apiRef?.current) {
       apiRef.current.setCellFocus = (id: string | number, field: string) => {
         getSetCellFocusMock()(id, field);
@@ -613,6 +626,51 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
       expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'true'),
     );
     expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'false');
+  });
+
+  it('arrow keys navigate normally after confirming an inline edit', async () => {
+    // Regression: handleHierarchyProcessRowUpdate called clearHierarchyInteractionState
+    // which reset treeActive=false and selectedRowId=null, so ArrowDown/Up after saving
+    // would scroll the page instead of moving row focus.
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());
+
+    // Click field-1 to select it and activate tree navigation.
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-1-name')); });
+    expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'true');
+    expect(screen.getByTestId('mode-field-1')).toHaveTextContent('edit');
+
+    // Mock the API update to return success.
+    fieldUpdateMock.mockResolvedValue({ data: { id: 1, name: 'Parzelle 1', location: 1, area_sqm: 10 } });
+
+    // Simulate confirming the edit by calling processRowUpdate with the field's row data.
+    const processRowUpdate = getCapturedProcessRowUpdate();
+    expect(processRowUpdate).toBeDefined();
+    await act(async () => {
+      await processRowUpdate!({
+        id: 'field-1',
+        type: 'field',
+        name: 'Parzelle 1',
+        fieldId: 1,
+        locationId: 1,
+        area_sqm: 10,
+        level: 1,
+        parentId: 'location-1',
+        hasChildren: false,
+      });
+    });
+
+    // Row should be back in view mode after save.
+    await waitFor(() =>
+      expect(screen.getByTestId('mode-field-1')).toHaveTextContent('view'),
+    );
+
+    // ArrowDown must navigate to field-2, NOT scroll the page.
+    await pressArrowDown();
+    await waitFor(() =>
+      expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'true'),
+    );
+    expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'false');
   });
 
   it('pressing a printable key while a row is keyboard-focused does not start edit mode', async () => {

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -819,6 +819,53 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     expect(event.preventDefault).toHaveBeenCalled();
   });
 
+  it('Tab in edit mode skips the calculated area column and goes to notes', async () => {
+    // Regression: Tab while a row is in edit mode was not intercepted, so MUI DataGrid's
+    // default Tab handler moved focus to area_sqm (a non-editable calculated column).
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());
+
+    // Click field-1 to start editing.
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-1-name')); });
+    expect(screen.getByTestId('mode-field-1')).toHaveTextContent('edit');
+
+    const onCellKeyDown = getCapturedOnCellKeyDown();
+    expect(onCellKeyDown).toBeDefined();
+
+    getSetCellFocusMock().mockClear();
+
+    const event = {
+      key: 'Tab',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      defaultMuiPrevented: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    // Tab from width_m while the row is in edit mode. MUI's default handler would
+    // go to area_sqm next; our handler must skip it and go to notes instead.
+    act(() => {
+      onCellKeyDown!(
+        {
+          id: 'field-1',
+          field: 'width_m',
+          isEditable: true,
+          row: { id: 'field-1', type: 'field' },
+        },
+        event,
+      );
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    // Must focus notes, never area_sqm.
+    expect(getSetCellFocusMock()).toHaveBeenLastCalledWith('field-1', 'notes');
+    expect(getSetCellFocusMock()).not.toHaveBeenCalledWith('field-1', 'area_sqm');
+  });
+
   it('pressing spacebar on a field row without children does not let MUI DataGrid jump focus', async () => {
     renderHierarchy();
     await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());

--- a/frontend/src/__tests__/useHierarchyGridFocus.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridFocus.test.ts
@@ -29,6 +29,18 @@ const ROWS: HierarchyRow[] = [
   makeRow('field-3'),
 ];
 
+const ROWS_WITH_NUMERIC_BED_ID: HierarchyRow[] = [
+  makeRow('field-1'),
+  {
+    id: 2,
+    type: 'bed',
+    name: 'Bed 2',
+    level: 1,
+    hasChildren: false,
+    isNew: false,
+  },
+];
+
 interface HookProps {
   rowModesModel: GridRowModesModel;
   selectedRowId: string | number | null;
@@ -46,6 +58,30 @@ const renderFocusHook = (initialProps: HookProps) => {
         gridApiRef,
         rowModesModel,
         rows: ROWS,
+        selectedRowId,
+        setSelectedRowId,
+        treeActive,
+      }),
+    { initialProps },
+  );
+
+  return { ...hookResult, setCellFocus, setSelectedRowId };
+};
+
+const renderFocusHookWithRows = (
+  initialProps: HookProps,
+  rows: HierarchyRow[],
+) => {
+  const setCellFocus = vi.fn();
+  const setSelectedRowId = vi.fn();
+  const gridApiRef = { current: { setCellFocus } };
+
+  const hookResult = renderHook(
+    ({ rowModesModel, selectedRowId, treeActive }: HookProps) =>
+      useHierarchyGridFocus({
+        gridApiRef,
+        rowModesModel,
+        rows,
         selectedRowId,
         setSelectedRowId,
         treeActive,
@@ -204,5 +240,31 @@ describe('useHierarchyGridFocus', () => {
     });
 
     expect(setSelectedRowId).toHaveBeenCalledWith('field-3');
+  });
+
+  it('restores focus with the numeric bed row id after Edit→View', () => {
+    const { rerender, setCellFocus, setSelectedRowId } = renderFocusHookWithRows(
+      {
+        rowModesModel: { 2: { mode: GridRowModes.Edit } },
+        selectedRowId: 'field-1',
+        treeActive: true,
+      },
+      ROWS_WITH_NUMERIC_BED_ID,
+    );
+
+    setCellFocus.mockClear();
+    setSelectedRowId.mockClear();
+
+    act(() => {
+      rerender({
+        rowModesModel: {},
+        selectedRowId: 'field-1',
+        treeActive: true,
+      });
+    });
+
+    expect(setCellFocus).toHaveBeenCalledWith(2, 'name');
+    expect(setCellFocus).not.toHaveBeenCalledWith('2', 'name');
+    expect(setSelectedRowId).toHaveBeenCalledWith(2);
   });
 });

--- a/frontend/src/__tests__/useHierarchyGridFocus.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridFocus.test.ts
@@ -159,6 +159,30 @@ describe('useHierarchyGridFocus', () => {
     expect(restorationCalls).toHaveLength(0);
   });
 
+  it('preFocusEditCell calls getCellElement().focus() for the remembered field', () => {
+    const mockElement = { focus: vi.fn() };
+    const getCellElement = vi.fn().mockReturnValue(mockElement);
+    const setSelectedRowId = vi.fn();
+    const gridApiRef = { current: { setCellFocus: vi.fn(), getCellElement } };
+
+    const { result } = renderHook(() =>
+      useHierarchyGridFocus({
+        gridApiRef,
+        rowModesModel: {},
+        rows: ROWS,
+        selectedRowId: 'field-1',
+        setSelectedRowId,
+        treeActive: true,
+      }),
+    );
+
+    act(() => { result.current.rememberFocusedField('width_m'); });
+    act(() => { result.current.preFocusEditCell('field-1'); });
+
+    expect(getCellElement).toHaveBeenCalledWith('field-1', 'width_m');
+    expect(mockElement.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
   it('syncs selectedRowId state after focusing the edited row', () => {
     // After Edit→View, setSelectedRowId must be called so that subsequent
     // arrow navigation and useLayoutEffect([selectedRowId]) start from the

--- a/frontend/src/__tests__/useHierarchyGridFocus.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridFocus.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for useHierarchyGridFocus.
+ *
+ * These tests verify focus-restoration behaviour that is difficult to cover
+ * at the component level because the critical scenarios depend on the
+ * internal relationship between selectedRowId React state and the
+ * selectedRowIdRef that is updated transiently during arrow-key navigation.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GridRowModes } from '@mui/x-data-grid';
+import type { GridRowModesModel } from '@mui/x-data-grid';
+import { useHierarchyGridFocus } from '../components/hierarchy/hooks/useHierarchyGridFocus';
+import type { HierarchyRow } from '../components/hierarchy/utils/types';
+
+const makeRow = (id: string, type: HierarchyRow['type'] = 'field'): HierarchyRow => ({
+  id,
+  type,
+  name: id,
+  level: 0,
+  hasChildren: false,
+  isNew: false,
+});
+
+const ROWS: HierarchyRow[] = [
+  makeRow('field-1'),
+  makeRow('field-2'),
+  makeRow('field-3'),
+];
+
+interface HookProps {
+  rowModesModel: GridRowModesModel;
+  selectedRowId: string | number | null;
+  treeActive: boolean;
+}
+
+const renderFocusHook = (initialProps: HookProps) => {
+  const setCellFocus = vi.fn();
+  const setSelectedRowId = vi.fn();
+  const gridApiRef = { current: { setCellFocus } };
+
+  const hookResult = renderHook(
+    ({ rowModesModel, selectedRowId, treeActive }: HookProps) =>
+      useHierarchyGridFocus({
+        gridApiRef,
+        rowModesModel,
+        rows: ROWS,
+        selectedRowId,
+        setSelectedRowId,
+        treeActive,
+      }),
+    { initialProps },
+  );
+
+  return { ...hookResult, setCellFocus, setSelectedRowId };
+};
+
+describe('useHierarchyGridFocus', () => {
+  it('focuses the edited row on Edit→View transition, not the stale selectedRowId', () => {
+    // Reproduce the bug: user arrow-navigated to field-2 (only ref updated),
+    // so selectedRowId state is still field-1 from the last click.
+    const { rerender, setCellFocus, setSelectedRowId } = renderFocusHook({
+      rowModesModel: { 'field-2': { mode: GridRowModes.Edit } },
+      selectedRowId: 'field-1', // stale — last clicked row
+      treeActive: true,
+    });
+
+    setCellFocus.mockClear();
+    setSelectedRowId.mockClear();
+
+    // Simulate save: row exits edit mode while selectedRowId state is still stale.
+    act(() => {
+      rerender({
+        rowModesModel: {},
+        selectedRowId: 'field-1', // still stale (state not updated yet)
+        treeActive: true,
+      });
+    });
+
+    // Must focus field-2 (the row that was being edited), not field-1 (the stale state).
+    expect(setCellFocus).toHaveBeenCalledWith('field-2', 'name');
+    const callsToField1 = setCellFocus.mock.calls.filter(([id]) => id === 'field-1');
+    expect(callsToField1).toHaveLength(0);
+
+    // State must be synced so subsequent arrow navigation starts from field-2.
+    expect(setSelectedRowId).toHaveBeenCalledWith('field-2');
+  });
+
+  it('focuses selectedRowId when no editing row is identifiable in prevModel', () => {
+    // Degenerate case: rowModesModel transitions from {} to {} (no editing row ever set).
+    const { rerender, setCellFocus } = renderFocusHook({
+      rowModesModel: {},
+      selectedRowId: 'field-1',
+      treeActive: true,
+    });
+
+    setCellFocus.mockClear();
+
+    act(() => {
+      rerender({
+        rowModesModel: {},
+        selectedRowId: 'field-2',
+        treeActive: true,
+      });
+    });
+
+    // No Edit→View transition — the selectedRowId change should trigger
+    // the selectedRowId/treeActive effect and focus field-2.
+    expect(setCellFocus).toHaveBeenCalledWith('field-2', 'name');
+  });
+
+  it('does not focus when treeActive is false', () => {
+    const { rerender, setCellFocus } = renderFocusHook({
+      rowModesModel: {},
+      selectedRowId: 'field-1',
+      treeActive: false,
+    });
+
+    setCellFocus.mockClear();
+
+    act(() => {
+      rerender({
+        rowModesModel: {},
+        selectedRowId: 'field-2',
+        treeActive: false,
+      });
+    });
+
+    expect(setCellFocus).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger Edit→View restoration when only entering edit mode', () => {
+    // Entering Edit mode must NOT call focusRow (that would fight with MUI's own
+    // focus management for the edit cell).
+    const { rerender, setCellFocus } = renderFocusHook({
+      rowModesModel: {},
+      selectedRowId: 'field-1',
+      treeActive: true,
+    });
+
+    setCellFocus.mockClear();
+
+    act(() => {
+      rerender({
+        rowModesModel: { 'field-1': { mode: GridRowModes.Edit } },
+        selectedRowId: 'field-1',
+        treeActive: true,
+      });
+    });
+
+    // No Edit→View transition occurred — no restoration focus call expected.
+    // (The existing cell click / MUI focus management handles the edit focus.)
+    const restorationCalls = setCellFocus.mock.calls;
+    // It's OK if setCellFocus was called (e.g. by the selectedRowId/treeActive effect),
+    // but there must be no spurious call that would fight with the edit input focus.
+    // Since field-1 was already selected and treeActive was already true, the
+    // selectedRowId/treeActive effect also should not fire (deps didn't change).
+    expect(restorationCalls).toHaveLength(0);
+  });
+
+  it('syncs selectedRowId state after focusing the edited row', () => {
+    // After Edit→View, setSelectedRowId must be called so that subsequent
+    // arrow navigation and useLayoutEffect([selectedRowId]) start from the
+    // correct row.
+    const { rerender, setSelectedRowId } = renderFocusHook({
+      rowModesModel: { 'field-3': { mode: GridRowModes.Edit } },
+      selectedRowId: 'field-1',
+      treeActive: true,
+    });
+
+    setSelectedRowId.mockClear();
+
+    act(() => {
+      rerender({
+        rowModesModel: {},
+        selectedRowId: 'field-1',
+        treeActive: true,
+      });
+    });
+
+    expect(setSelectedRowId).toHaveBeenCalledWith('field-3');
+  });
+});

--- a/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
@@ -1,0 +1,237 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GridRowModes } from '@mui/x-data-grid';
+import type {
+  GridCellParams,
+  GridColDef,
+  GridRowId,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import { useHierarchyGridKeyboard } from '../components/hierarchy/hooks/useHierarchyGridKeyboard';
+import type { HierarchyRow } from '../components/hierarchy/utils/types';
+
+type KeyboardEventStub = React.KeyboardEvent & {
+  defaultMuiPrevented: boolean;
+};
+
+type MouseEventStub = React.MouseEvent<HTMLElement> & {
+  defaultMuiPrevented: boolean;
+};
+
+const columns: GridColDef<HierarchyRow>[] = [
+  { field: 'name', editable: true },
+  { field: 'length_m', editable: true },
+  { field: 'width_m', editable: true },
+  { field: 'area_sqm', editable: false },
+  { field: 'notes', editable: false },
+];
+
+const rows: HierarchyRow[] = [
+  {
+    id: 'field-1',
+    type: 'field',
+    name: 'Field 1',
+    level: 0,
+    hasChildren: true,
+    isNew: false,
+  },
+  {
+    id: 101,
+    type: 'bed',
+    name: 'Bed 1',
+    level: 1,
+    hasChildren: false,
+    isNew: false,
+  },
+];
+
+const rowsById = new Map(rows.map((row) => [String(row.id), row]));
+
+const makeCellParams = (
+  id: GridRowId,
+  field: string,
+  row = rowsById.get(String(id))!,
+): GridCellParams<HierarchyRow> => ({
+  id,
+  field,
+  row,
+  isEditable: field === 'name' || field === 'length_m' || field === 'width_m',
+}) as GridCellParams<HierarchyRow>;
+
+const makeKeyboardEvent = (key: string, overrides: Partial<KeyboardEventStub> = {}): KeyboardEventStub => ({
+  key,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  defaultMuiPrevented: false,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+  currentTarget: document.createElement('div'),
+  ...overrides,
+}) as KeyboardEventStub;
+
+const makeMouseEvent = (): MouseEventStub => ({
+  defaultMuiPrevented: false,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+}) as unknown as MouseEventStub;
+
+const renderKeyboardHook = (rowModesModel: GridRowModesModel = {}) => {
+  const discardRowEdit = vi.fn();
+  const focusCell = vi.fn();
+  const notesOpen = vi.fn();
+  const openContextMenu = vi.fn();
+  const rememberFocusedField = vi.fn();
+  const rememberRowSnapshot = vi.fn();
+  const selectRow = vi.fn();
+  const setRowModesModel = vi.fn();
+  const setTreeActive = vi.fn();
+  const toggleExpand = vi.fn();
+  const scrollToIndexes = vi.fn();
+
+  const api = {
+    getAllRowIds: () => rows.map((row) => row.id),
+    getCellParams: (id: GridRowId, field: string) => makeCellParams(id, field),
+    getColumnIndexRelativeToVisibleColumns: (field: string) =>
+      columns.findIndex((column) => column.field === field),
+    getRowIndexRelativeToVisibleRows: (id: GridRowId) =>
+      rows.findIndex((row) => String(row.id) === String(id)),
+    getVisibleColumns: () => columns,
+    isCellEditable: (params: GridCellParams<HierarchyRow>) =>
+      params.field === 'name' || params.field === 'length_m' || params.field === 'width_m',
+    scrollToIndexes,
+    setCellFocus: focusCell,
+  };
+
+  const hook = renderHook(() =>
+    useHierarchyGridKeyboard({
+      columns,
+      discardRowEdit,
+      gridApiRef: { current: api },
+      isCellFocusable: (row, field) => field === 'notes' || row.type !== 'location' && field !== 'area_sqm',
+      isHierarchyCellAction: (params) => params.field === 'notes',
+      notesEditor: { handleOpen: notesOpen },
+      openContextMenuForRow: openContextMenu,
+      rememberFocusedField,
+      rememberRowSnapshot,
+      rowModesModel,
+      rows,
+      rowsById,
+      selectRow,
+      setRowModesModel,
+      setTreeActive,
+      toggleExpand,
+    }),
+  );
+
+  return {
+    ...hook,
+    discardRowEdit,
+    focusCell,
+    notesOpen,
+    openContextMenu,
+    rememberFocusedField,
+    rememberRowSnapshot,
+    scrollToIndexes,
+    selectRow,
+    setRowModesModel,
+    setTreeActive,
+    toggleExpand,
+  };
+};
+
+describe('useHierarchyGridKeyboard', () => {
+  it('skips the calculated area column when tabbing in edit mode', () => {
+    const { result, focusCell, selectRow } = renderKeyboardHook({
+      'field-1': { mode: GridRowModes.Edit },
+    });
+    const event = makeKeyboardEvent('Tab');
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'width_m'), event);
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(focusCell).toHaveBeenCalledWith('field-1', 'notes');
+    expect(focusCell).not.toHaveBeenCalledWith('field-1', 'area_sqm');
+    expect(selectRow).toHaveBeenCalledWith('field-1');
+  });
+
+  it('suppresses printable keys in view mode without entering edit mode', () => {
+    const { result, setRowModesModel } = renderKeyboardHook();
+    const event = makeKeyboardEvent('a');
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'name'), event);
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(setRowModesModel).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-focusable calculated-cell clicks before row selection or editing', () => {
+    const { result, rememberRowSnapshot, selectRow, setRowModesModel } = renderKeyboardHook();
+    const event = makeMouseEvent();
+
+    act(() => {
+      result.current.handleCellClick(makeCellParams('field-1', 'area_sqm'), event);
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(rememberRowSnapshot).not.toHaveBeenCalled();
+    expect(selectRow).not.toHaveBeenCalled();
+    expect(setRowModesModel).not.toHaveBeenCalled();
+  });
+
+  it('opens notes from the keyboard without starting row edit mode', () => {
+    const { result, notesOpen, setRowModesModel } = renderKeyboardHook();
+    const event = makeKeyboardEvent('Enter');
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'notes'), event);
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(notesOpen).toHaveBeenCalledWith('field-1', 'notes');
+    expect(setRowModesModel).not.toHaveBeenCalled();
+  });
+
+  it('discards the active row edit before clicking into another editable row', () => {
+    const { result, discardRowEdit, selectRow, setRowModesModel } = renderKeyboardHook({
+      'field-1': { mode: GridRowModes.Edit },
+    });
+
+    act(() => {
+      result.current.handleCellClick(makeCellParams(101, 'name'), makeMouseEvent());
+    });
+
+    expect(discardRowEdit).toHaveBeenCalledWith('field-1');
+    expect(selectRow).toHaveBeenCalledWith(101);
+    expect(setRowModesModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses spacebar for expandable rows and blocks default grid focus jumps for leaf rows', () => {
+    const { result, toggleExpand } = renderKeyboardHook();
+    const expandableEvent = makeKeyboardEvent(' ');
+    const leafEvent = makeKeyboardEvent(' ');
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'name'), expandableEvent);
+      result.current.handleCellKeyDown(makeCellParams(101, 'name'), leafEvent);
+    });
+
+    expect(expandableEvent.defaultMuiPrevented).toBe(true);
+    expect(expandableEvent.preventDefault).toHaveBeenCalled();
+    expect(toggleExpand).toHaveBeenCalledWith('field-1');
+    expect(leafEvent.defaultMuiPrevented).toBe(true);
+    expect(leafEvent.preventDefault).toHaveBeenCalled();
+    expect(toggleExpand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -1,10 +1,10 @@
 import { useCallback, useLayoutEffect, useRef } from "react";
-import type { MutableRefObject } from "react";
 import { GridRowModes } from "@mui/x-data-grid";
 import type { GridRowId, GridRowModesModel, GridRowsProp } from "@mui/x-data-grid";
 import type { HierarchyRow } from "../utils/types";
 
 interface HierarchyGridFocusApi {
+  getCellElement?: (id: GridRowId, field: string) => HTMLElement | null;
   setCellFocus?: (id: GridRowId, field: string) => void;
 }
 
@@ -22,7 +22,8 @@ interface UseHierarchyGridFocusParams {
 
 interface UseHierarchyGridFocusResult {
   focusRow: (rowId: GridRowId, preferredField?: string) => void;
-  focusedFieldRef: MutableRefObject<string>;
+  /** Call immediately before setRowModesModel(View) to prevent a browser focus-fixup flash. */
+  preFocusEditCell: (rowId: GridRowId) => void;
   rememberFocusedField: (field: string) => void;
 }
 
@@ -78,25 +79,30 @@ export function useHierarchyGridFocus({
     api?.setCellFocus?.(rowId, focusField);
   }, [getFocusableField, gridApiRef]);
 
+  // Pre-focus the stable cell container div before switching the row back to View mode.
+  // When React removes the edit <input> from the DOM, the browser's native focus-fixup
+  // would otherwise move focus to the nearest focusable ancestor (often the first row),
+  // causing a visible flash. Moving focus to the container first keeps DOM focus anchored
+  // through the transition. This does NOT fire MUI's cellFocusOut custom event (which is
+  // only emitted by setCellFocus), so it has no unintended edit-stop side-effect.
+  const preFocusEditCell = useCallback((rowId: GridRowId): void => {
+    gridApiRef.current?.getCellElement?.(rowId, focusedFieldRef.current)?.focus({ preventScroll: true });
+  }, [gridApiRef]);
+
   const focusSelectedCell = useCallback((): void => {
     if (selectedRowId != null) {
       focusRow(selectedRowId);
     }
   }, [focusRow, selectedRowId]);
 
-  // useLayoutEffect (not useEffect) so focus is restored synchronously during the
-  // commit phase, before the browser paints.
+  // useLayoutEffect (not useEffect) fires synchronously before the browser paints,
+  // so focus is always corrected within the same commit — no visible flash.
   //
-  // When a row exits edit mode, we focus the row that WAS being edited (identified
-  // from prevModel), NOT selectedRowId state. This is critical because arrow-key
-  // navigation only updates selectedRowIdRef (transient), not the selectedRowId
-  // React state. If the user navigated to a row via arrow keys and pressed Enter to
-  // edit it, selectedRowId state is stale (the last clicked row). Focusing it would
-  // visually jump to the wrong row. Using prevModel's editing row ID guarantees we
-  // focus the row the user actually just saved, regardless of how they started the edit.
-  //
-  // We also call setSelectedRowId to sync state, so subsequent arrow navigation and
-  // focus restoration start from the correct row.
+  // On Edit→View transition we focus the row that WAS being edited (from prevModel),
+  // not selectedRowId state. Arrow-key navigation only updates selectedRowIdRef (transient);
+  // if editing was started via keyboard, selectedRowId state is the last clicked row and
+  // would land focus on the wrong row. We also sync selectedRowId so subsequent arrow
+  // navigation and focus restoration start from the correct row.
   useLayoutEffect(() => {
     const prevModel = prevRowModesModelRef.current;
     prevRowModesModelRef.current = rowModesModel;
@@ -139,7 +145,7 @@ export function useHierarchyGridFocus({
 
   return {
     focusRow,
-    focusedFieldRef,
+    preFocusEditCell,
     rememberFocusedField,
   };
 }

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 import { GridRowModes } from "@mui/x-data-grid";
 import type { GridRowId, GridRowModesModel, GridRowsProp } from "@mui/x-data-grid";
 import type { HierarchyRow } from "../utils/types";
@@ -79,7 +79,11 @@ export function useHierarchyGridFocus({
     }
   }, [focusRow, selectedRowId]);
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so focus is restored synchronously during the
+  // commit phase, before the browser paints.  Without this, the DOM loses focus when
+  // the edit-cell input is removed, the browser briefly shows the first row focused,
+  // and then an async useEffect would move focus back — causing a visible flash.
+  useLayoutEffect(() => {
     const prevModel = prevRowModesModelRef.current;
     prevRowModesModelRef.current = rowModesModel;
 

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -32,8 +32,19 @@ const DEFAULT_FOCUS_FIELD = "name";
 const hasEditingRow = (rowModesModel: GridRowModesModel): boolean =>
   Object.values(rowModesModel).some((mode) => mode.mode === GridRowModes.Edit);
 
-const getEditingRowId = (rowModesModel: GridRowModesModel): string | null =>
-  Object.entries(rowModesModel).find(([, mode]) => mode.mode === GridRowModes.Edit)?.[0] ?? null;
+const getEditingRowId = (
+  rowModesModel: GridRowModesModel,
+  rows: GridRowsProp<HierarchyRow>,
+): GridRowId | null => {
+  const editingRowKey = Object.entries(rowModesModel).find(
+    ([, mode]) => mode.mode === GridRowModes.Edit,
+  )?.[0];
+  if (editingRowKey == null) {
+    return null;
+  }
+
+  return rows.find((row) => String(row.id) === editingRowKey)?.id ?? editingRowKey;
+};
 
 const findFallbackVisibleRow = (
   previousRows: GridRowsProp<HierarchyRow>,
@@ -111,7 +122,7 @@ export function useHierarchyGridFocus({
       return;
     }
 
-    const editingRowId = getEditingRowId(prevModel);
+    const editingRowId = getEditingRowId(prevModel, rows);
     if (editingRowId != null) {
       focusRow(editingRowId);
       setSelectedRowId(editingRowId);

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -31,6 +31,9 @@ const DEFAULT_FOCUS_FIELD = "name";
 const hasEditingRow = (rowModesModel: GridRowModesModel): boolean =>
   Object.values(rowModesModel).some((mode) => mode.mode === GridRowModes.Edit);
 
+const getEditingRowId = (rowModesModel: GridRowModesModel): string | null =>
+  Object.entries(rowModesModel).find(([, mode]) => mode.mode === GridRowModes.Edit)?.[0] ?? null;
+
 const findFallbackVisibleRow = (
   previousRows: GridRowsProp<HierarchyRow>,
   visibleRows: GridRowsProp<HierarchyRow>,
@@ -82,17 +85,34 @@ export function useHierarchyGridFocus({
   }, [focusRow, selectedRowId]);
 
   // useLayoutEffect (not useEffect) so focus is restored synchronously during the
-  // commit phase, before the browser paints.  Without this, the DOM loses focus when
-  // the edit-cell input is removed, the browser briefly shows the first row focused,
-  // and then an async useEffect would move focus back — causing a visible flash.
+  // commit phase, before the browser paints.
+  //
+  // When a row exits edit mode, we focus the row that WAS being edited (identified
+  // from prevModel), NOT selectedRowId state. This is critical because arrow-key
+  // navigation only updates selectedRowIdRef (transient), not the selectedRowId
+  // React state. If the user navigated to a row via arrow keys and pressed Enter to
+  // edit it, selectedRowId state is stale (the last clicked row). Focusing it would
+  // visually jump to the wrong row. Using prevModel's editing row ID guarantees we
+  // focus the row the user actually just saved, regardless of how they started the edit.
+  //
+  // We also call setSelectedRowId to sync state, so subsequent arrow navigation and
+  // focus restoration start from the correct row.
   useLayoutEffect(() => {
     const prevModel = prevRowModesModelRef.current;
     prevRowModesModelRef.current = rowModesModel;
 
-    if (hasEditingRow(prevModel) && !hasEditingRow(rowModesModel)) {
+    if (!hasEditingRow(prevModel) || hasEditingRow(rowModesModel)) {
+      return;
+    }
+
+    const editingRowId = getEditingRowId(prevModel);
+    if (editingRowId != null) {
+      focusRow(editingRowId);
+      setSelectedRowId(editingRowId);
+    } else {
       focusSelectedCell();
     }
-  }, [focusSelectedCell, rowModesModel]);
+  }, [focusRow, focusSelectedCell, rowModesModel, setSelectedRowId]);
 
   useLayoutEffect(() => {
     if (treeActive) {

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useRef } from "react";
+import type { MutableRefObject } from "react";
 import { GridRowModes } from "@mui/x-data-grid";
 import type { GridRowId, GridRowModesModel, GridRowsProp } from "@mui/x-data-grid";
 import type { HierarchyRow } from "../utils/types";
@@ -21,6 +22,7 @@ interface UseHierarchyGridFocusParams {
 
 interface UseHierarchyGridFocusResult {
   focusRow: (rowId: GridRowId, preferredField?: string) => void;
+  focusedFieldRef: MutableRefObject<string>;
   rememberFocusedField: (field: string) => void;
 }
 
@@ -117,6 +119,7 @@ export function useHierarchyGridFocus({
 
   return {
     focusRow,
+    focusedFieldRef,
     rememberFocusedField,
   };
 }

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
@@ -1,0 +1,285 @@
+import { useCallback } from "react";
+import { GridRowModes } from "@mui/x-data-grid";
+import type {
+  GridCellParams,
+  GridColDef,
+  GridRowId,
+  GridRowModesModel,
+} from "@mui/x-data-grid";
+import { handleEditableCellClick } from "../../data-grid/handlers";
+import {
+  focusKeyboardNavigableCell,
+  getKeyboardNavigationTarget,
+} from "../../data-grid/keyboardNavigation";
+import type { HierarchyRow } from "../utils/types";
+
+type HierarchyKeyboardEvent = React.KeyboardEvent & {
+  defaultMuiPrevented?: boolean;
+};
+
+interface HierarchyGridKeyboardApi {
+  getAllRowIds?: () => GridRowId[];
+  getCellParams?: (id: GridRowId, field: string) => GridCellParams<HierarchyRow>;
+  getColumnIndexRelativeToVisibleColumns?: (field: string) => number;
+  getRowIndexRelativeToVisibleRows?: (id: GridRowId) => number;
+  getVisibleColumns?: () => GridColDef<HierarchyRow>[];
+  isCellEditable?: (params: GridCellParams<HierarchyRow>) => boolean;
+  scrollToIndexes?: (indexes: { rowIndex?: number; colIndex?: number }) => void;
+  setCellFocus?: (id: GridRowId, field: string) => void;
+}
+
+interface UseHierarchyGridKeyboardParams {
+  columns: GridColDef<HierarchyRow>[];
+  discardRowEdit: (rowId: GridRowId) => void;
+  gridApiRef: {
+    current?: HierarchyGridKeyboardApi | null;
+  };
+  isCellFocusable: (row: HierarchyRow, field: string) => boolean;
+  isHierarchyCellAction: (params: GridCellParams<HierarchyRow>) => boolean;
+  notesEditor: {
+    handleOpen: (rowId: GridRowId, field: string) => void;
+  };
+  openContextMenuForRow: (
+    row: HierarchyRow,
+    mouseX: number,
+    mouseY: number,
+    origin?: HTMLElement | null,
+  ) => void;
+  rememberFocusedField: (field: string) => void;
+  rememberRowSnapshot: (rowId: GridRowId) => void;
+  rowModesModel: GridRowModesModel;
+  rows: readonly HierarchyRow[];
+  rowsById: Map<string, HierarchyRow>;
+  selectRow: (rowId: GridRowId) => void;
+  setRowModesModel: React.Dispatch<React.SetStateAction<GridRowModesModel>>;
+  setTreeActive: (active: boolean) => void;
+  toggleExpand: (rowId: GridRowId) => void;
+}
+
+interface UseHierarchyGridKeyboardResult {
+  handleCellClick: (
+    params: GridCellParams<HierarchyRow>,
+    event?: React.MouseEvent<HTMLElement> & { defaultMuiPrevented?: boolean },
+  ) => void;
+  handleCellKeyDown: (
+    params: GridCellParams<HierarchyRow>,
+    event: React.KeyboardEvent,
+  ) => void;
+}
+
+const isRowEditing = (rowModesModel: GridRowModesModel, rowId: GridRowId): boolean =>
+  rowModesModel[rowId]?.mode === GridRowModes.Edit;
+
+const getEditingRowId = (rowModesModel: GridRowModesModel): string | undefined =>
+  Object.entries(rowModesModel).find(([, mode]) => mode.mode === GridRowModes.Edit)?.[0];
+
+const shouldSuppressPrintableViewEdit = (
+  event: HierarchyKeyboardEvent,
+  rowModesModel: GridRowModesModel,
+  rowId: GridRowId,
+): boolean => (
+  event.key.length === 1
+  && !event.ctrlKey
+  && !event.metaKey
+  && !isRowEditing(rowModesModel, rowId)
+);
+
+export function useHierarchyGridKeyboard({
+  columns,
+  discardRowEdit,
+  gridApiRef,
+  isCellFocusable,
+  isHierarchyCellAction,
+  notesEditor,
+  openContextMenuForRow,
+  rememberFocusedField,
+  rememberRowSnapshot,
+  rowModesModel,
+  rows,
+  rowsById,
+  selectRow,
+  setRowModesModel,
+  setTreeActive,
+  toggleExpand,
+}: UseHierarchyGridKeyboardParams): UseHierarchyGridKeyboardResult {
+  const navigateCell = useCallback((
+    params: GridCellParams<HierarchyRow>,
+    event: HierarchyKeyboardEvent,
+  ): boolean => {
+    const editMode = isRowEditing(rowModesModel, params.id);
+    if (
+      (editMode && event.key !== "Tab")
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+    ) {
+      return false;
+    }
+
+    const direction = event.key === "ArrowLeft" || event.shiftKey ? -1 : 1;
+    const target = event.key === "Tab" || event.key === "ArrowLeft" || event.key === "ArrowRight"
+      ? getKeyboardNavigationTarget<HierarchyRow>({
+        api: gridApiRef.current,
+        columns,
+        current: { id: params.id, field: params.field },
+        direction,
+        isActionCell: isHierarchyCellAction,
+        rows,
+        wrapRows: event.key === "Tab" && !editMode,
+      })
+      : null;
+
+    if (!target) {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.defaultMuiPrevented = true;
+    rememberFocusedField(target.field);
+    selectRow(target.id);
+    setTreeActive(true);
+    focusKeyboardNavigableCell<HierarchyRow>({
+      api: gridApiRef.current,
+      cell: target,
+    });
+    return true;
+  }, [
+    columns,
+    gridApiRef,
+    isHierarchyCellAction,
+    rememberFocusedField,
+    rowModesModel,
+    rows,
+    selectRow,
+    setTreeActive,
+  ]);
+
+  const handleCellClick = useCallback((
+    params: GridCellParams<HierarchyRow>,
+    event?: React.MouseEvent<HTMLElement> & { defaultMuiPrevented?: boolean },
+  ): void => {
+    if (!isCellFocusable(params.row, params.field)) {
+      event?.preventDefault();
+      event?.stopPropagation();
+      if (event) {
+        event.defaultMuiPrevented = true;
+      }
+      return;
+    }
+
+    const editingRowId = getEditingRowId(rowModesModel);
+    if (editingRowId !== undefined && String(editingRowId) !== String(params.id)) {
+      discardRowEdit(rowsById.get(editingRowId)?.id ?? editingRowId);
+    }
+
+    rememberFocusedField(params.field);
+    rememberRowSnapshot(params.id);
+    selectRow(params.id);
+    setTreeActive(true);
+    handleEditableCellClick(params, rowModesModel, setRowModesModel);
+  }, [
+    discardRowEdit,
+    isCellFocusable,
+    rememberFocusedField,
+    rememberRowSnapshot,
+    rowModesModel,
+    rowsById,
+    selectRow,
+    setRowModesModel,
+    setTreeActive,
+  ]);
+
+  const handleCellKeyDown = useCallback((
+    params: GridCellParams<HierarchyRow>,
+    event: React.KeyboardEvent,
+  ): void => {
+    const keyboardEvent = event as HierarchyKeyboardEvent;
+    rememberFocusedField(params.field);
+
+    if (
+      keyboardEvent.key === "Tab"
+      || keyboardEvent.key === "ArrowLeft"
+      || keyboardEvent.key === "ArrowRight"
+    ) {
+      if (navigateCell(params, keyboardEvent)) {
+        return;
+      }
+    }
+
+    if (keyboardEvent.key === "Escape" && isRowEditing(rowModesModel, params.id)) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.defaultMuiPrevented = true;
+      discardRowEdit(params.id);
+      return;
+    }
+
+    if (
+      params.field === "notes"
+      && (keyboardEvent.key === "Enter"
+        || keyboardEvent.key === " "
+        || keyboardEvent.key === "Spacebar")
+    ) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      keyboardEvent.defaultMuiPrevented = true;
+      notesEditor.handleOpen(params.id, "notes");
+      return;
+    }
+
+    if (
+      (keyboardEvent.key === " " || keyboardEvent.key === "Spacebar")
+      && params.field !== "notes"
+      && !isRowEditing(rowModesModel, params.id)
+    ) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.defaultMuiPrevented = true;
+      const row = params.row as HierarchyRow;
+      if ((row.type === "location" || row.type === "field") && row.hasChildren) {
+        toggleExpand(params.id);
+      }
+      return;
+    }
+
+    if (
+      (keyboardEvent.key === "ArrowDown" || keyboardEvent.key === "ArrowUp")
+      && !isRowEditing(rowModesModel, params.id)
+    ) {
+      keyboardEvent.defaultMuiPrevented = true;
+    }
+
+    if (shouldSuppressPrintableViewEdit(keyboardEvent, rowModesModel, params.id)) {
+      keyboardEvent.defaultMuiPrevented = true;
+    }
+
+    if (keyboardEvent.key === "ContextMenu" || (keyboardEvent.shiftKey && keyboardEvent.key === "F10")) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      const targetRow = rows.find((row) => row.id === params.id);
+      if (targetRow) {
+        const targetElement = keyboardEvent.currentTarget as HTMLElement;
+        const rect = targetElement.getBoundingClientRect();
+        openContextMenuForRow(
+          targetRow,
+          rect.left + Math.min(240, rect.width),
+          rect.top + 12,
+          targetElement,
+        );
+      }
+    }
+  }, [
+    discardRowEdit,
+    navigateCell,
+    notesEditor,
+    openContextMenuForRow,
+    rememberFocusedField,
+    rowModesModel,
+    rows,
+    toggleExpand,
+  ]);
+
+  return {
+    handleCellClick,
+    handleCellKeyDown,
+  };
+}

--- a/frontend/src/cultures/spreadsheetColumns.ts
+++ b/frontend/src/cultures/spreadsheetColumns.ts
@@ -1,0 +1,226 @@
+export type SpreadsheetColumnDef = {
+  header: string;
+  key: string;
+  aliases: string[];
+  type: 'string' | 'number' | 'boolean';
+  enumExport?: Record<string, string>;
+  enumImport?: Record<string, string>;
+};
+
+export const NUTRIENT_DEMAND_EXPORT: Record<string, string> = {
+  low: 'Niedrig',
+  medium: 'Mittel',
+  high: 'Hoch',
+};
+
+export const NUTRIENT_DEMAND_IMPORT: Record<string, string> = {
+  niedrig: 'low',
+  mittel: 'medium',
+  hoch: 'high',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+};
+
+export const CULTIVATION_TYPE_EXPORT: Record<string, string> = {
+  direct_sowing: 'Direktsaat',
+  pre_cultivation: 'Pflanzung',
+};
+
+export const CULTIVATION_TYPE_IMPORT: Record<string, string> = {
+  direktsaat: 'direct_sowing',
+  direktsaht: 'direct_sowing',
+  pflanzung: 'pre_cultivation',
+  direct_sowing: 'direct_sowing',
+  pre_cultivation: 'pre_cultivation',
+};
+
+export const HARVEST_METHOD_EXPORT: Record<string, string> = {
+  per_plant: 'Pro Pflanze',
+  per_sqm: 'Pro m²',
+};
+
+export const HARVEST_METHOD_IMPORT: Record<string, string> = {
+  'pro pflanze': 'per_plant',
+  'je pflanze': 'per_plant',
+  'pro m²': 'per_sqm',
+  'pro qm': 'per_sqm',
+  per_plant: 'per_plant',
+  per_sqm: 'per_sqm',
+};
+
+export const SEED_RATE_UNIT_EXPORT: Record<string, string> = {
+  g_per_m2: 'g/m²',
+  g_per_lfm: 'g/lfm',
+  seeds_per_m2: 'Körner/m²',
+  seeds_per_lfm: 'Körner/lfm',
+  seeds_per_plant: 'Körner/Pflanze',
+};
+
+export const SEED_RATE_UNIT_IMPORT: Record<string, string> = {
+  'g/m²': 'g_per_m2',
+  'g/qm': 'g_per_m2',
+  'g/lfm': 'g_per_lfm',
+  'körner/m²': 'seeds_per_m2',
+  'körner/qm': 'seeds_per_m2',
+  'körner/lfm': 'seeds_per_lfm',
+  'körner/pflanze': 'seeds_per_plant',
+  g_per_m2: 'g_per_m2',
+  g_per_lfm: 'g_per_lfm',
+  seeds_per_m2: 'seeds_per_m2',
+  seeds_per_lfm: 'seeds_per_lfm',
+  seeds_per_plant: 'seeds_per_plant',
+};
+
+export const CULTURE_COLUMNS: SpreadsheetColumnDef[] = [
+  {
+    key: 'name',
+    header: 'Name',
+    aliases: ['kulturname', 'kultur', 'bezeichnung'],
+    type: 'string',
+  },
+  {
+    key: 'variety',
+    header: 'Sorte',
+    aliases: ['sortenname', 'varietät', 'cultivar'],
+    type: 'string',
+  },
+  {
+    key: 'supplier_name',
+    header: 'Saatgutlieferant',
+    aliases: ['lieferant', 'seed_supplier', 'hersteller', 'lieferanten'],
+    type: 'string',
+  },
+  {
+    key: 'crop_family',
+    header: 'Pflanzenfamilie',
+    aliases: ['familie', 'pflanzenart', 'pfanzenfamilie'],
+    type: 'string',
+  },
+  {
+    key: 'nutrient_demand',
+    header: 'Nährstoffbedarf',
+    aliases: ['nährstoff', 'düngebedarf', 'nutrient_demand'],
+    type: 'string',
+    enumExport: NUTRIENT_DEMAND_EXPORT,
+    enumImport: NUTRIENT_DEMAND_IMPORT,
+  },
+  {
+    key: 'cultivation_type',
+    header: 'Anbauart',
+    aliases: ['anbaumethode', 'saatmethode', 'cultivation_type'],
+    type: 'string',
+    enumExport: CULTIVATION_TYPE_EXPORT,
+    enumImport: CULTIVATION_TYPE_IMPORT,
+  },
+  {
+    key: 'growth_duration_days',
+    header: 'Wachstumsdauer (Tage)',
+    aliases: ['wachstumsdauer', 'wachstumstage', 'tage bis ernte', 'growth_duration_days'],
+    type: 'number',
+  },
+  {
+    key: 'harvest_duration_days',
+    header: 'Erntezeitraum (Tage)',
+    aliases: ['erntezeitraum', 'erntedauer', 'erntedauer tage', 'harvest_duration_days'],
+    type: 'number',
+  },
+  {
+    key: 'propagation_duration_days',
+    header: 'Anzuchtdauer (Tage)',
+    aliases: ['anzuchtdauer', 'anzuchttage', 'propagation_duration_days'],
+    type: 'number',
+  },
+  {
+    key: 'harvest_method',
+    header: 'Erntemethode',
+    aliases: ['ernte methode', 'ernteart', 'harvest_method'],
+    type: 'string',
+    enumExport: HARVEST_METHOD_EXPORT,
+    enumImport: HARVEST_METHOD_IMPORT,
+  },
+  {
+    key: 'expected_yield',
+    header: 'Erwarteter Ertrag (kg/m²)',
+    aliases: ['ertrag', 'erwarteter ertrag', 'expected_yield'],
+    type: 'number',
+  },
+  {
+    key: 'distance_within_row_cm',
+    header: 'Abstand in Reihe (cm)',
+    aliases: ['pflanzenabstand', 'abstand in der reihe', 'abstand reihe', 'distance_within_row_cm'],
+    type: 'number',
+  },
+  {
+    key: 'row_spacing_cm',
+    header: 'Reihenabstand (cm)',
+    aliases: ['zeilenabstand', 'reihenzwischenabstand', 'row_spacing_cm'],
+    type: 'number',
+  },
+  {
+    key: 'sowing_depth_cm',
+    header: 'Saattiefe (cm)',
+    aliases: ['tiefe', 'aussaattiefe', 'sowing_depth_cm'],
+    type: 'number',
+  },
+  {
+    key: 'thousand_kernel_weight_g',
+    header: '1000-Korn-Gewicht (g)',
+    aliases: ['tkg', 'tausendkorngewicht', '1000-korn', 'thousand_kernel_weight_g'],
+    type: 'number',
+  },
+  {
+    key: 'sowing_calculation_safety_percent',
+    header: 'Sicherheitszuschlag (%)',
+    aliases: ['sicherheitsaufschlag', 'sicherheitsmarge', 'sowing_calculation_safety_percent'],
+    type: 'number',
+  },
+  {
+    key: 'seed_rate_direct_value',
+    header: 'Direktsaat Menge',
+    aliases: ['direktsaat menge', 'direktsaat saatgut', 'seed_rate_direct_value'],
+    type: 'number',
+  },
+  {
+    key: 'seed_rate_direct_unit',
+    header: 'Direktsaat Einheit',
+    aliases: ['direktsaat einheit', 'seed_rate_direct_unit'],
+    type: 'string',
+    enumExport: SEED_RATE_UNIT_EXPORT,
+    enumImport: SEED_RATE_UNIT_IMPORT,
+  },
+  {
+    key: 'seed_rate_pre_cultivation_value',
+    header: 'Pflanzung Menge',
+    aliases: ['pflanzung menge', 'pflanzung saatgut', 'seed_rate_pre_cultivation_value'],
+    type: 'number',
+  },
+  {
+    key: 'seed_rate_pre_cultivation_unit',
+    header: 'Pflanzung Einheit',
+    aliases: ['pflanzung einheit', 'seed_rate_pre_cultivation_unit'],
+    type: 'string',
+    enumExport: SEED_RATE_UNIT_EXPORT,
+    enumImport: SEED_RATE_UNIT_IMPORT,
+  },
+  {
+    key: 'notes',
+    header: 'Notizen',
+    aliases: ['anmerkungen', 'kommentar', 'notiz', 'hinweise'],
+    type: 'string',
+  },
+];
+
+export const normalizeHeaderForLookup = (header: string): string =>
+  header.trim().toLowerCase().replace(/\s+/g, ' ');
+
+export const buildHeaderToKeyMap = (): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const col of CULTURE_COLUMNS) {
+    map.set(normalizeHeaderForLookup(col.header), col.key);
+    for (const alias of col.aliases) {
+      map.set(normalizeHeaderForLookup(alias), col.key);
+    }
+  }
+  return map;
+};

--- a/frontend/src/cultures/spreadsheetExport.ts
+++ b/frontend/src/cultures/spreadsheetExport.ts
@@ -1,0 +1,76 @@
+import * as XLSX from 'xlsx';
+import type { Culture } from '../api/types';
+import { toPortableCulture, slugifyFilenamePart } from './exportUtils';
+import { CULTURE_COLUMNS } from './spreadsheetColumns';
+
+export type SpreadsheetExportFormat = 'xlsx' | 'ods' | 'csv';
+
+const MIME_TYPES: Record<SpreadsheetExportFormat, string> = {
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ods: 'application/vnd.oasis.opendocument.spreadsheet',
+  csv: 'text/csv;charset=utf-8',
+};
+
+const buildSheetData = (cultures: Culture[]): (string | number | null)[][] => {
+  const headers = CULTURE_COLUMNS.map((col) => col.header);
+  const rows = cultures.map((culture) => {
+    const portable = toPortableCulture(culture) as unknown as Record<string, unknown>;
+    return CULTURE_COLUMNS.map((col) => {
+      const raw = portable[col.key];
+      if (raw === undefined || raw === null) return null;
+      if (col.enumExport && typeof raw === 'string') return col.enumExport[raw] ?? raw;
+      if (typeof raw === 'number') return raw;
+      if (typeof raw === 'boolean') return raw ? 'ja' : 'nein';
+      return String(raw);
+    });
+  });
+  return [headers, ...rows];
+};
+
+const triggerDownload = (data: Uint8Array | string, filename: string, mimeType: string): void => {
+  const blob = new Blob([data as BlobPart], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
+export const exportCulturesToSpreadsheet = (
+  cultures: Culture[],
+  format: SpreadsheetExportFormat,
+  filename: string,
+): void => {
+  const sheetData = buildSheetData(cultures);
+  const worksheet = XLSX.utils.aoa_to_sheet(sheetData);
+
+  // Set column widths for readability
+  worksheet['!cols'] = CULTURE_COLUMNS.map((col) => ({
+    wch: Math.min(Math.max(col.header.length + 4, 12), 40),
+  }));
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Kulturen');
+
+  const output = XLSX.write(workbook, { bookType: format, type: 'array' }) as Uint8Array;
+  triggerDownload(output, filename, MIME_TYPES[format]);
+};
+
+const formatDate = (date = new Date()): string => date.toISOString().split('T')[0];
+
+export const buildSpreadsheetFilename = (
+  format: SpreadsheetExportFormat,
+  scope: 'single' | 'all',
+  culture?: Culture,
+): string => {
+  const ext = format;
+  if (scope === 'single' && culture) {
+    const supplier = slugifyFilenamePart(culture.supplier?.name ?? culture.seed_supplier ?? '');
+    const variety = slugifyFilenamePart(culture.variety ?? '');
+    return `kultur_${supplier}_${variety}_${formatDate()}.${ext}`;
+  }
+  return `kulturen_export_${formatDate()}.${ext}`;
+};

--- a/frontend/src/cultures/spreadsheetImport.ts
+++ b/frontend/src/cultures/spreadsheetImport.ts
@@ -1,0 +1,107 @@
+import * as XLSX from 'xlsx';
+import { normalizeImportCultureEntry } from './importUtils';
+import { buildHeaderToKeyMap, normalizeHeaderForLookup, CULTURE_COLUMNS } from './spreadsheetColumns';
+
+export type SpreadsheetParseResult = {
+  entries: Record<string, unknown>[];
+  skippedRows: number;
+  warnings: string[];
+};
+
+const readFileAsArrayBuffer = (file: File): Promise<ArrayBuffer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error ?? new Error('Datei konnte nicht gelesen werden'));
+    reader.readAsArrayBuffer(file);
+  });
+
+const parseRawValue = (
+  value: unknown,
+  type: 'string' | 'number' | 'boolean',
+  enumImport?: Record<string, string>,
+): unknown => {
+  if (value === null || value === undefined || value === '') return undefined;
+
+  if (type === 'number') {
+    const n = typeof value === 'number' ? value : Number(String(value).replace(',', '.'));
+    return Number.isFinite(n) ? n : undefined;
+  }
+
+  if (type === 'boolean') {
+    const s = String(value).trim().toLowerCase();
+    if (s === 'ja' || s === 'yes' || s === '1' || s === 'true') return true;
+    if (s === 'nein' || s === 'no' || s === '0' || s === 'false') return false;
+    return undefined;
+  }
+
+  const s = String(value).trim();
+  if (!s) return undefined;
+
+  if (enumImport) {
+    const mapped = enumImport[normalizeHeaderForLookup(s)];
+    return mapped ?? s;
+  }
+
+  return s;
+};
+
+export const parseSpreadsheetFile = async (file: File): Promise<SpreadsheetParseResult> => {
+  const buffer = await readFileAsArrayBuffer(file);
+  const workbook = XLSX.read(buffer, { type: 'array', cellDates: false });
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) {
+    return { entries: [], skippedRows: 0, warnings: ['Keine Tabelle in der Datei gefunden.'] };
+  }
+  const worksheet = workbook.Sheets[sheetName];
+  const rows = XLSX.utils.sheet_to_json<unknown[]>(worksheet, { header: 1, defval: null, blankrows: false });
+
+  if (rows.length < 1) {
+    return { entries: [], skippedRows: 0, warnings: ['Die Tabelle enthält keine Daten.'] };
+  }
+
+  const headerRow = rows[0] as (string | null)[];
+  const headerToKey = buildHeaderToKeyMap();
+  const columnMap: (string | null)[] = headerRow.map((h) => {
+    if (!h) return null;
+    return headerToKey.get(normalizeHeaderForLookup(String(h))) ?? null;
+  });
+
+  const keyToColDef = new Map(CULTURE_COLUMNS.map((col) => [col.key, col]));
+
+  const warnings: string[] = [];
+  const unrecognized = headerRow.filter((h, i) => h && !columnMap[i]);
+  if (unrecognized.length > 0) {
+    warnings.push(`Nicht erkannte Spalten werden ignoriert: ${unrecognized.filter(Boolean).join(', ')}`);
+  }
+
+  const dataRows = rows.slice(1);
+  let skippedRows = 0;
+  const entries: Record<string, unknown>[] = [];
+
+  for (const rawRow of dataRows) {
+    const row = rawRow as (unknown | null)[];
+    const entry: Record<string, unknown> = {};
+
+    for (let i = 0; i < columnMap.length; i++) {
+      const key = columnMap[i];
+      if (!key) continue;
+      const colDef = keyToColDef.get(key);
+      if (!colDef) continue;
+      const raw = i < row.length ? row[i] : null;
+      const parsed = parseRawValue(raw, colDef.type, colDef.enumImport);
+      if (parsed !== undefined) {
+        entry[key] = parsed;
+      }
+    }
+
+    if (!entry['name']) {
+      skippedRows++;
+      continue;
+    }
+
+    entries.push(normalizeImportCultureEntry(entry));
+  }
+
+  return { entries, skippedRows, warnings };
+};

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -375,8 +375,23 @@
     "aiCompleteAll": "KI: Alle Kulturen vervollständigen"
   },
   "export": {
+    "menuLabel": "Exportieren…",
     "current": "Aktuelle Kultur als JSON herunterladen",
-    "all": "Alle Kulturen als JSON herunterladen"
+    "all": "Alle Kulturen als JSON herunterladen",
+    "dialogTitle": "Kulturen exportieren",
+    "scopeLabel": "Umfang",
+    "scopeCurrent": "Aktuelle Kultur",
+    "scopeAll": "Alle Kulturen",
+    "scopeCurrentDisabled": "Keine Kultur ausgewählt",
+    "formatLabel": "Format",
+    "formatXlsx": "Excel (.xlsx)",
+    "formatOds": "OpenDocument Tabelle (.ods)",
+    "formatCsv": "CSV (.csv)",
+    "formatJson": "JSON (.json)",
+    "formatJsonHint": "Für vollständige Datensicherung und Datenaustausch.",
+    "submit": "Exportieren",
+    "cancel": "Abbrechen",
+    "success": "Export abgeschlossen"
   },
   "buttons": {
     "addNew": "Kultur hinzufügen",
@@ -444,11 +459,18 @@
     }
   },
   "import": {
-    "menuLabel": "Weitere Aktionen",
+    "menuLabel": "Importieren…",
     "menuItem": "Aus JSON importieren…",
     "title": "Kulturen importieren",
+    "selectFileTitle": "Kulturen importieren",
+    "selectFileButton": "Datei auswählen",
+    "supportedFormats": "Unterstützte Formate: JSON, CSV, Excel (.xlsx), OpenDocument (.ods)",
+    "formatHintTable": "Excel, ODS, CSV: einfache Bearbeitung in Tabellenkalkulationen wie LibreOffice oder Excel.",
+    "formatHintJson": "JSON: verlustfreies Austausch- und Backup-Format.",
     "foundCount": "{{count}} Einträge gefunden",
     "invalidCount": "{{invalid}} Einträge ohne gültigen Namen",
+    "skippedRows": "{{count}} Zeilen ohne gültigen Namen wurden übersprungen.",
+    "warnings": "Hinweise",
     "start": "Import starten",
     "close": "Schließen",
     "done": "Fertig",
@@ -467,6 +489,7 @@
     "errors": {
       "notArray": "Die Datei muss ein JSON-Array enthalten.",
       "noValidEntries": "Keine gültigen Einträge gefunden.",
+      "unsupportedFormat": "Dieses Dateiformat wird nicht unterstützt. Bitte JSON, CSV, XLSX oder ODS verwenden.",
       "parse": "Die Datei konnte nicht gelesen werden.",
       "server": "Import fehlgeschlagen.",
       "network": "Netzwerkfehler beim Import.",

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -78,6 +78,8 @@ import { useEnrichmentFeature } from './useEnrichmentFeature';
 import { useCultureDelete } from './useCultureDelete';
 import { useCultureImportExport } from './useCultureImportExport';
 import { CulturesImportDialog } from './CulturesImportDialog';
+import { CulturesImportStartDialog } from './CulturesImportStartDialog';
+import { CulturesExportDialog } from './CulturesExportDialog';
 import { EnrichmentLoadingDialog } from './EnrichmentLoadingDialog';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
@@ -187,17 +189,22 @@ function Cultures() {
 
   const {
     importDialogOpen,
-    fileInputRef,
+    importStartDialogOpen,
+    exportDialogOpen,
     importState,
     hasImportableEntries,
     confirmUpdates,
     setConfirmUpdates,
     handleImportFileTrigger,
+    handleImportFileSelected,
     handleExportCurrentCulture,
     handleExportAllCultures,
-    handleImportFileChange,
+    handleOpenExportDialog,
+    handleExport,
     handleImportStart,
     handleImportDialogClose,
+    setImportStartDialogOpen,
+    setExportDialogOpen,
   } = useCultureImportExport({
     selectedCulture,
     fetchCultures,
@@ -513,28 +520,20 @@ function Cultures() {
       },
     },
     {
-      id: 'cultures-import-json',
-      label: 'Kulturen importieren (JSON)',
-      ariaLabel: 'Kulturen importieren (JSON)',
+      id: 'cultures-import',
+      label: t('import.menuLabel'),
+      ariaLabel: t('import.menuLabel'),
       onClick: handleImportFileTrigger,
       shortcutHint: 'Alt+I',
     },
     {
-      id: 'cultures-export-current-json',
-      label: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
-      ariaLabel: selectedCulture ? 'Aktuelle Kultur exportieren (JSON)' : 'Kulturen exportieren (JSON)',
-      onClick: handleExportCurrentCulture,
-      disabled: !selectedCulture,
-      shortcutHint: 'Alt+J',
+      id: 'cultures-export',
+      label: t('export.menuLabel'),
+      ariaLabel: t('export.menuLabel'),
+      onClick: handleOpenExportDialog,
+      shortcutHint: 'Alt+X',
     },
-    {
-      id: 'cultures-export-all-json',
-      label: 'Alle Kulturen exportieren (JSON)',
-      ariaLabel: 'Alle Kulturen exportieren (JSON)',
-      onClick: handleExportAllCultures,
-      shortcutHint: 'Alt+Shift+J',
-    },
-  ]), [handleExportAllCultures, handleExportCurrentCulture, handleImportFileTrigger, handleOpenPublicLibrary, selectedCulture]);
+  ]), [handleImportFileTrigger, handleOpenExportDialog, handleOpenPublicLibrary, t]);
 
   useTopbarContextActions(setTopbarContextActions, contextActions);
 
@@ -579,6 +578,7 @@ function Cultures() {
     handleImportFileTrigger,
     selectedCulture,
     selectedCultureId,
+    setEnrichAllConfirmOpen,
   ]);
 
   useRegisterCommands('cultures-page', commandSpecs);
@@ -596,14 +596,7 @@ function Cultures() {
 
   return (
     <PageContainer variant="xwide">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json,.json"
-          onChange={handleImportFileChange}
-          hidden
-        />
-      
+
       {enrichmentCostBanner && (
         <Alert severity="info" sx={{ mb: 2 }}>
           {enrichmentCostBanner}
@@ -767,6 +760,13 @@ function Cultures() {
         />
       ) : null}
 
+      <CulturesImportStartDialog
+        open={importStartDialogOpen}
+        onClose={() => setImportStartDialogOpen(false)}
+        onFileSelected={(file) => void handleImportFileSelected(file)}
+        t={t}
+      />
+
       <CulturesImportDialog
         open={importDialogOpen}
         importState={importState}
@@ -775,6 +775,14 @@ function Cultures() {
         onConfirmUpdatesChange={setConfirmUpdates}
         onClose={handleImportDialogClose}
         onImportStart={() => void handleImportStart()}
+        t={t}
+      />
+
+      <CulturesExportDialog
+        open={exportDialogOpen}
+        hasCurrentCulture={Boolean(selectedCulture)}
+        onClose={() => setExportDialogOpen(false)}
+        onExport={handleExport}
         t={t}
       />
 

--- a/frontend/src/pages/CulturesExportDialog.tsx
+++ b/frontend/src/pages/CulturesExportDialog.tsx
@@ -105,14 +105,7 @@ export function CulturesExportDialog({
               <FormControlLabel
                 value="json"
                 control={<Radio size="small" />}
-                label={
-                  <Box>
-                    <Typography variant="body2">{t('export.formatJson')}</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {t('export.formatJsonHint')}
-                    </Typography>
-                  </Box>
-                }
+                label={t('export.formatJson')}
               />
             </RadioGroup>
           </Box>

--- a/frontend/src/pages/CulturesExportDialog.tsx
+++ b/frontend/src/pages/CulturesExportDialog.tsx
@@ -1,0 +1,135 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import type { SpreadsheetExportFormat } from '../cultures/spreadsheetExport';
+
+type ExportScope = 'current' | 'all';
+type ExportFormat = SpreadsheetExportFormat | 'json';
+
+type Translator = (key: string, options?: Record<string, unknown>) => string;
+
+type CulturesExportDialogProps = {
+  open: boolean;
+  hasCurrentCulture: boolean;
+  onClose: () => void;
+  onExport: (scope: ExportScope, format: ExportFormat) => Promise<void>;
+  t: Translator;
+};
+
+export function CulturesExportDialog({
+  open,
+  hasCurrentCulture,
+  onClose,
+  onExport,
+  t,
+}: CulturesExportDialogProps) {
+  const [scope, setScope] = useState<ExportScope>('all');
+  const [format, setFormat] = useState<ExportFormat>('xlsx');
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      await onExport(scope, format);
+      onClose();
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('export.dialogTitle')}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, mt: 0.5 }}>
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              {t('export.scopeLabel')}
+            </Typography>
+            <RadioGroup
+              value={scope}
+              onChange={(e) => setScope(e.target.value as ExportScope)}
+            >
+              <FormControlLabel
+                value="all"
+                control={<Radio size="small" />}
+                label={t('export.scopeAll')}
+              />
+              <FormControlLabel
+                value="current"
+                control={<Radio size="small" />}
+                label={t('export.scopeCurrent')}
+                disabled={!hasCurrentCulture}
+              />
+              {!hasCurrentCulture && scope === 'current' && (
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 4 }}>
+                  {t('export.scopeCurrentDisabled')}
+                </Typography>
+              )}
+            </RadioGroup>
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              {t('export.formatLabel')}
+            </Typography>
+            <RadioGroup
+              value={format}
+              onChange={(e) => setFormat(e.target.value as ExportFormat)}
+            >
+              <FormControlLabel
+                value="xlsx"
+                control={<Radio size="small" />}
+                label={t('export.formatXlsx')}
+              />
+              <FormControlLabel
+                value="ods"
+                control={<Radio size="small" />}
+                label={t('export.formatOds')}
+              />
+              <FormControlLabel
+                value="csv"
+                control={<Radio size="small" />}
+                label={t('export.formatCsv')}
+              />
+              <FormControlLabel
+                value="json"
+                control={<Radio size="small" />}
+                label={
+                  <Box>
+                    <Typography variant="body2">{t('export.formatJson')}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {t('export.formatJsonHint')}
+                    </Typography>
+                  </Box>
+                }
+              />
+            </RadioGroup>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose} disabled={exporting}>
+          {t('export.cancel')}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleExport()}
+          disabled={exporting || (scope === 'current' && !hasCurrentCulture)}
+        >
+          {t('export.submit')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/CulturesImportStartDialog.tsx
+++ b/frontend/src/pages/CulturesImportStartDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Box,
   Button,
   Dialog,
@@ -86,12 +85,6 @@ export function CulturesImportStartDialog({
             </Typography>
           </Box>
 
-          <Alert severity="info" variant="outlined" sx={{ '& .MuiAlert-message': { width: '100%' } }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-              <Typography variant="body2">{t('import.formatHintTable')}</Typography>
-              <Typography variant="body2">{t('import.formatHintJson')}</Typography>
-            </Box>
-          </Alert>
         </Box>
       </DialogContent>
       <DialogActions>

--- a/frontend/src/pages/CulturesImportStartDialog.tsx
+++ b/frontend/src/pages/CulturesImportStartDialog.tsx
@@ -1,0 +1,104 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
+import { useRef, useState } from 'react';
+
+type Translator = (key: string, options?: Record<string, unknown>) => string;
+
+type CulturesImportStartDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  onFileSelected: (file: File) => void;
+  t: Translator;
+};
+
+export function CulturesImportStartDialog({
+  open,
+  onClose,
+  onFileSelected,
+  t,
+}: CulturesImportStartDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (file) onFileSelected(file);
+  };
+
+  const handleDrop = (event: React.DragEvent) => {
+    event.preventDefault();
+    setDragOver(false);
+    const file = event.dataTransfer.files[0];
+    if (file) onFileSelected(file);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('import.selectFileTitle')}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 0.5 }}>
+          <Box
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleDrop}
+            sx={{
+              border: '2px dashed',
+              borderColor: dragOver ? 'primary.main' : 'divider',
+              borderRadius: 1,
+              p: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1.5,
+              backgroundColor: dragOver ? 'action.hover' : 'transparent',
+              cursor: 'pointer',
+              transition: 'border-color 0.15s, background-color 0.15s',
+            }}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <UploadFileOutlinedIcon sx={{ fontSize: 40, color: 'text.secondary' }} />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,.csv,.xlsx,.ods"
+              style={{ display: 'none' }}
+              onChange={handleFileChange}
+            />
+            <Button
+              variant="contained"
+              component="span"
+              onClick={(e) => { e.stopPropagation(); fileInputRef.current?.click(); }}
+            >
+              {t('import.selectFileButton')}
+            </Button>
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              {t('import.supportedFormats')}
+            </Typography>
+          </Box>
+
+          <Alert severity="info" variant="outlined" sx={{ '& .MuiAlert-message': { width: '100%' } }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              <Typography variant="body2">{t('import.formatHintTable')}</Typography>
+              <Typography variant="body2">{t('import.formatHintJson')}</Typography>
+            </Box>
+          </Alert>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose}>
+          {t('import.close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -625,15 +625,6 @@ function FieldsBedsHierarchy({
     [navigate],
   );
 
-  const handleHierarchyRowEditStop = useCallback<GridEventListener<"rowEditStop">>((params, event): void => {
-    if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
-      event.defaultMuiPrevented = true;
-      discardRowEdit(params.id);
-      return;
-    }
-
-  }, [discardRowEdit]);
-
   const isHierarchyCellAction = useCallback((params: GridCellParams<HierarchyRow>): boolean => (
     params.field === "notes"
   ), []);
@@ -686,6 +677,22 @@ function FieldsBedsHierarchy({
     setSelectedRowId,
     treeActive,
   });
+
+  const handleHierarchyRowEditStop = useCallback<GridEventListener<"rowEditStop">>((params, event): void => {
+    if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
+      event.defaultMuiPrevented = true;
+      discardRowEdit(params.id);
+      return;
+    }
+
+    if (
+      params.reason === GridRowEditStopReasons.enterKeyDown ||
+      params.reason === GridRowEditStopReasons.tabKeyDown ||
+      params.reason === GridRowEditStopReasons.shiftTabKeyDown
+    ) {
+      preFocusEditCell(params.id);
+    }
+  }, [discardRowEdit, preFocusEditCell]);
 
   const activateFirstRowForKeyboard = useCallback((rowId: GridRowId): void => {
     selectedRowIdRef.current = rowId;

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -11,6 +11,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -31,7 +32,6 @@ import type {
   GridRowId,
   GridRowsProp,
   GridRowModesModel,
-  MuiEvent,
 } from "@mui/x-data-grid";
 import { Box, Alert, useMediaQuery } from "@mui/material";
 import Divider from "@mui/material/Divider";
@@ -51,11 +51,6 @@ import {
 } from "../components/data-grid";
 import { handleContextMenuKeyboardNavigation } from "../components/data-grid/contextMenuFocus";
 import {
-  handleEditableCellClick,
-} from "../components/data-grid/handlers";
-import {
-  focusKeyboardNavigableCell,
-  getKeyboardNavigationTarget,
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
 } from "../components/data-grid/keyboardNavigation";
@@ -69,6 +64,7 @@ import { useHierarchyNavigationState } from "../components/hierarchy/hooks/useHi
 import { useHierarchyRowUpdate } from "../components/hierarchy/hooks/useHierarchyRowUpdate";
 import { useHierarchyContextMenu } from "../components/hierarchy/hooks/useHierarchyContextMenu";
 import { useHierarchyKeyboard } from "../components/hierarchy/hooks/useHierarchyKeyboard";
+import { useHierarchyGridKeyboard } from "../components/hierarchy/hooks/useHierarchyGridKeyboard";
 import { usePersistentSortModel } from "../hooks/usePersistentSortModel";
 import { fieldAPI, bedAPI, locationAPI, type Field } from "../api/api";
 import {
@@ -116,10 +112,6 @@ interface HierarchyRowAction {
   color?: "default" | "error";
   onClick: () => void;
 }
-
-type HierarchyKeyboardEvent = React.KeyboardEvent & {
-  defaultMuiPrevented?: boolean;
-};
 
 const HIERARCHY_SELECTED_VIEW_ROW_SELECTOR =
   "& .MuiDataGrid-row.Mui-selected:not(.MuiDataGrid-row--editing)";
@@ -669,7 +661,9 @@ function FieldsBedsHierarchy({
   // If it did, focusRow → focusSelectedCell → useLayoutEffect would re-fire after each
   // rows update and re-focus selectedRowId STATE instead of the arrow-navigated row.
   const rowsByIdRef = useRef(rowsById);
-  rowsByIdRef.current = rowsById;
+  useLayoutEffect(() => {
+    rowsByIdRef.current = rowsById;
+  }, [rowsById]);
 
   const getHierarchyFocusableField = useCallback((rowId: GridRowId, preferredField: string): string | null => {
     const row = rowsByIdRef.current.get(String(rowId));
@@ -752,7 +746,7 @@ function FieldsBedsHierarchy({
     if (row.type === "location" || row.type === "field" || row.type === "bed") {
       void deleteHierarchyRowWithUndo(row);
     }
-  }, [deleteHierarchyRowWithUndo]);
+  }, [deleteHierarchyRowWithUndo, rowsRef, selectedRowIdRef]);
 
   const handleCreateBySelection = useCallback(() => {
     const row = rowsRef.current.find((r) => r.id === selectedRowIdRef.current);
@@ -768,7 +762,7 @@ function FieldsBedsHierarchy({
     if (row.type === "bed" && row.field) {
       handleAddBed(row.field);
     }
-  }, [handleAddBed, handleAddField]);
+  }, [handleAddBed, handleAddField, rowsRef, selectedRowIdRef]);
 
   const handleEditSelected = useCallback(() => {
     const row = rowsRef.current.find((r) => r.id === selectedRowIdRef.current);
@@ -778,7 +772,7 @@ function FieldsBedsHierarchy({
       ...previous,
       [row.id]: { mode: GridRowModes.Edit, fieldToFocus: "name" },
     }));
-  }, [rememberRowSnapshot]);
+  }, [rememberRowSnapshot, rowsRef, selectedRowIdRef]);
 
   const getHierarchyRowActions = useCallback((row: HierarchyRow): HierarchyRowAction[] => {
     const createActions: HierarchyRowAction[] = [];
@@ -863,7 +857,7 @@ function FieldsBedsHierarchy({
         action: handleDeleteSelected,
       },
     ],
-    [handleCreateBySelection, handleDeleteSelected, handleEditSelected],
+    [handleCreateBySelection, handleDeleteSelected, handleEditSelected, rowsRef, selectedRowIdRef],
   );
 
   useRegisterCommands("areas-page", areaCommands);
@@ -973,82 +967,27 @@ function FieldsBedsHierarchy({
     isMobileViewport,
   ]);
 
-  const handleHierarchyCellNavigation = useCallback((
-    params: GridCellParams<HierarchyRow>,
-    event: HierarchyKeyboardEvent,
-  ): boolean => {
-    const isEditMode = rowModesModel[params.id]?.mode === GridRowModes.Edit;
-
-    // ArrowLeft/Right have meaning inside edit-cell inputs — let MUI handle them.
-    // Tab is intercepted in both view and edit mode so MUI's default Tab never
-    // reaches the calculated area_sqm column (which is not keyboard-navigable).
-    if (
-      (isEditMode && event.key !== "Tab") ||
-      event.altKey ||
-      event.ctrlKey ||
-      event.metaKey
-    ) {
-      return false;
-    }
-
-    const target =
-      event.key === "Tab"
-        ? getKeyboardNavigationTarget<HierarchyRow>({
-          api: gridApiRef.current,
-          columns,
-          current: { id: params.id, field: params.field },
-          direction: event.shiftKey ? -1 : 1,
-          isActionCell: isHierarchyCellAction,
-          rows: rows as HierarchyRow[],
-          // In edit mode, don't wrap to the next row — Tab past the last editable
-          // field falls through to MUI (which confirms the row edit).
-          wrapRows: !isEditMode,
-        })
-        : event.key === "ArrowRight"
-          ? getKeyboardNavigationTarget<HierarchyRow>({
-            api: gridApiRef.current,
-            columns,
-            current: { id: params.id, field: params.field },
-            direction: 1,
-            isActionCell: isHierarchyCellAction,
-            rows: rows as HierarchyRow[],
-          })
-          : event.key === "ArrowLeft"
-            ? getKeyboardNavigationTarget<HierarchyRow>({
-              api: gridApiRef.current,
-              columns,
-              current: { id: params.id, field: params.field },
-              direction: -1,
-              isActionCell: isHierarchyCellAction,
-              rows: rows as HierarchyRow[],
-            })
-            : null;
-
-    if (!target) {
-      return false;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    event.defaultMuiPrevented = true;
-    rememberFocusedField(target.field);
-    selectRow(target.id);
-    setTreeActive(true);
-    focusKeyboardNavigableCell<HierarchyRow>({
-      api: gridApiRef.current,
-      cell: target,
-    });
-    return true;
-  }, [
+  const {
+    handleCellClick: handleHierarchyCellClick,
+    handleCellKeyDown: handleHierarchyCellKeyDown,
+  } = useHierarchyGridKeyboard({
     columns,
+    discardRowEdit,
     gridApiRef,
+    isCellFocusable: isHierarchyCellFocusable,
     isHierarchyCellAction,
+    notesEditor,
+    openContextMenuForRow,
     rememberFocusedField,
+    rememberRowSnapshot,
     rowModesModel,
-    rows,
+    rows: rows as HierarchyRow[],
+    rowsById,
     selectRow,
+    setRowModesModel,
     setTreeActive,
-  ]);
+    toggleExpand,
+  });
 
   const getRowHeight = useCallback((params: GridRowHeightParams) => {
     const row = params.model as HierarchyRow;
@@ -1073,7 +1012,7 @@ function FieldsBedsHierarchy({
     });
 
     return hasBeds && allBedsMissingLengthAndWidth;
-  }, [beds, parseDimensionValue]);
+  }, [beds]);
 
   const hasUnsavedInvalidNewRows = useMemo(() => (
     beds.some((bed) => isPartiallyFilledNamelessNewHierarchyRow({
@@ -1227,120 +1166,8 @@ function FieldsBedsHierarchy({
               isCellEditable={isCellEditable}
               sx={HIERARCHY_DATA_GRID_SX}
               disableRowSelectionOnClick
-              onCellClick={(params, event) => {
-                if (!isHierarchyCellFocusable(params.row, params.field)) {
-                  event?.preventDefault();
-                  event?.stopPropagation();
-                  if (event) {
-                    event.defaultMuiPrevented = true;
-                  }
-                  return;
-                }
-
-                const editingRowId = Object.entries(rowModesModel).find(([, mode]) => mode.mode === GridRowModes.Edit)?.[0];
-                if (editingRowId !== undefined && String(editingRowId) !== String(params.id)) {
-                  discardRowEdit(rowsById.get(editingRowId)?.id ?? editingRowId);
-                }
-                rememberFocusedField(params.field);
-                rememberRowSnapshot(params.id);
-                selectRow(params.id);
-                setTreeActive(true);
-                handleEditableCellClick(params, rowModesModel, setRowModesModel);
-              }}
-              onCellKeyDown={(params: GridCellParams<HierarchyRow>, event) => {
-                const keyboardEvent = event as MuiEvent<React.KeyboardEvent>;
-                rememberFocusedField(params.field);
-                if (
-                  keyboardEvent.key === "Tab" ||
-                  keyboardEvent.key === "ArrowLeft" ||
-                  keyboardEvent.key === "ArrowRight"
-                ) {
-                  const didNavigate = handleHierarchyCellNavigation(
-                    params,
-                    keyboardEvent as unknown as HierarchyKeyboardEvent,
-                  );
-                  if (didNavigate) {
-                    return;
-                  }
-                }
-
-                if (
-                  keyboardEvent.key === "Escape" &&
-                  rowModesModel[params.id]?.mode === GridRowModes.Edit
-                ) {
-                  keyboardEvent.preventDefault();
-                  keyboardEvent.defaultMuiPrevented = true;
-                  discardRowEdit(params.id);
-                  return;
-                }
-
-                if (
-                  params.field === "notes" &&
-                  (keyboardEvent.key === "Enter" ||
-                    keyboardEvent.key === " " ||
-                    keyboardEvent.key === "Spacebar")
-                ) {
-                  keyboardEvent.preventDefault();
-                  keyboardEvent.stopPropagation();
-                  keyboardEvent.defaultMuiPrevented = true;
-                  notesEditor.handleOpen(params.id, "notes");
-                  return;
-                }
-
-                if (
-                  (keyboardEvent.key === " " || keyboardEvent.key === "Spacebar") &&
-                  params.field !== "notes" &&
-                  rowModesModel[params.id]?.mode !== GridRowModes.Edit
-                ) {
-                  // Always block MUI DataGrid's default spacebar behaviour (jumps focus to
-                  // first row) — we handle spacebar ourselves for expand/collapse only.
-                  keyboardEvent.preventDefault();
-                  keyboardEvent.defaultMuiPrevented = true;
-                  const row = params.row as HierarchyRow;
-                  if ((row.type === "location" || row.type === "field") && row.hasChildren) {
-                    toggleExpand(params.id);
-                  }
-                  return;
-                }
-
-                // Prevent DataGrid from moving cell focus on ArrowDown/Up in view mode.
-                // Our window-level handleTreeNavigation handles navigation exclusively and
-                // explicitly syncs the active row ref and DataGrid cell focus, so keyboard
-                // navigation does not create a visual row selection.
-                if (
-                  (keyboardEvent.key === "ArrowDown" || keyboardEvent.key === "ArrowUp") &&
-                  rowModesModel[params.id]?.mode !== GridRowModes.Edit
-                ) {
-                  keyboardEvent.defaultMuiPrevented = true;
-                }
-
-                // Prevent a printable character from triggering DataGrid's "type to start
-                // editing" behaviour in view mode. Editing must be started explicitly via
-                // Enter, F2, or a double-click — not by accidentally pressing a letter.
-                // We also block Alt+letter (e.g. Alt+T) because MUI DataGrid v8's
-                // isPrintableKey() does not exclude altKey, so Alt+T would otherwise
-                // start editing rather than fire our Alt+T navigation shortcut.
-                // Ctrl/Meta are already excluded by MUI's own check, but Alt is not.
-                if (
-                  keyboardEvent.key.length === 1 &&
-                  !keyboardEvent.ctrlKey &&
-                  !keyboardEvent.metaKey &&
-                  rowModesModel[params.id]?.mode !== GridRowModes.Edit
-                ) {
-                  keyboardEvent.defaultMuiPrevented = true;
-                }
-
-                if (keyboardEvent.key === "ContextMenu" || (keyboardEvent.shiftKey && keyboardEvent.key === "F10")) {
-                  keyboardEvent.preventDefault();
-                  keyboardEvent.stopPropagation();
-                  const targetRow = rows.find((row) => row.id === params.id);
-                  if (targetRow) {
-                    const targetElement = keyboardEvent.currentTarget as HTMLElement;
-                    const rect = targetElement.getBoundingClientRect();
-                    openContextMenuForRow(targetRow, rect.left + Math.min(240, rect.width), rect.top + 12, targetElement);
-                  }
-                }
-              }}
+              onCellClick={handleHierarchyCellClick}
+              onCellKeyDown={handleHierarchyCellKeyDown}
               localeText={germanDataGridLocaleText}
               apiRef={gridApiRef}
             />

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -683,7 +683,7 @@ function FieldsBedsHierarchy({
     return focusableFields.includes(preferredField) ? preferredField : focusableFields[0] ?? null;
   }, []);
 
-  const { focusRow, rememberFocusedField } = useHierarchyGridFocus({
+  const { focusRow, focusedFieldRef, rememberFocusedField } = useHierarchyGridFocus({
     getFocusableField: getHierarchyFocusableField,
     gridApiRef,
     rowModesModel,
@@ -706,16 +706,28 @@ function FieldsBedsHierarchy({
     focusRow(rowId);
   }, [focusRow, selectRowTransient]);
 
-  const handleHierarchyProcessRowUpdate = useCallback(async (newRow: HierarchyRow): Promise<HierarchyRow> => {
-    const savedRow = await processRowUpdate(newRow);
-    setRowModesModel((previousModel) => ({
-      ...previousModel,
-      [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
-    }));
-    // Do NOT clear treeActive/selectedRowId here. useHierarchyGridFocus's useEffect
-    // watches rowModesModel and restores focus to the saved row automatically.
-    return savedRow;
-  }, [processRowUpdate]);
+  const handleHierarchyProcessRowUpdate = useCallback(
+    async (newRow: HierarchyRow): Promise<HierarchyRow> => {
+      const savedRow = await processRowUpdate(newRow);
+      // Pre-focus the stable cell container div before switching the row back to
+      // View mode. When React removes the edit <input> from the DOM the browser
+      // would otherwise move focus to the nearest focusable ancestor (often the
+      // first row), causing a visible flash. Calling .focus() on the container
+      // now keeps DOM focus here through the transition. Note: this does NOT
+      // trigger MUI's cellFocusOut (which is a custom event fired only by
+      // setCellFocus), so no unintended edit-stop side-effect occurs.
+      const api = gridApiRef.current as unknown as {
+        getCellElement?: (id: GridRowId, field: string) => HTMLElement | null;
+      };
+      api.getCellElement?.(newRow.id, focusedFieldRef.current)?.focus({ preventScroll: true });
+      setRowModesModel((previousModel) => ({
+        ...previousModel,
+        [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
+      }));
+      return savedRow;
+    },
+    [focusedFieldRef, gridApiRef, processRowUpdate],
+  );
 
   const handleReadOnlyHierarchyCellMouseDown = useCallback((event: React.MouseEvent<HTMLElement>): void => {
     const target = event.target;

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -987,8 +987,13 @@ function FieldsBedsHierarchy({
     params: GridCellParams<HierarchyRow>,
     event: HierarchyKeyboardEvent,
   ): boolean => {
+    const isEditMode = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+
+    // ArrowLeft/Right have meaning inside edit-cell inputs — let MUI handle them.
+    // Tab is intercepted in both view and edit mode so MUI's default Tab never
+    // reaches the calculated area_sqm column (which is not keyboard-navigable).
     if (
-      rowModesModel[params.id]?.mode === GridRowModes.Edit ||
+      (isEditMode && event.key !== "Tab") ||
       event.altKey ||
       event.ctrlKey ||
       event.metaKey
@@ -1005,7 +1010,9 @@ function FieldsBedsHierarchy({
           direction: event.shiftKey ? -1 : 1,
           isActionCell: isHierarchyCellAction,
           rows: rows as HierarchyRow[],
-          wrapRows: true,
+          // In edit mode, don't wrap to the next row — Tab past the last editable
+          // field falls through to MUI (which confirms the row edit).
+          wrapRows: !isEditMode,
         })
         : event.key === "ArrowRight"
           ? getKeyboardNavigationTarget<HierarchyRow>({

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -706,37 +706,16 @@ function FieldsBedsHierarchy({
     focusRow(rowId);
   }, [focusRow, selectRowTransient]);
 
-  const clearHierarchyInteractionState = useCallback((rowId: GridRowId): void => {
-    selectedRowIdRef.current = null;
-    treeActiveRef.current = false;
-    setSelectedRowId(null);
-    setTreeActive(false);
-
-    const api = gridApiRef.current as typeof gridApiRef.current & {
-      state?: { focus?: { cell?: { id?: GridRowId; field?: string } | null } };
-    };
-    const focusedCell = api?.state?.focus?.cell;
-    if (focusedCell && String(focusedCell.id) === String(rowId)) {
-      api.state.focus.cell = null;
-    }
-
-    if (document.activeElement instanceof HTMLElement) {
-      const tableWrapper = tableWrapperRef.current;
-      if (!tableWrapper || tableWrapper.contains(document.activeElement)) {
-        document.activeElement.blur();
-      }
-    }
-  }, [gridApiRef, selectedRowIdRef, setSelectedRowId, setTreeActive, treeActiveRef]);
-
   const handleHierarchyProcessRowUpdate = useCallback(async (newRow: HierarchyRow): Promise<HierarchyRow> => {
     const savedRow = await processRowUpdate(newRow);
     setRowModesModel((previousModel) => ({
       ...previousModel,
       [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
     }));
-    clearHierarchyInteractionState(newRow.id);
+    // Do NOT clear treeActive/selectedRowId here. useHierarchyGridFocus's useEffect
+    // watches rowModesModel and restores focus to the saved row automatically.
     return savedRow;
-  }, [clearHierarchyInteractionState, processRowUpdate]);
+  }, [processRowUpdate]);
 
   const handleReadOnlyHierarchyCellMouseDown = useCallback((event: React.MouseEvent<HTMLElement>): void => {
     const target = event.target;

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -683,7 +683,7 @@ function FieldsBedsHierarchy({
     return focusableFields.includes(preferredField) ? preferredField : focusableFields[0] ?? null;
   }, []);
 
-  const { focusRow, focusedFieldRef, rememberFocusedField } = useHierarchyGridFocus({
+  const { focusRow, preFocusEditCell, rememberFocusedField } = useHierarchyGridFocus({
     getFocusableField: getHierarchyFocusableField,
     gridApiRef,
     rowModesModel,
@@ -709,24 +709,14 @@ function FieldsBedsHierarchy({
   const handleHierarchyProcessRowUpdate = useCallback(
     async (newRow: HierarchyRow): Promise<HierarchyRow> => {
       const savedRow = await processRowUpdate(newRow);
-      // Pre-focus the stable cell container div before switching the row back to
-      // View mode. When React removes the edit <input> from the DOM the browser
-      // would otherwise move focus to the nearest focusable ancestor (often the
-      // first row), causing a visible flash. Calling .focus() on the container
-      // now keeps DOM focus here through the transition. Note: this does NOT
-      // trigger MUI's cellFocusOut (which is a custom event fired only by
-      // setCellFocus), so no unintended edit-stop side-effect occurs.
-      const api = gridApiRef.current as unknown as {
-        getCellElement?: (id: GridRowId, field: string) => HTMLElement | null;
-      };
-      api.getCellElement?.(newRow.id, focusedFieldRef.current)?.focus({ preventScroll: true });
+      preFocusEditCell(newRow.id);
       setRowModesModel((previousModel) => ({
         ...previousModel,
         [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
       }));
       return savedRow;
     },
-    [focusedFieldRef, gridApiRef, processRowUpdate],
+    [preFocusEditCell, processRowUpdate],
   );
 
   const handleReadOnlyHierarchyCellMouseDown = useCallback((event: React.MouseEvent<HTMLElement>): void => {
@@ -983,7 +973,7 @@ function FieldsBedsHierarchy({
     isMobileViewport,
   ]);
 
-  const handleHierarchyViewModeCellNavigation = useCallback((
+  const handleHierarchyCellNavigation = useCallback((
     params: GridCellParams<HierarchyRow>,
     event: HierarchyKeyboardEvent,
   ): boolean => {
@@ -1265,7 +1255,7 @@ function FieldsBedsHierarchy({
                   keyboardEvent.key === "ArrowLeft" ||
                   keyboardEvent.key === "ArrowRight"
                 ) {
-                  const didNavigate = handleHierarchyViewModeCellNavigation(
+                  const didNavigate = handleHierarchyCellNavigation(
                     params,
                     keyboardEvent as unknown as HierarchyKeyboardEvent,
                   );

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -801,25 +801,25 @@ function GanttChartPage() {
         className="rmg-header-content"
         sx={{
           gap: 1.5,
-          alignItems: { xs: 'flex-start', md: 'center' },
-          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: 'center',
+          flexDirection: 'row',
         }}
       >
         <Box
           sx={{
             display: 'inline-flex',
             alignItems: 'center',
-            justifyContent: { xs: 'space-between', md: 'flex-start' },
-            gap: { xs: 1.5, md: 2.5 },
+            gap: { xs: 0.75, md: 2.5 },
             minWidth: 0,
-            width: { xs: '100%', md: 'auto' },
+            flex: '0 1 auto',
+            overflow: 'hidden',
           }}
         >
           <Typography
             component="h1"
             className="rmg-title"
             sx={{
-              flex: { xs: '1 1 auto', md: '0 1 auto' },
+              flex: '0 1 auto',
               minWidth: 0,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
@@ -828,109 +828,105 @@ function GanttChartPage() {
           >
             {title}
           </Typography>
-          {showViewModeSelector || calendarMode === 'occupancy' ? (
-            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-              {showViewModeSelector ? (
-                <Select
-                  size="small"
-                  value={viewMode}
-                  onChange={(event) => handleTimelineViewModeChange(event.target.value as ViewMode, onViewModeChange)}
-                  inputProps={{ 'aria-label': t('ganttChart:viewSelectorAriaLabel') }}
-                  sx={{
-                    display: { xs: 'inline-flex', md: 'none' },
-                    width: 'auto',
-                    minWidth: 0,
-                    bgcolor: 'background.paper',
-                    color: 'text.primary',
-                    '& .MuiSelect-select': {
-                      width: 'auto',
-                      minWidth: 0,
-                      py: 0.75,
-                      pl: 1,
-                      pr: '26px !important',
-                    },
-                  }}
-                >
-                  {GANTT_HEADER_VIEW_MODES.map((mode) => (
-                    <MenuItem key={mode} value={mode}>
-                      {t(`ganttChart:chartLocaleText.viewModes.${mode}`)}
-                    </MenuItem>
-                  ))}
-                </Select>
-              ) : null}
-              {calendarMode === 'occupancy' ? (
-                <Tooltip title={t('ganttChart:moveModeOption')}>
-                  <Button
-                    size="small"
-                    variant={editMode ? 'contained' : 'outlined'}
-                    color={editMode ? 'success' : 'inherit'}
-                    aria-label={t('ganttChart:moveModeOption')}
-                    aria-pressed={editMode}
-                    onClick={() => setEditMode((value) => !value)}
-                    sx={{
-                      flexShrink: 0,
-                      gap: { xs: 0, md: 0.75 },
-                      minWidth: { xs: 34, md: 'auto' },
-                      width: { xs: 34, md: 'auto' },
-                      height: { xs: 34, md: 'auto' },
-                      px: { xs: 0, md: 1.25 },
-                      textTransform: 'none',
-                      whiteSpace: 'nowrap',
-                      ...(editMode
-                        ? {}
-                        : {
-                          borderColor: 'success.main',
-                          color: 'success.dark',
-                          bgcolor: 'background.paper',
-                          '&:hover': {
-                            borderColor: 'success.dark',
-                            bgcolor: 'success.50',
-                          },
-                        }),
-                    }}
-                  >
-                    <SwapHorizIcon
-                      sx={{ display: { xs: 'inline-flex', md: editMode ? 'none' : 'inline-flex' } }}
-                      fontSize="small"
-                    />
-                    {editMode ? (
-                      <CheckCircleOutlineIcon
-                        sx={{ display: { xs: 'none', md: 'inline-flex' } }}
-                        fontSize="small"
-                      />
-                    ) : null}
-                    <Box component="span" sx={{ display: { xs: 'none', md: 'inline' } }}>
-                      {editMode ? t('ganttChart:moveModeActiveOption') : t('ganttChart:moveModeOption')}
-                    </Box>
-                  </Button>
-                </Tooltip>
-              ) : null}
-            </Box>
+          {calendarMode === 'occupancy' ? (
+            <Tooltip title={t('ganttChart:moveModeOption')}>
+              <Button
+                size="small"
+                variant={editMode ? 'contained' : 'outlined'}
+                color={editMode ? 'success' : 'inherit'}
+                aria-label={t('ganttChart:moveModeOption')}
+                aria-pressed={editMode}
+                onClick={() => setEditMode((value) => !value)}
+                sx={{
+                  flexShrink: 0,
+                  gap: { xs: 0, md: 0.75 },
+                  minWidth: { xs: 44, md: 'auto' },
+                  width: { xs: 44, md: 'auto' },
+                  height: { xs: 44, md: 'auto' },
+                  px: { xs: 0, md: 1.25 },
+                  textTransform: 'none',
+                  whiteSpace: 'nowrap',
+                  ...(editMode
+                    ? {}
+                    : {
+                      borderColor: 'success.main',
+                      color: 'success.dark',
+                      bgcolor: 'background.paper',
+                      '&:hover': {
+                        borderColor: 'success.dark',
+                        bgcolor: 'success.50',
+                      },
+                    }),
+                }}
+              >
+                <SwapHorizIcon
+                  sx={{ display: { xs: 'inline-flex', md: editMode ? 'none' : 'inline-flex' } }}
+                  fontSize="small"
+                />
+                {editMode ? (
+                  <CheckCircleOutlineIcon
+                    sx={{ display: { xs: 'none', md: 'inline-flex' } }}
+                    fontSize="small"
+                  />
+                ) : null}
+                <Box component="span" sx={{ display: { xs: 'none', md: 'inline' } }}>
+                  {editMode ? t('ganttChart:moveModeActiveOption') : t('ganttChart:moveModeOption')}
+                </Box>
+              </Button>
+            </Tooltip>
           ) : null}
         </Box>
         {showViewModeSelector ? (
-          <ButtonGroup
-            size="small"
-            variant="outlined"
-            sx={{
-              ...segmentedButtonGroupSx,
-              display: { xs: 'none', md: 'inline-flex' },
-            }}
-            aria-label={t('ganttChart:chartLocaleText.titleOccupancy')}
-          >
-            {GANTT_HEADER_VIEW_MODES.map((mode) => (
-              <Button
-                key={mode}
-                onClick={() => handleTimelineViewModeChange(mode, onViewModeChange)}
-                aria-pressed={viewMode === mode}
-                variant={viewMode === mode ? 'contained' : 'outlined'}
-                color={viewMode === mode ? 'success' : 'inherit'}
-                sx={{ ...getSegmentedActionButtonSx({ active: viewMode === mode }) }}
-              >
-                {t(`ganttChart:chartLocaleText.viewModes.${mode}`)}
-              </Button>
-            ))}
-          </ButtonGroup>
+          <Box sx={{ ml: 'auto', display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>
+            <Select
+              size="small"
+              value={viewMode}
+              onChange={(event) => handleTimelineViewModeChange(event.target.value as ViewMode, onViewModeChange)}
+              inputProps={{ 'aria-label': t('ganttChart:viewSelectorAriaLabel') }}
+              sx={{
+                display: { xs: 'inline-flex', md: 'none' },
+                width: 'auto',
+                minWidth: 0,
+                bgcolor: 'background.paper',
+                color: 'text.primary',
+                '& .MuiSelect-select': {
+                  width: 'auto',
+                  minWidth: 0,
+                  py: 0.75,
+                  pl: 1,
+                  pr: '26px !important',
+                },
+              }}
+            >
+              {GANTT_HEADER_VIEW_MODES.map((mode) => (
+                <MenuItem key={mode} value={mode}>
+                  {t(`ganttChart:chartLocaleText.viewModes.${mode}`)}
+                </MenuItem>
+              ))}
+            </Select>
+            <ButtonGroup
+              size="small"
+              variant="outlined"
+              sx={{
+                ...segmentedButtonGroupSx,
+                display: { xs: 'none', md: 'inline-flex' },
+              }}
+              aria-label={t('ganttChart:chartLocaleText.titleOccupancy')}
+            >
+              {GANTT_HEADER_VIEW_MODES.map((mode) => (
+                <Button
+                  key={mode}
+                  onClick={() => handleTimelineViewModeChange(mode, onViewModeChange)}
+                  aria-pressed={viewMode === mode}
+                  variant={viewMode === mode ? 'contained' : 'outlined'}
+                  color={viewMode === mode ? 'success' : 'inherit'}
+                  sx={{ ...getSegmentedActionButtonSx({ active: viewMode === mode }) }}
+                >
+                  {t(`ganttChart:chartLocaleText.viewModes.${mode}`)}
+                </Button>
+              ))}
+            </ButtonGroup>
+          </Box>
         ) : null}
       </Box>
     </Box>

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -809,7 +809,7 @@ function GanttChartPage() {
           sx={{
             display: 'inline-flex',
             alignItems: 'center',
-            gap: { xs: 0.75, md: 2.5 },
+            gap: { xs: 1.5, md: 2.5 },
             minWidth: 0,
             flex: '0 1 auto',
             overflow: 'hidden',

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -1768,7 +1768,7 @@ function PlantingPlans() {
                     aria-haspopup="menu"
                     aria-expanded={Boolean(mobileActionMenuAnchor && mobileActionMenuRow?.id === item.id)}
                     onClick={(event) => openMobileActionMenu(event, item)}
-                    sx={{ width: 36, height: 36 }}
+                    sx={{ width: 44, height: 44 }}
                   >
                     <MoreVertIcon fontSize="small" />
                   </IconButton>

--- a/frontend/src/pages/culturesCommandSpecs.ts
+++ b/frontend/src/pages/culturesCommandSpecs.ts
@@ -11,7 +11,7 @@ export type CreateCulturesCommandSpecsOptions = {
   handleDelete: (culture: Culture) => void;
   handleEdit: (culture: Culture) => void;
   handleEnrichCurrent: (mode: 'complete' | 'reresearch') => Promise<void>;
-  handleExportAllCultures: () => Promise<void>;
+  handleExportAllCultures: () => void;
   handleExportCurrentCulture: () => void;
   handleImportFileTrigger: () => void;
   selectedCulture?: Culture;

--- a/frontend/src/pages/useCultureImportExport.ts
+++ b/frontend/src/pages/useCultureImportExport.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, type ChangeEvent } from 'react';
+import { useState, useCallback, type ChangeEvent } from 'react';
 import { cultureAPI, type Culture } from '../api/api';
 import { useTranslation } from '../i18n';
 import {
@@ -8,9 +8,14 @@ import {
   buildSingleCultureFilename,
   downloadJsonFile,
 } from '../cultures/exportUtils';
+import { exportCulturesToSpreadsheet, buildSpreadsheetFilename, type SpreadsheetExportFormat } from '../cultures/spreadsheetExport';
+import { parseSpreadsheetFile } from '../cultures/spreadsheetImport';
 import { buildImportSuccessMessage, mapImportErrors } from './culturesPageUtils';
 import { analyzeCultureImportJson, readFileAsText } from './culturesImportUtils';
 import { useCultureImportState } from './useCultureImportState';
+
+export type ExportFormat = SpreadsheetExportFormat | 'json';
+export type ExportScope = 'current' | 'all';
 
 interface UseCultureImportExportConfig {
   selectedCulture: Culture | undefined;
@@ -26,8 +31,9 @@ export function useCultureImportExport({
   const { t } = useTranslation(['cultures', 'common']);
 
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importStartDialogOpen, setImportStartDialogOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [confirmUpdates, setConfirmUpdates] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const {
     state: importState,
@@ -42,92 +48,149 @@ export function useCultureImportExport({
 
   const handleImportFileTrigger = useCallback(() => {
     resetImportState();
-    fileInputRef.current?.click();
+    setImportStartDialogOpen(true);
   }, [resetImportState]);
 
-  const handleExportCurrentCulture = useCallback(() => {
-    if (!selectedCulture) {
+  const handleImportFileSelected = useCallback(async (file: File) => {
+    setImportStartDialogOpen(false);
+    resetImportState();
+
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    const isSpreadsheet = ['xlsx', 'ods', 'csv'].includes(ext);
+
+    if (isSpreadsheet) {
+      try {
+        const { entries, skippedRows, warnings } = await parseSpreadsheetFile(file);
+
+        if (entries.length === 0) {
+          const warningText = warnings.length > 0 ? warnings.join(' ') : t('import.errors.noValidEntries');
+          setImportErrorState({ error: warningText, previewCount: skippedRows, validCount: 0, invalidEntries: [] });
+          setImportDialogOpen(true);
+          return;
+        }
+
+        setImportUploading();
+        try {
+          const response = await cultureAPI.importPreview(entries);
+          const invalidEntries: string[] = [];
+          if (skippedRows > 0) invalidEntries.push(t('import.skippedRows', { count: skippedRows }));
+          warnings.forEach((w) => invalidEntries.push(w));
+          setPreviewReadyState({
+            previewCount: entries.length + skippedRows,
+            validCount: entries.length,
+            invalidEntries,
+            payload: entries,
+            previewResults: response.data.results,
+          });
+          setImportDialogOpen(true);
+        } catch (error) {
+          console.error('Error calling preview endpoint:', error);
+          setImportErrorState({ error: t('import.errors.network') });
+          setImportDialogOpen(true);
+        }
+      } catch (error) {
+        console.error('Error parsing spreadsheet file:', error);
+        setImportErrorState({ error: t('import.errors.parse') });
+        setImportDialogOpen(true);
+      }
       return;
     }
 
-    const exportPayload = buildSingleCultureExport(selectedCulture);
-    const filename = buildSingleCultureFilename(selectedCulture);
-    downloadJsonFile(exportPayload, filename);
-    showSnackbar(t('messages.exportSuccess'), 'success');
-  }, [selectedCulture, showSnackbar, t]);
+    if (ext === 'json') {
+      try {
+        const jsonString = await readFileAsText(file);
+        const importAnalysis = analyzeCultureImportJson(jsonString, t);
 
-  const handleExportAllCultures = useCallback(async () => {
-    try {
-      const allCultures: Culture[] = [];
-      let nextUrl: string | null = '/cultures/';
+        if (importAnalysis.status === 'error') {
+          setImportErrorState({
+            error: t(importAnalysis.errorKey),
+            previewCount: importAnalysis.originalCount,
+            validCount: 0,
+            invalidEntries: importAnalysis.invalidEntries,
+          });
+          setImportDialogOpen(true);
+          return;
+        }
 
-      while (nextUrl) {
-        const response = await cultureAPI.list(nextUrl);
-        allCultures.push(...response.data.results);
-        nextUrl = response.data.next;
+        setImportUploading();
+        try {
+          const response = await cultureAPI.importPreview(importAnalysis.validEntries);
+          setPreviewReadyState({
+            previewCount: importAnalysis.originalCount,
+            validCount: importAnalysis.validEntries.length,
+            invalidEntries: importAnalysis.invalidEntries,
+            payload: importAnalysis.validEntries,
+            previewResults: response.data.results,
+          });
+          setImportDialogOpen(true);
+        } catch (error) {
+          console.error('Error calling preview endpoint:', error);
+          setImportErrorState({ error: t('import.errors.network') });
+          setImportDialogOpen(true);
+        }
+      } catch (error) {
+        console.error('Error reading JSON file:', error);
+        setImportErrorState({ error: t('import.errors.parse') });
+        setImportDialogOpen(true);
       }
+      return;
+    }
 
-      const exportPayload = buildAllCulturesExport(allCultures);
-      const filename = buildAllCulturesFilename();
-      downloadJsonFile(exportPayload, filename);
-      showSnackbar(t('messages.exportSuccess'), 'success');
+    setImportErrorState({ error: t('import.errors.unsupportedFormat') });
+    setImportDialogOpen(true);
+  }, [resetImportState, t, setImportErrorState, setImportUploading, setPreviewReadyState]);
+
+  const handleOpenExportDialog = useCallback(() => {
+    setExportDialogOpen(true);
+  }, []);
+
+  // Called by the command palette (expects separate current/all handlers)
+  const handleExportCurrentCulture = handleOpenExportDialog;
+  const handleExportAllCultures = handleOpenExportDialog;
+
+  const handleExport = useCallback(async (scope: ExportScope, format: ExportFormat) => {
+    try {
+      if (format === 'json') {
+        if (scope === 'current' && selectedCulture) {
+          const exportPayload = buildSingleCultureExport(selectedCulture);
+          const filename = buildSingleCultureFilename(selectedCulture);
+          downloadJsonFile(exportPayload, filename);
+        } else {
+          const allCultures: Culture[] = [];
+          let nextUrl: string | null = '/cultures/';
+          while (nextUrl) {
+            const response = await cultureAPI.list(nextUrl);
+            allCultures.push(...response.data.results);
+            nextUrl = response.data.next;
+          }
+          const exportPayload = buildAllCulturesExport(allCultures);
+          const filename = buildAllCulturesFilename();
+          downloadJsonFile(exportPayload, filename);
+        }
+      } else {
+        const culturesToExport: Culture[] = [];
+        if (scope === 'current' && selectedCulture) {
+          culturesToExport.push(selectedCulture);
+        } else {
+          let nextUrl: string | null = '/cultures/';
+          while (nextUrl) {
+            const response = await cultureAPI.list(nextUrl);
+            culturesToExport.push(...response.data.results);
+            nextUrl = response.data.next;
+          }
+        }
+        const filename = buildSpreadsheetFilename(format, scope === 'current' ? 'single' : 'all', selectedCulture ?? undefined);
+        exportCulturesToSpreadsheet(culturesToExport, format, filename);
+      }
+      showSnackbar(t('export.success'), 'success');
     } catch (error) {
       console.error('Error exporting cultures:', error);
       showSnackbar(t('messages.fetchError'), 'error');
     }
-  }, [showSnackbar, t]);
-
-  const handleImportFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    event.target.value = '';
-
-    if (!file) {
-      return;
-    }
-
-    try {
-      const jsonString = await readFileAsText(file);
-      const importAnalysis = analyzeCultureImportJson(jsonString, t);
-
-      if (importAnalysis.status === 'error') {
-        setImportErrorState({
-          error: t(importAnalysis.errorKey),
-          previewCount: importAnalysis.originalCount,
-          validCount: 0,
-          invalidEntries: importAnalysis.invalidEntries,
-        });
-        setImportDialogOpen(true);
-        return;
-      }
-
-      setImportUploading();
-      try {
-        const response = await cultureAPI.importPreview(importAnalysis.validEntries);
-
-        setPreviewReadyState({
-          previewCount: importAnalysis.originalCount,
-          validCount: importAnalysis.validEntries.length,
-          invalidEntries: importAnalysis.invalidEntries,
-          payload: importAnalysis.validEntries,
-          previewResults: response.data.results,
-        });
-        setImportDialogOpen(true);
-      } catch (error) {
-        console.error('Error calling preview endpoint:', error);
-        setImportErrorState({ error: t('import.errors.network') });
-        setImportDialogOpen(true);
-      }
-    } catch (error) {
-      console.error('Error reading JSON file:', error);
-      setImportErrorState({ error: t('import.errors.parse') });
-      setImportDialogOpen(true);
-    }
-  };
+  }, [selectedCulture, showSnackbar, t]);
 
   const handleImportStart = async () => {
-    if (!hasImportableEntries || importState.status === 'uploading') {
-      return;
-    }
+    if (!hasImportableEntries || importState.status === 'uploading') return;
 
     setImportUploading();
 
@@ -142,15 +205,12 @@ export function useCultureImportExport({
       if (errors.length > 0) {
         setImportPartialFailure({
           failedEntries: mapImportErrors(errors, importState.payload),
-          error: t('import.errors.someFailures', {
-            failed: errors.length,
-          }),
+          error: t('import.errors.someFailures', { failed: errors.length }),
         });
         return;
       }
 
       const successMessage = buildImportSuccessMessage(created_count, updated_count, skipped_count, t);
-
       setImportSuccessState(successMessage || t('import.success'));
       await fetchCultures();
     } catch (error) {
@@ -163,18 +223,31 @@ export function useCultureImportExport({
     setImportDialogOpen(false);
   };
 
+  // Legacy: kept for compatibility with hidden <input> path (unused when dialogs are active)
+  const handleImportFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (file) await handleImportFileSelected(file);
+  };
+
   return {
     importDialogOpen,
-    fileInputRef,
-    importState,
-    hasImportableEntries,
+    importStartDialogOpen,
+    exportDialogOpen,
     confirmUpdates,
     setConfirmUpdates,
+    importState,
+    hasImportableEntries,
     handleImportFileTrigger,
+    handleImportFileSelected,
+    handleImportFileChange,
+    handleOpenExportDialog,
     handleExportCurrentCulture,
     handleExportAllCultures,
-    handleImportFileChange,
+    handleExport,
     handleImportStart,
     handleImportDialogClose,
+    setImportStartDialogOpen,
+    setExportDialogOpen,
   };
 }


### PR DESCRIPTION
handleHierarchyProcessRowUpdate called clearHierarchyInteractionState after saving, which reset treeActive=false and selectedRowId=null. This meant arrow keys would scroll the page instead of navigating rows immediately after the user confirmed an edit with Enter.

Fix: remove clearHierarchyInteractionState entirely — it is now dead code. After save, useHierarchyGridFocus's useEffect already watches rowModesModel and restores cell focus when editing ends. treeActive and selectedRowId remain set so keyboard navigation continues uninterrupted.