### PR TITLE
Make the occupancy calendar's left column a real Standort/Parzelle/Beet tree

### DIFF
--- a/docs/occupancy-tree-hierarchy.md
+++ b/docs/occupancy-tree-hierarchy.md
@@ -1,0 +1,50 @@
+# Standort → Parzelle → Beet tree in the occupancy calendar
+
+## Where the code lives
+
+| Piece | Location | Generic or OFP-specific |
+|---|---|---|
+| Tree flattening (`flattenTreeRows`, `collectVisibleIdsWithAncestors`) | `frontend/src/components/hierarchy/utils/treeRows.ts` | **Generic.** Only knows `{id, parentId}`. No farm vocabulary, no MUI, no Gantt import. |
+| Expand/collapse state (`useExpandedState`) | `frontend/src/components/hierarchy/hooks/useExpandedState.ts` | **Generic.** Set-based, sessionStorage-backed. Already shared with `FieldsBedsHierarchy.tsx` (DataGrid tree) and `GraphicalFields.tsx` (canvas view) — this is the third consumer. |
+| Chevron/indent/collapse rendering, `depth`/`isExpandable`/`isExpanded`/`emptyRowLabel` on `TaskGroup` | `frontend/src/gantt-chart/src/{types,components/task}` | **Generic.** The vendored Gantt component only renders whatever depth/expand hints it's given via props; it has no notion of Standort/Parzelle/Beet. See `TaskList.tsx`'s `isTreeRow` branch and `TaskRow/index.tsx`'s `emptyRowLabel` handling. |
+| Building the Standort → Parzelle → Beet node list (`buildFieldOccupancyHierarchy`) | `frontend/src/pages/ganttChartUtils.ts` | **OFP-specific.** Knows about locations/fields/beds/planting plans. |
+| Wiring state, filters, search, default expansion | `frontend/src/pages/GanttChart.tsx` | **OFP-specific** (the page). Consumes only the generic pieces above. |
+
+The dependency direction is one-way: `GanttChart.tsx` (app) → `ganttChartUtils.ts` (app) → generic `treeRows.ts` / `useExpandedState` / gantt-chart rendering hints. Nothing generic imports anything domain-specific.
+
+## Data model
+
+`buildFieldOccupancyHierarchy` returns a **flat list** of `OccupancyHierarchyNode` (`type: 'location' | 'field' | 'bed'`, `id`, `parentId`), not a nested breadcrumb string. This replaced the old `hierarchyPath: string[]` convention (`buildFieldOccupancyTaskGroups`, still present and tested for backward compatibility, but no longer used by the page) where every bed row carried its own copy of "Standort / Parzelle / Beet" as a joined label. Now Standort and Parzelle are real rows with their own identity, instead of text duplicated across every bed.
+
+Unlike the old function, `buildFieldOccupancyHierarchy` includes **beds without any planting plan** — the "Nur belegte Beete" filter is what hides them, rather than them never existing in the data at all.
+
+`GanttChart.tsx` turns this into the rows the Gantt library actually renders:
+
+1. Apply the "Nur belegte Beete" structural filter (removes empty beds and any now-childless field/location ancestors) — independent of expand/collapse state.
+2. If search text or a Standort/Parzelle filter is active, compute matched bed ids and expand that set to include all ancestors (`collectVisibleIdsWithAncestors`), so a matching bed's parent chain stays visible for context, bypassing collapse state.
+3. `flattenTreeRows` turns the (pruned, possibly filtered) node list into ordered, depth-annotated visible rows, respecting `expandedRows` from `useExpandedState`.
+4. Each visible row becomes a `GanttTaskGroup` with `depth`/`isExpandable`/`isExpanded` set and, for Standort/Parzelle rows, an `emptyRowLabel` summary string (bed/occupied/field counts).
+
+That flat `GanttTaskGroup[]` is exactly what feeds into the existing `getGanttRenderWindow` scroll-virtualization (`ganttRenderWindow.ts`), unchanged — the tree is flattened into a flat array *before* windowing runs, so windowing doesn't need to know anything about the tree.
+
+## Default expansion
+
+Locations are always expanded by default. Fields are also expanded by default **unless** the combined location+field+bed node count exceeds `OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD` (30, in `GanttChart.tsx`), in which case fields start collapsed. This only applies once per project, on first load with no persisted expand state (`hasPersistedState` + a `hasInitiallyExpandedHierarchyRef` latch, mirroring the identical pattern already used by `FieldsBedsHierarchy.tsx`). After that, the user's manual expand/collapse choices persist via `useExpandedState`'s sessionStorage backing and survive both a page reload and switching the timeline view mode (day/week/month/quarter/year) or the occupancy/seedling calendar mode, since none of those remount the hook.
+
+Small farms (the common case) see a fully expanded tree by default; large ones get a scannable, collapsed-by-default starting point.
+
+## What's aggregated vs. not
+
+Standort/Parzelle rows currently show a **meta-text summary** in place of bars (`emptyRowLabel`, e.g. "3 Parzellen · 12 Beete · 8 belegt") rather than an aggregate bar rolling up their descendants' planting-plan date ranges. This was a deliberate scope cut — implementing a generic "aggregate child date ranges into a parent bar" concept in the Gantt base component, without leaking farm-specific meaning into it, is a larger piece of work (deciding what "aggregate" means when children have overlapping or gapped ranges, how it renders at different zoom levels, etc.).
+
+**Next step, if this is picked up later:** add an optional `aggregateTasks?: Task[]` (or a `renderEmptyRow?: (group) => ReactNode` render-prop, consistent with the library's existing `renderTask`/`renderTooltip` pattern) to `TaskGroup`, computed by `buildFieldOccupancyHierarchy` per Standort/Parzelle node from its descendant beds' task date ranges, and rendered by `TaskRow` in the same code path that currently renders `emptyRowLabel`.
+
+## Filters and search
+
+The filter bar (`GanttChart.tsx`, occupancy mode only) has: free-text search, a Standort `<Select>`, a Parzelle `<Select>` (populated from the selected Standort's fields, disabled until one is chosen), and a "Nur belegte Beete" checkbox (defaults to checked, matching the old always-hide-empty-beds behavior). Search matches a bed's own name, its field's name, its location's name, or any of its planting plans' culture names, case-insensitively. All of this is scoped to the occupancy view — the seedling/culture view keeps its existing flat, non-tree list.
+
+## Tests
+
+- `frontend/src/__tests__/treeRows.test.ts` — generic flatten/expand/collapse/filter mechanics, no OFP domain involved.
+- `frontend/src/__tests__/ganttChartUtils.test.ts` (`describe('buildFieldOccupancyHierarchy', ...)`) — node construction, parent/child wiring, count aggregation, empty-bed inclusion.
+- `frontend/src/__tests__/GanttChart.test.tsx` (`describe('occupancy tree filters and search', ...)`) — end-to-end: search reveals a match with parent context and hides unrelated branches, Standort filter reduces the tree, "Nur belegte Beete" toggles empty-bed visibility. The existing windowing/large-dataset test was updated to expand a field before asserting on scroll virtualization, since large trees now start with fields collapsed by design.

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { act } from 'react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -128,9 +128,17 @@ vi.mock('react-router-dom', async () => {
 vi.mock('../gantt-chart/src', () => ({
   __esModule: true,
   default: (props: {
-    tasks: Array<{ name: string; tasks: Array<Record<string, unknown> & { id: string; name: string }> }>;
+    tasks: Array<{
+      id: string;
+      name: string;
+      tasks: Array<Record<string, unknown> & { id: string; name: string }>;
+      isExpandable?: boolean;
+      isExpanded?: boolean;
+      emptyRowLabel?: string;
+    }>;
     renderTooltip?: ({ task }: { task: Record<string, unknown> }) => ReactNode;
     onTaskUpdate?: (groupId: string, task: { id: string; startDate: Date }) => void | Promise<void>;
+    onToggleGroupExpand?: (groupId: string) => void;
     editMode?: boolean;
     allowTaskMove?: boolean;
     renderHeader?: (props: {
@@ -147,8 +155,13 @@ vi.mock('../gantt-chart/src', () => ({
     maxHeight?: string | number;
   }) => {
     mocks.ganttProps(props);
-    const firstTask = props.tasks[0]?.tasks[0];
-    const firstGroupName = props.tasks[0]?.name ?? '';
+    // With the occupancy tree, tasks[0] is often a Standort/Parzelle parent
+    // row with no bars of its own — find the first group that actually has
+    // tasks (a bed/leaf row), matching what the old flat model always had
+    // at index 0.
+    const firstGroupWithTasks = props.tasks.find((group) => group.tasks.length > 0);
+    const firstTask = firstGroupWithTasks?.tasks[0];
+    const firstGroupName = firstGroupWithTasks?.name ?? '';
     return (
       <div data-testid="mock-gantt">
         {props.renderHeader?.({
@@ -195,6 +208,17 @@ vi.mock('../gantt-chart/src', () => ({
         {props.tasks.map((group) => (
         <div key={group.name}>
           <span>{group.name}</span>
+          {group.isExpandable ? (
+            <button
+              type="button"
+              aria-label={`toggle-${group.name}`}
+              aria-expanded={Boolean(group.isExpanded)}
+              onClick={() => props.onToggleGroupExpand?.(group.id)}
+            >
+              {group.isExpanded ? 'collapse' : 'expand'}
+            </button>
+          ) : null}
+          {group.emptyRowLabel ? <span>{group.emptyRowLabel}</span> : null}
           {group.tasks.map((task) => <span key={`${group.name}-${task.name}`}>{task.name}</span>)}
           {group.tasks[0] && props.renderTooltip ? (
             <div data-testid={`mock-tooltip-${group.name}`}>
@@ -220,6 +244,7 @@ vi.mock('../gantt-chart/src', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
+  window.sessionStorage.clear();
   projectRequirementState.shouldShowProjectRequiredState = false;
   projectRequirementState.missingProjectReason = null;
 
@@ -423,8 +448,9 @@ describe('GanttChartPage', () => {
       tooltip: PROPAGATION_MODE_TOOLTIP,
     });
     expect(screen.getByRole('button', { name: 'Zeitraum verschieben' })).toBeInTheDocument();
-    expect(screen.getByText('Feld / Beet 1')).toBeInTheDocument();
-    expect(screen.queryByText('Hof / Feld / Beet 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Hof')).toBeInTheDocument();
+    expect(screen.getByText('Feld')).toBeInTheDocument();
+    expect(screen.getByText('Beet 1')).toBeInTheDocument();
     expect(mocks.ganttProps).toHaveBeenCalled();
     const latestProps = mocks.ganttProps.mock.calls.at(-1)?.[0];
     expect(latestProps?.locale).toBe('de-DE');
@@ -626,7 +652,7 @@ describe('GanttChartPage', () => {
 
     renderWithAuth();
 
-    await screen.findByText('Feld / Beet 1');
+    await screen.findByText('Beet 1');
     fireEvent.click(screen.getByRole('button', { name: 'Woche' }));
 
     await waitFor(() => {
@@ -675,7 +701,7 @@ describe('GanttChartPage', () => {
 
     renderWithAuth();
 
-    await screen.findByText('Feld / Beet 1');
+    await screen.findByText('Beet 1');
     fireEvent.click(screen.getByRole('button', { name: 'Woche' }));
     await waitFor(() => {
       expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.viewMode).toBe('week');
@@ -686,8 +712,9 @@ describe('GanttChartPage', () => {
     await waitFor(() => expect(mocks.planList).toHaveBeenCalledTimes(2));
     const latestProps = mocks.ganttProps.mock.calls.at(-1)?.[0];
     expect(latestProps?.viewMode).toBe('week');
-    expect(latestProps?.tasks[0]?.tasks[0]?.endDate).toEqual(new Date('2026-05-10T00:00:00.000Z'));
-    expect(latestProps?.tasks[0]?.tasks[1]?.endDate).toEqual(new Date('2026-05-20T00:00:00.000Z'));
+    const bedGroup = latestProps?.tasks.find((group: { tasks: unknown[] }) => group.tasks.length > 0);
+    expect(bedGroup?.tasks[0]?.endDate).toEqual(new Date('2026-05-10T00:00:00.000Z'));
+    expect(bedGroup?.tasks[1]?.endDate).toEqual(new Date('2026-05-20T00:00:00.000Z'));
   });
 
   it('keeps large projects renderable by windowing rows passed to the Gantt library', async () => {
@@ -725,17 +752,34 @@ describe('GanttChartPage', () => {
     );
 
     expect(await screen.findByTestId('gantt-virtual-viewport')).toBeInTheDocument();
+    // The field starts collapsed by default (200+ beds exceeds the
+    // auto-expand-all threshold): only the location + field parent rows are
+    // visible until it's expanded.
+    await waitFor(() => {
+      expect(debugSpy).toHaveBeenCalledWith('[Gantt diagnostics]', expect.objectContaining({
+        beds: rowCount,
+        plantingPlans: rowCount,
+        totalRows: 2,
+        totalTimelineItems: rowCount,
+      }));
+    });
     let latestProps = mocks.ganttProps.mock.calls.at(-1)?.[0];
     expect(latestProps?.tasks.length).toBeGreaterThan(0);
     expect(latestProps?.tasks.length).toBeLessThan(rowCount);
-    expect(debugSpy).toHaveBeenCalledWith('[Gantt diagnostics]', expect.objectContaining({
-      beds: rowCount,
-      plantingPlans: rowCount,
-      totalRows: rowCount,
-      totalTimelineItems: rowCount,
-      renderedRows: expect.any(Number),
-      renderedTimelineItems: expect.any(Number),
-    }));
+
+    // Expand it to reveal all 200 bed rows and actually exercise scroll
+    // windowing across them.
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-Feld' }));
+    await screen.findByText('Beet 1');
+    await waitFor(() => {
+      expect(debugSpy).toHaveBeenCalledWith('[Gantt diagnostics]', expect.objectContaining({
+        beds: rowCount,
+        plantingPlans: rowCount,
+        // +2 for the single location + field parent rows in the occupancy tree
+        totalRows: rowCount + 2,
+        totalTimelineItems: rowCount,
+      }));
+    });
 
     fireEvent.scroll(screen.getByTestId('gantt-virtual-viewport'), {
       target: { scrollTop: 7200 },
@@ -985,7 +1029,7 @@ describe('GanttChartPage', () => {
       </MemoryRouter>,
     );
 
-    await screen.findByText('Feld / Beet 1');
+    await screen.findByText('Beet 1');
     expect(screen.queryByTestId('mock-update-task')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Zeitraum verschieben' }));
     await screen.findByTestId('mock-update-task');
@@ -1021,7 +1065,7 @@ describe('GanttChartPage', () => {
       </MemoryRouter>,
     );
 
-    await screen.findByText('Feld / Beet 1');
+    await screen.findByText('Beet 1');
     expect(screen.queryByTestId('mock-update-task')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Zeitraum verschieben' }));
     await screen.findByTestId('mock-update-task');
@@ -1029,5 +1073,110 @@ describe('GanttChartPage', () => {
 
     await waitFor(() => expect(mocks.planUpdate).toHaveBeenCalledTimes(1));
     expect(screen.queryByText('Fehler beim Aktualisieren des Anbauplans')).not.toBeInTheDocument();
+  });
+
+  describe('occupancy tree filters and search', () => {
+    const setUpMultiLocationFixture = () => {
+      mocks.locationList.mockResolvedValue({
+        data: { results: [{ id: 1, name: 'Hof' }, { id: 2, name: 'Pacht' }] },
+      });
+      mocks.fieldList.mockResolvedValue({
+        data: {
+          results: [
+            { id: 10, name: 'Nordfeld', location: 1 },
+            { id: 20, name: 'Südfeld', location: 2 },
+          ],
+        },
+      });
+      mocks.bedList.mockResolvedValue({
+        data: {
+          results: [
+            { id: 100, name: 'Karottenbeet', field: 10 },
+            { id: 101, name: 'Leerbeet', field: 10 },
+            { id: 200, name: 'Tomatenbeet', field: 20 },
+          ],
+        },
+      });
+      mocks.planList.mockResolvedValue({
+        data: {
+          results: [
+            {
+              id: 1,
+              culture: 1,
+              culture_name: 'Karotte',
+              bed: 100,
+              planting_date: '2026-03-01',
+              harvest_date: '2026-05-01',
+            },
+            {
+              id: 2,
+              culture: 2,
+              culture_name: 'Tomate',
+              bed: 200,
+              planting_date: '2026-04-01',
+              harvest_date: '2026-07-01',
+            },
+          ],
+        },
+      });
+      mocks.cultureList.mockResolvedValue({
+        data: { results: [{ id: 1, name: 'Karotte' }, { id: 2, name: 'Tomate' }] },
+      });
+    };
+
+    it('search finds a matching bed and keeps its parent Standort/Parzelle visible while hiding unrelated branches', async () => {
+      setUpMultiLocationFixture();
+      renderWithAuth();
+
+      await screen.findByText('Karottenbeet');
+      expect(screen.getByText('Tomatenbeet')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…'), {
+        target: { value: 'Karotte' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Hof')).toBeInTheDocument();
+        expect(screen.getByText('Nordfeld')).toBeInTheDocument();
+        expect(screen.getByText('Karottenbeet')).toBeInTheDocument();
+        expect(screen.queryByText('Pacht')).not.toBeInTheDocument();
+        expect(screen.queryByText('Südfeld')).not.toBeInTheDocument();
+        expect(screen.queryByText('Tomatenbeet')).not.toBeInTheDocument();
+      });
+    });
+
+    it('Standort filter reduces the visible tree to the selected location', async () => {
+      setUpMultiLocationFixture();
+      renderWithAuth();
+
+      await screen.findByText('Karottenbeet');
+
+      fireEvent.mouseDown(screen.getByText('Alle Standorte'));
+      fireEvent.click(await screen.findByRole('option', { name: 'Pacht' }));
+
+      await waitFor(() => {
+        const tree = within(screen.getByTestId('mock-gantt'));
+        expect(tree.getByText('Pacht')).toBeInTheDocument();
+        expect(tree.getByText('Südfeld')).toBeInTheDocument();
+        expect(tree.getByText('Tomatenbeet')).toBeInTheDocument();
+        expect(tree.queryByText('Hof')).not.toBeInTheDocument();
+        expect(tree.queryByText('Nordfeld')).not.toBeInTheDocument();
+        expect(tree.queryByText('Karottenbeet')).not.toBeInTheDocument();
+      });
+    });
+
+    it('"Nur belegte Beete" hides beds without a planting plan by default and shows them when unchecked', async () => {
+      setUpMultiLocationFixture();
+      renderWithAuth();
+
+      await screen.findByText('Karottenbeet');
+      expect(screen.queryByText('Leerbeet')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur belegte Beete' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Leerbeet')).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/frontend/src/__tests__/ganttChartUtils.test.ts
+++ b/frontend/src/__tests__/ganttChartUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildFieldOccupancyHierarchy,
   buildFieldOccupancyTaskGroups,
   buildSeedlingTaskGroups,
   buildSeedlingTooltipDetails,
@@ -351,5 +352,154 @@ describe('buildSeedlingTaskGroups', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].tasks).toHaveLength(2);
     expect(groups[0].tasks[1].name).toBe('Salat (Bijella) (Ernte)');
+  });
+});
+
+describe('buildFieldOccupancyHierarchy', () => {
+  const multiLocationLocations = [
+    { id: 1, name: 'Hof' },
+    { id: 2, name: 'Pacht' },
+  ];
+  const multiLocationFields = [
+    { id: 10, name: 'Nordfeld', location: 1 },
+    { id: 20, name: 'Südfeld', location: 2 },
+  ];
+  const multiLocationBeds = [
+    { id: 100, name: 'Beet A', field: 10 },
+    { id: 101, name: 'Beet A2', field: 10 },
+    { id: 200, name: 'Beet B', field: 20 },
+  ];
+
+  it('always builds a location node and a field node, even for a single location', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [],
+    });
+
+    const locationNode = nodes.find((n) => n.type === 'location');
+    const fieldNode = nodes.find((n) => n.type === 'field');
+    expect(locationNode?.name).toBe('Hof');
+    expect(locationNode?.parentId).toBeNull();
+    expect(fieldNode?.name).toBe('Nordfeld');
+    expect(fieldNode?.parentId).toBe(locationNode?.id);
+  });
+
+  it('includes beds without any planting plan as empty leaf nodes', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [],
+    });
+
+    const bedNode = nodes.find((n) => n.type === 'bed');
+    expect(bedNode).toBeDefined();
+    expect(bedNode?.tasks).toEqual([]);
+    expect(bedNode?.occupiedBedCount).toBe(0);
+  });
+
+  it('sets parentId references forming a Standort -> Parzelle -> Beet chain', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations: multiLocationLocations,
+      fields: multiLocationFields,
+      beds: multiLocationBeds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [],
+    });
+
+    const bedA = nodes.find((n) => n.type === 'bed' && n.name === 'Beet A');
+    const fieldNord = nodes.find((n) => n.type === 'field' && n.name === 'Nordfeld');
+    const locationHof = nodes.find((n) => n.type === 'location' && n.name === 'Hof');
+
+    expect(bedA?.parentId).toBe(fieldNord?.id);
+    expect(fieldNord?.parentId).toBe(locationHof?.id);
+    expect(locationHof?.parentId).toBeNull();
+  });
+
+  it('aggregates bed/occupied-bed/plan counts up through field and location nodes', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations: multiLocationLocations,
+      fields: multiLocationFields,
+      beds: multiLocationBeds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [
+        {
+          id: 1,
+          culture: 1,
+          culture_name: 'Salat',
+          bed: 100,
+          planting_date: '2026-03-01',
+          harvest_date: '2026-04-15',
+        },
+        {
+          id: 2,
+          culture: 2,
+          culture_name: 'Kohl',
+          bed: 101,
+          planting_date: '2026-03-05',
+          harvest_date: '2026-04-20',
+        },
+      ],
+    });
+
+    const fieldNord = nodes.find((n) => n.type === 'field' && n.name === 'Nordfeld');
+    const locationHof = nodes.find((n) => n.type === 'location' && n.name === 'Hof');
+    const locationPacht = nodes.find((n) => n.type === 'location' && n.name === 'Pacht');
+
+    expect(fieldNord?.bedCount).toBe(2);
+    expect(fieldNord?.occupiedBedCount).toBe(2);
+    expect(fieldNord?.planCount).toBe(2);
+    expect(locationHof?.bedCount).toBe(2);
+    expect(locationHof?.occupiedBedCount).toBe(2);
+    expect(locationPacht?.bedCount).toBe(1);
+    expect(locationPacht?.occupiedBedCount).toBe(0);
+  });
+
+  it('builds growth and harvest tasks for occupied beds the same way as buildFieldOccupancyTaskGroups', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [
+        {
+          id: 21,
+          culture: 42,
+          culture_name: 'Salat',
+          culture_variety: 'Bijella',
+          bed: 100,
+          planting_date: '2026-03-01',
+          harvest_date: '2026-04-15',
+          harvest_end_date: '2026-04-30',
+        },
+      ],
+    });
+
+    const bedNode = nodes.find((n) => n.type === 'bed');
+    expect(bedNode?.tasks).toHaveLength(2);
+    expect(bedNode?.tasks[0].name).toBe('Salat (Bijella)');
+    expect(bedNode?.tasks[1].name).toBe('Salat (Bijella) (Ernte)');
+  });
+
+  it('returns an empty list when there are no locations', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations: [],
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [],
+    });
+
+    expect(nodes).toEqual([]);
   });
 });

--- a/frontend/src/__tests__/treeRows.test.ts
+++ b/frontend/src/__tests__/treeRows.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectVisibleIdsWithAncestors,
+  flattenTreeRows,
+  type TreeRowNode,
+} from '../components/hierarchy/utils/treeRows';
+
+interface TestNode extends TreeRowNode {
+  name: string;
+}
+
+const nodes: TestNode[] = [
+  { id: 'loc-1', parentId: null, name: 'Standort A' },
+  { id: 'field-1', parentId: 'loc-1', name: 'Parzelle 1' },
+  { id: 'bed-1', parentId: 'field-1', name: 'Beet 1' },
+  { id: 'bed-2', parentId: 'field-1', name: 'Beet 2' },
+  { id: 'field-2', parentId: 'loc-1', name: 'Parzelle 2' },
+  { id: 'bed-3', parentId: 'field-2', name: 'Beet 3' },
+  { id: 'loc-2', parentId: null, name: 'Standort B' },
+  { id: 'field-3', parentId: 'loc-2', name: 'Parzelle 3' },
+];
+
+describe('flattenTreeRows', () => {
+  it('converts a nested tree into correctly ordered, depth-annotated rows when fully expanded', () => {
+    const expandedIds = new Set(nodes.map((n) => n.id));
+    const rows = flattenTreeRows(nodes, { expandedIds });
+
+    expect(rows.map((r) => r.node.id)).toEqual([
+      'loc-1', 'field-1', 'bed-1', 'bed-2', 'field-2', 'bed-3', 'loc-2', 'field-3',
+    ]);
+    expect(rows.find((r) => r.node.id === 'loc-1')?.depth).toBe(0);
+    expect(rows.find((r) => r.node.id === 'field-1')?.depth).toBe(1);
+    expect(rows.find((r) => r.node.id === 'bed-1')?.depth).toBe(2);
+  });
+
+  it('reports hasChildren correctly for parents and leaves', () => {
+    const expandedIds = new Set(nodes.map((n) => n.id));
+    const rows = flattenTreeRows(nodes, { expandedIds });
+
+    expect(rows.find((r) => r.node.id === 'loc-1')?.hasChildren).toBe(true);
+    expect(rows.find((r) => r.node.id === 'bed-1')?.hasChildren).toBe(false);
+  });
+
+  it('collapse hides children: a collapsed node is shown but its descendants are omitted', () => {
+    const expandedIds = new Set(['loc-1', 'loc-2', 'field-2']); // field-1 collapsed
+    const rows = flattenTreeRows(nodes, { expandedIds });
+
+    const ids = rows.map((r) => r.node.id);
+    expect(ids).toContain('field-1');
+    expect(ids).not.toContain('bed-1');
+    expect(ids).not.toContain('bed-2');
+    // sibling branch under field-2 (expanded) still shows its children
+    expect(ids).toContain('bed-3');
+  });
+
+  it('expand reveals children again after being collapsed', () => {
+    const collapsed = new Set(['loc-1', 'loc-2']);
+    const collapsedRows = flattenTreeRows(nodes, { expandedIds: collapsed });
+    expect(collapsedRows.map((r) => r.node.id)).not.toContain('bed-1');
+
+    const expanded = new Set(['loc-1', 'loc-2', 'field-1', 'field-2']);
+    const expandedRows = flattenTreeRows(nodes, { expandedIds: expanded });
+    expect(expandedRows.map((r) => r.node.id)).toContain('bed-1');
+  });
+
+  it('an empty expandedIds set only shows root-level rows', () => {
+    const rows = flattenTreeRows(nodes, { expandedIds: new Set() });
+    expect(rows.map((r) => r.node.id)).toEqual(['loc-1', 'loc-2']);
+  });
+
+  it('with a visibleIds filter, only matched nodes are shown and expandedIds is ignored (full path to matches revealed)', () => {
+    const matched = new Set(['bed-1']);
+    const visibleIds = collectVisibleIdsWithAncestors(nodes, matched);
+    // even with nothing manually expanded, filtering reveals the full ancestor chain
+    const rows = flattenTreeRows(nodes, { expandedIds: new Set(), visibleIds });
+
+    expect(rows.map((r) => r.node.id)).toEqual(['loc-1', 'field-1', 'bed-1']);
+  });
+});
+
+describe('collectVisibleIdsWithAncestors', () => {
+  it('includes the matched node and every ancestor up to the root', () => {
+    const visible = collectVisibleIdsWithAncestors(nodes, new Set(['bed-3']));
+    expect(visible).toEqual(new Set(['bed-3', 'field-2', 'loc-1']));
+  });
+
+  it('deduplicates shared ancestors across multiple matches', () => {
+    const visible = collectVisibleIdsWithAncestors(nodes, new Set(['bed-1', 'bed-3']));
+    expect(visible).toEqual(new Set(['bed-1', 'field-1', 'loc-1', 'bed-3', 'field-2']));
+  });
+
+  it('returns an empty set when nothing matches', () => {
+    const visible = collectVisibleIdsWithAncestors(nodes, new Set());
+    expect(visible.size).toBe(0);
+  });
+});

--- a/frontend/src/components/hierarchy/utils/treeRows.ts
+++ b/frontend/src/components/hierarchy/utils/treeRows.ts
@@ -1,0 +1,106 @@
+/**
+ * Generic parent-child tree flattening, independent of any domain
+ * (locations/fields/beds, cultures, etc.). Used to turn a flat list of
+ * {id, parentId} nodes into an ordered, depth-annotated list of visible
+ * rows, respecting expand/collapse state and an optional visibility
+ * filter (e.g. from search) that keeps ancestors of a match visible.
+ */
+
+export interface TreeRowNode {
+  id: string | number;
+  parentId?: string | number | null;
+}
+
+export interface FlattenedTreeRow<T> {
+  node: T;
+  depth: number;
+  hasChildren: boolean;
+}
+
+export function buildChildrenIndex<T extends TreeRowNode>(
+  nodes: readonly T[],
+): Map<string | number | null, T[]> {
+  const index = new Map<string | number | null, T[]>();
+  nodes.forEach((node) => {
+    const key = node.parentId ?? null;
+    const list = index.get(key);
+    if (list) {
+      list.push(node);
+    } else {
+      index.set(key, [node]);
+    }
+  });
+  return index;
+}
+
+/**
+ * Given a set of "matched" node ids (e.g. search/filter results), returns
+ * that set expanded to include every ancestor of each match, so a matched
+ * leaf's parent chain stays visible for context.
+ */
+export function collectVisibleIdsWithAncestors<T extends TreeRowNode>(
+  nodes: readonly T[],
+  matchedIds: ReadonlySet<string | number>,
+): Set<string | number> {
+  const byId = new Map<string | number, T>(nodes.map((node) => [node.id, node]));
+  const visible = new Set<string | number>();
+
+  matchedIds.forEach((id) => {
+    let current: T | undefined = byId.get(id);
+    while (current) {
+      if (visible.has(current.id)) {
+        break;
+      }
+      visible.add(current.id);
+      const parentId = current.parentId;
+      current = parentId != null ? byId.get(parentId) : undefined;
+    }
+  });
+
+  return visible;
+}
+
+/**
+ * Flattens a parent-child node list into ordered, depth-annotated rows.
+ *
+ * - Without `visibleIds`, every node is included and descending into
+ *   children is gated by `expandedIds` (normal expand/collapse browsing).
+ * - With `visibleIds` (typically matches + their ancestors, see
+ *   `collectVisibleIdsWithAncestors`), only nodes in that set are
+ *   included, and descending into children ignores `expandedIds` — an
+ *   active filter reveals the full path to every match regardless of
+ *   manual collapse state.
+ */
+export function flattenTreeRows<T extends TreeRowNode>(
+  nodes: readonly T[],
+  options: {
+    expandedIds: ReadonlySet<string | number>;
+    visibleIds?: ReadonlySet<string | number> | null;
+  },
+): FlattenedTreeRow<T>[] {
+  const childrenIndex = buildChildrenIndex(nodes);
+  const { expandedIds, visibleIds } = options;
+  const isFiltering = visibleIds != null;
+
+  const result: FlattenedTreeRow<T>[] = [];
+
+  const walk = (parentId: string | number | null, depth: number): void => {
+    const children = childrenIndex.get(parentId) ?? [];
+    children.forEach((node) => {
+      if (isFiltering && !visibleIds.has(node.id)) {
+        return;
+      }
+
+      const hasChildren = (childrenIndex.get(node.id)?.length ?? 0) > 0;
+      result.push({ node, depth, hasChildren });
+
+      const shouldDescend = isFiltering || expandedIds.has(node.id);
+      if (shouldDescend) {
+        walk(node.id, depth + 1);
+      }
+    });
+  };
+
+  walk(null, 0);
+  return result;
+}

--- a/frontend/src/gantt-chart/src/components/core/GanttChart.tsx
+++ b/frontend/src/gantt-chart/src/components/core/GanttChart.tsx
@@ -83,6 +83,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       onTaskClick,
       onTaskSelect,
       onGroupClick,
+      onToggleGroupExpand,
       onViewModeChange,
 
       // Visual customization
@@ -1085,6 +1086,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
               tasks,
               headerLabel: resolvedHeaderLabel,
               onGroupClick,
+              onToggleGroupExpand,
               viewMode: activeViewMode,
               leftColumnWidth,
             })
@@ -1093,6 +1095,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
               tasks={tasks}
               headerLabel={resolvedHeaderLabel}
               onGroupClick={onGroupClick}
+              onToggleGroupExpand={onToggleGroupExpand}
               className={getComponentClassName("taskList", "rmg-task-list")}
               viewMode={activeViewMode}
               showTimelineHeader={showTimelineHeader}

--- a/frontend/src/gantt-chart/src/components/task/TaskList.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskList.tsx
@@ -11,6 +11,20 @@ import {
 /**
  * TaskList Component - Displays the list of task groups on the left side of the Gantt chart
  */
+const TREE_INDENT_PX = 20;
+
+const ChevronIcon: React.FC<{ expanded: boolean }> = ({ expanded }) => (
+  <svg
+    viewBox="0 0 16 16"
+    width="12"
+    height="12"
+    className={`rmg-task-group-chevron-icon ${expanded ? "rmg-task-group-chevron-icon-expanded" : ""}`}
+    aria-hidden="true"
+  >
+    <path d="M5 3l5 5-5 5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
 const TaskList: React.FC<TaskListProps> = ({
   tasks = [],
   headerLabel = "Resources",
@@ -20,6 +34,7 @@ const TaskList: React.FC<TaskListProps> = ({
   rowHeight = 40,
   className = "",
   onGroupClick,
+  onToggleGroupExpand,
   viewMode,
   showTimelineHeader = true,
   leftColumnWidth = 160,
@@ -31,15 +46,14 @@ const TaskList: React.FC<TaskListProps> = ({
 
   // Calculate height for each group based on tasks
   const getGroupHeight = (taskGroup: TaskGroup) => {
-    const hierarchyLevels = getHierarchyLevels(taskGroup);
-    const labelLinesSource = getLabelLinesSource(
-      taskGroup,
-      hierarchyLevels,
-      showDescription,
-    );
+    const isTreeRow = taskGroup.depth !== undefined;
+    const hierarchyLevels = isTreeRow ? null : getHierarchyLevels(taskGroup);
+    const labelLinesSource = isTreeRow
+      ? [taskGroup.name || "Unnamed"]
+      : getLabelLinesSource(taskGroup, hierarchyLevels, showDescription);
     const estimatedHeight = estimateLabelHeight(
       labelLinesSource,
-      normalizedLeftColumnWidth,
+      normalizedLeftColumnWidth - (isTreeRow ? (taskGroup.depth ?? 0) * TREE_INDENT_PX : 0),
     );
 
     if (!taskGroup.tasks || !Array.isArray(taskGroup.tasks)) {
@@ -56,6 +70,11 @@ const TaskList: React.FC<TaskListProps> = ({
     if (onGroupClick) {
       onGroupClick(group);
     }
+  };
+
+  const handleChevronClick = (event: React.MouseEvent, groupId: string) => {
+    event.stopPropagation();
+    onToggleGroupExpand?.(groupId);
   };
 
   return (
@@ -81,6 +100,74 @@ const TaskList: React.FC<TaskListProps> = ({
         if (!taskGroup) return null;
 
         const groupHeight = getGroupHeight(taskGroup);
+        const isTreeRow = taskGroup.depth !== undefined;
+
+        if (isTreeRow) {
+          const depth = taskGroup.depth ?? 0;
+          const isExpanded = Boolean(taskGroup.isExpanded);
+          const displayName = taskGroup.name || "Unnamed";
+
+          return (
+            <div
+              key={`task-group-${taskGroup.id || "unknown"}`}
+              className="rmg-task-group rmg-task-group-tree-row"
+              style={{ minHeight: `${groupHeight}px` }}
+              onClick={() => handleGroupClick(taskGroup)}
+              data-testid={`task-group-${taskGroup.id || "unknown"}`}
+              data-rmg-component="task-group"
+              data-group-id={taskGroup.id}
+              data-depth={depth}
+              data-expanded={taskGroup.isExpandable ? isExpanded : undefined}
+            >
+              <div
+                className="rmg-task-group-content rmg-task-group-tree-content"
+                style={{ paddingLeft: `${depth * TREE_INDENT_PX}px` }}
+              >
+                {taskGroup.isExpandable ? (
+                  <button
+                    type="button"
+                    className="rmg-task-group-chevron"
+                    onClick={(event) => handleChevronClick(event, taskGroup.id)}
+                    aria-expanded={isExpanded}
+                    aria-label={isExpanded ? "Collapse" : "Expand"}
+                    data-rmg-component="task-group-chevron"
+                  >
+                    <ChevronIcon expanded={isExpanded} />
+                  </button>
+                ) : (
+                  <span className="rmg-task-group-chevron-spacer" aria-hidden="true" />
+                )}
+
+                {showIcon && taskGroup.icon && (
+                  <span
+                    className="rmg-task-group-icon"
+                    dangerouslySetInnerHTML={{ __html: taskGroup.icon }}
+                    data-rmg-component="task-group-icon"
+                  />
+                )}
+
+                <span
+                  className="rmg-task-group-name rmg-task-group-tree-name"
+                  data-rmg-component="task-group-name"
+                  title={displayName}
+                >
+                  {displayName}
+                </span>
+              </div>
+
+              {showTaskCount && taskGroup.tasks && taskGroup.tasks.length > 0 && (
+                <div
+                  className="rmg-task-group-count"
+                  data-rmg-component="task-group-count"
+                >
+                  {taskGroup.tasks.length}{" "}
+                  {taskGroup.tasks.length === 1 ? "task" : "tasks"}
+                </div>
+              )}
+            </div>
+          );
+        }
+
         const hierarchyLevels = getHierarchyLevels(taskGroup);
         const hasHierarchy = Boolean(hierarchyLevels);
         const fullLabelTitle = (

--- a/frontend/src/gantt-chart/src/components/task/TaskRow/index.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskRow/index.tsx
@@ -876,7 +876,21 @@ const TaskRow: React.FC<TaskRowProps> = ({
 
   if (groupTasks.length === 0) {
     return (
-      <div className="rmg-task-row rmg-task-row-empty">No tasks available</div>
+      <div
+        className="rmg-task-row rmg-task-row-empty"
+        style={{
+          minHeight: `${resolvedRowHeight}px`,
+          minWidth: `${totalMonths * monthWidth}px`,
+        }}
+        data-testid={`task-row-${taskGroupId}`}
+        data-group-id={taskGroupId}
+      >
+        {taskGroup?.emptyRowLabel && (
+          <span className="rmg-task-row-empty-label">
+            {taskGroup.emptyRowLabel}
+          </span>
+        )}
+      </div>
     );
   }
 

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -294,6 +294,87 @@
   color: var(--rmg-gray-400);
 }
 
+.rmg-task-group-tree-content {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.rmg-task-group-tree-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rmg-task-group-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--rmg-gray-600);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.rmg-task-group-chevron:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.rmg-dark .rmg-task-group-chevron {
+  color: var(--rmg-gray-400);
+}
+
+.rmg-dark .rmg-task-group-chevron:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.rmg-task-group-chevron-spacer {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+}
+
+.rmg-task-group-chevron-icon {
+  transition: transform 0.12s ease;
+}
+
+.rmg-task-group-chevron-icon-expanded {
+  transform: rotate(90deg);
+}
+
+.rmg-task-group-tree-row[data-depth="0"] .rmg-task-group-tree-name {
+  font-weight: 600;
+}
+
+.rmg-task-group-tree-row[data-depth="1"] .rmg-task-group-tree-name {
+  color: var(--rmg-gray-700);
+}
+
+.rmg-dark .rmg-task-group-tree-row[data-depth="1"] .rmg-task-group-tree-name {
+  color: var(--rmg-gray-300);
+}
+
+.rmg-task-row-empty-label {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-left: 12px;
+  font-size: 0.8rem;
+  color: var(--rmg-gray-500);
+  font-style: italic;
+}
+
+.rmg-dark .rmg-task-row-empty-label {
+  color: var(--rmg-gray-400);
+}
+
 /* ======================================================
    6. Timeline und Grid
    ====================================================== */

--- a/frontend/src/gantt-chart/src/types/components.ts
+++ b/frontend/src/gantt-chart/src/types/components.ts
@@ -6,6 +6,7 @@ export interface TaskListRenderProps {
   tasks: TaskGroup[];
   headerLabel?: string;
   onGroupClick?: (group: TaskGroup) => void;
+  onToggleGroupExpand?: (groupId: string) => void;
   viewMode: ViewMode;
   leftColumnWidth?: number;
 }
@@ -134,6 +135,7 @@ export interface GanttChartProps {
   onTaskSelect?: (task: Task, isSelected: boolean) => void;
   onTaskDoubleClick?: (task: Task) => void;
   onGroupClick?: (group: TaskGroup) => void;
+  onToggleGroupExpand?: (groupId: string) => void;
   onViewModeChange?: (viewMode: ViewMode) => void;
 
   // Visual customization
@@ -193,6 +195,7 @@ export interface TaskListProps {
   rowHeight?: number;
   className?: string;
   onGroupClick?: (group: TaskGroup) => void;
+  onToggleGroupExpand?: (groupId: string) => void;
   viewMode?: ViewMode;
   showTimelineHeader?: boolean; // Pass through for styling adjustments
   leftColumnWidth?: number;

--- a/frontend/src/gantt-chart/src/types/core.ts
+++ b/frontend/src/gantt-chart/src/types/core.ts
@@ -23,6 +23,23 @@ export interface TaskGroup {
   bedName?: string;
   icon?: string;
   tasks: Task[];
+  /**
+   * Tree-row rendering hints. All optional and purely presentational — the
+   * caller (e.g. an app page) is responsible for computing the actual tree
+   * structure, flattening it into a visible-row list, and passing depth /
+   * isExpandable / isExpanded per group. Without these, a group renders
+   * exactly as before (flat row, no chevron/indent).
+   */
+  depth?: number;
+  isExpandable?: boolean;
+  isExpanded?: boolean;
+  /**
+   * Shown in the timeline area instead of bars when `tasks` is empty —
+   * e.g. a parent row summarizing its children ("12 beds, 34 plans").
+   * Purely a caller-provided string; this library has no opinion on its
+   * content.
+   */
+  emptyRowLabel?: string;
   [key: string]: any;
 }
 

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -156,5 +156,11 @@
       "createAreas": "Zu Anbauflächen",
       "createPlan": "Anbauplan hinzufügen"
     }
+  },
+  "treeFilters": {
+    "searchPlaceholder": "Suche nach Kultur, Beet, Parzelle oder Standort…",
+    "allLocations": "Alle Standorte",
+    "allFields": "Alle Parzellen",
+    "onlyOccupiedBeds": "Nur belegte Beete"
   }
 }

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -17,11 +17,16 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Checkbox,
+  FormControlLabel,
+  InputAdornment,
   MenuItem,
   Select,
+  TextField,
   Tooltip,
   Typography,
 } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import {
   bedAPI,
   cultureAPI,
@@ -49,7 +54,7 @@ import EmptyStateCard from '../components/project/EmptyStateCard';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../App';
 import { AuthContext } from '../auth/authContextShared';
 import {
-  buildFieldOccupancyTaskGroups,
+  buildFieldOccupancyHierarchy,
   buildOccupancyTooltipDetails,
   buildSeedlingTaskGroups,
   buildSeedlingTooltipDetails,
@@ -58,6 +63,7 @@ import {
   parseDateString,
   type GanttTask,
   type GanttTaskGroup,
+  type OccupancyHierarchyNode,
 } from './ganttChartUtils';
 import { getFirstMissingCultivationPlanRequirement, getProjectSetupActions } from './requirementFlow';
 import {
@@ -65,6 +71,8 @@ import {
   segmentedButtonGroupSx,
 } from '../components/buttons/segmentedControlStyles';
 import { getGanttRenderWindow } from './ganttRenderWindow';
+import { useExpandedState } from '../components/hierarchy/hooks/useExpandedState';
+import { collectVisibleIdsWithAncestors, flattenTreeRows } from '../components/hierarchy/utils/treeRows';
 
 type CalendarMode = 'occupancy' | 'seedlings';
 const GanttChartWithFocusMode = GanttChart as React.ComponentType<
@@ -76,6 +84,9 @@ const CALENDAR_TIMELINE_VIEW_MODE_STORAGE_KEY = 'openFarmPlanner.ganttChart.time
 const GANTT_STATE_STORAGE_PREFIX = 'openfarmplanner:gantt';
 const DEFAULT_TIMELINE_VIEW_MODE = ViewMode.MONTH;
 const GANTT_LEFT_COLUMN_WIDTH = 220;
+// Above this many combined location+field+bed nodes, default to
+// locations-expanded/fields-collapsed instead of fully expanding the tree.
+const OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD = 30;
 const GANTT_HEADER_VIEW_MODES = [
   ViewMode.DAY,
   ViewMode.WEEK,
@@ -437,6 +448,23 @@ function GanttChartPage() {
   const [beds, setBeds] = useState<Bed[]>([]);
   const [plantingPlans, setPlantingPlans] = useState<PlantingPlan[]>([]);
   const [cultures, setCultures] = useState<Culture[]>([]);
+
+  // Standort/Parzelle/Beet tree: filter + search state for the occupancy view
+  const [occupancySearchText, setOccupancySearchText] = useState('');
+  const [occupancyLocationFilter, setOccupancyLocationFilter] = useState<number | 'all'>('all');
+  const [occupancyFieldFilter, setOccupancyFieldFilter] = useState<number | 'all'>('all');
+  const [onlyOccupiedBeds, setOnlyOccupiedBeds] = useState(true);
+  const occupancyTreeStorageKey = activeProjectId
+    ? `occupancyTree.${activeProjectId}`
+    : 'occupancyTree';
+  const {
+    expandedRows: expandedHierarchyIds,
+    hasPersistedState: hasPersistedHierarchyExpansion,
+    toggleExpand: toggleHierarchyExpand,
+    expandAll: expandAllHierarchy,
+  } = useExpandedState(occupancyTreeStorageKey);
+  const hasInitiallyExpandedHierarchyRef = useRef(false);
+
   const [ganttRenderKey, setGanttRenderKey] = useState(0);
   const [ganttScrollTop, setGanttScrollTop] = useState(0);
   const [ganttViewportHeight, setGanttViewportHeight] = useState(640);
@@ -738,7 +766,7 @@ function GanttChartPage() {
     }
   };
 
-  const occupancyTaskGroups = useMemo<GanttTaskGroup[]>(() => buildFieldOccupancyTaskGroups({
+  const occupancyHierarchyNodes = useMemo<OccupancyHierarchyNode[]>(() => buildFieldOccupancyHierarchy({
     locations,
     fields,
     beds,
@@ -746,6 +774,149 @@ function GanttChartPage() {
     cultures,
     displayYear,
   }), [beds, cultures, displayYear, fields, locations, plantingPlans]);
+
+  // Default expansion — once per project, until the user manually
+  // expands/collapses something (which then persists via useExpandedState's
+  // sessionStorage backing). For small farms (few locations/fields/beds
+  // combined), fully expanding is more useful than hiding everything behind
+  // a chevron. Once the tree grows past a size where that would get
+  // unwieldy, fall back to locations-open/fields-collapsed so the view
+  // stays scannable.
+  useEffect(() => {
+    if (
+      !hasPersistedHierarchyExpansion
+      && !hasInitiallyExpandedHierarchyRef.current
+      && occupancyHierarchyNodes.length > 0
+    ) {
+      const canFullyExpand = occupancyHierarchyNodes.length <= OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD;
+      const idsToExpand = occupancyHierarchyNodes
+        .filter((node) => node.type === 'location' || (canFullyExpand && node.type === 'field'))
+        .map((node) => node.id);
+      expandAllHierarchy(idsToExpand);
+      hasInitiallyExpandedHierarchyRef.current = true;
+    }
+  }, [expandAllHierarchy, hasPersistedHierarchyExpansion, occupancyHierarchyNodes]);
+
+  const occupancyFieldOptions = useMemo(
+    () => (occupancyLocationFilter === 'all'
+      ? []
+      : occupancyHierarchyNodes.filter(
+        (node) => node.type === 'field' && node.locationId === occupancyLocationFilter,
+      )),
+    [occupancyHierarchyNodes, occupancyLocationFilter],
+  );
+
+  const occupancyTaskGroups = useMemo<GanttTaskGroup[]>(() => {
+    // Structural filter: "only occupied beds" removes empty beds (and any
+    // now-childless field/location ancestors) from the tree entirely,
+    // independent of expand/collapse state.
+    const structurallyVisibleIds = onlyOccupiedBeds
+      ? collectVisibleIdsWithAncestors(
+        occupancyHierarchyNodes,
+        new Set(
+          occupancyHierarchyNodes
+            .filter((node) => node.type === 'bed' && node.occupiedBedCount > 0)
+            .map((node) => node.id),
+        ),
+      )
+      : null;
+    const prunedNodes = structurallyVisibleIds
+      ? occupancyHierarchyNodes.filter((node) => structurallyVisibleIds.has(node.id))
+      : occupancyHierarchyNodes;
+
+    const fieldNameById = new Map<number, string>(
+      prunedNodes
+        .filter((node): node is OccupancyHierarchyNode & { fieldId: number } => node.type === 'field' && node.fieldId !== undefined)
+        .map((node) => [node.fieldId, node.name]),
+    );
+    const locationNameById = new Map<number, string>(
+      prunedNodes.filter((node) => node.type === 'location').map((node) => [node.locationId, node.name]),
+    );
+
+    const normalizedSearch = occupancySearchText.trim().toLowerCase();
+    const isActivelyFiltering = Boolean(normalizedSearch)
+      || occupancyLocationFilter !== 'all'
+      || occupancyFieldFilter !== 'all';
+
+    let visibleIds: Set<string | number> | null = null;
+    if (isActivelyFiltering) {
+      const matchedBedIds = new Set(
+        prunedNodes
+          .filter((node) => {
+            if (node.type !== 'bed') {
+              return false;
+            }
+            if (occupancyLocationFilter !== 'all' && node.locationId !== occupancyLocationFilter) {
+              return false;
+            }
+            if (occupancyFieldFilter !== 'all' && node.fieldId !== occupancyFieldFilter) {
+              return false;
+            }
+            if (!normalizedSearch) {
+              return true;
+            }
+            const haystack = [
+              node.name,
+              node.fieldId !== undefined ? fieldNameById.get(node.fieldId) : undefined,
+              locationNameById.get(node.locationId),
+              ...node.tasks.map((task) => task.cultureName),
+            ]
+              .filter(Boolean)
+              .join(' ')
+              .toLowerCase();
+            return haystack.includes(normalizedSearch);
+          })
+          .map((node) => node.id),
+      );
+      visibleIds = collectVisibleIdsWithAncestors(prunedNodes, matchedBedIds);
+    }
+
+    const flatRows = flattenTreeRows(prunedNodes, {
+      expandedIds: expandedHierarchyIds,
+      visibleIds,
+    });
+
+    return flatRows.map(({ node, depth, hasChildren }) => {
+      const isExpandable = node.type !== 'bed' && hasChildren;
+      const isExpanded = expandedHierarchyIds.has(node.id);
+
+      let emptyRowLabel: string | undefined;
+      if (node.type === 'field') {
+        emptyRowLabel = `${node.bedCount} Beet${node.bedCount === 1 ? '' : 'e'} · ${node.occupiedBedCount} belegt`;
+      } else if (node.type === 'location') {
+        const fieldCount = prunedNodes.filter(
+          (candidate) => candidate.type === 'field' && candidate.parentId === node.id,
+        ).length;
+        emptyRowLabel = `${fieldCount} Parzelle${fieldCount === 1 ? '' : 'n'} · ${node.bedCount} Beet${node.bedCount === 1 ? '' : 'e'} · ${node.occupiedBedCount} belegt`;
+      }
+
+      const group: GanttTaskGroup = {
+        id: node.id,
+        name: node.name,
+        tasks: node.tasks,
+        depth,
+        isExpandable,
+        isExpanded,
+        emptyRowLabel,
+        locationId: node.locationId,
+        fieldId: node.fieldId,
+        bedId: node.bedId,
+        area: node.area,
+      };
+      return group;
+    });
+  }, [
+    expandedHierarchyIds,
+    occupancyFieldFilter,
+    occupancyHierarchyNodes,
+    occupancyLocationFilter,
+    occupancySearchText,
+    onlyOccupiedBeds,
+  ]);
+
+  const handleToggleGroupExpand = useCallback((groupId: string) => {
+    toggleHierarchyExpand(groupId);
+  }, [toggleHierarchyExpand]);
 
   const seedlingTaskGroups = useMemo<GanttTaskGroup[]>(() => buildSeedlingTaskGroups({
     locations: [],
@@ -942,8 +1113,13 @@ function GanttChartPage() {
   );
   const renderedTaskGroups = renderWindow.groups;
   const totalTimelineItems = useMemo(
-    () => activeTaskGroups.reduce((total, group) => total + group.tasks.length, 0),
-    [activeTaskGroups],
+    // For occupancy mode, count tasks across the full tree (every bed),
+    // not just the currently visible/expanded rows — collapsing a field
+    // shouldn't make the dataset look smaller than it is.
+    () => (calendarMode === 'occupancy'
+      ? occupancyHierarchyNodes.reduce((total, node) => total + node.tasks.length, 0)
+      : activeTaskGroups.reduce((total, group) => total + group.tasks.length, 0)),
+    [activeTaskGroups, calendarMode, occupancyHierarchyNodes],
   );
   const renderedTimelineItems = useMemo(
     () => renderedTaskGroups.reduce((total, group) => total + group.tasks.length, 0),
@@ -1504,6 +1680,75 @@ function GanttChartPage() {
           </PageSurface>
         ) : (
           <PageSurface variant="fullWorkspace" sx={{ mt: 0.5 }}>
+          {calendarMode === 'occupancy' && (
+            <Box
+              data-testid="occupancy-tree-filters"
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 1.5,
+                alignItems: 'center',
+                mb: 1.5,
+              }}
+            >
+              <TextField
+                size="small"
+                placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
+                value={occupancySearchText}
+                onChange={(event) => setOccupancySearchText(event.target.value)}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={{ minWidth: 240, flex: '1 1 240px' }}
+              />
+              <Select
+                size="small"
+                value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
+                onChange={(event) => {
+                  const { value } = event.target;
+                  setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
+                  setOccupancyFieldFilter('all');
+                }}
+                sx={{ minWidth: 160 }}
+              >
+                <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
+                {locations.filter((location) => location.id).map((location) => (
+                  <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
+                ))}
+              </Select>
+              <Select
+                size="small"
+                value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
+                onChange={(event) => {
+                  const { value } = event.target;
+                  setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
+                }}
+                disabled={occupancyLocationFilter === 'all'}
+                sx={{ minWidth: 160 }}
+              >
+                <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
+                {occupancyFieldOptions.map((field) => (
+                  <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
+                ))}
+              </Select>
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    size="small"
+                    checked={onlyOccupiedBeds}
+                    onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
+                  />
+                )}
+                label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
+              />
+            </Box>
+          )}
           <Box
             className={`gantt-container-wrapper gantt-container-wrapper--${calendarMode}`}
             sx={{
@@ -1559,6 +1804,7 @@ function GanttChartPage() {
                       showProgress={false}
                       darkMode={false}
                       onTaskUpdate={calendarMode === 'occupancy' && editMode ? handleTaskUpdate : undefined}
+                      onToggleGroupExpand={calendarMode === 'occupancy' ? handleToggleGroupExpand : undefined}
                       renderHeader={renderGanttHeader}
                       renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
                         ? renderSeedlingTooltip({ task })

--- a/frontend/src/pages/ganttChartUtils.ts
+++ b/frontend/src/pages/ganttChartUtils.ts
@@ -41,6 +41,11 @@ export interface GanttTaskGroup {
   area?: number;
   isGroup?: boolean;
   level?: number;
+  /** Tree-row rendering hints, forwarded as-is to the Gantt library. */
+  depth?: number;
+  isExpandable?: boolean;
+  isExpanded?: boolean;
+  emptyRowLabel?: string;
 }
 
 interface BuildTaskGroupsArgs {
@@ -377,6 +382,217 @@ export function buildFieldOccupancyTaskGroups({
       area: candidate.area,
     };
   });
+}
+
+export type OccupancyHierarchyNodeType = 'location' | 'field' | 'bed';
+
+/**
+ * A single row of the Standort -> Parzelle -> Beet tree, built as a flat
+ * list with parent references (see frontend/src/components/hierarchy/utils/treeRows.ts
+ * for the generic flatten/expand logic this feeds into) rather than the
+ * older hierarchyPath breadcrumb-per-leaf convention.
+ */
+export interface OccupancyHierarchyNode {
+  id: string;
+  parentId: string | null;
+  type: OccupancyHierarchyNodeType;
+  name: string;
+  locationId: number;
+  fieldId?: number;
+  bedId?: number;
+  tasks: GanttTask[];
+  area?: number;
+  /** Total descendant bed count (1 for bed nodes themselves). */
+  bedCount: number;
+  /** Descendant beds that have at least one planting plan. */
+  occupiedBedCount: number;
+  /** Descendant planting plan count (growth tasks only, harvest duplicates excluded). */
+  planCount: number;
+}
+
+/**
+ * Builds the full Standort -> Parzelle -> Beet tree for the occupancy
+ * calendar, including beds without any planting plan (unlike
+ * buildFieldOccupancyTaskGroups, which only emits occupied beds as flat
+ * rows). Location and Field are always their own nodes, regardless of
+ * count, so the tree structure is consistent rather than collapsing a
+ * single location the way the old hierarchyPath label did.
+ */
+export function buildFieldOccupancyHierarchy({
+  locations,
+  fields,
+  beds,
+  plantingPlans,
+  cultures,
+  displayYear,
+}: BuildTaskGroupsArgs): OccupancyHierarchyNode[] {
+  if (!locations.length) {
+    return [];
+  }
+
+  const { start: visStart, end: visEnd } = getVisibleYearInterval(displayYear);
+  const plansByBed = new Map<number, PlantingPlan[]>();
+
+  plantingPlans.forEach((plan) => {
+    if (!plan.bed || !plan.planting_date || !plan.harvest_date) {
+      return;
+    }
+    const plantingDate = parseDateString(plan.planting_date);
+    const harvestDate = parseDateString(plan.harvest_date);
+    if (harvestDate < visStart || plantingDate > visEnd) {
+      return;
+    }
+    const bedPlans = plansByBed.get(plan.bed) ?? [];
+    bedPlans.push(plan);
+    plansByBed.set(plan.bed, bedPlans);
+  });
+
+  const bedsByField = beds.reduce<Record<number, Bed[]>>((accumulator, bed) => {
+    const fieldId = bed.field;
+    accumulator[fieldId] = accumulator[fieldId] ?? [];
+    accumulator[fieldId].push(bed);
+    return accumulator;
+  }, {});
+
+  const fieldsByLocation = fields.reduce<Record<number, Field[]>>((accumulator, field) => {
+    const locationId = field.location;
+    accumulator[locationId] = accumulator[locationId] ?? [];
+    accumulator[locationId].push(field);
+    return accumulator;
+  }, {});
+
+  const buildBedTasks = (bedPlans: PlantingPlan[]): GanttTask[] => {
+    const tasks: GanttTask[] = [];
+    bedPlans.forEach((plan) => {
+      const plantingDate = parseDateString(plan.planting_date);
+      const harvestStartDate = parseDateString(plan.harvest_date!);
+      const baseColor = getCultureColor(cultures, plan.culture, plan.culture_name || '', plan.culture_display_color);
+      const cultureLabel = formatCultureDisplayLabel(
+        plan.culture_name || `Culture ${plan.culture}`,
+        plan.culture_variety,
+      );
+      const harvestEndDate = plan.harvest_end_date
+        ? parseDateString(plan.harvest_end_date)
+        : harvestStartDate;
+
+      tasks.push({
+        id: `plan-${plan.id}-growth`,
+        name: cultureLabel,
+        startDate: plantingDate,
+        endDate: harvestStartDate,
+        color: baseColor,
+        percent: 100,
+        plantingPlanId: plan.id,
+        cultureName: plan.culture_name,
+        cultureVariety: plan.culture_variety,
+        areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
+        notes: plan.notes,
+        harvestStartDate,
+        harvestEndDate,
+      });
+
+      if (harvestEndDate > harvestStartDate) {
+        tasks.push({
+          id: `plan-${plan.id}-harvest`,
+          name: `${cultureLabel} (Ernte)`,
+          startDate: harvestStartDate,
+          endDate: harvestEndDate,
+          color: baseColor.startsWith('#') ? `${baseColor}CC` : baseColor,
+          percent: 100,
+          plantingPlanId: plan.id,
+          cultureName: plan.culture_name,
+          cultureVariety: plan.culture_variety,
+          areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
+          notes: `Erntezeitraum: ${plan.notes || ''}`.trim(),
+          harvestStartDate,
+          harvestEndDate,
+        });
+      }
+    });
+    return tasks;
+  };
+
+  const nodes: OccupancyHierarchyNode[] = [];
+
+  locations.forEach((location) => {
+    const locationId = location.id;
+    if (!locationId) {
+      return;
+    }
+
+    const locationNodeId = `location-${locationId}`;
+    const locationNode: OccupancyHierarchyNode = {
+      id: locationNodeId,
+      parentId: null,
+      type: 'location',
+      name: location.name,
+      locationId,
+      tasks: [],
+      bedCount: 0,
+      occupiedBedCount: 0,
+      planCount: 0,
+    };
+    nodes.push(locationNode);
+
+    const locationFields = fieldsByLocation[locationId] ?? [];
+    locationFields.forEach((field) => {
+      const fieldId = field.id;
+      if (!fieldId) {
+        return;
+      }
+
+      const fieldNodeId = `field-${fieldId}`;
+      const fieldNode: OccupancyHierarchyNode = {
+        id: fieldNodeId,
+        parentId: locationNodeId,
+        type: 'field',
+        name: field.name,
+        locationId,
+        fieldId,
+        tasks: [],
+        bedCount: 0,
+        occupiedBedCount: 0,
+        planCount: 0,
+      };
+      nodes.push(fieldNode);
+
+      const fieldBeds = bedsByField[fieldId] ?? [];
+      fieldBeds.forEach((bed) => {
+        const bedId = bed.id;
+        if (!bedId) {
+          return;
+        }
+
+        const bedPlans = plansByBed.get(bedId) ?? [];
+        const tasks = buildBedTasks(bedPlans);
+        const isOccupied = bedPlans.length > 0;
+
+        nodes.push({
+          id: `bed-${bedId}`,
+          parentId: fieldNodeId,
+          type: 'bed',
+          name: bed.name,
+          locationId,
+          fieldId,
+          bedId,
+          tasks,
+          area: bed.area_sqm ? Number(bed.area_sqm) : undefined,
+          bedCount: 1,
+          occupiedBedCount: isOccupied ? 1 : 0,
+          planCount: bedPlans.length,
+        });
+
+        fieldNode.bedCount += 1;
+        fieldNode.occupiedBedCount += isOccupied ? 1 : 0;
+        fieldNode.planCount += bedPlans.length;
+        locationNode.bedCount += 1;
+        locationNode.occupiedBedCount += isOccupied ? 1 : 0;
+        locationNode.planCount += bedPlans.length;
+      });
+    });
+  });
+
+  return nodes;
 }
 
 export function buildSeedlingTaskGroups({


### PR DESCRIPTION
## Summary
- **Targets `chore/inline-gantt-chart` (#242), not `main`** — this builds on the vendored gantt-chart module from that PR.
- Replaces the flat `hierarchyPath` breadcrumb (every bed row carrying its own joined "Standort / Parzelle / Beet" text) with a real parent-child tree: Standort and Parzelle are now their own expandable/collapsible rows.
- New generic building block: `frontend/src/components/hierarchy/utils/treeRows.ts` (flattens a `{id, parentId}` list into visible, depth-annotated rows, respecting expand/collapse and an optional search-filter that keeps matched ancestors visible). No farm-domain knowledge.
- `gantt-chart/src` gained optional tree-rendering hints on `TaskGroup` (`depth`, `isExpandable`, `isExpanded`, `emptyRowLabel`) and `onToggleGroupExpand` — purely presentational, the library still has zero domain knowledge and existing flat usage is untouched (`hierarchyPath` / `buildFieldOccupancyTaskGroups` remain supported).
- `useExpandedState` (already generic) is now shared a third time, alongside `FieldsBedsHierarchy.tsx` and `GraphicalFields.tsx`.
- New filter bar above the occupancy calendar: search (culture/bed/field/location name), Standort filter, Parzelle filter, "Nur belegte Beete" toggle.
- Adaptive default expansion: fully expanded for small farms, locations-open/fields-collapsed above a 30-node threshold.
- Standort/Parzelle rows show a meta-text summary (bed/occupied/field counts) instead of bars for now — see `docs/occupancy-tree-hierarchy.md` for the documented next step (aggregate bars).
- Compatible with the existing `getGanttRenderWindow` scroll-virtualization — the tree flattens into a flat row array before windowing runs, windowing itself is unchanged.

## Test plan
- [x] `tsc -b` clean
- [x] `npm run lint` — 0 new errors
- [x] Full `vitest run` — 941/941 passing
- [x] `npm run build` — succeeds
- [x] New tests: `treeRows.test.ts` (generic mechanics), `ganttChartUtils.test.ts` (`buildFieldOccupancyHierarchy` node construction), `GanttChart.test.tsx` `occupancy tree filters and search` suite (search+parent-context, Standort filter, occupied-only toggle)
- [x] Updated the existing large-dataset windowing test to expand a field first, since large trees now start collapsed by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)