### PR TITLE
Unify the "context menu available here" indicator across the app

### DIFF
--- a/frontend/e2e/gantt-context-menu-smoke.spec.ts
+++ b/frontend/e2e/gantt-context-menu-smoke.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/test';
 
-const backendPort = process.env.BACKEND_PORT ?? '8099';
+// Must match playwright.config.ts's webServer default, or this hits whatever
+// else happens to be running on port 8000 (e.g. a developer's own dev backend)
+// instead of the backend actually under test.
+const backendPort = process.env.BACKEND_PORT ?? '8000';
 const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
 const apiBase = `http://127.0.0.1:${backendPort}/api`;
 

--- a/frontend/src/components/contextMenu/ContextMenuIndicator.tsx
+++ b/frontend/src/components/contextMenu/ContextMenuIndicator.tsx
@@ -1,0 +1,75 @@
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { MouseEvent } from 'react';
+import { CONTEXT_MENU_INDICATOR_CLASS } from './contextMenuIndicatorStyles';
+
+interface ContextMenuIndicatorProps {
+  /** Tooltip text and aria-label. */
+  label: string;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  tabIndex?: number;
+  sx?: SxProps<Theme>;
+  /**
+   * Adds a small translucent backdrop behind the icon, for hosts with
+   * unpredictable content/color directly behind the indicator (a Gantt bar,
+   * a chart segment) where plain `color: inherit` can leave it hard to spot
+   * against similarly-colored or overlapping text. Not needed for the
+   * data-grid-row case, which already sits on its own opaque overlay panel.
+   */
+  withBackdrop?: boolean;
+}
+
+/**
+ * One shared "more actions / context menu available here" affordance, used
+ * everywhere a row/bar/segment supports right-click (desktop) or long-press
+ * (touch) for a context menu. Renders the standard Material Design MoreVert
+ * (⋮) icon — same icon, size, and hover animation everywhere — rather than
+ * a bespoke cursor or icon, so the same visual language appears across
+ * data-grid rows, hierarchy rows, supplier/seed-demand tables, Gantt
+ * bars/rows, and chart segments.
+ *
+ * Not visible on its own: render it inside a host styled with
+ * `contextMenuIndicatorHostSx` (simple case) or inside a
+ * `contextMenuActionsOverlaySx` panel (data-grid-style row case) — both in
+ * `./contextMenuIndicatorStyles`. Those reveal it on hover/focus-within, and
+ * keep it visible on coarse-pointer (touch) devices, where hover doesn't
+ * apply.
+ */
+export function ContextMenuIndicator({ label, onClick, tabIndex, sx, withBackdrop }: ContextMenuIndicatorProps) {
+  return (
+    <Tooltip
+      title={label}
+      disableInteractive
+      slotProps={{ popper: { style: { pointerEvents: 'none' } } }}
+    >
+      <IconButton
+        className={CONTEXT_MENU_INDICATOR_CLASS}
+        size="small"
+        aria-label={label}
+        tabIndex={tabIndex}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onClick(event);
+        }}
+        sx={{
+          opacity: 0,
+          pointerEvents: 'none',
+          transition: 'opacity 120ms ease-in-out, background-color 120ms ease-in-out',
+          ...(withBackdrop
+            ? {
+                color: '#fff',
+                bgcolor: 'rgba(0, 0, 0, 0.32)',
+                '&:hover': { bgcolor: 'rgba(0, 0, 0, 0.48)' },
+              }
+            : undefined),
+          ...sx,
+        }}
+      >
+        <MoreVertIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/contextMenu/contextMenuIndicatorStyles.ts
+++ b/frontend/src/components/contextMenu/contextMenuIndicatorStyles.ts
@@ -1,0 +1,101 @@
+import { alpha } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import type { SystemStyleObject } from '@mui/system';
+
+/** Applied to the `ContextMenuIndicator` button itself, to reveal it. */
+export const CONTEXT_MENU_INDICATOR_CLASS = 'ofp-context-menu-indicator';
+
+/** The class every "actions overlay" host targets to reveal its indicator(s). */
+export const CONTEXT_MENU_ACTIONS_OVERLAY_CLASS = 'ofp-context-menu-actions-overlay';
+
+const revealOnHoverOrFocus = {
+  opacity: 1,
+  pointerEvents: 'auto' as const,
+};
+
+/**
+ * Spread into a hoverable/focusable ancestor's `sx` (e.g. a Gantt bar, a
+ * chart segment, a sidebar tree row) so any `ContextMenuIndicator` rendered
+ * inside it fades in on hover/focus-within, and stays visible on touch.
+ * Use this for simple cases with no adjacent truncated text to mask — for
+ * data-grid-style rows, use `contextMenuActionsOverlaySx` instead.
+ */
+export const contextMenuIndicatorHostSx: SystemStyleObject<Theme> = {
+  [`&:hover .${CONTEXT_MENU_INDICATOR_CLASS}, &:focus-within .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
+  '@media (pointer: coarse)': {
+    [`& .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
+  },
+};
+
+/**
+ * The positioned, gradient-masked overlay panel used by table-style rows
+ * (DataGrid, hierarchy tree, Suppliers, SeedDemand) to host one or more
+ * inline action buttons (including a `ContextMenuIndicator`) at the right
+ * edge of a cell whose text would otherwise be truncated underneath it.
+ * `hoverSelector` is the CSS selector (relative to the row) that reveals
+ * the overlay — e.g. `.MuiDataGrid-row:hover &` for DataGrid-based rows, or
+ * `tr:hover &` for a plain MUI `<TableRow>`. `focusWithinSelector` is an
+ * optional extra reveal condition (e.g. `tr:focus-within &`) for keyboard
+ * users on plain tables that don't already have DataGrid's own cell-focus
+ * handling — it only toggles opacity/pointer-events, skipping the
+ * background/gradient touch-up `hoverSelector` gets.
+ */
+export function contextMenuActionsOverlaySx(
+  hoverSelector: string,
+  focusWithinSelector?: string,
+): SystemStyleObject<Theme> {
+  return {
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 0.5,
+    py: 0.25,
+    pl: 0.25,
+    pr: 0.25,
+    borderRadius: 1,
+    bgcolor: 'background.paper',
+    opacity: 0,
+    pointerEvents: 'none',
+    transition: 'background-color 120ms ease-in-out, opacity 120ms ease-in-out',
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      right: '100%',
+      width: 16,
+      pointerEvents: 'none',
+      background: (theme: Theme) =>
+        `linear-gradient(90deg, ${alpha(theme.palette.background.paper, 0)} 0%, ${theme.palette.background.paper} 100%)`,
+    },
+    [hoverSelector]: {
+      bgcolor: 'surface.surfaceHoverBackground',
+      ...revealOnHoverOrFocus,
+    },
+    [`${hoverSelector}::before`]: {
+      background: (theme: Theme) => {
+        const hoverBackground = theme.palette.surface?.surfaceHoverBackground ?? theme.palette.action.hover;
+        return `linear-gradient(90deg, ${alpha(hoverBackground, 0)} 0%, ${hoverBackground} 100%)`;
+      },
+    },
+    // A nested ContextMenuIndicator hides itself by default (for the
+    // simple-host case elsewhere), so it needs its own reveal rule here too
+    // — the panel's own opacity/pointer-events above don't override a
+    // child's explicitly-set opacity:0/pointer-events:none.
+    [`${hoverSelector} .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
+    ...(focusWithinSelector
+      ? {
+          [focusWithinSelector]: revealOnHoverOrFocus,
+          [`${focusWithinSelector} .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
+        }
+      : {}),
+    '@media (pointer: coarse)': {
+      opacity: 1,
+      pointerEvents: 'auto',
+      [`& .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
+    },
+  };
+}

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -26,13 +26,13 @@ import { dataGridSx, dataGridFooterSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
 import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRenderCellParams, GridRowParams, GridPaginationModel } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import CheckIcon from '@mui/icons-material/Check';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { ContextMenuIndicator } from '../contextMenu/ContextMenuIndicator';
+import { contextMenuActionsOverlaySx } from '../contextMenu/contextMenuIndicatorStyles';
 import { useNavigationBlocker } from '../../hooks/autosave';
 import { usePersistentSortModel } from '../../hooks/usePersistentSortModel';
 import { useTranslation } from '../../i18n';
@@ -1424,43 +1424,7 @@ export function EditableDataGrid<T extends EditableRow>({
         <Box
           className="ofp-inline-row-actions"
           sx={{
-            position: 'absolute',
-            right: 0,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.5,
-            py: 0.25,
-            pl: 0.25,
-            pr: 0.25,
-            borderRadius: 1,
-            bgcolor: 'background.paper',
-            opacity: 0,
-            pointerEvents: 'none',
-            transition: 'background-color 120ms ease-in-out, opacity 120ms ease-in-out',
-            '&::before': {
-              content: '""',
-              position: 'absolute',
-              top: 0,
-              bottom: 0,
-              right: '100%',
-              width: 16,
-              pointerEvents: 'none',
-              background: (theme) =>
-                `linear-gradient(90deg, ${alpha(theme.palette.background.paper, 0)} 0%, ${theme.palette.background.paper} 100%)`,
-            },
-            '.MuiDataGrid-row:hover &': {
-              bgcolor: 'surface.surfaceHoverBackground',
-              opacity: 1,
-              pointerEvents: 'auto',
-            },
-            '.MuiDataGrid-row:hover &::before': {
-              background: (theme) => {
-                const hoverBackground = theme.palette.surface?.surfaceHoverBackground ?? theme.palette.action.hover;
-                return `linear-gradient(90deg, ${alpha(hoverBackground, 0)} 0%, ${hoverBackground} 100%)`;
-              },
-            },
+            ...contextMenuActionsOverlaySx('.MuiDataGrid-row:hover &'),
             '.MuiDataGrid-row--editing:hover &, .ofp-row-editing:hover &': {
               opacity: 0,
               pointerEvents: 'none',
@@ -1487,22 +1451,13 @@ export function EditableDataGrid<T extends EditableRow>({
             </Tooltip>
           ))}
           {hasInlineMenuAction ? (
-            <Tooltip title={t('actions.actions')} arrow>
-              <span>
-                <IconButton
-                  size="small"
-                  aria-label={t('actions.actions')}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    openRowActionMenuAt(row.id, event.currentTarget, rect.right - 8, rect.top + 12);
-                  }}
-                >
-                  <MoreVertIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
+            <ContextMenuIndicator
+              label={t('actions.actions')}
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                openRowActionMenuAt(row.id, event.currentTarget, rect.right - 8, rect.top + 12);
+              }}
+            />
           ) : null}
         </Box>
       </Box>

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -6,12 +6,10 @@ import type { ReactElement, KeyboardEvent, MouseEvent } from 'react';
 import type { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import type { TFunction } from 'i18next';
 import { Box, IconButton, Tooltip } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
 import DeleteIcon from '@mui/icons-material/Delete';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import type { HierarchyRow } from './utils/types';
@@ -19,6 +17,8 @@ import { NotesCell } from '../data-grid/NotesCell';
 import { HierarchyAddIcon } from './HierarchyAddIcon';
 import { getPlainExcerpt } from '../data-grid/markdown';
 import { CALCULATED_COLUMN_CELL_CLASS, getCalculatedColumnProps } from '../data-grid/calculatedColumns';
+import { ContextMenuIndicator } from '../contextMenu/ContextMenuIndicator';
+import { contextMenuActionsOverlaySx } from '../contextMenu/contextMenuIndicatorStyles';
 
 export interface HierarchyColumnWidths {
   name: number;
@@ -197,24 +197,15 @@ function renderMoreActionsButton(
   row: HierarchyRow,
   callbacks: NameCellCallbacks,
   t: TFunction,
+  isStandaloneRender: boolean,
 ): ReactElement {
-  const label = t('common:actions.actions');
-
   return (
-    <Tooltip title={label} {...NON_BLOCKING_TOOLTIP_PROPS}>
-      <IconButton
-        size="small"
-        aria-label={label}
-        tabIndex={-1}
-        onClick={(event) => {
-          event.stopPropagation();
-          callbacks.onOpenContextMenu(event, row);
-        }}
-        sx={{ p: 0.5, '& .MuiSvgIcon-root': { fontSize: 18 } }}
-      >
-        <MoreVertIcon />
-      </IconButton>
-    </Tooltip>
+    <ContextMenuIndicator
+      label={t('common:actions.actions')}
+      tabIndex={-1}
+      onClick={(event) => callbacks.onOpenContextMenu(event, row)}
+      sx={isStandaloneRender ? { opacity: 1, pointerEvents: 'auto' } : undefined}
+    />
   );
 }
 
@@ -223,6 +214,7 @@ function renderInlineActions(
   callbacks: NameCellCallbacks,
   t: TFunction,
   options: HierarchyColumnOptions,
+  isStandaloneRender: boolean,
 ): ReactElement | null {
   if (options.disableInlineHoverActions) {
     return null;
@@ -236,7 +228,7 @@ function renderInlineActions(
           onClick: () => callbacks.onAddField(row.locationId),
         })}
         {renderDeleteActionButton(row, callbacks, t)}
-        {renderMoreActionsButton(row, callbacks, t)}
+        {renderMoreActionsButton(row, callbacks, t, isStandaloneRender)}
       </Box>
     );
   }
@@ -249,7 +241,7 @@ function renderInlineActions(
           onClick: () => callbacks.onAddBed(row.fieldId!),
         })}
         {renderDeleteActionButton(row, callbacks, t)}
-        {renderMoreActionsButton(row, callbacks, t)}
+        {renderMoreActionsButton(row, callbacks, t, isStandaloneRender)}
       </Box>
     );
   }
@@ -259,7 +251,7 @@ function renderInlineActions(
       <Box className="action-icons" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
         {renderPlantingPlanActionButton(row, callbacks, t)}
         {renderDeleteActionButton(row, callbacks, t)}
-        {renderMoreActionsButton(row, callbacks, t)}
+        {renderMoreActionsButton(row, callbacks, t, isStandaloneRender)}
       </Box>
     );
   }
@@ -278,7 +270,7 @@ function renderNameCell(
   const hasChildren = row.hasChildren === true;
   const hasExpandToggle = (row.type === 'location' || row.type === 'field') && hasChildren;
   const isStandaloneRender = params.api === undefined;
-  const inlineActions = renderInlineActions(row, callbacks, t, options);
+  const inlineActions = renderInlineActions(row, callbacks, t, options, isStandaloneRender);
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', pl: `${baseIndent}px`, width: '100%', gap: 0.5 }}>
@@ -360,46 +352,9 @@ function renderNameCell(
           <Box
             data-testid="hierarchy-name-actions-overlay"
             sx={{
-              position: 'absolute',
-              right: 0,
-              top: '50%',
-              transform: 'translateY(-50%)',
-              display: 'inline-flex',
-              alignItems: 'center',
-              py: 0.25,
-              pl: 0.25,
-              pr: 0.25,
-              borderRadius: 1,
-              bgcolor: 'background.paper',
-              opacity: isStandaloneRender ? 1 : 0,
-              pointerEvents: isStandaloneRender ? 'auto' : 'none',
-              transition: 'background-color 120ms ease-in-out, opacity 120ms ease-in-out',
-              '&::before': {
-                content: '""',
-                position: 'absolute',
-                top: 0,
-                bottom: 0,
-                right: '100%',
-                width: 16,
-                pointerEvents: 'none',
-                background: (theme) =>
-                  `linear-gradient(90deg, ${alpha(theme.palette.background.paper, 0)} 0%, ${theme.palette.background.paper} 100%)`,
-              },
-              '.MuiDataGrid-row:hover &': {
-                bgcolor: 'surface.surfaceHoverBackground',
-                opacity: 1,
-                pointerEvents: 'auto',
-              },
-              '.MuiDataGrid-row:hover &::before': {
-                background: (theme) => {
-                  const hoverBackground = theme.palette.surface?.surfaceHoverBackground ?? theme.palette.action.hover;
-                  return `linear-gradient(90deg, ${alpha(hoverBackground, 0)} 0%, ${hoverBackground} 100%)`;
-                },
-              },
-              '.MuiDataGrid-row--editing:hover &': {
-                opacity: 0,
-                pointerEvents: 'none',
-              },
+              ...contextMenuActionsOverlaySx('.MuiDataGrid-row:hover &'),
+              ...(isStandaloneRender ? { opacity: 1, pointerEvents: 'auto' } : {}),
+              '.MuiDataGrid-row--editing:hover &': { opacity: 0, pointerEvents: 'none' },
             }}
           >
             {inlineActions}

--- a/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from "react";
 import type { TaskItemProps } from "../../types";
+import { ContextMenuIndicator } from "../../../../components/contextMenu/ContextMenuIndicator";
 
 /**
  * TaskItem Component - Renders an individual task bar in the Gantt chart
@@ -271,6 +272,16 @@ const TaskItem: React.FC<TaskItemProps> = ({
 
       {/* Task name */}
       <div className="rmg-task-item-name">{task.name || "Unnamed Task"}</div>
+
+      {onContextMenu && (
+        <ContextMenuIndicator
+          label="Aktionen"
+          tabIndex={-1}
+          onClick={(e) => onContextMenu(e, task)}
+          withBackdrop
+          sx={{ position: "absolute", top: 2, right: 2 }}
+        />
+      )}
 
       {/* Progress bar with interactive bubble */}
       {showProgress && typeof progressPercent === "number" && (

--- a/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
@@ -217,6 +217,15 @@ const TaskItem: React.FC<TaskItemProps> = ({
         data-rmg-component="task"
       >
         {customTaskContent}
+        {onContextMenu && (
+          <ContextMenuIndicator
+            label="Aktionen"
+            tabIndex={-1}
+            onClick={(e) => onContextMenu(e, task)}
+            withBackdrop
+            sx={{ position: "absolute", top: 2, right: 2 }}
+          />
+        )}
       </div>
     );
   }
@@ -271,7 +280,9 @@ const TaskItem: React.FC<TaskItemProps> = ({
       )}
 
       {/* Task name */}
-      <div className="rmg-task-item-name">{task.name || "Unnamed Task"}</div>
+      <div className={`rmg-task-item-name${onContextMenu ? " rmg-task-item-name-maskable" : ""}`}>
+        {task.name || "Unnamed Task"}
+      </div>
 
       {onContextMenu && (
         <ContextMenuIndicator

--- a/frontend/src/gantt-chart/src/components/task/TaskList.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskList.tsx
@@ -7,6 +7,7 @@ import {
   normalizeLeftColumnWidth,
   TREE_INDENT_PX,
 } from "../../utils";
+import { ContextMenuIndicator } from "../../../../components/contextMenu/ContextMenuIndicator";
 
 /**
  * TaskList Component - Displays the list of task groups on the left side of the Gantt chart
@@ -187,6 +188,15 @@ const TaskList: React.FC<TaskListProps> = ({
                   {taskGroup.tasks.length}{" "}
                   {taskGroup.tasks.length === 1 ? "task" : "tasks"}
                 </div>
+              )}
+
+              {onGroupContextMenu && (
+                <ContextMenuIndicator
+                  label="Aktionen"
+                  tabIndex={-1}
+                  onClick={(event) => onGroupContextMenu(event, taskGroup)}
+                  sx={{ position: "absolute", top: "50%", right: 4, transform: "translateY(-50%)" }}
+                />
               )}
             </div>
           );

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -233,6 +233,21 @@
   background-color: rgba(255, 255, 255, 0.05);
 }
 
+/* "Weitere Aktionen" affordance (shared ContextMenuIndicator component) —
+   invisible until the row is hovered/focused, always visible on touch. */
+.rmg-task-group:hover .ofp-context-menu-indicator,
+.rmg-task-group:focus-within .ofp-context-menu-indicator {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (pointer: coarse) {
+  .rmg-task-group .ofp-context-menu-indicator {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 /* Compact tree rows (e.g. a Gantt row-height override for a parent row
    with no bars of its own) need tighter vertical padding so they don't
    look like they're wasting space next to full-height leaf rows. */
@@ -617,6 +632,21 @@
 
 .rmg-task-item:hover .rmg-resize-handle {
   opacity: 1;
+}
+
+/* "Weitere Aktionen" affordance (shared ContextMenuIndicator component) —
+   invisible until the bar is hovered/focused, always visible on touch. */
+.rmg-task-item:hover .ofp-context-menu-indicator,
+.rmg-task-item:focus-within .ofp-context-menu-indicator {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (pointer: coarse) {
+  .rmg-task-item .ofp-context-menu-indicator {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 /* ======================================================

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -603,6 +603,31 @@
   min-width: 0;
 }
 
+/* When a bar has a context-menu indicator, its text fades out (rather than
+   getting cut off mid-letter) over the last ~30px before the icon, exactly
+   while the icon itself is revealed (hover/focus-within/touch) — same
+   condition, so the bar's static appearance is untouched otherwise. A CSS
+   mask (not a solid-color gradient overlay) reveals whatever the bar's
+   actual background is, so this works for any task color without knowing
+   it, and needs no JS/measurement — pure CSS, GPU-composited, no repaints.
+   Shared by both the default bar (.rmg-task-item) and any custom-rendered
+   one (.rmg-task-item-custom, e.g. the seedling calendar's bars). */
+.rmg-task-item:hover .rmg-task-item-name-maskable,
+.rmg-task-item:focus-within .rmg-task-item-name-maskable,
+.rmg-task-item-custom:hover .rmg-task-item-name-maskable,
+.rmg-task-item-custom:focus-within .rmg-task-item-name-maskable {
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+  mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+}
+
+@media (pointer: coarse) {
+  .rmg-task-item .rmg-task-item-name-maskable,
+  .rmg-task-item-custom .rmg-task-item-name-maskable {
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+    mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
+  }
+}
+
 /* ======================================================
    8. Resize Handles
    ====================================================== */

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -660,15 +660,20 @@
 }
 
 /* "Weitere Aktionen" affordance (shared ContextMenuIndicator component) —
-   invisible until the bar is hovered/focused, always visible on touch. */
+   invisible until the bar is hovered/focused, always visible on touch.
+   Covers both the default bar (.rmg-task-item) and any custom-rendered one
+   (.rmg-task-item-custom, e.g. the seedling calendar's bars). */
 .rmg-task-item:hover .ofp-context-menu-indicator,
-.rmg-task-item:focus-within .ofp-context-menu-indicator {
+.rmg-task-item:focus-within .ofp-context-menu-indicator,
+.rmg-task-item-custom:hover .ofp-context-menu-indicator,
+.rmg-task-item-custom:focus-within .ofp-context-menu-indicator {
   opacity: 1;
   pointer-events: auto;
 }
 
 @media (pointer: coarse) {
-  .rmg-task-item .ofp-context-menu-indicator {
+  .rmg-task-item .ofp-context-menu-indicator,
+  .rmg-task-item-custom .ofp-context-menu-indicator {
     opacity: 1;
     pointer-events: auto;
   }

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -2096,14 +2096,10 @@ function GanttChartPage() {
                         ? renderSeedlingTooltip({ task })
                         : renderOccupancyTooltip({ task }))}
                       renderTask={calendarMode === 'seedlings'
-                        ? ({ task, leftPx, widthPx, topPx }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
+                        ? ({ task }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
                             <Box
                               sx={{
-                                position: 'absolute',
-                                left: `${leftPx}px`,
-                                top: `${topPx}px`,
-                                width: `${widthPx}px`,
-                                minWidth: `${widthPx}px`,
+                                width: '100%',
                                 height: 26,
                                 px: 1,
                                 borderRadius: 1,

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -2118,7 +2118,11 @@ function GanttChartPage() {
                                 cursor: 'default',
                               }}
                             >
-                              <Typography variant="caption" sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                              <Typography
+                                variant="caption"
+                                className="rmg-task-item-name-maskable"
+                                sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}
+                              >
                                 {typeof task.plantsCount === 'number' && task.plantsCount > 0
                                   ? `${task.name} · ${formatPlantCount(task.plantsCount)} ${t('ganttChart:seedlings.plantsUnit')}`
                                   : task.name}

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -6,7 +6,6 @@ import {
   CircularProgress,
   FormControl,
   Link,
-  IconButton,
   ListItemIcon,
   ListItemText,
   Menu,
@@ -20,13 +19,13 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import EditIcon from '@mui/icons-material/Edit';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { bedAPI, cultureAPI, fieldAPI, locationAPI, plantingPlanAPI, seedDemandAPI } from '../api/api';
 import type { SeedDemand } from '../api/types';
 import { useTranslation } from '../i18n';
+import { ContextMenuIndicator } from '../components/contextMenu/ContextMenuIndicator';
+import { contextMenuActionsOverlaySx } from '../components/contextMenu/contextMenuIndicatorStyles';
 import { useCommandContextTag } from '../commands/useCommandContext';
 import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
@@ -425,8 +424,6 @@ export default function SeedDemandPage() {
                     onKeyDown={(event) => openKeyboardContextMenu(event, row)}
                     sx={{
                       WebkitTouchCallout: 'none',
-                      '&:hover .seed-demand-row-actions': { opacity: 1, pointerEvents: 'auto' },
-                      '&:focus-within .seed-demand-row-actions': { opacity: 1, pointerEvents: 'auto' },
                     }}
                   >
                     <TableCell sx={{ maxWidth: { xs: 180, sm: 240 } }}>
@@ -456,50 +453,12 @@ export default function SeedDemandPage() {
                         </Box>
                         <Box
                           className="seed-demand-row-actions"
-                          sx={{
-                            position: 'absolute',
-                            right: 0,
-                            top: '50%',
-                            transform: 'translateY(-50%)',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            py: 0.25,
-                            pl: 0.25,
-                            pr: 0.25,
-                            borderRadius: 1,
-                            bgcolor: 'background.paper',
-                            opacity: 0,
-                            pointerEvents: 'none',
-                            transition: 'background-color 120ms ease-in-out, opacity 120ms ease-in-out',
-                            '&::before': {
-                              content: '""',
-                              position: 'absolute',
-                              top: 0,
-                              bottom: 0,
-                              right: '100%',
-                              width: 16,
-                              pointerEvents: 'none',
-                              background: (theme) =>
-                                `linear-gradient(90deg, ${alpha(theme.palette.background.paper, 0)} 0%, ${theme.palette.background.paper} 100%)`,
-                            },
-                            'tr:hover &': {
-                              bgcolor: 'surface.surfaceHoverBackground',
-                            },
-                            'tr:hover &::before': {
-                              background: (theme) => {
-                                const hoverBackground = theme.palette.surface?.surfaceHoverBackground ?? theme.palette.action.hover;
-                                return `linear-gradient(90deg, ${alpha(hoverBackground, 0)} 0%, ${hoverBackground} 100%)`;
-                              },
-                            },
-                          }}
+                          sx={contextMenuActionsOverlaySx('tr:hover &', 'tr:focus-within &')}
                         >
-                          <IconButton
-                            size="small"
-                            aria-label={t('common:actions.actions')}
+                          <ContextMenuIndicator
+                            label={t('common:actions.actions')}
                             onClick={(event) => openInlineActionMenu(event, row)}
-                          >
-                            <MoreVertIcon fontSize="small" />
-                          </IconButton>
+                          />
                         </Box>
                       </Box>
                     </TableCell>

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -24,14 +24,14 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { supplierAPI } from '../api/api';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
 import PageSurface from '../components/layout/PageSurface';
+import { ContextMenuIndicator } from '../components/contextMenu/ContextMenuIndicator';
+import { contextMenuActionsOverlaySx } from '../components/contextMenu/contextMenuIndicatorStyles';
 import TableSurface from '../components/layout/TableSurface';
 import type { Supplier, SupplierDeleteUndoPayload, SupplierDeleteUsage } from '../api/types';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -641,8 +641,6 @@ export default function Suppliers() {
                     sx={{
                       cursor: 'pointer',
                       WebkitTouchCallout: 'none',
-                      '&:hover .supplier-row-actions': { opacity: 1, pointerEvents: 'auto' },
-                      '&:focus-within .supplier-row-actions': { opacity: 1, pointerEvents: 'auto' },
                     }}
                   >
                     <TableCell sx={{ py: 1.25, maxWidth: { xs: 180, sm: 240 } }}>
@@ -671,43 +669,7 @@ export default function Suppliers() {
                         </Box>
                         <Box
                           className="supplier-row-actions"
-                          sx={{
-                            position: 'absolute',
-                            right: 0,
-                            top: '50%',
-                            transform: 'translateY(-50%)',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 0.5,
-                            py: 0.25,
-                            pl: 0.25,
-                            pr: 0.25,
-                            borderRadius: 1,
-                            bgcolor: 'background.paper',
-                            opacity: 0,
-                            pointerEvents: 'none',
-                            transition: 'background-color 120ms ease-in-out, opacity 120ms ease-in-out',
-                            '&::before': {
-                              content: '""',
-                              position: 'absolute',
-                              top: 0,
-                              bottom: 0,
-                              right: '100%',
-                              width: 16,
-                              pointerEvents: 'none',
-                              background: (theme) =>
-                                `linear-gradient(90deg, ${alpha(theme.palette.background.paper, 0)} 0%, ${theme.palette.background.paper} 100%)`,
-                            },
-                            'tr:hover &': {
-                              bgcolor: 'surface.surfaceHoverBackground',
-                            },
-                            'tr:hover &::before': {
-                              background: (theme) => {
-                                const hoverBackground = theme.palette.surface?.surfaceHoverBackground ?? theme.palette.action.hover;
-                                return `linear-gradient(90deg, ${alpha(hoverBackground, 0)} 0%, ${hoverBackground} 100%)`;
-                              },
-                            },
-                          }}
+                          sx={contextMenuActionsOverlaySx('tr:hover &', 'tr:focus-within &')}
                         >
                           <IconButton
                             size="small"
@@ -725,13 +687,10 @@ export default function Suppliers() {
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>
-                          <IconButton
-                            size="small"
-                            aria-label={t('common:actions.actions')}
+                          <ContextMenuIndicator
+                            label={t('common:actions.actions')}
                             onClick={(event) => openSupplierInlineActionMenu(event, supplier)}
-                          >
-                            <MoreVertIcon fontSize="small" />
-                          </IconButton>
+                          />
                         </Box>
                       </Box>
                     </TableCell>

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -38,6 +38,8 @@ import {
   suppressNativeContextMenu,
   useCloseCustomContextMenuOnNativeContextMenu,
 } from "../utils/contextMenu";
+import { ContextMenuIndicator } from "../components/contextMenu/ContextMenuIndicator";
+import { contextMenuIndicatorHostSx } from "../components/contextMenu/contextMenuIndicatorStyles";
 import { parseDateString } from "./ganttChartUtils";
 import {
   getYieldAxisLabelStep,
@@ -463,6 +465,11 @@ function YieldDistributionChart({
                       return (
                         <Tooltip
                           key={`${column.id}-${culture.culture_id}`}
+                          // Force-close while a context menu is open — MUI's
+                          // hover-driven tooltip would otherwise stay visible
+                          // (the pointer is still technically hovering the
+                          // segment) and overlap the menu.
+                          open={contextMenuState ? false : undefined}
                           slotProps={{
                             tooltip: {
                               sx: {
@@ -504,13 +511,22 @@ function YieldDistributionChart({
                             onTouchEnd={clearSegmentLongPress}
                             onTouchMove={clearSegmentLongPress}
                             sx={{
+                              position: "relative",
                               width: "100%",
                               height: `${maxTotalYield > 0 ? (culture.yield / maxTotalYield) * 100 : 0}%`,
                               minHeight: culture.yield > 0 ? "2px" : 0,
                               backgroundColor: culture.color,
-                              cursor: "context-menu",
+                              ...contextMenuIndicatorHostSx,
                             }}
-                          />
+                          >
+                            <ContextMenuIndicator
+                              label={t('common:actions.actions')}
+                              tabIndex={-1}
+                              onClick={(event) => openContextMenu(event, segmentPayload)}
+                              withBackdrop
+                              sx={{ position: "absolute", top: -2, right: -2 }}
+                            />
+                          </Box>
                         </Tooltip>
                       );
                     })}


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc `cursor: 'context-menu'` hint (Yield Overview chart segments) and four independently re-implemented hover-reveal MoreVertIcon buttons (DataGrid, hierarchy tree, Suppliers, SeedDemand) with one shared `ContextMenuIndicator` component + two reusable sx builders (`contextMenuIndicatorHostSx`, `contextMenuActionsOverlaySx`).
- Extends the same visual affordance to surfaces that previously had none despite already supporting right-click/long-press: Gantt calendar bars, sidebar rows, and the seedling/Anzuchtplanung calendar's custom-rendered bars.
- FieldsBeds' graphical view intentionally gets no indicator — confirmed it has no context menu wired up at all.
- Fixed three real bugs found along the way:
  - Yield Overview's hover tooltip stayed open and overlapped a just-opened context menu (same class of bug already fixed for the Gantt calendar's tooltip) — now force-closed via a controlled `open` prop.
  - The shared indicator's own default hidden state wasn't being overridden when nested inside the data-grid-style overlay panel, making it invisible/unclickable there until the overlay's reveal rule was extended to also target the nested indicator.
  - On Gantt bars, the indicator sat directly on top of the bar's own text, clipping the last few letters — bar text now fades out via a CSS `mask-image` over the last ~30px before the icon, active only while the icon itself is revealed (same hover/focus/touch condition), so it works for any bar color with no JS/measurement and no extra repaints.
  - The seedling/Anzuchtplanung calendar's custom-rendered bars had a real, user-visible regression: the custom `renderTask` re-applied `position: absolute`/`left`/`top`/`width` on its inner content Box, duplicating the positioning already provided by the outer `.rmg-task-item-custom` wrapper. The stacked offsets visually shifted the bar and collapsed the wrapper's own bounding box to `height: 0`, which misplaced the hover tooltip (anchored on that wrapper's rect) and left the three-dot indicator permanently hidden (its hover-reveal CSS only covered `.rmg-task-item`, not `.rmg-task-item-custom`). Fixed both: the inner Box now just fills its parent (no redundant positioning), and the CSS reveal rules cover both classes.
- The indicator also gets an optional translucent backdrop (`withBackdrop`) on Gantt bars/chart segments, where plain color-inheritance made the icon hard to spot against unpredictable bar colors.

## Test plan
- [x] `tsc -b` clean
- [x] `npm run lint` on all touched files — 0 new errors/warnings
- [x] Full `vitest run` — 953/953 passing
- [x] `npm run build` — succeeds
- [x] Full real-browser Playwright e2e run — 17/17 passing (three times, once per commit)
- [x] Desktop hover, touch long-press (coarse-pointer media query keeps the indicator always visible), and keyboard (`:focus-within`) all verified to still reveal/trigger the indicator
- [x] Manual check across different bar lengths, zoom levels (Day/Week/Month/Quarter/Year), and browser widths for the fade-mask, including a live repro (Playwright) confirming the seedling-view bar position, tooltip anchor, and indicator hover state are all now correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
