### PR TITLE
feat: extend history retention cleanup and add missing command tests

### DIFF
--- a/backend/accounts/tests/test_auth_api.py
+++ b/backend/accounts/tests/test_auth_api.py
@@ -667,3 +667,34 @@ class AuthApiTest(APITestCase):
         second = StringIO()
         call_command('purge_deleted_accounts', stdout=second)
         self.assertIn('Finalized 0 accounts.', second.getvalue())
+
+    def test_delete_expired_inactive_users_removes_only_expired_accounts(self) -> None:
+        expired = User.objects.create_user(
+            username='expired',
+            email='expired@example.com',
+            password=self.password,
+            is_active=False,
+        )
+        PendingActivation.objects.update_or_create(
+            user=expired,
+            defaults={'activation_expires_at': timezone.now() - timedelta(days=1)},
+        )
+
+        still_pending = User.objects.create_user(
+            username='stillpending',
+            email='stillpending@example.com',
+            password=self.password,
+            is_active=False,
+        )
+        PendingActivation.objects.update_or_create(
+            user=still_pending,
+            defaults={'activation_expires_at': timezone.now() + timedelta(days=1)},
+        )
+
+        output = StringIO()
+        call_command('delete_expired_inactive_users', stdout=output)
+
+        self.assertFalse(User.objects.filter(id=expired.id).exists())
+        self.assertTrue(User.objects.filter(id=still_pending.id).exists())
+        self.assertTrue(User.objects.filter(id=self.user.id).exists())
+        self.assertIn('Deleted 1 expired inactive users.', output.getvalue())

--- a/backend/farm/management/commands/cleanup_history.py
+++ b/backend/farm/management/commands/cleanup_history.py
@@ -3,13 +3,18 @@ from datetime import timedelta
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from farm.models import CultureRevision
+from farm.models import CultureRevision, ProjectRevision
 
 
 class Command(BaseCommand):
-    help = 'Delete culture history entries older than 30 days.'
+    help = 'Delete culture and project history entries older than 30 days.'
 
     def handle(self, *args, **options):
         cutoff = timezone.now() - timedelta(days=30)
-        deleted, _ = CultureRevision.objects.filter(created_at__lt=cutoff).delete()
-        self.stdout.write(self.style.SUCCESS(f'Deleted {deleted} historical records.'))
+        deleted_culture, _ = CultureRevision.objects.filter(created_at__lt=cutoff).delete()
+        deleted_project, _ = ProjectRevision.objects.filter(created_at__lt=cutoff).delete()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Deleted {deleted_culture} culture and {deleted_project} project historical records.'
+            )
+        )

--- a/backend/farm/tests/test_culture_history.py
+++ b/backend/farm/tests/test_culture_history.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-from farm.models import Culture, MediaFile, CultureRevision, Project, ProjectMembership
+from farm.models import Culture, MediaFile, CultureRevision, Project, ProjectMembership, ProjectRevision
 
 User = get_user_model()
 
@@ -158,6 +158,17 @@ class CultureHistoryTests(TestCase):
 
         call_command('cleanup_history')
         self.assertFalse(CultureRevision.objects.filter(id=old.id).exists())
+
+    def test_cleanup_history_command_also_prunes_project_revisions(self):
+        recent = ProjectRevision.objects.create(snapshot={}, summary='Recent snapshot', project=self.project)
+        old = ProjectRevision.objects.create(snapshot={}, summary='Old snapshot', project=self.project)
+        old.created_at = timezone.now() - timedelta(days=40)
+        old.save(update_fields=['created_at'])
+
+        call_command('cleanup_history')
+
+        self.assertFalse(ProjectRevision.objects.filter(id=old.id).exists())
+        self.assertTrue(ProjectRevision.objects.filter(id=recent.id).exists())
 
     def test_global_history_is_scoped_to_active_project(self):
         other_user = User.objects.create_user(username='otherhist', email='otherhist@example.com', password='testpass', is_active=True)

--- a/backend/farm/tests/test_projects_api.py
+++ b/backend/farm/tests/test_projects_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
@@ -557,3 +558,15 @@ class ProjectsApiTests(APITestCase):
             format='json',
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cleanup_deleted_projects_command_purges_expired_trash(self) -> None:
+        self.project2.deleted_at = timezone.now() - timedelta(days=31)
+        self.project2.save(update_fields=['deleted_at'])
+
+        recently_trashed = Project.objects.create(name='P3', slug='p3', deleted_at=timezone.now() - timedelta(days=1))
+
+        call_command('cleanup_deleted_projects')
+
+        self.assertFalse(Project.objects.filter(id=self.project2.id).exists())
+        self.assertTrue(Project.objects.filter(id=recently_trashed.id).exists())
+        self.assertTrue(Project.objects.filter(id=self.project.id).exists())


### PR DESCRIPTION
## Summary
- `cleanup_history` now also prunes `ProjectRevision` snapshots (full-project restore history), not just `CultureRevision` — previously these grew unbounded
- Add regression tests for `cleanup_deleted_projects` and `delete_expired_inactive_users`, which previously had no test coverage

## Context
Related ops-side change (scheduling these commands via cron on Uberspace): stipsitzm/OpenFarmPlanner-ops#5

## Test plan
- [x] `pdm run pytest` (via `config.settings_test`) — all 51 tests in the affected files pass