### PR TITLE
fix: resync a tab when the active project changes in another tab

### DIFF
--- a/frontend/src/__tests__/AuthContext.test.tsx
+++ b/frontend/src/__tests__/AuthContext.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+import { AuthProvider } from '../auth/AuthContext';
+import { AuthContext } from '../auth/authContextShared';
+import type { AuthUser } from '../auth/types';
+
+const baseUser: AuthUser = {
+  id: 1,
+  email: 'demo@example.com',
+  display_name: 'Demo',
+  display_label: 'Demo',
+  is_active: true,
+  default_project_id: 1,
+  last_project_id: 1,
+  resolved_project_id: 1,
+  needs_project_selection: false,
+  memberships: [],
+  account_pending_deletion: false,
+  scheduled_deletion_at: null,
+};
+
+const getMeMock = vi.hoisted(() => vi.fn(async () => baseUser));
+
+vi.mock('../auth/authApi', () => ({
+  getMe: getMeMock,
+  login: vi.fn(),
+  logout: vi.fn(),
+  register: vi.fn(),
+  activate: vi.fn(),
+  resendActivation: vi.fn(),
+  requestPasswordReset: vi.fn(),
+  confirmPasswordReset: vi.fn(),
+  requestAccountDeletion: vi.fn(),
+  restoreAccount: vi.fn(),
+  switchActiveProject: vi.fn(),
+}));
+
+function ActiveProjectProbe() {
+  const auth = useContext(AuthContext);
+  return <div data-testid="active-project-id">{auth?.activeProjectId ?? 'none'}</div>;
+}
+
+describe('AuthProvider cross-tab project sync', () => {
+  const originalLocation = window.location;
+
+  // jsdom's window.location.reload is a non-configurable, non-writable own property,
+  // so it can't be spied on (directly, or via a Proxy — the reload-invariant check
+  // rejects a Proxy that reports a different value for it). Replace the whole object
+  // instead, and restore the original in afterEach so no other test observes this.
+  function stubLocationReload(): ReturnType<typeof vi.fn> {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+    return reloadSpy;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    getMeMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  it('reloads the page when activeProjectId changes in another tab', async () => {
+    const reloadSpy = stubLocationReload();
+
+    render(<AuthProvider><ActiveProjectProbe /></AuthProvider>);
+    await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('1'));
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'activeProjectId',
+      oldValue: '1',
+      newValue: '2',
+    }));
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload for unrelated storage keys or unchanged values', async () => {
+    const reloadSpy = stubLocationReload();
+
+    render(<AuthProvider><ActiveProjectProbe /></AuthProvider>);
+    await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('1'));
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'someOtherKey',
+      oldValue: 'a',
+      newValue: 'b',
+    }));
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'activeProjectId',
+      oldValue: '1',
+      newValue: '1',
+    }));
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -90,6 +90,21 @@ export function AuthProvider({
     })();
   }, []);
 
+  // localStorage is shared across tabs, but React state and the API's X-Project-Id
+  // header (read fresh from localStorage per request, see httpClient.ts) are not: if
+  // another tab switches the active project, this tab would keep showing stale data
+  // while its own requests silently target the new project. Reload to resync.
+  useEffect(() => {
+    function handleStorageChange(event: StorageEvent): void {
+      if (event.key !== "activeProjectId" || event.newValue === event.oldValue) {
+        return;
+      }
+      window.location.reload();
+    }
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user,


### PR DESCRIPTION
## Summary
- Root cause of the reported production 404 (`Fehler beim Aktualisieren der Kultur`, PUT `/api/cultures/<id>/` → 404): `activeProjectId` lives in `localStorage`, shared across same-origin tabs. Switching the active project in one tab updates `localStorage` and reloads *that* tab, but a second open tab keeps its stale React state/UI for the old project while `httpClient.ts` reads `X-Project-Id` fresh from `localStorage` on every request — so the second tab's requests silently targeted the *new* project. The backend correctly scopes `CultureViewSet.get_queryset()` by that header and 404s for records that don't belong to it. Worse, a **create** in the stale tab would silently succeed under the wrong project instead of the one displayed.
- Fix: `AuthContext` now listens for the `storage` event and reloads the page when `activeProjectId` changes from another tab — mirroring the existing reload-on-switch behavior in the tab that made the change, so every open tab stays consistent with whichever project is actually active.

## Test plan
- [x] New test (`AuthContext.test.tsx`) verifies: reload fires when `activeProjectId` changes via a `storage` event; no reload for unrelated keys or unchanged values. Fails without the fix, passes with it.
- [x] `tsc --noEmit` and `eslint` clean on changed files
- [x] Full frontend suite passes (869 tests) except one pre-existing, load-sensitive flaky test in `App.test.tsx` (`creates a project from the dialog with only a project name`) that reproduces identically with unrelated file pairs and is unaffected by this change — not something I introduced.
- [ ] Manual repro on staging/production: open two tabs, switch project in tab A, confirm tab B reloads automatically instead of erroring on save in the old context

🤖 Generated with [Claude Code](https://claude.com/claude-code)