### PR TITLE
[codex] fix mobile planting plan deep link

### DIFF
--- a/frontend/e2e/gantt-context-menu-smoke.spec.ts
+++ b/frontend/e2e/gantt-context-menu-smoke.spec.ts
@@ -108,6 +108,45 @@ test.describe('gantt calendar context-menu smoke test', () => {
     await expect(page).toHaveURL(/\/app\/planting-plans\?planId=\d+&edit=true/, { timeout: 10_000 });
     await expect(page.locator('.MuiDataGrid-row--editing')).toHaveCount(1, { timeout: 5_000 });
 
+    // --- Mobile context menu links: the selected plan opens expanded, and
+    // related culture/area links still land on the intended target. ---
+    await page.setViewportSize({ width: 390, height: 844 });
+    const openMobileTaskMenu = async (): Promise<void> => {
+      await page.goto('/app/gantt-chart');
+      await expect(page.getByText('Testhof')).toBeVisible({ timeout: 10_000 });
+      const mobileTaskBar = page.locator('[data-rmg-component="task"]').first();
+      await expect(mobileTaskBar).toBeVisible({ timeout: 10_000 });
+      await mobileTaskBar.click({ button: 'right' });
+    };
+
+    await openMobileTaskMenu();
+    await page.getByRole('menuitem', { name: 'Anbauplan öffnen' }).click();
+    await expect(page).toHaveURL(/\/app\/planting-plans/, { timeout: 10_000 });
+    await expect(page.getByText('Testkultur (Sorte A)').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/Anbauart:/)).toBeVisible({ timeout: 10_000 });
+
+    await openMobileTaskMenu();
+    await page.getByRole('menuitem', { name: 'Kultur öffnen' }).click();
+    await expect(page).toHaveURL(new RegExp(`/app/cultures\\?cultureId=${culture.id}`), { timeout: 10_000 });
+    await expect(page.getByText('Testkultur')).toBeVisible({ timeout: 10_000 });
+
+    await openMobileTaskMenu();
+    await page.getByRole('menuitem', { name: 'Beet öffnen' }).click();
+    await expect(page).toHaveURL(new RegExp(`/app/fields-beds\\?highlight=bed:${bed.id}`), { timeout: 10_000 });
+    await expect(page.getByText('Testbeet')).toBeVisible({ timeout: 10_000 });
+
+    await openMobileTaskMenu();
+    await page.getByRole('menuitem', { name: 'Parzelle öffnen' }).click();
+    await expect(page).toHaveURL(new RegExp(`/app/fields-beds\\?highlight=field:${field.id}`), { timeout: 10_000 });
+    await expect(page.getByText('Testfeld')).toBeVisible({ timeout: 10_000 });
+
+    await openMobileTaskMenu();
+    await page.getByRole('menuitem', { name: 'Standort öffnen' }).click();
+    await expect(page).toHaveURL(new RegExp(`/app/fields-beds\\?highlight=location:${location.id}`), { timeout: 10_000 });
+    await expect(page.getByText('Testhof')).toBeVisible({ timeout: 10_000 });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+
     // --- Drag-and-drop: moving a bar persists a new planting_date, and the
     // bar's on-screen position never regresses back toward its start once
     // the drag begins (the "snaps back, then moves" flicker this session's

--- a/frontend/src/components/mobile/MobileCardList.tsx
+++ b/frontend/src/components/mobile/MobileCardList.tsx
@@ -41,7 +41,7 @@ export function MobileCardList<T extends MobileCardListItem>({
       {items.map((item) => {
         const isExpanded = expandedIds.has(item.id);
         return (
-          <Card key={item.id} variant="outlined">
+          <Card key={item.id} variant="outlined" data-mobile-card-id={item.id}>
             <CardContent sx={{ px: 1.5, py: 1.25, '&:last-child': { pb: 1.25 } }}>
               <Stack spacing={1}>
                 <Stack direction="row" spacing={0.5} alignItems="flex-start">

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -529,6 +529,8 @@ function PlantingPlans() {
   const [mobileActionMenuRow, setMobileActionMenuRow] = useState<PlantingPlanRow | null>(null);
   const mobilePrefillHandledRef = useRef(false);
   const createIntentHandledRef = useRef(false);
+  const planIdParamProcessedRef = useRef(false);
+  const openMobileEditDialogRef = useRef<((row: PlantingPlanRow) => void) | null>(null);
 
   const replacePlantingPlanSearchParams = useCallback((nextParams: URLSearchParams): void => {
     const browserPathname = window.location.pathname;
@@ -711,35 +713,6 @@ function PlantingPlans() {
 
     urlParamProcessedRef.current = true;
   }, [initialSelection, replacePlantingPlanSearchParams, searchParams]);
-
-  // Consumes a `?planId=<id>` deep link (e.g. "Anbauplan öffnen"/"bearbeiten"
-  // or a double-click from the Gantt calendar's context menu): scrolls to and
-  // selects the existing plan row, instead of the `bedId`/`cultureId` path
-  // above which always prefills a brand-new draft row. An additional
-  // `edit=true` also opens it in edit mode straight away.
-  const planIdParamProcessedRef = useRef(false);
-  useEffect(() => {
-    if (planIdParamProcessedRef.current || isPlansLoading) {
-      return;
-    }
-
-    const planIdParam = searchParams.get("planId");
-    if (!planIdParam) {
-      return;
-    }
-
-    const planId = parseInt(planIdParam, 10);
-    const shouldStartEdit = searchParams.get("edit") === "true";
-    planIdParamProcessedRef.current = true;
-    if (!isNaN(planId)) {
-      gridCommandApiRef.current?.openRowById(planId, { startEdit: shouldStartEdit });
-    }
-
-    const newParams = new URLSearchParams(searchParams);
-    newParams.delete("edit");
-    newParams.delete("planId");
-    replacePlantingPlanSearchParams(newParams);
-  }, [isPlansLoading, replacePlantingPlanSearchParams, searchParams]);
 
   /**
    * Define columns for the Data Grid with inline editing
@@ -1598,6 +1571,53 @@ function PlantingPlans() {
     setMobileLastEditedField(null);
     setIsMobileCreateOpen(true);
   };
+  openMobileEditDialogRef.current = openMobileEditDialog;
+
+  // Consumes a `?planId=<id>` deep link (e.g. "Anbauplan öffnen"/"bearbeiten"
+  // or a double-click from the Gantt calendar's context menu): opens the
+  // existing plan row/card instead of the `bedId`/`cultureId` path above,
+  // which always prefills a brand-new draft row. An additional `edit=true`
+  // also opens it in edit mode straight away.
+  useEffect(() => {
+    if (planIdParamProcessedRef.current || isPlansLoading) {
+      return;
+    }
+
+    const planIdParam = searchParams.get("planId");
+    if (!planIdParam) {
+      return;
+    }
+
+    const planId = parseInt(planIdParam, 10);
+    const shouldStartEdit = searchParams.get("edit") === "true";
+    planIdParamProcessedRef.current = true;
+
+    if (!isNaN(planId)) {
+      if (isMobile) {
+        const targetRow = mobileRows.find((row) => row.id === planId);
+        if (targetRow) {
+          setSelectedPlan(targetRow);
+          setExpandedCardIds((previous) => new Set(previous).add(planId));
+          window.setTimeout(() => {
+            document
+              .querySelector(`[data-mobile-card-id="${planId}"]`)
+              ?.scrollIntoView({ block: "center", behavior: "smooth" });
+          }, 0);
+
+          if (shouldStartEdit) {
+            openMobileEditDialogRef.current?.(targetRow);
+          }
+        }
+      } else {
+        gridCommandApiRef.current?.openRowById(planId, { startEdit: shouldStartEdit });
+      }
+    }
+
+    const newParams = new URLSearchParams(searchParams);
+    newParams.delete("edit");
+    newParams.delete("planId");
+    replacePlantingPlanSearchParams(newParams);
+  }, [isMobile, isPlansLoading, mobileRows, replacePlantingPlanSearchParams, searchParams]);
 
   const openMobileDuplicateDialog = (row: PlantingPlanRow): void => {
     const derivedArea = getDerivedAreaFromRow(row);


### PR DESCRIPTION
## Summary

- Expands and scrolls to the selected planting plan card when mobile users open a plan from the Gantt context menu.
- Preserves desktop grid deep-link behavior and mobile edit-mode behavior for `edit=true`.
- Extends the Gantt context-menu smoke test to cover mobile links for planting plans, cultures, beds, fields, and locations.

## Root Cause

The Gantt menu already navigated to `/app/planting-plans?planId=...`, but the planting-plan page only consumed that deep link through the hidden desktop grid command API. On mobile, the visible card list keeps its own expanded-card state, so the page loaded but did not open the selected plan.

## Validation

- `npm test -- --run src/__tests__/plantingPlans.mobile.test.ts src/__tests__/PlantingPlans.escapeFocus.test.tsx src/__tests__/GanttChart.test.tsx`
- `npm run build`
- `npx playwright test e2e/gantt-context-menu-smoke.spec.ts --project=chromium`