### PR TITLE
refactor: prepare a Crop Library / Farm Planning architecture split

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -135,6 +135,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'corsheaders',
+    'crops',
     'farm',
     'accounts',
 ]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -30,6 +30,10 @@ urlpatterns = [
     path(_with_prefix('admin/'), admin.site.urls),
     path(_with_prefix('api/auth/'), include('accounts.urls')),
     path(_with_prefix('api/'), include('farm.urls')),
+    # Additive, forward-looking crop-library surface — see
+    # docs/crop-library-architecture.md. Not yet public: same
+    # IsAuthenticated requirement as everything else.
+    path(_with_prefix('api/crops/'), include('crops.urls')),
     path(_with_prefix('agent-login/<str:token>/'), agent_login_consume_view, name='agent-login-consume'),
 ]
 
@@ -38,6 +42,7 @@ if getattr(settings, 'URL_PREFIX', '').strip('/') != legacy_prefix:
     urlpatterns += [
         path(f'{legacy_prefix}/api/auth/', include('accounts.urls')),
         path(f'{legacy_prefix}/api/', include('farm.urls')),
+        path(f'{legacy_prefix}/api/crops/', include('crops.urls')),
         path(f'{legacy_prefix}/agent-login/<str:token>/', agent_login_consume_view, name='agent-login-consume-legacy'),
     ]
 

--- a/backend/crops/apps.py
+++ b/backend/crops/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class CropsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'crops'
+    verbose_name = 'Crop Library'

--- a/backend/crops/models.py
+++ b/backend/crops/models.py
@@ -1,0 +1,16 @@
+"""
+This app deliberately defines no models of its own yet.
+
+The data this app serves (`PublicCulture`) still lives in `farm.models`,
+because moving a model to a different Django app changes its migration
+state and (without careful `SeparateDatabaseAndState` migrations) its
+`app_label`-derived db_table — a real risk to existing data that isn't
+justified until the crop library is actually extracted into its own
+service. See docs/crop-library-architecture.md for the full reasoning and
+the migration path to take when that extraction happens.
+
+Until then, `crops.services`/`crops.serializers`/`crops.views` import
+`PublicCulture` directly from `farm.models` — the one sanctioned
+dependency this app has on `farm`, and the thing to remove first in a
+future extraction.
+"""

--- a/backend/crops/serializers.py
+++ b/backend/crops/serializers.py
@@ -1,0 +1,63 @@
+"""
+Defined independently from `farm.serializers.PublicCultureSerializer` on
+purpose, even though the two are currently near-identical: this app must
+depend on `farm.models` only, never on `farm.serializers` or `farm.views`
+(that would put the dependency arrow backwards — see
+docs/crop-library-architecture.md). The small duplication is the
+deliberate cost of keeping that direction correct until `PublicCulture`
+itself moves into this app.
+"""
+from rest_framework import serializers
+
+from farm.models import PublicCulture
+
+
+class CropSerializer(serializers.ModelSerializer):
+    """Read-only representation of a published crop, for the /api/crops/ surface."""
+
+    created_by_label = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PublicCulture
+        fields = [
+            'id',
+            'status',
+            'name',
+            'variety',
+            'notes',
+            'seed_supplier',
+            'supplier_name',
+            'crop_family',
+            'nutrient_demand',
+            'cultivation_types',
+            'cultivation_type',
+            'growth_duration_days',
+            'harvest_duration_days',
+            'propagation_duration_days',
+            'harvest_method',
+            'expected_yield',
+            'allow_deviation_delivery_weeks',
+            'distance_within_row_m',
+            'row_spacing_m',
+            'sowing_depth_m',
+            'seed_rate_value',
+            'seed_rate_unit',
+            'seed_rate_by_cultivation',
+            'sowing_calculation_safety_percent',
+            'thousand_kernel_weight_g',
+            'seeding_requirement',
+            'seeding_requirement_type',
+            'display_color',
+            'seed_packages',
+            'version',
+            'published_at',
+            'created_at',
+            'updated_at',
+            'created_by_label',
+        ]
+        read_only_fields = fields
+
+    def get_created_by_label(self, obj: PublicCulture) -> str:
+        if not obj.created_by:
+            return ''
+        return obj.created_by.get_full_name().strip() or obj.created_by.username or obj.created_by.email or ''

--- a/backend/crops/services.py
+++ b/backend/crops/services.py
@@ -1,0 +1,60 @@
+"""
+Crop Library service layer — the single place `crops.views` (and, in the
+future, any other consumer) reads published crop data from.
+
+This module must never import anything project-scoped (`Project`,
+`PlantingPlan`, `Bed`, ...) or anything from `farm.views`/`farm.serializers`
+— see docs/crop-library-architecture.md for the dependency rule this
+enforces ("the crop library knows nothing about projects; farm planning
+uses the crop library, never the other way round").
+
+Publishing a project's `Culture` into the library, and importing a
+published crop back into a project, are intentionally NOT in this module:
+those are bridge operations that need `Culture`/`Project`, and stay in
+`farm.services.public_cultures` until a future step decides how that
+bridge should work once the crop library is a genuinely separate service
+(e.g. an HTTP call instead of a direct ORM write). See the architecture
+doc's "deliberately deferred" section.
+"""
+from __future__ import annotations
+
+from django.db.models import Q, QuerySet
+
+from farm.models import PublicCulture
+from farm.utils import normalize_text
+
+
+def list_published_crops(*, query: str = '', name: str = '', variety: str = '') -> QuerySet[PublicCulture]:
+    """Published crops, optionally filtered by a free-text query and/or exact-field substrings."""
+    queryset = PublicCulture.objects.filter(status=PublicCulture.STATUS_PUBLISHED).order_by('name', 'variety')
+
+    query = query.strip()
+    name = name.strip()
+    variety = variety.strip()
+
+    if query:
+        queryset = queryset.filter(Q(name__icontains=query) | Q(variety__icontains=query))
+    if name:
+        queryset = queryset.filter(name__icontains=name)
+    if variety:
+        queryset = queryset.filter(variety__icontains=variety)
+    return queryset
+
+
+def get_published_crop(pk: int) -> PublicCulture:
+    """A single published crop by id. Raises `PublicCulture.DoesNotExist` if not found or unpublished."""
+    return PublicCulture.objects.get(pk=pk, status=PublicCulture.STATUS_PUBLISHED)
+
+
+def find_exact_crop_match(*, name: str | None, variety: str | None) -> PublicCulture | None:
+    """The most recently published crop whose normalized name+variety match exactly, if any."""
+    normalized_name = normalize_text(name)
+    normalized_variety = normalize_text(variety)
+    if not normalized_name or not normalized_variety:
+        return None
+
+    return PublicCulture.objects.filter(
+        status=PublicCulture.STATUS_PUBLISHED,
+        name_normalized=normalized_name,
+        variety_normalized=normalized_variety,
+    ).only('id', 'name', 'variety', 'published_at').order_by('-published_at', '-id').first()

--- a/backend/crops/tests/test_services.py
+++ b/backend/crops/tests/test_services.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+
+from crops import services
+from farm.models import PublicCulture
+
+
+class ListPublishedCropsTest(TestCase):
+    def setUp(self):
+        self.published = PublicCulture.objects.create(
+            name='Lettuce', variety='Bijella', status=PublicCulture.STATUS_PUBLISHED, version=1,
+        )
+        self.draft = PublicCulture.objects.create(
+            name='Carrot', variety='Nantes', status='draft', version=1,
+        )
+
+    def test_excludes_unpublished_crops(self):
+        results = list(services.list_published_crops())
+        self.assertIn(self.published, results)
+        self.assertNotIn(self.draft, results)
+
+    def test_filters_by_name_and_variety(self):
+        other = PublicCulture.objects.create(
+            name='Lettuce', variety='Lollo Rosso', status=PublicCulture.STATUS_PUBLISHED, version=1,
+        )
+
+        results = list(services.list_published_crops(variety='Bijella'))
+
+        self.assertEqual(results, [self.published])
+        self.assertNotIn(other, results)
+
+
+class FindExactCropMatchTest(TestCase):
+    def test_returns_none_when_name_or_variety_missing(self):
+        self.assertIsNone(services.find_exact_crop_match(name=None, variety='Bijella'))
+        self.assertIsNone(services.find_exact_crop_match(name='Lettuce', variety=None))
+
+    def test_matches_regardless_of_case_and_whitespace(self):
+        crop = PublicCulture.objects.create(
+            name='Lettuce', variety='Bijella', status=PublicCulture.STATUS_PUBLISHED, version=1,
+        )
+
+        match = services.find_exact_crop_match(name='  lettuce ', variety='BIJELLA')
+
+        self.assertEqual(match, crop)

--- a/backend/crops/tests/test_views.py
+++ b/backend/crops/tests/test_views.py
@@ -1,0 +1,82 @@
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase as DRFAPITestCase
+
+from farm.models import PublicCulture
+
+User = get_user_model()
+
+
+class CropViewSetTest(DRFAPITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='crops-user', email='crops@example.com', password='testpass', is_active=True,
+        )
+        self.published = PublicCulture.objects.create(
+            name='Lettuce', variety='Bijella', status=PublicCulture.STATUS_PUBLISHED,
+            version=1, created_by=self.user,
+        )
+        self.draft = PublicCulture.objects.create(
+            name='Carrot', variety='Nantes', status='draft', version=1, created_by=self.user,
+        )
+
+    def test_requires_authentication(self):
+        response = self.client.get('/api/crops/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_lists_only_published_crops(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/crops/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        names = [item['name'] for item in response.data['results']]
+        self.assertIn('Lettuce', names)
+        self.assertNotIn('Carrot', names)
+
+    def test_filters_by_free_text_query(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/crops/', {'q': 'lett'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['name'], 'Lettuce')
+
+    def test_retrieves_a_single_published_crop(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f'/api/crops/{self.published.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'Lettuce')
+        self.assertEqual(response.data['variety'], 'Bijella')
+        # Provenance fields are project-scoped and must not leak into the
+        # crop-library-facing serializer.
+        self.assertNotIn('source_project', response.data)
+        self.assertNotIn('source_project_culture', response.data)
+
+    def test_retrieving_an_unpublished_crop_404s(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f'/api/crops/{self.draft.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_match_finds_an_exact_normalized_match(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/crops/match/', {'name': 'lettuce', 'variety': 'bijella'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['exists'])
+        self.assertEqual(response.data['crop']['id'], self.published.id)
+
+    def test_match_reports_no_match(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get('/api/crops/match/', {'name': 'Kohlrabi', 'variety': 'Superschmelz'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data['exists'])
+        self.assertIsNone(response.data['crop'])
+
+    def test_write_methods_are_not_allowed(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post('/api/crops/', {'name': 'X', 'variety': 'Y'})
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/backend/crops/urls.py
+++ b/backend/crops/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import CropViewSet
+
+router = DefaultRouter()
+router.register(r'', CropViewSet, basename='crops')
+
+urlpatterns = router.urls

--- a/backend/crops/views.py
+++ b/backend/crops/views.py
@@ -1,0 +1,52 @@
+"""
+Read-only crop library API. Intentionally requires authentication only
+(`IsAuthenticated`, the same DRF default every other endpoint in this
+project uses) and does no project scoping at all — a published crop
+belongs to the library, not to any one project.
+
+This mirrors `farm.views.PublicCultureViewSet` (which keeps serving
+`/api/public-cultures/` unchanged for the current frontend) rather than
+replacing it, so this is purely additive: a new, forward-looking surface
+at `/api/crops/` that can later be made genuinely public (e.g. by
+swapping the permission class) without touching anything that already
+works. See docs/crop-library-architecture.md.
+"""
+from rest_framework import permissions, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from . import services
+from .serializers import CropSerializer
+
+
+class CropViewSet(viewsets.ReadOnlyModelViewSet):
+    """Published crops: list/retrieve, plus an exact-match lookup."""
+
+    serializer_class = CropSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        params = self.request.query_params
+        return services.list_published_crops(
+            query=params.get('q') or '',
+            name=params.get('name') or '',
+            variety=params.get('variety') or '',
+        )
+
+    @action(detail=False, methods=['get'], url_path='match')
+    def match(self, request):
+        crop = services.find_exact_crop_match(
+            name=request.query_params.get('name'),
+            variety=request.query_params.get('variety'),
+        )
+        if crop is None:
+            return Response({'exists': False, 'crop': None})
+
+        return Response({
+            'exists': True,
+            'crop': {
+                'id': crop.id,
+                'name': crop.name,
+                'variety': crop.variety,
+            },
+        })

--- a/docs/crop-library-architecture.md
+++ b/docs/crop-library-architecture.md
@@ -1,0 +1,185 @@
+# Crop Library / Farm Planning Architecture
+
+Date: 2026-07-03
+Scope: `backend/`, `frontend/src/`
+
+Goal: prepare the architecture for a future public Crop Library
+(`/crops`) without splitting the repository, changing any data, or
+changing anything a user can currently see or do. This documents what
+already existed, what was added, and what was deliberately left alone.
+
+## 1. The current situation (before this pass)
+
+The domain split the long-term vision asks for — a public Crop Library
+vs. project-scoped Farm Planning — **already existed at the data model
+level**, just not as a formalized service/app boundary:
+
+- **`Culture`** (`backend/farm/models.py`) is project-owned: it has a
+  required `project` FK. Every project has its own private copy of every
+  variety it grows, with growing parameters, supplier links, seed
+  packages, AI-enrichment results, and revision history
+  (`CultureRevision`). This is Farm Planning data.
+- **`PublicCulture`** (same file) is the shared library: no `project` FK
+  of its own, only nullable *provenance* links (`source_project_culture`,
+  `source_project`) recording where a published entry came from. This is
+  Crop Library data.
+- A bridge, `backend/farm/services/public_cultures.py`, copies data both
+  ways: `publish_culture_to_public_library()` (a project's `Culture` →
+  the library) and `import_public_culture_into_project()` (a library
+  entry → a new project-owned `Culture`).
+- `PublicCultureViewSet` (`/api/public-cultures/`) was already read-only
+  and required only authentication — no project scoping at all, since a
+  published crop isn't owned by any one project.
+- The frontend already has an equivalent precedent for "routes outside
+  the authenticated app": `frontend/src/pages/public/` (landing page,
+  imprint, privacy policy) and `frontend/src/pages/auth/` (login,
+  registration, ...) both render outside `/app`, gated only by
+  `<ProtectedRoute />` wrapping the `/app` branch specifically. `/app` is
+  already the prefix for the entire authenticated Farm Planning app; `/`
+  is already the public root.
+
+So the real work here was formalizing an existing, correct data split
+into an explicit service/app boundary — not inventing the split from
+scratch.
+
+## 2. What this pass added
+
+### Backend — a new `crops` Django app
+
+`backend/crops/` is a real Django app (`INSTALLED_APPS`), but it
+**defines no models**. `PublicCulture` stays in `farm.models` — moving a
+model to a different app changes its migration state and (without
+careful `SeparateDatabaseAndState` migrations) its `app_label`-derived
+`db_table`. That's a real risk to existing data, and the task explicitly
+asks to avoid exactly this kind of unnecessary risk. `crops/models.py`
+documents this and names `PublicCulture` as the thing to move first in a
+future extraction.
+
+```
+backend/crops/
+  apps.py          CropsConfig
+  models.py        (empty — see above)
+  services.py      list_published_crops(), get_published_crop(),
+                    find_exact_crop_match() — reads farm.models.PublicCulture,
+                    nothing else
+  serializers.py   CropSerializer (read-only; deliberately excludes
+                    source_project/source_project_culture — see §3)
+  views.py         CropViewSet (ReadOnlyModelViewSet, IsAuthenticated)
+  urls.py          router → included at /api/crops/
+  tests/
+```
+
+This is **additive**: `/api/public-cultures/` keeps working exactly as
+before (still defined in `farm/views.py`/`farm/urls.py`, untouched) —
+the current frontend keeps using it. `/api/crops/` and `/api/crops/<id>/`
+are new, parallel endpoints with the same `IsAuthenticated` requirement
+as everything else — **not actually public yet**. Making them public
+later is a one-line permission-class change, not a rewrite.
+
+`config/settings.py` (`INSTALLED_APPS`) and `config/urls.py` (both the
+plain and legacy-prefixed mounts, matching how `farm.urls` is already
+double-mounted) were updated to register the new app.
+
+### Frontend — `frontend/src/crops/`
+
+```
+frontend/src/crops/
+  api/cropsApi.ts        new client for /api/crops (list/get/match) —
+                         NOT wired into any page yet
+  components/
+    PublicCultureLibraryDialog.tsx   moved from src/cultures/ (see §3)
+  pages/                 empty (README explains what goes here later)
+  hooks/                 empty (README explains what goes here later)
+  index.ts               barrel (mirrors src/cultures/index.ts's convention
+                         of exporting only the public-facing pieces)
+```
+
+`cropsApi.ts` exists so future code has somewhere to import from, but
+`Cultures.tsx` / `PublicCultureLibraryDialog` still call the existing
+`publicCultureAPI` in `api/api.ts` — switching the data source is a
+separate, deliberate future step (see §5), not bundled into this
+architecture pass.
+
+`App.tsx`'s router got one comment, no new route: a reserved spot for a
+future `/crops` branch as a sibling of `/app` (not nested under
+`<ProtectedRoute />`), pointing at `frontend/src/crops/pages/`.
+
+## 3. The domain rule, and where it bites
+
+> "Die Crop Library darf keinerlei Wissen über Projekte besitzen. Die
+> Projektlogik darf lediglich die Crop Library verwenden."
+
+Applied concretely:
+
+- `crops/services.py`, `crops/serializers.py`, `crops/views.py` import
+  only `farm.models.PublicCulture` and `farm.utils.normalize_text` — never
+  `farm.views`, `farm.serializers`, `Project`, or `Culture`. This is the
+  one dependency direction that matters: if `crops` ever imported from
+  `farm.serializers`, the arrow would point the wrong way (crop library
+  depending on farm planning).
+- `crops/serializers.py`'s `CropSerializer` is **not** a re-export or
+  subclass of `farm.serializers.PublicCultureSerializer`, even though
+  they're currently near-identical — importing it would create exactly
+  that backwards dependency. It's a small, deliberate duplication.
+- `CropSerializer` also deliberately **excludes**
+  `source_project_culture`/`source_project` (present in the legacy
+  `PublicCultureSerializer`) — those are project-provenance fields, and
+  exposing them on the crop-library-facing surface would leak Farm
+  Planning knowledge outward.
+- The publish/import bridge itself (`farm/services/public_cultures.py`)
+  is **not** moved into `crops`. It inherently needs both `Culture` and
+  `Project` — it's a bridge, not a pure citizen of either domain. It's
+  called "farm's dependency on the crop library" already (`farm/views.py`
+  imports it), which is the correct direction; deciding whether it should
+  someday become a real network call (once crops is an actual separate
+  service) is future work, documented in §5, not solved now.
+- `frontend/src/pages/usePublicCultureLibrary.ts` — the hook driving
+  publish/import from the Cultures page — stays in `pages/` for the same
+  reason: it's the Farm-Planning-side integration point, not
+  crop-library-only logic (it reads/writes a project's `Culture` and
+  needs a `selectedCulture`/`onImportSuccess` callback tied to that
+  page's state).
+- `frontend/src/cultures/CultureDetail.tsx` also stays where it is: it's
+  reusable, prop-driven code, but the *data* it displays (a project's own
+  cultures) is Farm Planning data, not the library. Only
+  `PublicCultureLibraryDialog.tsx` — which genuinely only ever renders
+  `PublicCulture[]` — moved to `crops/components/`.
+
+## 4. Naming
+
+New code in `crops/` uses "Crop" (`CropSerializer`, `CropViewSet`,
+`cropsApi`, `Crop` type alias) per the task's naming rule. Existing
+backend fields/models/endpoints (`Culture`, `PublicCulture`,
+`/api/cultures/`, `/api/public-cultures/`) were **not** renamed — the
+task explicitly allows deferring "umfangreiche Umbenennungen" rather than
+risking them, and renaming a Django model/db column/serializer field
+touches migrations, the DRF response shape, and every frontend call site
+for no functional benefit right now. German UI text (`"Kultur"`,
+`"Kulturbibliothek"`) is untouched, as required.
+
+## 5. Deliberately NOT done (and why)
+
+| Not done | Why | Future path |
+|---|---|---|
+| Moving `PublicCulture` (or `Culture`) into `crops.models` | Changes migration state / `app_label`-derived `db_table`; real risk to existing data for zero current benefit | A dedicated migration using `SeparateDatabaseAndState` to move the model's Django state into `crops` while keeping (or explicitly renaming, in one controlled step) the actual table |
+| Removing/renaming `/api/public-cultures/` | Would break the current frontend (`publicCultureAPI`) — a functional change the task forbids | Once `Cultures.tsx`/`PublicCultureLibraryDialog` are switched to `cropsApi`/`/api/crops`, deprecate and remove the legacy path |
+| Switching the frontend to actually call `/api/crops` | Not required to "prepare" the architecture, and swapping a working data source is exactly the kind of change to do deliberately and separately, with its own testing pass | Point `Cultures.tsx` at `cropsApi` instead of `publicCultureAPI`, delete the old client, delete `/api/public-cultures/` |
+| A real `/crops` route/page | Explicitly "noch NICHT veröffentlichen" | Add route components under `frontend/src/crops/pages/`, wire the reserved router branch in `App.tsx`, flip `CropViewSet.permission_classes` |
+| Splitting `i18n/locales/*/cultures.json` into a `crops` namespace | Namespace holds both library- and farm-planning-flavored strings today; splitting now is pure churn for zero user-visible benefit | Split when `crops/pages/` gets real UI text to hold |
+| Moving `Culture`/`CultureViewSet`/`CultureSupplierData`/`SeedPackage`/AI enrichment into `crops` | These are genuinely Farm Planning (project-owned, or only meaningful attached to a project-owned `Culture`) — moving them would be the large, risky refactor the task asks to avoid | Not planned; these belong in Farm Planning long-term too |
+| Fixing `PublicCultureLibraryDialog.tsx`'s cross-import of `stripCitationMarkers` from `components/data-grid/markdown`, or its two pre-existing `react-hooks/set-state-in-effect` lint errors | Both pre-date this move (confirmed by lint-checking the file at its old path before moving it) — fixing them isn't in scope for an architecture-only pass | A future cleanup could move the markdown helper to a shared, domain-neutral location |
+
+## 6. Verifying nothing changed for users
+
+- Every existing API path (`/api/cultures/...`, `/api/public-cultures/...`)
+  is untouched — same views, same serializers, same URLs.
+- The frontend still imports `PublicCultureLibraryDialog` and calls
+  `publicCultureAPI` exactly as before; only its file location and import
+  path changed.
+- No new frontend route is reachable; the `/crops` reservation is a
+  comment.
+- Backend: 409 existing tests pass (1 pre-existing, unrelated failure —
+  a German-umlaut encoding mismatch in
+  `accounts/tests/test_auth_api.py`, confirmed present on `main` before
+  this branch too), plus 12 new tests for the `crops` app.
+- Frontend: all 956 existing tests pass, plus 3 new tests for `cropsApi`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2316,6 +2316,11 @@ function createAppRouter(basename: string) {
           path: 'invite/:token',
           element: <TokenInvitationRedirect />,
         },
+        // Reserved: a future public `/crops` branch (sibling to `/app`, not
+        // nested under <ProtectedRoute />) for the Crop Library — see
+        // docs/crop-library-architecture.md. Deliberately not added yet;
+        // `frontend/src/crops/pages/` is where its route components would
+        // live once it is.
         {
           path: 'app',
           element: <ProtectedRoute />,

--- a/frontend/src/__tests__/PublicCultureLibraryDialog.test.tsx
+++ b/frontend/src/__tests__/PublicCultureLibraryDialog.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PublicCultureLibraryDialog } from '../cultures/PublicCultureLibraryDialog';
+import { PublicCultureLibraryDialog } from '../crops/components/PublicCultureLibraryDialog';
 import type { PublicCulture } from '../api/types';
 
 const culture: PublicCulture = {

--- a/frontend/src/__tests__/crops/cropsApi.test.ts
+++ b/frontend/src/__tests__/crops/cropsApi.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}));
+
+vi.mock('../../api/httpClient', () => ({
+  default: {
+    get: getMock,
+  },
+}));
+
+import { cropsApi } from '../../crops/api/cropsApi';
+
+describe('cropsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists crops from the /crops/ endpoint', async () => {
+    getMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
+
+    await cropsApi.list({ q: 'lettuce' });
+
+    expect(getMock).toHaveBeenCalledWith('/crops/', { params: { q: 'lettuce' } });
+  });
+
+  it('retrieves a single crop by id', async () => {
+    getMock.mockResolvedValue({ data: { id: 1, name: 'Lettuce' } });
+
+    await cropsApi.get(1);
+
+    expect(getMock).toHaveBeenCalledWith('/crops/1/');
+  });
+
+  it('checks for an exact match', async () => {
+    getMock.mockResolvedValue({ data: { exists: false, crop: null } });
+
+    await cropsApi.match({ name: 'Lettuce', variety: 'Bijella' });
+
+    expect(getMock).toHaveBeenCalledWith('/crops/match/', { params: { name: 'Lettuce', variety: 'Bijella' }, signal: undefined });
+  });
+});

--- a/frontend/src/crops/api/cropsApi.ts
+++ b/frontend/src/crops/api/cropsApi.ts
@@ -1,0 +1,33 @@
+/**
+ * Crop Library API client — talks to the new, additive `/api/crops` surface
+ * (see docs/crop-library-architecture.md) rather than the legacy
+ * `/api/public-cultures` one `api/api.ts`'s `publicCultureAPI` still uses.
+ *
+ * Not wired into any page yet. `Cultures.tsx`/`PublicCultureLibraryDialog`
+ * keep using `publicCultureAPI` unchanged — switching them over is a
+ * separate, deliberately deferred step (see the architecture doc) once
+ * `/api/crops` has been exercised in production for a while.
+ *
+ * Known limitation: this reuses the shared `httpClient`, which attaches an
+ * `X-Project-Id` header to every request whenever a project happens to be
+ * active in local storage. The crop library ignores that header today, but
+ * a genuinely standalone crop-library client should eventually get its own
+ * instance instead of inheriting app-wide, project-scoped plumbing.
+ */
+import http from '../../api/httpClient';
+import type { PaginatedResponse, PublicCulture, PublicCultureMatchResponse } from '../../api/types';
+
+/** Alias so new crop-library code can talk about "Crop" rather than the
+ * backend/historical "Culture" naming — see docs/crop-library-architecture.md
+ * section 7. The shape is identical to `PublicCulture`; this is a type
+ * alias, not a copy, so it can never drift. */
+export type Crop = PublicCulture;
+export type CropMatchResponse = PublicCultureMatchResponse;
+
+export const cropsApi = {
+  list: (params?: { q?: string; name?: string; variety?: string }) =>
+    http.get<PaginatedResponse<Crop>>('/crops/', { params }),
+  get: (id: number) => http.get<Crop>(`/crops/${id}/`),
+  match: (params: { name: string; variety: string }, signal?: AbortSignal) =>
+    http.get<CropMatchResponse>('/crops/match/', { params, signal }),
+};

--- a/frontend/src/crops/components/PublicCultureLibraryDialog.tsx
+++ b/frontend/src/crops/components/PublicCultureLibraryDialog.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useTranslation } from '../i18n';
-import type { PublicCulture } from '../api/types';
+import { useTranslation } from '../../i18n';
+import type { PublicCulture } from '../../api/types';
 import {
   Accordion,
   AccordionDetails,
@@ -31,7 +31,11 @@ import {
 import SearchIcon from '@mui/icons-material/Search';
 import TuneIcon from '@mui/icons-material/Tune';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { stripCitationMarkers } from '../components/data-grid/markdown';
+// Cross-domain import: a markdown helper that today lives under the
+// app-specific data-grid module. Kept as-is rather than duplicated/moved —
+// see docs/crop-library-architecture.md for why this is flagged as a
+// future cleanup candidate rather than fixed now.
+import { stripCitationMarkers } from '../../components/data-grid/markdown';
 
 interface PublicCultureLibraryDialogProps {
   open: boolean;

--- a/frontend/src/crops/hooks/README.md
+++ b/frontend/src/crops/hooks/README.md
@@ -1,0 +1,9 @@
+# Crop Library hooks
+
+Empty on purpose for now. Reserved for hooks that are purely about crop
+library data (browsing, searching a `Crop`) with no project/planting-plan
+context. `frontend/src/pages/usePublicCultureLibrary.ts` deliberately stays
+in `pages/` rather than moving here: it also publishes a project's `Culture`
+into the library and imports a `Crop` back into the active project, so it's
+the Farm Planning-side integration hook, not a Crop Library one — see
+docs/crop-library-architecture.md.

--- a/frontend/src/crops/index.ts
+++ b/frontend/src/crops/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel export for the Crop Library domain — see
+ * docs/crop-library-architecture.md. Kept intentionally small (not every
+ * file needs to be re-exported here) to match the existing convention in
+ * `src/cultures/index.ts`.
+ */
+export { PublicCultureLibraryDialog } from './components/PublicCultureLibraryDialog';

--- a/frontend/src/crops/pages/README.md
+++ b/frontend/src/crops/pages/README.md
@@ -1,0 +1,6 @@
+# Crop Library pages
+
+Empty on purpose for now. This is where a future public `/crops` route's
+page components (search/list, detail) would live once that route is
+actually built and mounted in `App.tsx`'s router — see
+`docs/crop-library-architecture.md` for why that isn't done yet.

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -18,7 +18,7 @@ import type {
 } from '../api/types';
 import { CultureDetail } from '../cultures/CultureDetail';
 import { CultureForm } from '../cultures/CultureForm';
-import { PublicCultureLibraryDialog } from '../cultures/PublicCultureLibraryDialog';
+import { PublicCultureLibraryDialog } from '../crops/components/PublicCultureLibraryDialog';
 import {
   Alert,
   Box,


### PR DESCRIPTION
## Summary

Prepares the architecture for a future public Crop Library (`/crops`), without splitting the repo/deployment, changing any data, or changing anything users can see. Full analysis and decisions in `docs/crop-library-architecture.md`.

**Key finding from analysis**: the domain split already existed at the data level — `Culture` is project-owned (has a required `project` FK), while `PublicCulture` is already the global/shared library concept (no project FK, only provenance links). This PR formalizes that into an explicit service/app boundary rather than inventing a split from scratch.

**Backend** — new `crops` Django app:
- `services.py`/`serializers.py`/`views.py`/`urls.py`, **no models** (`PublicCulture` stays in `farm.models` — moving it would touch migration state / `db_table` naming, a real risk to existing data for no current benefit; documented as the future step).
- Imports only `farm.models.PublicCulture` — never `farm.views`/`farm.serializers`/`Project`/`Culture` — enforcing "crop library knows nothing about projects."
- New, **additive** `/api/crops/` + `/api/crops/<id>/` (same `IsAuthenticated` requirement as today — not actually public). The existing `/api/public-cultures/` is untouched and still what the frontend uses.

**Frontend** — new `frontend/src/crops/` (`api/`, `components/`, `pages/`, `hooks/`), mirroring the existing `pages/public/`/`pages/auth/` convention for routes outside `/app`:
- Moved `PublicCultureLibraryDialog.tsx` there (already fully props-driven, project-agnostic). Left `CultureDetail.tsx` and `usePublicCultureLibrary.ts` in place — their data/logic is genuinely project-scoped, explained in the doc.
- New `cropsApi.ts` client for `/api/crops` — **not wired into any page yet**; `Cultures.tsx` keeps using the existing `publicCultureAPI`.
- A router comment reserving a future `/crops` branch (sibling to `/app`). No new route added.

## Test plan
- [x] Backend: `pdm run pytest --no-cov` — 409 passed, 1 pre-existing failure unrelated to this change (German-umlaut encoding mismatch in `accounts/tests/test_auth_api.py`, confirmed present on `main` before this branch too), plus 12 new tests for the `crops` app
- [x] Frontend: `npx vitest run` — 108 files / 956 tests passed, plus 3 new tests for `cropsApi`
- [x] `npx tsc --noEmit` — no errors
- [x] Confirmed the 2 lint errors in the moved `PublicCultureLibraryDialog.tsx` are pre-existing (checked the file at its old path before moving — identical errors)
- [x] Verified every existing API path and frontend import is unchanged in behavior; only the dialog's file location moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)