### PR TITLE
fix: release workflow can now push past branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -17,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -28,5 +30,5 @@ jobs:
 
       - name: Run semantic release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: semantic-release version --push --vcs-release


### PR DESCRIPTION
## Summary
- Every run of the Release workflow has been failing since it was introduced, because `GITHUB_TOKEN` cannot push directly to the protected `main` branch (`GH006: Protected branch update failed`).
- Switches the checkout/push/release steps to use a `RELEASE_PAT` secret (an admin-scoped PAT that can bypass the PR requirement), and adds `workflow_dispatch` so the fix can be verified manually.

## Test plan
- [ ] Confirm the `RELEASE_PAT` repository secret is set with `Contents: Read and write`
- [ ] Confirm the branch protection rule for `main` allows this token/account to bypass "require pull request"
- [ ] Merge this PR, then run the workflow manually via `gh workflow run release.yml` (or wait for the next push to main) and check it completes without the `GitCommandError` push failure