### PR TITLE
[codex] fix focus for prefilled planting plan drafts

### DIFF
--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -315,6 +315,21 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('view'));
   });
 
+  it('focuses an initial draft row created from navigation context', async () => {
+    render(
+      <EditableDataGrid
+        {...baseProps()}
+        initialRow={{ name: 'Vorgefüllter Entwurf' }}
+        showDeleteAction={false}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('row--1')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('mode--1')).toHaveTextContent('edit'));
+    expect(screen.getByTestId('row--1')).toHaveAttribute('data-selected', 'true');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('-1-name'));
+  });
+
   it('prevents delete when canceled and deletes when confirmed', async () => {
     const user = userEvent.setup();
     const props = baseProps();

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -562,15 +562,20 @@ export function EditableDataGrid<T extends EditableRow>({
       const newRow = { ...createNewRow(), ...initialRow };
       setRows((oldRows) => [...oldRows, newRow]);
       setStableRowOrder((previousOrder) => [...previousOrder, newRow.id]);
+      setSelectedRowIds([newRow.id]);
       // Set row to edit mode after a small delay to ensure row is added first
       setTimeout(() => {
+        const fieldToFocus = columns.find((column) => column.editable !== false)?.field ?? columns[0]?.field;
         setRowModesModel((oldModel) => ({
           ...oldModel,
-          [newRow.id]: { mode: GridRowModes.Edit },
+          [newRow.id]: { mode: GridRowModes.Edit, fieldToFocus },
         }));
+        if (fieldToFocus) {
+          gridApiRef.current?.setCellFocus(newRow.id, fieldToFocus);
+        }
       }, 0);
     }
-  }, [initialRow, dataFetched, loading, createNewRow]);
+  }, [columns, gridApiRef, initialRow, dataFetched, loading, createNewRow, setSelectedRowIds]);
 
   /**
    * Handle adding a new row to the grid


### PR DESCRIPTION
## Summary

- Focuses and selects the draft row created from `initialRow` navigation context.
- Starts edit mode with `fieldToFocus` so cross-page "Anbauplan erstellen" flows land keyboard focus on the new row.
- Adds a regression test for initial draft rows in `EditableDataGrid`.

## Root Cause

The regular grid add button set edit mode with a target field, but the URL-prefilled `initialRow` path only appended the row and switched it to edit mode later. That left keyboard focus behind on the originating page/control after navigating from the areas table.

## Validation

- `npm test -- --run src/__tests__/EditableDataGrid.test.tsx src/__tests__/PlantingPlans.escapeFocus.test.tsx`
- `npm run build`

## Notes

- Targeted ESLint on the touched files still reports existing `react-hooks/refs` issues in the `EditableDataGrid` test mock and an existing DataGrid hook warning; the focused tests and build pass.