### PR TITLE
feat: unify mobile chart context menus behind long-press

### DIFF
--- a/frontend/src/__tests__/YieldOverview.test.tsx
+++ b/frontend/src/__tests__/YieldOverview.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LONG_PRESS_THRESHOLD_MS } from "../utils/contextMenu";
 import YieldOverviewPage from "../pages/YieldOverview";
 import { getYieldAxisLabelStep } from "../pages/yieldOverviewUtils";
 
@@ -187,6 +188,95 @@ describe("YieldOverviewPage", () => {
     fireEvent.contextMenu(segment);
     fireEvent.click(await screen.findByRole("menuitem", { name: "Zeile kopieren" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("Kohl · W13 Mär · 0.70 kg"));
+  });
+
+  describe("mobile long-press behavior on yield segments", () => {
+    beforeEach(() => {
+      mocks.yieldList.mockResolvedValue({
+        data: [
+          {
+            iso_week: "2026-W13",
+            week_start: "2026-03-23",
+            cultures: [
+              { culture_id: 1, culture_name: "Kohl", yield: 0.7, color: "#16a34a" },
+            ],
+          },
+        ],
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("never permanently shows the three-dot context-menu icon", async () => {
+      render(
+        <MemoryRouter>
+          <YieldOverviewPage />
+        </MemoryRouter>,
+      );
+      await screen.findByTestId("yield-bar-2026-W13-1");
+
+      const indicator = screen.getByRole("button", { name: "Aktionen" });
+      expect(getComputedStyle(indicator).opacity).toBe("0");
+      expect(getComputedStyle(indicator).pointerEvents).toBe("none");
+    });
+
+    it("opens the context menu after a long press", async () => {
+      render(
+        <MemoryRouter>
+          <YieldOverviewPage />
+        </MemoryRouter>,
+      );
+      const segment = await screen.findByTestId("yield-bar-2026-W13-1");
+
+      vi.useFakeTimers();
+      fireEvent.touchStart(segment, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+      });
+      vi.useRealTimers();
+
+      expect(await screen.findByRole("menuitem", { name: "Kultur öffnen" })).toBeInTheDocument();
+    });
+
+    it("does not open the context menu on a short tap", async () => {
+      render(
+        <MemoryRouter>
+          <YieldOverviewPage />
+        </MemoryRouter>,
+      );
+      const segment = await screen.findByTestId("yield-bar-2026-W13-1");
+
+      vi.useFakeTimers();
+      fireEvent.touchStart(segment, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+      fireEvent.touchEnd(segment);
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+      });
+      vi.useRealTimers();
+
+      expect(screen.queryByRole("menuitem", { name: "Kultur öffnen" })).not.toBeInTheDocument();
+    });
+
+    it("cancels the long press when the touch moves (scroll/drag)", async () => {
+      render(
+        <MemoryRouter>
+          <YieldOverviewPage />
+        </MemoryRouter>,
+      );
+      const segment = await screen.findByTestId("yield-bar-2026-W13-1");
+
+      vi.useFakeTimers();
+      fireEvent.touchStart(segment, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+      fireEvent.touchMove(segment, { touches: [{ identifier: 1, clientX: 60, clientY: 60 }] });
+      act(() => {
+        vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+      });
+      vi.useRealTimers();
+
+      expect(screen.queryByRole("menuitem", { name: "Kultur öffnen" })).not.toBeInTheDocument();
+    });
   });
 
   it("shows a helpful empty state when no planting plans exist", async () => {

--- a/frontend/src/__tests__/contextMenu.test.tsx
+++ b/frontend/src/__tests__/contextMenu.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { useCallback } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  LONG_PRESS_THRESHOLD_MS,
   shouldOpenCustomContextMenu,
   useCloseCustomContextMenuOnNativeContextMenu,
+  useLongPress,
 } from '../utils/contextMenu';
 
 function ContextMenuBoundary({
@@ -81,5 +83,92 @@ describe('context menu helpers', () => {
     expect(event.defaultPrevented).toBe(true);
     expect(onClose).not.toHaveBeenCalled();
     expect(onOpenMenuContextMenu).toHaveBeenCalledTimes(1);
+  });
+});
+
+function LongPressProbe({ onLongPress }: { onLongPress: () => void }) {
+  const { onTouchStart, onTouchEnd, onTouchMove, isLongPressing } = useLongPress(onLongPress);
+
+  return (
+    <div
+      data-testid="press-target"
+      data-long-pressing={isLongPressing ? 'true' : undefined}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      onTouchMove={onTouchMove}
+    />
+  );
+}
+
+describe('useLongPress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('opens the context menu after the touch is held past the threshold', () => {
+    const onLongPress = vi.fn();
+    const { getByTestId } = render(<LongPressProbe onLongPress={onLongPress} />);
+    const target = getByTestId('press-target');
+
+    fireEvent.touchStart(target, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    expect(target).toHaveAttribute('data-long-pressing', 'true');
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the context menu on a short tap', () => {
+    const onLongPress = vi.fn();
+    const { getByTestId } = render(<LongPressProbe onLongPress={onLongPress} />);
+    const target = getByTestId('press-target');
+
+    fireEvent.touchStart(target, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(target).not.toHaveAttribute('data-long-pressing');
+  });
+
+  it('cancels the long press when the finger moves (scroll/drag)', () => {
+    const onLongPress = vi.fn();
+    const { getByTestId } = render(<LongPressProbe onLongPress={onLongPress} />);
+    const target = getByTestId('press-target');
+
+    fireEvent.touchStart(target, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    fireEvent.touchMove(target, { touches: [{ identifier: 1, clientX: 40, clientY: 40 }] });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(target).not.toHaveAttribute('data-long-pressing');
+  });
+
+  it('cancels the long press when released just before the threshold', () => {
+    const onLongPress = vi.fn();
+    const { getByTestId } = render(<LongPressProbe onLongPress={onLongPress} />);
+    const target = getByTestId('press-target');
+
+    fireEvent.touchStart(target, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS - 50);
+    });
+    fireEvent.touchEnd(target);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onLongPress).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/gantt-chart/ContextMenuLongPress.test.tsx
+++ b/frontend/src/__tests__/gantt-chart/ContextMenuLongPress.test.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GanttChart, ViewMode, type TaskGroup } from "../../gantt-chart/src";
+import { LONG_PRESS_THRESHOLD_MS } from "../../utils/contextMenu";
+
+// Same underlying TaskItem/TaskList components (and long-press behavior) are
+// used by both the field occupancy and seedling calendar views, so a single
+// suite against the shared gantt-chart library covers both charts.
+const currentDate = new Date(2026, 1, 15);
+
+const tasksWithBar: TaskGroup[] = [
+  {
+    id: "group-1",
+    name: "Bed A1",
+    tasks: [
+      {
+        id: "task-1",
+        name: "Carrot",
+        startDate: new Date(2026, 1, 1),
+        endDate: new Date(2026, 1, 20),
+      },
+    ],
+  },
+];
+
+const tasksWithTreeRow: TaskGroup[] = [
+  {
+    id: "group-1",
+    name: "Field North",
+    depth: 0,
+    isExpandable: false,
+    tasks: [],
+  },
+];
+
+describe("Gantt chart context-menu long press (occupancy + seedling views)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never permanently shows the three-dot context-menu icon on a task bar", () => {
+    render(
+      <GanttChart
+        tasks={tasksWithBar}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onTaskContextMenu={vi.fn()}
+      />,
+    );
+
+    const bar = screen.getByTestId("task-task-1");
+    const indicator = bar.querySelector('[aria-label="Aktionen"]');
+    expect(indicator).not.toBeNull();
+    expect(getComputedStyle(indicator as Element).opacity).toBe("0");
+    expect(getComputedStyle(indicator as Element).pointerEvents).toBe("none");
+  });
+
+  it("opens the task context menu after a long press", () => {
+    const onTaskContextMenu = vi.fn();
+    render(
+      <GanttChart
+        tasks={tasksWithBar}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onTaskContextMenu={onTaskContextMenu}
+      />,
+    );
+    const bar = screen.getByTestId("task-task-1");
+
+    vi.useFakeTimers();
+    fireEvent.touchStart(bar, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onTaskContextMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open the task context menu on a short tap", () => {
+    const onTaskContextMenu = vi.fn();
+    render(
+      <GanttChart
+        tasks={tasksWithBar}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onTaskContextMenu={onTaskContextMenu}
+      />,
+    );
+    const bar = screen.getByTestId("task-task-1");
+
+    vi.useFakeTimers();
+    fireEvent.touchStart(bar, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    fireEvent.touchEnd(bar);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onTaskContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("cancels the task long press when the touch moves (scroll/drag)", () => {
+    const onTaskContextMenu = vi.fn();
+    render(
+      <GanttChart
+        tasks={tasksWithBar}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onTaskContextMenu={onTaskContextMenu}
+      />,
+    );
+    const bar = screen.getByTestId("task-task-1");
+
+    vi.useFakeTimers();
+    fireEvent.touchStart(bar, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    fireEvent.touchMove(bar, { touches: [{ identifier: 1, clientX: 60, clientY: 60 }] });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+
+    expect(onTaskContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("keeps desktop right-click on a task bar working unchanged", () => {
+    const onTaskContextMenu = vi.fn();
+    render(
+      <GanttChart
+        tasks={tasksWithBar}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onTaskContextMenu={onTaskContextMenu}
+      />,
+    );
+    const bar = screen.getByTestId("task-task-1");
+
+    fireEvent.contextMenu(bar);
+
+    expect(onTaskContextMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the group context menu on a tree row after a long press, and not on a short tap", () => {
+    const onGroupContextMenu = vi.fn();
+    render(
+      <GanttChart
+        tasks={tasksWithTreeRow}
+        currentDate={currentDate}
+        viewMode={ViewMode.MONTH}
+        viewModes={false}
+        onGroupContextMenu={onGroupContextMenu}
+      />,
+    );
+    const row = screen.getByTestId("task-group-group-1");
+
+    // Short tap: no menu.
+    vi.useFakeTimers();
+    fireEvent.touchStart(row, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    fireEvent.touchEnd(row);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+    expect(onGroupContextMenu).not.toHaveBeenCalled();
+
+    // Long press: opens the menu.
+    fireEvent.touchStart(row, { touches: [{ identifier: 1, clientX: 10, clientY: 10 }] });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_THRESHOLD_MS);
+    });
+    expect(onGroupContextMenu).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/contextMenu/contextMenuIndicatorStyles.ts
+++ b/frontend/src/components/contextMenu/contextMenuIndicatorStyles.ts
@@ -16,15 +16,14 @@ const revealOnHoverOrFocus = {
 /**
  * Spread into a hoverable/focusable ancestor's `sx` (e.g. a Gantt bar, a
  * chart segment, a sidebar tree row) so any `ContextMenuIndicator` rendered
- * inside it fades in on hover/focus-within, and stays visible on touch.
+ * inside it fades in on hover/focus-within. On touch devices it stays
+ * hidden at all times — a long press opens the context menu directly
+ * instead of relying on the icon.
  * Use this for simple cases with no adjacent truncated text to mask — for
  * data-grid-style rows, use `contextMenuActionsOverlaySx` instead.
  */
 export const contextMenuIndicatorHostSx: SystemStyleObject<Theme> = {
   [`&:hover .${CONTEXT_MENU_INDICATOR_CLASS}, &:focus-within .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
-  '@media (pointer: coarse)': {
-    [`& .${CONTEXT_MENU_INDICATOR_CLASS}`]: revealOnHoverOrFocus,
-  },
 };
 
 /**

--- a/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskItem.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from "react";
 import type { TaskItemProps } from "../../types";
 import { ContextMenuIndicator } from "../../../../components/contextMenu/ContextMenuIndicator";
+import { useLongPress } from "../../../../utils/contextMenu";
 
 /**
  * TaskItem Component - Renders an individual task bar in the Gantt chart
@@ -158,21 +159,9 @@ const TaskItem: React.FC<TaskItemProps> = ({
   }, [task?.percent]);
 
   // Long-press (touch) opens the same context menu as a desktop right-click.
-  const longPressTimeoutRef = useRef<number | null>(null);
-  const handleTouchStart = (e: React.TouchEvent) => {
-    if (!onContextMenu) return;
-    const touch = e.touches[0];
-    if (!touch) return;
-    longPressTimeoutRef.current = window.setTimeout(() => {
-      onContextMenu(e as unknown as React.MouseEvent, task);
-    }, 550);
-  };
-  const clearLongPress = () => {
-    if (longPressTimeoutRef.current !== null) {
-      window.clearTimeout(longPressTimeoutRef.current);
-      longPressTimeoutRef.current = null;
-    }
-  };
+  const { onTouchStart, onTouchEnd, onTouchMove, isLongPressing } = useLongPress((event) => {
+    onContextMenu?.(event, task);
+  });
 
   if (!isValidTask) {
     return null;
@@ -204,9 +193,9 @@ const TaskItem: React.FC<TaskItemProps> = ({
         onClick={(e) => onClick(e, task)}
         onDoubleClick={onDoubleClick ? (e) => onDoubleClick(e, task) : undefined}
         onContextMenu={onContextMenu ? (e) => onContextMenu(e, task) : undefined}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={clearLongPress}
-        onTouchMove={clearLongPress}
+        onTouchStart={onContextMenu ? onTouchStart : undefined}
+        onTouchEnd={onContextMenu ? onTouchEnd : undefined}
+        onTouchMove={onContextMenu ? onTouchMove : undefined}
         onMouseDown={canMoveTask ? handleTaskMouseDown : undefined}
         onMouseEnter={(e) => onMouseEnter(e, task)}
         onMouseLeave={onMouseLeave}
@@ -214,6 +203,7 @@ const TaskItem: React.FC<TaskItemProps> = ({
         data-task-id={task.id}
         data-instance-id={instanceId}
         data-dragging={isDragging ? "true" : "false"}
+        data-long-pressing={onContextMenu && isLongPressing ? "true" : undefined}
         data-rmg-component="task"
       >
         {customTaskContent}
@@ -256,9 +246,9 @@ const TaskItem: React.FC<TaskItemProps> = ({
       onClick={(e) => onClick(e, task)}
       onDoubleClick={onDoubleClick ? (e) => onDoubleClick(e, task) : undefined}
       onContextMenu={onContextMenu ? (e) => onContextMenu(e, task) : undefined}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={clearLongPress}
-      onTouchMove={clearLongPress}
+      onTouchStart={onContextMenu ? onTouchStart : undefined}
+      onTouchEnd={onContextMenu ? onTouchEnd : undefined}
+      onTouchMove={onContextMenu ? onTouchMove : undefined}
       onMouseDown={canMoveTask ? handleTaskMouseDown : undefined}
       onMouseEnter={(e) => onMouseEnter(e, task)}
       onMouseLeave={onMouseLeave}
@@ -266,6 +256,7 @@ const TaskItem: React.FC<TaskItemProps> = ({
       data-task-id={task.id}
       data-instance-id={instanceId}
       data-dragging={isDragging ? "true" : "false"}
+      data-long-pressing={onContextMenu && isLongPressing ? "true" : undefined}
       data-rmg-component="task"
     >
       {/* Left resize handle */}

--- a/frontend/src/gantt-chart/src/components/task/TaskList.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskList.tsx
@@ -8,6 +8,7 @@ import {
   TREE_INDENT_PX,
 } from "../../utils";
 import { ContextMenuIndicator } from "../../../../components/contextMenu/ContextMenuIndicator";
+import { useLongPress } from "../../../../utils/contextMenu";
 
 /**
  * TaskList Component - Displays the list of task groups on the left side of the Gantt chart
@@ -77,20 +78,29 @@ const TaskList: React.FC<TaskListProps> = ({
     onToggleGroupExpand?.(groupId);
   };
 
-  const longPressTimeoutRef = React.useRef<number | null>(null);
+  // Only one row can be pressed at a time, so a single long-press timer
+  // (keyed by the currently pressed group) covers every tree row.
+  const [pressedGroupId, setPressedGroupId] = React.useState<string | null>(null);
+  const pressedGroupRef = React.useRef<TaskGroup | null>(null);
+  const {
+    onTouchStart: startGroupLongPress,
+    onTouchEnd: clearGroupLongPressBase,
+    isLongPressing,
+  } = useLongPress((event) => {
+    const group = pressedGroupRef.current;
+    if (group && onGroupContextMenu) {
+      onGroupContextMenu(event, group);
+    }
+  });
   const handleGroupTouchStart = (event: React.TouchEvent, group: TaskGroup) => {
     if (!onGroupContextMenu) return;
-    const touch = event.touches[0];
-    if (!touch) return;
-    longPressTimeoutRef.current = window.setTimeout(() => {
-      onGroupContextMenu(event, group);
-    }, 550);
+    pressedGroupRef.current = group;
+    setPressedGroupId(group.id);
+    startGroupLongPress(event);
   };
   const clearGroupLongPress = () => {
-    if (longPressTimeoutRef.current !== null) {
-      window.clearTimeout(longPressTimeoutRef.current);
-      longPressTimeoutRef.current = null;
-    }
+    clearGroupLongPressBase();
+    setPressedGroupId(null);
   };
 
   return (
@@ -141,6 +151,7 @@ const TaskList: React.FC<TaskListProps> = ({
               data-depth={depth}
               data-expanded={taskGroup.isExpandable ? isExpanded : undefined}
               data-hover-linked={hoveredGroupId === taskGroup.id ? "true" : undefined}
+              data-long-pressing={isLongPressing && pressedGroupId === taskGroup.id ? "true" : undefined}
             >
               <div
                 className="rmg-task-group-content rmg-task-group-tree-content"

--- a/frontend/src/gantt-chart/src/components/task/TaskRow/index.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskRow/index.tsx
@@ -493,7 +493,7 @@ const TaskRow: React.FC<TaskRowProps> = ({
     onTaskDoubleClick?.(task, taskGroup);
   };
 
-  const handleTaskContextMenu = (event: React.MouseEvent, task: Task) => {
+  const handleTaskContextMenu = (event: React.MouseEvent | React.TouchEvent, task: Task) => {
     // Dismiss the hover tooltip immediately — otherwise it stays visible
     // (the pointer is still technically "hovering" the bar) and overlaps
     // the context menu that's about to open.

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -234,18 +234,22 @@
 }
 
 /* "Weitere Aktionen" affordance (shared ContextMenuIndicator component) —
-   invisible until the row is hovered/focused, always visible on touch. */
+   invisible until the row is hovered/focused. On touch devices it stays
+   hidden at all times; a long press opens the context menu directly. */
 .rmg-task-group:hover .ofp-context-menu-indicator,
 .rmg-task-group:focus-within .ofp-context-menu-indicator {
   opacity: 1;
   pointer-events: auto;
 }
 
-@media (pointer: coarse) {
-  .rmg-task-group .ofp-context-menu-indicator {
-    opacity: 1;
-    pointer-events: auto;
-  }
+/* Subtle feedback while a long press is being held, cleared as soon as it
+   fires, is released, or is cancelled by movement. */
+.rmg-task-group[data-long-pressing="true"] {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.rmg-dark .rmg-task-group[data-long-pressing="true"] {
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 /* Compact tree rows (e.g. a Gantt row-height override for a parent row
@@ -620,14 +624,6 @@
   mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
 }
 
-@media (pointer: coarse) {
-  .rmg-task-item .rmg-task-item-name-maskable,
-  .rmg-task-item-custom .rmg-task-item-name-maskable {
-    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
-    mask-image: linear-gradient(to right, #000 calc(100% - 30px), transparent 100%);
-  }
-}
-
 /* ======================================================
    8. Resize Handles
    ====================================================== */
@@ -660,7 +656,8 @@
 }
 
 /* "Weitere Aktionen" affordance (shared ContextMenuIndicator component) —
-   invisible until the bar is hovered/focused, always visible on touch.
+   invisible until the bar is hovered/focused. On touch devices it stays
+   hidden at all times; a long press opens the context menu directly.
    Covers both the default bar (.rmg-task-item) and any custom-rendered one
    (.rmg-task-item-custom, e.g. the seedling calendar's bars). */
 .rmg-task-item:hover .ofp-context-menu-indicator,
@@ -671,12 +668,11 @@
   pointer-events: auto;
 }
 
-@media (pointer: coarse) {
-  .rmg-task-item .ofp-context-menu-indicator,
-  .rmg-task-item-custom .ofp-context-menu-indicator {
-    opacity: 1;
-    pointer-events: auto;
-  }
+/* Subtle feedback while a long press is being held, cleared as soon as it
+   fires, is released, or is cancelled by movement. */
+.rmg-task-item[data-long-pressing="true"],
+.rmg-task-item-custom[data-long-pressing="true"] {
+  filter: brightness(0.92);
 }
 
 /* ======================================================

--- a/frontend/src/gantt-chart/src/types/components.ts
+++ b/frontend/src/gantt-chart/src/types/components.ts
@@ -265,7 +265,7 @@ export interface TaskItemProps {
   onMouseLeave: () => void;
   onClick: (event: React.MouseEvent, task: Task) => void;
   onDoubleClick?: (event: React.MouseEvent, task: Task) => void;
-  onContextMenu?: (event: React.MouseEvent, task: Task) => void;
+  onContextMenu?: (event: React.MouseEvent | React.TouchEvent, task: Task) => void;
   onProgressUpdate?: (task: Task, newPercent: number) => void;
 }
 

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -37,6 +37,7 @@ import {
   shouldOpenCustomContextMenu,
   suppressNativeContextMenu,
   useCloseCustomContextMenuOnNativeContextMenu,
+  useLongPress,
 } from "../utils/contextMenu";
 import { ContextMenuIndicator } from "../components/contextMenu/ContextMenuIndicator";
 import { contextMenuIndicatorHostSx } from "../components/contextMenu/contextMenuIndicatorStyles";
@@ -291,23 +292,31 @@ function YieldDistributionChart({
     void navigator.clipboard?.writeText(summary).catch(() => undefined);
   }, []);
 
-  const longPressTimeoutRef = useRef<number | null>(null);
+  // Only one segment can be pressed at a time, so a single long-press timer
+  // (keyed by the currently pressed segment's payload) covers every bar.
+  const [pressedSegmentKey, setPressedSegmentKey] = useState<string | null>(null);
+  const pressedSegmentPayloadRef = useRef<
+    { cultureId: number; cultureName: string; periodLabel: string; yieldValue: number } | null
+  >(null);
+  const { onTouchStart: startSegmentLongPress, onTouchEnd: clearSegmentLongPressBase, isLongPressing } = useLongPress(
+    (event) => {
+      const payload = pressedSegmentPayloadRef.current;
+      if (payload) openContextMenu(event, payload);
+    },
+  );
   const handleSegmentTouchStart = useCallback((
     event: React.TouchEvent,
     payload: { cultureId: number; cultureName: string; periodLabel: string; yieldValue: number },
+    segmentKey: string,
   ) => {
-    const touch = event.touches[0];
-    if (!touch) return;
-    longPressTimeoutRef.current = window.setTimeout(() => {
-      openContextMenu(event, payload);
-    }, 550);
-  }, [openContextMenu]);
+    pressedSegmentPayloadRef.current = payload;
+    setPressedSegmentKey(segmentKey);
+    startSegmentLongPress(event);
+  }, [startSegmentLongPress]);
   const clearSegmentLongPress = useCallback(() => {
-    if (longPressTimeoutRef.current !== null) {
-      window.clearTimeout(longPressTimeoutRef.current);
-      longPressTimeoutRef.current = null;
-    }
-  }, []);
+    clearSegmentLongPressBase();
+    setPressedSegmentKey(null);
+  }, [clearSegmentLongPressBase]);
   const [axisWidth, setAxisWidth] = useState(0);
   const labelStep = getYieldAxisLabelStep(
     axisWidth,
@@ -506,8 +515,9 @@ function YieldDistributionChart({
                           <Box
                             data-testid={`yield-bar-${column.id}-${culture.culture_id}`}
                             data-rmg-component="yield-segment"
+                            data-long-pressing={pressedSegmentKey === `${column.id}-${culture.culture_id}` && isLongPressing ? "true" : undefined}
                             onContextMenu={(event) => openContextMenu(event, segmentPayload)}
-                            onTouchStart={(event) => handleSegmentTouchStart(event, segmentPayload)}
+                            onTouchStart={(event) => handleSegmentTouchStart(event, segmentPayload, `${column.id}-${culture.culture_id}`)}
                             onTouchEnd={clearSegmentLongPress}
                             onTouchMove={clearSegmentLongPress}
                             sx={{
@@ -516,6 +526,10 @@ function YieldDistributionChart({
                               height: `${maxTotalYield > 0 ? (culture.yield / maxTotalYield) * 100 : 0}%`,
                               minHeight: culture.yield > 0 ? "2px" : 0,
                               backgroundColor: culture.color,
+                              filter: pressedSegmentKey === `${column.id}-${culture.culture_id}` && isLongPressing
+                                ? "brightness(0.9)"
+                                : undefined,
+                              transition: "filter 0.15s ease",
                               ...contextMenuIndicatorHostSx,
                             }}
                           >

--- a/frontend/src/utils/contextMenu.ts
+++ b/frontend/src/utils/contextMenu.ts
@@ -1,8 +1,54 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type React from 'react';
 
 interface SuppressibleEvent {
   preventDefault: () => void;
   stopPropagation: () => void;
+}
+
+/** Duration a touch must be held before it counts as a long press (ca. 500-700ms). */
+export const LONG_PRESS_THRESHOLD_MS = 600;
+
+export interface LongPressHandlers {
+  onTouchStart: (event: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchMove: () => void;
+  /** True while a touch is held but the long-press threshold hasn't fired yet — for optional, low-overhead "pressed" feedback. */
+  isLongPressing: boolean;
+}
+
+/**
+ * Shared touch long-press detection used by the yield distribution, seedling
+ * and field occupancy charts to open the same context menu that a desktop
+ * right-click opens. A plain tap never fires `onLongPress`; moving the
+ * finger or releasing before `thresholdMs` cancels it.
+ */
+export function useLongPress(
+  onLongPress: (event: React.TouchEvent) => void,
+  thresholdMs: number = LONG_PRESS_THRESHOLD_MS,
+): LongPressHandlers {
+  const timeoutRef = useRef<number | null>(null);
+  const [isLongPressing, setIsLongPressing] = useState(false);
+
+  const clear = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setIsLongPressing(false);
+  }, []);
+
+  const onTouchStart = useCallback((event: React.TouchEvent) => {
+    if (!event.touches[0]) return;
+    setIsLongPressing(true);
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = null;
+      setIsLongPressing(false);
+      onLongPress(event);
+    }, thresholdMs);
+  }, [onLongPress, thresholdMs]);
+
+  return { onTouchStart, onTouchEnd: clear, onTouchMove: clear, isLongPressing };
 }
 
 const editableSelector = [


### PR DESCRIPTION
## Summary
- Extracted the duplicated 550ms touch long-press timer logic (yield distribution chart, seedling calendar bars, field occupancy bars/rows) into a shared `useLongPress` hook in `frontend/src/utils/contextMenu.ts`.
- Removed the `@media (pointer: coarse)` rules that permanently revealed the three-dot context-menu indicator on touch devices — on mobile the icon now always stays hidden; a long press (600ms) opens the context menu directly at the touch position instead.
- Added a subtle, CSS-only "pressed" feedback (background/brightness dim) while a long press is being held, cleared immediately on release, firing, or cancellation by movement.
- Desktop behavior (hover-reveal icon, right-click) is unchanged.
- Widened `TaskItemProps.onContextMenu` to accept `React.TouchEvent` too, removing an unsafe event cast in `TaskItem.tsx`.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint` on all touched files — no new errors/warnings
- [x] `npx vitest run` — full suite: 108 files / 967 tests passed
- [x] New unit tests for `useLongPress` (fires after threshold, short tap cancels, touchmove cancels, touchend-before-threshold cancels)
- [x] New unit tests on `YieldOverviewPage`: icon never permanently visible, long press opens menu, short tap doesn't, touchmove cancels
- [x] New unit tests against the real (unmocked) gantt-chart library covering both the task-bar (shared by occupancy + seedling views) and tree-row group long press, plus a right-click regression check for desktop
- [x] Manually reasoned through touch/mouse interaction paths; existing `gantt-context-menu-smoke` Playwright e2e (desktop right-click) still passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)