### PR TITLE
feat: add Alt+S shortcut to focus the culture search input

### DIFF
--- a/frontend/src/__tests__/culturesCommandSpecs.test.ts
+++ b/frontend/src/__tests__/culturesCommandSpecs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCulturesCommandSpecs } from '../pages/culturesCommandSpecs';
+
+function buildOptions(overrides: Partial<Parameters<typeof createCulturesCommandSpecs>[0]> = {}) {
+  return {
+    canRunEnrichmentForCulture: () => false,
+    cultures: [],
+    enableAiEnrichment: false,
+    enrichmentLoading: false,
+    focusSearch: vi.fn(),
+    goToRelativeCulture: vi.fn(),
+    handleCreatePlantingPlan: vi.fn(),
+    handleDelete: vi.fn(),
+    handleEdit: vi.fn(),
+    handleEnrichCurrent: vi.fn(async () => {}),
+    handleExportAllCultures: vi.fn(),
+    handleExportCurrentCulture: vi.fn(),
+    handleImportFileTrigger: vi.fn(),
+    setEnrichAllConfirmOpen: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('createCulturesCommandSpecs', () => {
+  it('registers a culture.focusSearch command bound to Alt+S', () => {
+    const options = buildOptions();
+    const commands = createCulturesCommandSpecs(options);
+    const focusSearchCommand = commands.find((command) => command.id === 'culture.focusSearch');
+
+    expect(focusSearchCommand).toBeDefined();
+    expect(focusSearchCommand?.keys).toEqual({ alt: true, key: 's' });
+    expect(focusSearchCommand?.shortcutHint).toBe('Alt+S');
+    expect(focusSearchCommand?.isEnabled?.()).toBe(true);
+
+    focusSearchCommand?.action();
+    expect(options.focusSearch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/inputs/SearchableSelect.tsx
+++ b/frontend/src/components/inputs/SearchableSelect.tsx
@@ -15,13 +15,14 @@
  * @param props.fullWidth - Whether to stretch to container width.
  * @param props.autoFocus - Whether to focus the input on mount.
  * @param props.textFieldSx - Optional sx overrides for the TextField.
+ * @param props.inputRef - Ref to the underlying input element, for imperative focus.
  * @returns Searchable select input.
  */
 
 import { useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 export interface SearchableSelectOption<T = unknown> {
   value: number;
@@ -44,6 +45,25 @@ export interface SearchableSelectProps<T = unknown> {
   inputValue?: string;
   onInputChange?: (value: string) => void;
   endAdornment?: ReactNode;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
+// Combines Autocomplete's own internal input ref (needed for its keyboard/focus
+// handling) with a caller-supplied ref, without calling a hook inside renderInput
+// (renderInput runs during Autocomplete's own render, not this component's).
+function mergeRefs<T>(...refs: Array<Ref<T> | undefined>): (node: T | null) => void {
+  return (node) => {
+    refs.forEach((ref) => {
+      if (!ref) {
+        return;
+      }
+      if (typeof ref === 'function') {
+        ref(node);
+      } else {
+        (ref as React.MutableRefObject<T | null>).current = node;
+      }
+    });
+  };
 }
 
 export function SearchableSelect<T = unknown>({
@@ -61,6 +81,7 @@ export function SearchableSelect<T = unknown>({
   inputValue,
   onInputChange,
   endAdornment,
+  inputRef,
 }: SearchableSelectProps<T>) {
   const [internalInputValue, setInternalInputValue] = useState('');
   const resolvedInputValue = inputValue ?? internalInputValue;
@@ -103,6 +124,7 @@ export function SearchableSelect<T = unknown>({
           slotProps={{
             htmlInput: {
               ...params.inputProps,
+              ref: mergeRefs(params.inputProps.ref, inputRef),
               tabIndex: inputTabIndex,
             },
           }}

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import type { Ref } from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
@@ -79,6 +80,7 @@ interface CultureDetailProps {
   canCreatePlan?: boolean;
   isPublishingCulture?: boolean;
   publishActionLabel?: string;
+  searchInputRef?: Ref<HTMLInputElement>;
 }
 
 const CULTURE_FILTERS_STORAGE_KEY = 'culturesDetailFiltersV1';
@@ -181,6 +183,7 @@ export function CultureDetail({
   canCreatePlan = true,
   isPublishingCulture = false,
   publishActionLabel,
+  searchInputRef,
 }: CultureDetailProps) {
   const { t } = useTranslation('cultures');
   const [searchParams, setSearchParams] = useSearchParams();
@@ -641,6 +644,7 @@ export function CultureDetail({
               label={t('searchPlaceholder')}
               placeholder={t('searchInputPlaceholderEnhanced')}
               noOptionsText={t('noOptionsEnhanced')}
+              inputRef={searchInputRef}
               textFieldSx={{
                 width: '100%',
               }}

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -8,7 +8,7 @@
  * @returns The Cultures page component
  */
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link as RouterLink, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
@@ -113,6 +113,11 @@ function Cultures() {
   const [historyItems, setHistoryItems] = useState<CultureHistoryEntry[]>([]);
   const [historyScope, setHistoryScope] = useState<HistoryScope>('culture');
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const focusSearch = useCallback(() => {
+    searchInputRef.current?.focus();
+    searchInputRef.current?.select();
+  }, []);
   const [aiMenuAnchor, setAiMenuAnchor] = useState<null | HTMLElement>(null);
   const aiEnrichmentEnabled = FEATURES.AI_ENRICHMENT;
   const [hasFields, setHasFields] = useState(false);
@@ -553,6 +558,7 @@ function Cultures() {
     cultures,
     enableAiEnrichment: aiEnrichmentEnabled,
     enrichmentLoading,
+    focusSearch,
     goToRelativeCulture,
     handleCreatePlantingPlan,
     handleDelete,
@@ -568,6 +574,7 @@ function Cultures() {
     aiEnrichmentEnabled,
     cultures,
     enrichmentLoading,
+    focusSearch,
     goToRelativeCulture,
     handleCreatePlantingPlan,
     handleDelete,
@@ -609,6 +616,7 @@ function Cultures() {
           isLoading={isCulturesLoading}
           selectedCultureId={selectedCultureId}
           onCultureSelect={handleCultureSelect}
+          searchInputRef={searchInputRef}
           onCreateCulture={handleAddNew}
           onOpenPublicLibrary={() => {
             void handleOpenPublicLibrary();

--- a/frontend/src/pages/culturesCommandSpecs.ts
+++ b/frontend/src/pages/culturesCommandSpecs.ts
@@ -6,6 +6,7 @@ export type CreateCulturesCommandSpecsOptions = {
   cultures: Culture[];
   enableAiEnrichment: boolean;
   enrichmentLoading: boolean;
+  focusSearch: () => void;
   goToRelativeCulture: (direction: 'next' | 'previous') => void;
   handleCreatePlantingPlan: () => void;
   handleDelete: (culture: Culture) => void;
@@ -24,6 +25,7 @@ export function createCulturesCommandSpecs({
   cultures,
   enableAiEnrichment,
   enrichmentLoading,
+  focusSearch,
   goToRelativeCulture,
   handleCreatePlantingPlan,
   handleDelete,
@@ -77,6 +79,17 @@ export function createCulturesCommandSpecs({
   ] : [];
 
   return [
+    {
+      id: 'culture.focusSearch',
+      label: 'Kultur suchen fokussieren (Alt+S)',
+      group: 'navigation',
+      keywords: ['kultur', 'suchen', 'search', 'filter'],
+      shortcutHint: 'Alt+S',
+      keys: { alt: true, key: 's' },
+      contextTags: ['cultures'],
+      isEnabled: () => true,
+      action: focusSearch,
+    },
     {
       id: 'culture.edit',
       label: 'Kultur bearbeiten (Alt+E)',


### PR DESCRIPTION
## Summary
- Added a `culture.focusSearch` command (Alt+S) that focuses and selects the "Kultur suchen" search input on the Kulturen page, following the existing `culturesCommandSpecs` pattern (Alt+E edit, Alt+I import, Alt+J export, etc.). Shows up automatically in the command palette (Alt+K) like the other culture commands.
- `SearchableSelect` now accepts an optional `inputRef`, merged with Autocomplete's own internal input ref (needed for its keyboard/focus handling) via a small manual ref-merge helper — done manually rather than with MUI's `useForkRef` since `renderInput` runs during Autocomplete's own render, not this component's, so calling a hook there would be invalid.

## Test plan
- [x] New unit test (`culturesCommandSpecs.test.ts`) verifies the command is registered with the right keybinding and calls `focusSearch`
- [x] `SearchableSelect.test.tsx` (29 tests) still passes with the new `inputRef` prop
- [x] `tsc --noEmit` and `eslint` clean on changed files
- [x] Manually verified end-to-end in a running dev instance: logged in, opened Kulturen, pressed Alt+S — the search input receives focus and its dropdown opens, screenshot confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)