### PR TITLE
fix: keep Kulturbibliothek button visible after navigating away and back

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,6 +91,7 @@ import { getHistoryEntryTarget, getHistoryEntryTitle, isCurrentHistoryEntry } fr
 import { resolveRouterBasename } from './routerBasename';
 import { OPEN_CREATE_PROJECT_EVENT } from './projects/projectCreationFlow';
 import { useGlobalOverlayKeyboardScroll } from './hooks/useDialogKeyboardScroll';
+import { useTopbarActionsRouteReset } from './hooks/useTopbarActionsRouteReset';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, getKeyboardNavigationRouteFromPathname, normalizeMainRoutePath } from './navigation/mainNavigation';
 import {
   getMobileNavigationIconSx,
@@ -386,10 +387,7 @@ function RootLayout() {
   const [topbarPrimaryActionMenuAnchor, setTopbarPrimaryActionMenuAnchor] = useState<null | HTMLElement>(null);
   currentPathnameRef.current = location.pathname;
 
-  useEffect(() => {
-    setTopbarContextActions([]);
-    setTopbarTitleActions([]);
-  }, [location.pathname]);
+  useTopbarActionsRouteReset(location.pathname, setTopbarContextActions, setTopbarTitleActions);
 
   const navItems = useMemo(() => ([
     { to: '/app/dashboard', label: t('dashboard'), activeAliases: [], keywords: ['übersicht', 'dashboard'], icon: <DashboardOutlinedIcon fontSize="small" /> },

--- a/frontend/src/__tests__/useTopbarActionsRouteReset.test.tsx
+++ b/frontend/src/__tests__/useTopbarActionsRouteReset.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useMemo, useState } from 'react';
+import { useTopbarActionsRouteReset } from '../hooks/useTopbarActionsRouteReset';
+import { useTopbarContextActions } from '../hooks/useTopbarContextActions';
+import type { TopbarContextAction } from '../App';
+
+/**
+ * Regression test for a bug where the "Kulturbibliothek" toolbar button (and
+ * any other page-registered topbar action) vanished after navigating away
+ * from a page and back.
+ *
+ * Root cause: the layout resets topbarContextActions on every route change,
+ * while pages register their own actions via useTopbarContextActions on
+ * mount. Passive effects fire child-before-parent, so once a page mounts in
+ * the same commit as the route change (e.g. a lazy chunk that's already
+ * cached), a plain useEffect reset in the parent runs *after* the child's
+ * registration effect and wipes it out. Using a layout effect for the reset
+ * guarantees it always completes before any passive effect, regardless of
+ * mount timing.
+ */
+
+function Page({ setTopbarContextActions }: { setTopbarContextActions: (actions: TopbarContextAction[]) => void }) {
+  const actions = useMemo<TopbarContextAction[]>(() => [
+    { id: 'open-library', label: 'Kulturbibliothek öffnen', onClick: () => {} },
+  ], []);
+  useTopbarContextActions(setTopbarContextActions, actions);
+  return null;
+}
+
+function OtherPage() {
+  return null;
+}
+
+function Layout({ pathname }: { pathname: string }) {
+  const [actions, setActions] = useState<TopbarContextAction[]>([]);
+  const [, setTitleActions] = useState<TopbarContextAction[]>([]);
+  useTopbarActionsRouteReset(pathname, setActions, setTitleActions);
+
+  return (
+    <>
+      <div data-testid="actions">{actions.map((action) => action.label).join(',')}</div>
+      {pathname === '/cultures' ? <Page setTopbarContextActions={setActions} /> : <OtherPage />}
+    </>
+  );
+}
+
+describe('useTopbarActionsRouteReset', () => {
+  it('keeps a page-registered action visible when the page remounts in the same commit as the route change', () => {
+    const { rerender } = render(<Layout pathname="/cultures" />);
+    expect(screen.getByTestId('actions')).toHaveTextContent('Kulturbibliothek öffnen');
+
+    rerender(<Layout pathname="/other" />);
+    expect(screen.getByTestId('actions')).toHaveTextContent('');
+
+    // Same-commit remount: React swaps OtherPage for Page in one render pass,
+    // exactly like a route change where the target page's lazy chunk is
+    // already cached and mounts synchronously with the route transition.
+    rerender(<Layout pathname="/cultures" />);
+    expect(screen.getByTestId('actions')).toHaveTextContent('Kulturbibliothek öffnen');
+  });
+});

--- a/frontend/src/hooks/useTopbarActionsRouteReset.ts
+++ b/frontend/src/hooks/useTopbarActionsRouteReset.ts
@@ -1,0 +1,20 @@
+import { useLayoutEffect } from 'react';
+import type { TopbarContextAction } from '../App';
+
+// Must run as a layout effect: passive effects fire child-before-parent, so a
+// plain useEffect here would run after a newly routed page's own
+// useTopbarContextActions effect and wipe out the actions it just registered
+// whenever the page mounts in the same commit as the route change (e.g. once
+// its lazy chunk is already cached). A layout effect always completes before
+// any passive effect in the same commit, so the reset can never race the
+// child's registration.
+export function useTopbarActionsRouteReset(
+  pathname: string,
+  setTopbarContextActions: (actions: TopbarContextAction[]) => void,
+  setTopbarTitleActions: (actions: TopbarContextAction[]) => void,
+): void {
+  useLayoutEffect(() => {
+    setTopbarContextActions([]);
+    setTopbarTitleActions([]);
+  }, [pathname, setTopbarContextActions, setTopbarTitleActions]);
+}


### PR DESCRIPTION
## Summary
- Root cause: `RootLayout` reset `topbarContextActions` on every route change via a plain `useEffect`. React fires passive effects child-before-parent, so once a lazy page's chunk is already cached and it mounts in the same commit as the route change, the page's own `useTopbarContextActions` effect (child) registers its actions, and `RootLayout`'s reset effect (parent) then fires *after* it and wipes them out. This mostly surfaces on repeat visits in production — a fresh load or a slower dev-server chunk fetch decouples the mount into a separate commit, hiding the race on localhost.
- Extracted the reset into a small `useTopbarActionsRouteReset` hook using `useLayoutEffect`, which always completes before any passive effect in the same commit — eliminating the race regardless of mount timing, environment, or loading state.
- Added a deterministic regression test (`useTopbarActionsRouteReset.test.tsx`) that reproduces the exact ordering bug with the real `useTopbarContextActions` hook (no reliance on `React.lazy`/`Suspense` timing, which isn't controllable in jsdom).

## Test plan
- [x] New unit test fails without the fix (reverts to plain `useEffect`) and passes with it
- [x] Full frontend test suite passes (867 tests)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] Manual smoke test on staging: navigate Kulturen → another page → back to Kulturen, confirm "Kulturbibliothek" button stays visible; check desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)