### PR TITLE
fix: improve calendar layout scrolling

### DIFF
--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const backendPort = process.env.BACKEND_PORT ?? '8000';
+const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
+const apiBase = `http://127.0.0.1:${backendPort}/api`;
+
+type LayoutMetrics = {
+  bodyOverflowX: number;
+  documentOverflowX: number;
+  wrapperOverflowX: number;
+  timelineOverflowX: number;
+  viewportBottomGap: number;
+  viewportHeight: number;
+  viewportOverflowY: number;
+  wrapperOverflowStyleX: string;
+  timelineOverflowStyleX: string;
+  timelineOverflowStyleY: string;
+  timelineScrollbarWidth: string;
+};
+
+async function loginWithFreshProject(page: Page, request: APIRequestContext, scenarioPrefix: string): Promise<void> {
+  const scenario = `${scenarioPrefix}-${Date.now()}`;
+  const setupResponse = await request.post(`${apiBase}/__e2e__/invite-flow/`, {
+    headers: { 'X-E2E-Token': e2eToken },
+    data: { action: 'setup', scenario_id: scenario, invitation_state: 'pending' },
+  });
+  const setupText = await setupResponse.text();
+  expect(setupResponse.ok(), `fixture setup -> ${setupResponse.status()}: ${setupText}`).toBeTruthy();
+  const setup = JSON.parse(setupText) as { admin: { email: string; password: string } };
+
+  await page.goto('/login');
+  await page.getByLabel('E-Mail').fill(setup.admin.email);
+  await page.locator('input[type="password"]').fill(setup.admin.password);
+  await page.getByRole('button', { name: 'Anmelden' }).click();
+  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
+}
+
+async function createCalendarFixture(page: Page): Promise<void> {
+  const activeProjectId = await page.evaluate(() => window.localStorage.getItem('activeProjectId'));
+  expect(activeProjectId).toBeTruthy();
+  const projectId = Number(activeProjectId);
+  const csrfToken = await page.evaluate(() =>
+    document.cookie.split('; ').find((row) => row.startsWith('csrftoken='))?.split('=')[1] ?? '');
+
+  const api = async <T,>(path: string, data: Record<string, unknown>): Promise<T> => {
+    const result = await page.evaluate(async ({ requestPath, requestData, requestProjectId, requestCsrfToken }) => {
+      const response = await fetch(`/api${requestPath}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'X-CSRFToken': requestCsrfToken,
+          'Content-Type': 'application/json',
+          'X-Project-Id': String(requestProjectId),
+        },
+        body: JSON.stringify({ ...requestData, project: requestProjectId }),
+      });
+      const text = await response.text();
+      return {
+        ok: response.ok,
+        status: response.status,
+        text,
+      };
+    }, {
+      requestPath: path,
+      requestData: data,
+      requestProjectId: projectId,
+      requestCsrfToken: csrfToken,
+    });
+    expect(result.ok, `${path} -> ${result.status}: ${result.text}`).toBeTruthy();
+    return JSON.parse(result.text) as T;
+  };
+
+  const location = await api<{ id: number }>('/locations/', { name: 'Layout Testhof' });
+  const field = await api<{ id: number }>('/fields/', { name: 'Layout Testfeld', location: location.id });
+  const bed = await api<{ id: number }>('/beds/', {
+    name: 'Layout Testbeet',
+    field: field.id,
+    length_m: 10,
+    width_m: 1,
+    area_sqm: 10,
+  });
+  const culture = await api<{ id: number }>('/cultures/', {
+    name: 'Layout Kultur',
+    propagation_duration_days: 21,
+    cultivation_type: 'pre_cultivation',
+    cultivation_types: ['pre_cultivation'],
+    plants_per_m2: 4,
+  });
+  await api('/planting-plans/', {
+    bed: bed.id,
+    culture: culture.id,
+    cultivation_type: 'pre_cultivation',
+    planting_date: '2026-04-01',
+    harvest_date: '2026-05-01',
+    area_usage_sqm: 2,
+  });
+}
+
+async function readLayoutMetrics(page: Page): Promise<LayoutMetrics> {
+  await expect(page.locator('.gantt-container-wrapper .rmg-container')).toBeVisible({ timeout: 10_000 });
+
+  return page.evaluate(() => {
+    const wrapper = document.querySelector<HTMLElement>('.gantt-container-wrapper');
+    const viewport = document.querySelector<HTMLElement>('[data-testid="gantt-virtual-viewport"]');
+    const timeline = document.querySelector<HTMLElement>('.gantt-container-wrapper .rmg-container');
+    if (!wrapper || !viewport || !timeline) {
+      throw new Error('Missing Gantt layout elements');
+    }
+
+    const rowElements = [
+      ...wrapper.querySelectorAll<HTMLElement>('[data-rmg-component="task-group"]'),
+      ...wrapper.querySelectorAll<HTMLElement>('[data-rmg-component="task-row"]'),
+    ];
+    const lastRowBottom = rowElements.length > 0
+      ? Math.max(...rowElements.map((element) => element.getBoundingClientRect().bottom))
+      : viewport.getBoundingClientRect().top;
+    const viewportRect = viewport.getBoundingClientRect();
+    const timelineStyle = getComputedStyle(timeline);
+
+    return {
+      bodyOverflowX: document.body.scrollWidth - window.innerWidth,
+      documentOverflowX: document.documentElement.scrollWidth - window.innerWidth,
+      wrapperOverflowX: wrapper.scrollWidth - wrapper.clientWidth,
+      timelineOverflowX: timeline.scrollWidth - timeline.clientWidth,
+      viewportBottomGap: viewportRect.bottom - lastRowBottom,
+      viewportHeight: viewportRect.height,
+      viewportOverflowY: viewport.scrollHeight - viewport.clientHeight,
+      wrapperOverflowStyleX: getComputedStyle(wrapper).overflowX,
+      timelineOverflowStyleX: timelineStyle.overflowX,
+      timelineOverflowStyleY: timelineStyle.overflowY,
+      timelineScrollbarWidth: timelineStyle.scrollbarWidth,
+    };
+  });
+}
+
+async function expectCalendarLayout(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await expect(page.getByText(/Feldplanung|Anzuchtplanung/)).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('Layout Kultur').first()).toBeVisible({ timeout: 10_000 });
+
+  const metrics = await readLayoutMetrics(page);
+  expect(metrics.documentOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.bodyOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.wrapperOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.timelineOverflowX).toBeGreaterThan(0);
+  expect(metrics.viewportBottomGap).toBeLessThan(96);
+  expect(metrics.viewportHeight).toBeLessThan(360);
+  expect(metrics.viewportOverflowY).toBeLessThanOrEqual(1);
+  expect(metrics.wrapperOverflowStyleX).toBe('hidden');
+  expect(metrics.timelineOverflowStyleX).toBe('auto');
+  expect(metrics.timelineOverflowStyleY).toBe('hidden');
+}
+
+test.describe('Gantt calendar layout', () => {
+  test('keeps horizontal scrolling on the timeline and short calendars sized to content', async ({ page, request }) => {
+    await loginWithFreshProject(page, request, 'gantt-layout-desktop');
+    await createCalendarFixture(page);
+
+    for (const viewport of [
+      { width: 390, height: 844 },
+      { width: 600, height: 900 },
+      { width: 768, height: 900 },
+      { width: 1024, height: 900 },
+      { width: 1440, height: 900 },
+      { width: 1920, height: 1080 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await expectCalendarLayout(page, '/app/gantt-chart');
+      await expectCalendarLayout(page, '/app/gantt-chart?view=seedlings');
+    }
+  });
+});
+
+test.describe('Gantt calendar layout on touch devices', () => {
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+  test('hides the mobile timeline scrollbar while keeping touch scrolling available', async ({ page, request }) => {
+    await loginWithFreshProject(page, request, 'gantt-layout-mobile-touch');
+    await createCalendarFixture(page);
+    await expectCalendarLayout(page, '/app/gantt-chart');
+
+    const metrics = await readLayoutMetrics(page);
+    expect(metrics.timelineScrollbarWidth).toBe('none');
+  });
+});

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -323,6 +323,28 @@ describe('GanttChartPage', () => {
     expect(window.totalHeight).toBeGreaterThan(720);
   });
 
+  it('uses measured row heights for the Gantt render window when provided', () => {
+    const groups = [
+      { id: 'location-1', name: 'Location', tasks: [], rowHeightOverride: 32 },
+      { id: 'field-1', name: 'Field', tasks: [], rowHeightOverride: 32 },
+      {
+        id: 'bed-1',
+        name: 'Bed',
+        tasks: [{
+          id: 'task-1',
+          name: 'Salat',
+          startDate: new Date('2026-04-01'),
+          endDate: new Date('2026-05-01'),
+        }],
+      },
+    ];
+
+    const window = getGanttRenderWindow(groups, 0, 720, (group) => group.rowHeightOverride ?? 44);
+
+    expect(window.totalHeight).toBe(108);
+    expect(window.groups).toHaveLength(3);
+  });
+
   it.each([
     ['small', 5],
     ['medium', 80],
@@ -668,13 +690,38 @@ describe('GanttChartPage', () => {
       const chart = await screen.findByTestId('mock-gantt');
       await waitFor(() => {
         expect(virtualViewport.scrollTop).toBe(40);
-        expect(getComputedStyle(chart.parentElement as HTMLElement).top).toBe('40px');
+        expect(getComputedStyle(chart.parentElement as HTMLElement).position).not.toBe('absolute');
+        expect((chart.parentElement as HTMLElement).style.top).toBe('');
       });
     } finally {
       if (originalDescriptor) {
         Object.defineProperty(Element.prototype, 'scrollTop', originalDescriptor);
       }
     }
+  });
+
+  it('lets short calendars size to content instead of forcing viewport-height whitespace', async () => {
+    mocks.planList.mockResolvedValue({
+      data: {
+        results: [{
+          id: 10,
+          culture: 5,
+          culture_name: 'Salat',
+          bed: 3,
+          planting_date: '2026-04-01',
+          harvest_date: '2026-05-01',
+        }],
+      },
+    });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
+
+    renderWithAuth();
+
+    const virtualViewport = await screen.findByTestId('gantt-virtual-viewport');
+    await waitFor(() => expect(screen.getByTestId('mock-gantt')).toBeInTheDocument());
+
+    expect(virtualViewport).not.toHaveStyle({ height: 'calc(100vh - 220px)' });
+    expect(virtualViewport).not.toHaveStyle({ minHeight: '420px' });
   });
 
   it('persists timeline view mode changes and keeps them during data updates', async () => {

--- a/frontend/src/pages/GanttChart.css
+++ b/frontend/src/pages/GanttChart.css
@@ -3,17 +3,56 @@
  */
 
 .gantt-container-wrapper {
-  overflow: auto;
+  overflow: hidden;
   width: 100%;
   margin-top: 1rem;
-  min-height: 400px;
+  min-width: 0;
 }
 
-@media (max-width: 900px) and (max-height: 500px) {
-  .gantt-container-wrapper {
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+.gantt-container-wrapper .rmg-gantt-chart {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.gantt-container-wrapper .rmg-container {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .gantt-container-wrapper .rmg-container {
+    scrollbar-width: none;
+  }
+
+  .gantt-container-wrapper .rmg-container:hover,
+  .gantt-container-wrapper .rmg-container:focus-within {
+    scrollbar-width: thin;
+  }
+
+  .gantt-container-wrapper .rmg-container::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .gantt-container-wrapper .rmg-container:hover::-webkit-scrollbar,
+  .gantt-container-wrapper .rmg-container:focus-within::-webkit-scrollbar {
+    width: var(--rmg-scrollbar-size);
+    height: var(--rmg-scrollbar-size);
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .gantt-container-wrapper .rmg-container {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .gantt-container-wrapper .rmg-container::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
   }
 }
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -47,6 +47,8 @@ import {
   type PlantingPlan,
 } from '../api/api';
 import GanttChart, { ViewMode } from '../gantt-chart/src';
+import { CollisionService } from '../gantt-chart/src/services/CollisionService';
+import { estimateTaskGroupLabelHeight } from '../gantt-chart/src/utils';
 import './GanttChart.css';
 import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
 import PageContainer from '../components/layout/PageContainer';
@@ -93,6 +95,8 @@ const CALENDAR_TIMELINE_VIEW_MODE_STORAGE_KEY = 'openFarmPlanner.ganttChart.time
 const GANTT_STATE_STORAGE_PREFIX = 'openfarmplanner:gantt';
 const DEFAULT_TIMELINE_VIEW_MODE = ViewMode.MONTH;
 const GANTT_LEFT_COLUMN_WIDTH = 220;
+const GANTT_ROW_HEIGHT = 32;
+const GANTT_VIEWPORT_MAX_HEIGHT_SX = { xs: '70svh', sm: '72svh', lg: '76svh' } as const;
 // Above this many combined location+field+bed nodes, default to
 // locations-expanded/fields-collapsed instead of fully expanding the tree.
 const OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD = 30;
@@ -122,6 +126,17 @@ const GANTT_UNIT_WIDTH_BY_VIEW_MODE: Record<ViewMode, number> = {
   [ViewMode.QUARTER]: 180,
   [ViewMode.YEAR]: 200,
 };
+
+function getCalendarGanttRowHeight(group: GanttTaskGroup, viewMode: ViewMode): number {
+  if (group.rowHeightOverride !== undefined) {
+    return group.rowHeightOverride;
+  }
+
+  const estimatedLabelHeight = estimateTaskGroupLabelHeight(group, GANTT_LEFT_COLUMN_WIDTH);
+  const taskRows = CollisionService.detectOverlaps(group.tasks, viewMode);
+  return Math.max(estimatedLabelHeight, taskRows.length * GANTT_ROW_HEIGHT + 12);
+}
+
 const CALENDAR_SHORTCUT_VIEW_MODES: Array<{ mode: ViewMode; shortcut: string; labelKey: string }> = [
   { mode: ViewMode.DAY, shortcut: '1', labelKey: 'dayView' },
   { mode: ViewMode.WEEK, shortcut: '2', labelKey: 'weekView' },
@@ -1342,15 +1357,21 @@ function GanttChartPage() {
   ), [calendarMode, editMode, handleTimelineViewModeChange, t]);
 
   const activeTaskGroups = calendarMode === 'occupancy' ? occupancyTaskGroups : seedlingTaskGroups;
+  const getActiveGanttRowHeight = useCallback(
+    (group: GanttTaskGroup): number => getCalendarGanttRowHeight(group, timelineViewMode),
+    [timelineViewMode],
+  );
   const renderWindow = useMemo(
     () => getGanttRenderWindow(
       activeTaskGroups,
       ganttScrollTop,
       ganttViewportHeight,
+      getActiveGanttRowHeight,
     ),
-    [activeTaskGroups, ganttScrollTop, ganttViewportHeight],
+    [activeTaskGroups, ganttScrollTop, ganttViewportHeight, getActiveGanttRowHeight],
   );
   const renderedTaskGroups = renderWindow.groups;
+  const isGanttRenderWindowVirtualized = renderWindow.startIndex > 0 || renderWindow.endIndex < activeTaskGroups.length;
   const totalTimelineItems = useMemo(
     // For occupancy mode, count tasks across the full tree (every bed),
     // not just the currently visible/expanded rows — collapsing a field
@@ -1889,6 +1910,68 @@ function GanttChartPage() {
   useTopbarContextActions(setTopbarContextActions, contextActions);
   useTopbarTitleActions(setTopbarTitleActions, viewModeActions);
 
+  const calendarGanttChart = (
+    <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
+      <GanttChartWithFocusMode
+        key={`${calendarMode}-${ganttRenderKey}`}
+        tasks={renderedTaskGroups}
+        locale={resolvedLocale}
+        localeText={ganttLocaleText}
+        viewMode={timelineViewMode}
+        leftColumnWidth={GANTT_LEFT_COLUMN_WIDTH}
+        rowHeight={GANTT_ROW_HEIGHT}
+        startDate={startDate}
+        endDate={endDate}
+        focusMode={false}
+        editMode={calendarMode === 'occupancy' ? editMode : false}
+        allowTaskResize={false}
+        allowTaskMove={calendarMode === 'occupancy' && editMode}
+        showProgress={false}
+        darkMode={false}
+        onTaskUpdate={calendarMode === 'occupancy' && editMode ? handleTaskUpdate : undefined}
+        onToggleGroupExpand={calendarMode === 'occupancy' ? handleToggleGroupExpand : undefined}
+        onTaskDoubleClick={handleTaskDoubleClickToPlan}
+        onTaskContextMenu={handleTaskContextMenu}
+        onGroupContextMenu={calendarMode === 'occupancy' ? handleGroupContextMenu : undefined}
+        renderHeader={renderGanttHeader}
+        renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
+          ? renderSeedlingTooltip({ task })
+          : renderOccupancyTooltip({ task }))}
+        renderTask={calendarMode === 'seedlings'
+          ? ({ task }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
+              <Box
+                sx={{
+                  width: '100%',
+                  height: 26,
+                  px: 1,
+                  borderRadius: 1,
+                  backgroundColor: task.color || '#3b82f6',
+                  color: '#fff',
+                  display: 'flex',
+                  alignItems: 'center',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                  boxSizing: 'border-box',
+                  cursor: 'default',
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  className="rmg-task-item-name-maskable"
+                  sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}
+                >
+                  {typeof task.plantsCount === 'number' && task.plantsCount > 0
+                    ? `${task.name} · ${formatPlantCount(task.plantsCount)} ${t('ganttChart:seedlings.plantsUnit')}`
+                    : task.name}
+                </Typography>
+              </Box>
+            )
+          : undefined}
+      />
+    </GanttRenderBoundary>
+  );
+
   if (loading) {
     return (
       <PageContainer variant="workspacePage">
@@ -2054,82 +2137,26 @@ function GanttChartPage() {
               }}
               sx={{
                 position: 'relative',
-                height: 'calc(100vh - 220px)',
-                minHeight: 420,
+                maxHeight: GANTT_VIEWPORT_MAX_HEIGHT_SX,
                 overflowY: 'auto',
                 overflowX: 'hidden',
+                overscrollBehavior: 'contain',
               }}
             >
-              <Box sx={{ height: Math.max(renderWindow.totalHeight, ganttViewportHeight), position: 'relative' }}>
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: ganttScrollTop,
-                    left: 0,
-                    right: 0,
-                  }}
-                >
-                  <GanttRenderBoundary fallback={<Alert severity="error">{t('ganttChart:errors.render')}</Alert>}>
-                    <GanttChartWithFocusMode
-                      key={`${calendarMode}-${ganttRenderKey}`}
-                      tasks={renderedTaskGroups}
-                      locale={resolvedLocale}
-                      localeText={ganttLocaleText}
-                      viewMode={timelineViewMode}
-                      leftColumnWidth={GANTT_LEFT_COLUMN_WIDTH}
-                      rowHeight={32}
-                      startDate={startDate}
-                      endDate={endDate}
-                      focusMode={false}
-                      editMode={calendarMode === 'occupancy' ? editMode : false}
-                      allowTaskResize={false}
-                      allowTaskMove={calendarMode === 'occupancy' && editMode}
-                      showProgress={false}
-                      darkMode={false}
-                      onTaskUpdate={calendarMode === 'occupancy' && editMode ? handleTaskUpdate : undefined}
-                      onToggleGroupExpand={calendarMode === 'occupancy' ? handleToggleGroupExpand : undefined}
-                      onTaskDoubleClick={handleTaskDoubleClickToPlan}
-                      onTaskContextMenu={handleTaskContextMenu}
-                      onGroupContextMenu={calendarMode === 'occupancy' ? handleGroupContextMenu : undefined}
-                      renderHeader={renderGanttHeader}
-                      renderTooltip={({ task }: { task: GanttTask }) => (calendarMode === 'seedlings'
-                        ? renderSeedlingTooltip({ task })
-                        : renderOccupancyTooltip({ task }))}
-                      renderTask={calendarMode === 'seedlings'
-                        ? ({ task }: { task: GanttTask; leftPx: number; widthPx: number; topPx: number }) => (
-                            <Box
-                              sx={{
-                                width: '100%',
-                                height: 26,
-                                px: 1,
-                                borderRadius: 1,
-                                backgroundColor: task.color || '#3b82f6',
-                                color: '#fff',
-                                display: 'flex',
-                                alignItems: 'center',
-                                overflow: 'hidden',
-                                whiteSpace: 'nowrap',
-                                textOverflow: 'ellipsis',
-                                boxSizing: 'border-box',
-                                cursor: 'default',
-                              }}
-                            >
-                              <Typography
-                                variant="caption"
-                                className="rmg-task-item-name-maskable"
-                                sx={{ color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}
-                              >
-                                {typeof task.plantsCount === 'number' && task.plantsCount > 0
-                                  ? `${task.name} · ${formatPlantCount(task.plantsCount)} ${t('ganttChart:seedlings.plantsUnit')}`
-                                  : task.name}
-                              </Typography>
-                            </Box>
-                          )
-                        : undefined}
-                    />
-                  </GanttRenderBoundary>
+              {isGanttRenderWindowVirtualized ? (
+                <Box sx={{ height: renderWindow.totalHeight, position: 'relative' }}>
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: ganttScrollTop,
+                      left: 0,
+                      right: 0,
+                    }}
+                  >
+                    {calendarGanttChart}
+                  </Box>
                 </Box>
-              </Box>
+              ) : calendarGanttChart}
             </Box>
           </Box>
           </PageSurface>

--- a/frontend/src/pages/ganttRenderWindow.ts
+++ b/frontend/src/pages/ganttRenderWindow.ts
@@ -4,6 +4,8 @@ export const GANTT_ESTIMATED_ROW_HEIGHT = 72;
 export const GANTT_OVERSCAN_ROWS = 5;
 export const GANTT_MAX_RENDERED_TASKS = 500;
 
+type GanttRowHeightGetter = (group: GanttTaskGroup, index: number) => number;
+
 export interface GanttRenderWindow {
   groups: GanttTaskGroup[];
   startIndex: number;
@@ -15,6 +17,7 @@ export function getGanttRenderWindow(
   taskGroups: GanttTaskGroup[],
   scrollTop: number,
   viewportHeight: number,
+  getRowHeight?: GanttRowHeightGetter,
 ): GanttRenderWindow {
   if (taskGroups.length === 0) {
     return {
@@ -25,17 +28,40 @@ export function getGanttRenderWindow(
     };
   }
 
-  const firstVisibleIndex = Math.floor(
-    Math.max(0, scrollTop) / GANTT_ESTIMATED_ROW_HEIGHT,
-  );
-  const visibleRowCount = Math.max(
-    1,
-    Math.ceil(Math.max(1, viewportHeight) / GANTT_ESTIMATED_ROW_HEIGHT),
-  );
+  const rowHeights = taskGroups.map((group, index) => {
+    const rowHeight = getRowHeight?.(group, index) ?? GANTT_ESTIMATED_ROW_HEIGHT;
+    return Number.isFinite(rowHeight) && rowHeight > 0
+      ? rowHeight
+      : GANTT_ESTIMATED_ROW_HEIGHT;
+  });
+  const rowOffsets: number[] = [];
+  let totalHeight = 0;
+  rowHeights.forEach((rowHeight) => {
+    rowOffsets.push(totalHeight);
+    totalHeight += rowHeight;
+  });
+
+  const normalizedScrollTop = Math.max(0, scrollTop);
+  const viewportBottom = normalizedScrollTop + Math.max(1, viewportHeight);
+  let firstVisibleIndex = rowOffsets.findIndex((offset, index) => (
+    offset + rowHeights[index] > normalizedScrollTop
+  ));
+  if (firstVisibleIndex === -1) {
+    firstVisibleIndex = taskGroups.length - 1;
+  }
+
+  let firstHiddenAfterViewport = firstVisibleIndex + 1;
+  while (
+    firstHiddenAfterViewport < taskGroups.length
+    && rowOffsets[firstHiddenAfterViewport] < viewportBottom
+  ) {
+    firstHiddenAfterViewport += 1;
+  }
+
   const startIndex = Math.max(0, firstVisibleIndex - GANTT_OVERSCAN_ROWS);
   const targetEndIndex = Math.min(
     taskGroups.length,
-    firstVisibleIndex + visibleRowCount + GANTT_OVERSCAN_ROWS,
+    firstHiddenAfterViewport + GANTT_OVERSCAN_ROWS,
   );
 
   const groups: GanttTaskGroup[] = [];
@@ -67,6 +93,6 @@ export function getGanttRenderWindow(
     groups,
     startIndex,
     endIndex,
-    totalHeight: taskGroups.length * GANTT_ESTIMATED_ROW_HEIGHT,
+    totalHeight,
   };
 }


### PR DESCRIPTION
## Summary
- Make the calendar viewport height content-driven for short Feldplanung/Anzucht calendars while keeping vertical virtualization for large row sets.
- Move horizontal overflow ownership to the Gantt timeline container and hide persistent scrollbars on desktop/mobile without creating page overflow.
- Add row-height-aware Gantt render windowing and browser-level layout regression coverage across mobile, tablet, desktop, and touch contexts.

## Verification
- `npm test -- --run src/__tests__/GanttChart.test.tsx`
- `npm test` (initial full run: 987 passed, 1 unrelated `CulturesActionArea.test.tsx` failure; rerun of that file passed)
- `npm test -- --run src/__tests__/CulturesActionArea.test.tsx`
- `npm run build`
- `npx playwright test e2e/gantt-layout.spec.ts`

Note: a full `npx playwright test` run was attempted, but the local environment reused an already-running backend on port 8000 with stale e2e fixture state. That caused unrelated fields-beds/responsive fixture failures; the new calendar layout spec passes in isolation.