### PR TITLE
fix: start inline editing from typed keys

### DIFF
--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -10,6 +10,7 @@ import { mockT } from './helpers/testI18n';
 const mockUseNavigationBlocker = vi.fn();
 const mockStopRowEditMode = vi.hoisted(() => vi.fn());
 const mockSetCellFocus = vi.hoisted(() => vi.fn());
+const mockSetEditCellValue = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 
 vi.mock('../hooks/autosave', () => ({
   useNavigationBlocker: (...args: unknown[]) => mockUseNavigationBlocker(...args),
@@ -22,7 +23,7 @@ vi.mock('../i18n', () => ({
 vi.mock('@mui/x-data-grid', async () => {
   const React = await import('react');
   const createGridApiMockRefValue = () => ({
-    setEditCellValue: vi.fn().mockResolvedValue(true),
+    setEditCellValue: mockSetEditCellValue,
     stopRowEditMode: mockStopRowEditMode,
   });
   const useGridApiRef = vi.fn(() => React.useRef(createGridApiMockRefValue()));
@@ -242,6 +243,7 @@ describe('EditableDataGrid', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSetEditCellValue.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -370,6 +372,85 @@ describe('EditableDataGrid', () => {
     await waitFor(() => {
       expect(mockUseNavigationBlocker).toHaveBeenLastCalledWith(true, 'messages.unsavedChanges');
     });
+  });
+
+  it('starts editing from a typed number and replaces the focused cell value', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-area_sqm' });
+    fireEvent.keyDown(cell, { key: '5' });
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+    await waitFor(() => {
+      expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'area_sqm', value: '5' });
+    });
+    expect(mockSetCellFocus).toHaveBeenCalledWith(1, 'area_sqm');
+  });
+
+  it('starts editing from a typed letter and replaces the focused cell value', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-name' });
+    fireEvent.keyDown(cell, { key: 'T' });
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+    await waitFor(() => {
+      expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'name', value: 'T' });
+    });
+  });
+
+  it('keeps multiple fast typed characters when starting edit mode', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-area_sqm' });
+    fireEvent.keyDown(cell, { key: '1' });
+    fireEvent.keyDown(cell, { key: '2' });
+    fireEvent.keyDown(cell, { key: '3' });
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+    await waitFor(() => {
+      expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'area_sqm', value: '123' });
+    });
+  });
+
+  it('starts editing with F2 without replacing the existing value', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-name' });
+    fireEvent.keyDown(cell, { key: 'F2' });
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+    expect(mockSetEditCellValue).not.toHaveBeenCalled();
+    expect(mockSetCellFocus).toHaveBeenCalledWith(1, 'name');
+  });
+
+  it('does not start editing for browser shortcut keys', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-name' });
+    fireEvent.keyDown(cell, { key: 'c', ctrlKey: true });
+
+    expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+    expect(mockSetEditCellValue).not.toHaveBeenCalled();
+  });
+
+  it('does not start editing from typed keys on readonly cells', async () => {
+    render(
+      <EditableDataGrid
+        {...baseProps()}
+        columns={[
+          { field: 'name', headerName: 'Name', editable: true },
+          { field: 'area_sqm', headerName: 'Fläche', editable: false },
+        ]}
+        showDeleteAction={false}
+      />,
+    );
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-area_sqm' });
+    fireEvent.keyDown(cell, { key: '5' });
+
+    expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+    expect(mockSetEditCellValue).not.toHaveBeenCalled();
   });
 
   it('keeps draft rows local and exposes save controls until saved', async () => {

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -764,7 +764,7 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     expect(getSetCellFocusMock()).not.toHaveBeenCalledWith('field-1', 'name');
   });
 
-  it('pressing a printable key while a row is keyboard-focused does not start edit mode', async () => {
+  it('pressing a printable key while a row is keyboard-focused starts edit mode', async () => {
     renderHierarchy();
     await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());
 
@@ -785,32 +785,18 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     // The DataGrid mock stores the onCellKeyDown prop so we can call it directly.
     const onCellKeyDown = getCapturedOnCellKeyDown();
     expect(onCellKeyDown).toBeDefined();
-
-    // Simulate the event object that MUI passes to onCellKeyDown for the letter 'a'.
-    const event = {
-      key: 'a',
-      ctrlKey: false,
-      metaKey: false,
-      altKey: false,
-      shiftKey: false,
-      defaultMuiPrevented: false,
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
+    const fieldRow = {
+      id: 'field-1',
+      type: 'field',
+      name: 'Parzelle 1',
+      level: 0,
+      hasChildren: false,
+      isNew: false,
+      fieldId: 1,
+      location: 1,
     };
 
-    act(() => {
-      onCellKeyDown!(
-        { id: 'field-1', field: 'name', isEditable: true, row: {} },
-        event,
-      );
-    });
-
-    // The component must set defaultMuiPrevented so DataGrid does not start editing.
-    expect(event.defaultMuiPrevented).toBe(true);
-    // The row should remain in view mode (onCellKeyDown must not call setRowModesModel).
-    expect(screen.getByTestId('mode-field-1')).toHaveTextContent('view');
-
-    // Also verify that Alt+T (our navigation shortcut) is blocked.
+    // Verify that Alt+T (our navigation shortcut) is blocked.
     // MUI DataGrid v8's isPrintableKey() does not exclude altKey, so without our guard
     // pressing Alt+T while a cell has focus would start editing instead of navigating.
     const altTEvent = {
@@ -826,13 +812,38 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
 
     act(() => {
       onCellKeyDown!(
-        { id: 'field-1', field: 'name', isEditable: true, row: {} },
+        { id: 'field-1', field: 'name', isEditable: true, row: fieldRow },
         altTEvent,
       );
     });
 
     expect(altTEvent.defaultMuiPrevented).toBe(true);
     expect(screen.getByTestId('mode-field-1')).toHaveTextContent('view');
+
+    // Simulate the event object that MUI passes to onCellKeyDown for the letter 'a'.
+    const event = {
+      key: 'a',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      defaultMuiPrevented: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    act(() => {
+      onCellKeyDown!(
+        { id: 'field-1', field: 'name', isEditable: true, row: fieldRow },
+        event,
+      );
+    });
+
+    // The component owns the transition so MUI does not also start a separate edit flow.
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(screen.getByTestId('mode-field-1')).toHaveTextContent('edit');
   });
 
   it('pressing spacebar on a bed row does not let MUI DataGrid jump focus to the first row', async () => {

--- a/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { GridRowModes } from '@mui/x-data-grid';
 import type {
@@ -85,6 +85,7 @@ const renderKeyboardHook = (rowModesModel: GridRowModesModel = {}) => {
   const rememberFocusedField = vi.fn();
   const rememberRowSnapshot = vi.fn();
   const selectRow = vi.fn();
+  const setEditCellValue = vi.fn().mockResolvedValue(true);
   const setRowModesModel = vi.fn();
   const setTreeActive = vi.fn();
   const toggleExpand = vi.fn();
@@ -102,6 +103,7 @@ const renderKeyboardHook = (rowModesModel: GridRowModesModel = {}) => {
       params.field === 'name' || params.field === 'length_m' || params.field === 'width_m',
     scrollToIndexes,
     setCellFocus: focusCell,
+    setEditCellValue,
   };
 
   const hook = renderHook(() =>
@@ -135,6 +137,7 @@ const renderKeyboardHook = (rowModesModel: GridRowModesModel = {}) => {
     rememberRowSnapshot,
     scrollToIndexes,
     selectRow,
+    setEditCellValue,
     setRowModesModel,
     setTreeActive,
     toggleExpand,
@@ -159,9 +162,38 @@ describe('useHierarchyGridKeyboard', () => {
     expect(selectRow).toHaveBeenCalledWith('field-1');
   });
 
-  it('suppresses printable keys in view mode without entering edit mode', () => {
-    const { result, setRowModesModel } = renderKeyboardHook();
+  it('starts edit mode from printable keys in view mode', async () => {
+    const {
+      result,
+      focusCell,
+      rememberRowSnapshot,
+      selectRow,
+      setEditCellValue,
+      setRowModesModel,
+      setTreeActive,
+    } = renderKeyboardHook();
     const event = makeKeyboardEvent('a');
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'name'), event);
+    });
+
+    expect(event.defaultMuiPrevented).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(focusCell).toHaveBeenCalledWith('field-1', 'name');
+    expect(rememberRowSnapshot).toHaveBeenCalledWith('field-1');
+    expect(selectRow).toHaveBeenCalledWith('field-1');
+    expect(setTreeActive).toHaveBeenCalledWith(true);
+    expect(setRowModesModel).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(setEditCellValue).toHaveBeenCalledWith({ id: 'field-1', field: 'name', value: 'a' });
+    });
+  });
+
+  it('suppresses modified printable shortcuts in view mode without entering edit mode', () => {
+    const { result, setRowModesModel } = renderKeyboardHook();
+    const event = makeKeyboardEvent('T', { altKey: true });
 
     act(() => {
       result.current.handleCellKeyDown(makeCellParams('field-1', 'name'), event);

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -69,6 +69,7 @@ import {
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
 } from './keyboardNavigation';
+import { useSpreadsheetEditStarter } from './keyboardEditing';
 import type {
   EditableDataGridClipboardColumn,
   EditableDataGridProps,
@@ -1104,18 +1105,23 @@ export function EditableDataGrid<T extends EditableRow>({
     }));
   }, [columns, selectedRowIds]);
 
+  const rememberRowSnapshotForCellEdit = useCallback((params: GridCellParams<T>): void => {
+    const rowKey = String(params.id);
+    if (rowSnapshotRef.current.has(rowKey)) {
+      return;
+    }
+    const row = rowsById.get(rowKey);
+    if (row) {
+      rowSnapshotRef.current.set(rowKey, row as T);
+    }
+  }, [rowsById]);
+
   const handleStartCellEditFromKeyboard = useCallback((params: GridCellParams<T>): void => {
     if (!params.isEditable || rowModesModel[params.id]?.mode === GridRowModes.Edit) {
       return;
     }
 
-    const rowKey = String(params.id);
-    if (!rowSnapshotRef.current.has(rowKey)) {
-      const row = rowsById.get(rowKey);
-      if (row) {
-        rowSnapshotRef.current.set(rowKey, row as T);
-      }
-    }
+    rememberRowSnapshotForCellEdit(params);
 
     const api = gridApiRef.current;
     if (!api) {
@@ -1127,7 +1133,15 @@ export function EditableDataGrid<T extends EditableRow>({
       ...oldModel,
       [params.id]: { mode: GridRowModes.Edit, fieldToFocus: params.field },
     }));
-  }, [gridApiRef, rowModesModel, rowsById]);
+  }, [gridApiRef, rememberRowSnapshotForCellEdit, rowModesModel]);
+
+  const spreadsheetEditStarter = useSpreadsheetEditStarter<T>({
+    apiRef: gridApiRef,
+    rowModesModel,
+    setRowModesModel,
+    onBeforeEdit: rememberRowSnapshotForCellEdit,
+    onReplaceValue: (params) => markRowDirty(String(params.id)),
+  });
 
   const getRowIdFromElement = (target: EventTarget | null): GridRowId | null => {
     if (!(target instanceof HTMLElement)) {
@@ -1967,6 +1981,14 @@ export function EditableDataGrid<T extends EditableRow>({
               event.preventDefault();
               event.defaultMuiPrevented = true;
               notesEditor.handleOpen(params.id, params.field);
+              return;
+            }
+
+            if (spreadsheetEditStarter.startEditFromF2(params, event)) {
+              return;
+            }
+
+            if (spreadsheetEditStarter.startEditFromPrintableKey(params, event)) {
               return;
             }
 

--- a/frontend/src/components/data-grid/keyboardEditing.ts
+++ b/frontend/src/components/data-grid/keyboardEditing.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type React from 'react';
+import { GridRowModes } from '@mui/x-data-grid';
+import type { GridCellParams, GridRowId, GridRowModesModel, GridValidRowModel } from '@mui/x-data-grid';
+
+type DataGridKeyboardEvent = React.KeyboardEvent & {
+  defaultMuiPrevented?: boolean;
+};
+
+interface SpreadsheetEditApi {
+  isCellEditable?: (params: GridCellParams) => boolean;
+  setCellFocus?: (id: GridRowId, field: string) => void;
+  setEditCellValue?: (params: { id: GridRowId; field: string; value: unknown }) => Promise<boolean> | boolean | void;
+}
+
+interface PendingEditValue {
+  id: GridRowId;
+  field: string;
+  value: string;
+}
+
+interface UseSpreadsheetEditStarterParams<Row extends GridValidRowModel> {
+  apiRef: {
+    current?: SpreadsheetEditApi | null;
+  };
+  rowModesModel: GridRowModesModel;
+  setRowModesModel: React.Dispatch<React.SetStateAction<GridRowModesModel>>;
+  isCellEditable?: (params: GridCellParams<Row>) => boolean;
+  onBeforeEdit?: (params: GridCellParams<Row>) => void;
+  onReplaceValue?: (params: GridCellParams<Row>, value: string) => void;
+}
+
+interface UseSpreadsheetEditStarterResult<Row extends GridValidRowModel> {
+  startEditFromPrintableKey: (
+    params: GridCellParams<Row>,
+    event: React.KeyboardEvent,
+  ) => boolean;
+  startEditFromF2: (
+    params: GridCellParams<Row>,
+    event: React.KeyboardEvent,
+  ) => boolean;
+}
+
+const getPendingKey = (id: GridRowId, field: string): string => `${String(id)}\u0000${field}`;
+
+const isRowEditing = (rowModesModel: GridRowModesModel, rowId: GridRowId): boolean =>
+  rowModesModel[rowId]?.mode === GridRowModes.Edit
+  || rowModesModel[String(rowId)]?.mode === GridRowModes.Edit;
+
+const isSpreadsheetPrintableKey = (event: DataGridKeyboardEvent): boolean => (
+  event.key.length === 1
+  && event.key !== ' '
+  && !event.altKey
+  && !event.ctrlKey
+  && !event.metaKey
+  && !event.nativeEvent?.isComposing
+);
+
+const markMuiEventHandled = (event: DataGridKeyboardEvent): void => {
+  event.preventDefault();
+  event.stopPropagation();
+  event.defaultMuiPrevented = true;
+};
+
+export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
+  apiRef,
+  rowModesModel,
+  setRowModesModel,
+  isCellEditable,
+  onBeforeEdit,
+  onReplaceValue,
+}: UseSpreadsheetEditStarterParams<Row>): UseSpreadsheetEditStarterResult<Row> {
+  const pendingValuesRef = useRef<Map<string, PendingEditValue>>(new Map());
+  const clearTimersRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => () => {
+    clearTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    clearTimersRef.current.clear();
+    pendingValuesRef.current.clear();
+  }, []);
+
+  const clearPendingLater = useCallback((pendingKey: string): void => {
+    const existingTimer = clearTimersRef.current.get(pendingKey);
+    if (existingTimer !== undefined) {
+      window.clearTimeout(existingTimer);
+    }
+    const timerId = window.setTimeout(() => {
+      clearTimersRef.current.delete(pendingKey);
+      pendingValuesRef.current.delete(pendingKey);
+    }, 250);
+    clearTimersRef.current.set(pendingKey, timerId);
+  }, []);
+
+  const flushPendingValue = useCallback((pendingKey: string): void => {
+    const runFlush = (): void => {
+      const pendingValue = pendingValuesRef.current.get(pendingKey);
+      const api = apiRef.current;
+      if (!pendingValue || !api?.setEditCellValue) {
+        return;
+      }
+
+      const valueAtFlushStart = pendingValue.value;
+      void Promise.resolve(api.setEditCellValue({
+        id: pendingValue.id,
+        field: pendingValue.field,
+        value: valueAtFlushStart,
+      }));
+    };
+
+    queueMicrotask(runFlush);
+    window.setTimeout(runFlush, 0);
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(runFlush);
+    }
+  }, [apiRef]);
+
+  const canStartEdit = useCallback((params: GridCellParams<Row>): boolean => {
+    if (!params.isEditable || isRowEditing(rowModesModel, params.id)) {
+      return false;
+    }
+    if (isCellEditable && !isCellEditable(params)) {
+      return false;
+    }
+    return apiRef.current?.isCellEditable?.(params as GridCellParams) ?? true;
+  }, [apiRef, isCellEditable, rowModesModel]);
+
+  const startEdit = useCallback((params: GridCellParams<Row>): boolean => {
+    if (!canStartEdit(params)) {
+      return false;
+    }
+
+    onBeforeEdit?.(params);
+    apiRef.current?.setCellFocus?.(params.id, params.field);
+    setRowModesModel((oldModel) => ({
+      ...oldModel,
+      [params.id]: { mode: GridRowModes.Edit, fieldToFocus: params.field },
+    }));
+    return true;
+  }, [apiRef, canStartEdit, onBeforeEdit, setRowModesModel]);
+
+  const startEditFromPrintableKey = useCallback((
+    params: GridCellParams<Row>,
+    event: React.KeyboardEvent,
+  ): boolean => {
+    const keyboardEvent = event as DataGridKeyboardEvent;
+    if (!isSpreadsheetPrintableKey(keyboardEvent)) {
+      return false;
+    }
+
+    const pendingKey = getPendingKey(params.id, params.field);
+    const pendingValue = pendingValuesRef.current.get(pendingKey);
+    if (!pendingValue && !canStartEdit(params)) {
+      return false;
+    }
+
+    markMuiEventHandled(keyboardEvent);
+    if (!pendingValue) {
+      onBeforeEdit?.(params);
+      apiRef.current?.setCellFocus?.(params.id, params.field);
+      setRowModesModel((oldModel) => ({
+        ...oldModel,
+        [params.id]: { mode: GridRowModes.Edit, fieldToFocus: params.field },
+      }));
+    }
+
+    const previousValue = pendingValue?.value ?? '';
+    const nextValue = `${previousValue}${keyboardEvent.key}`;
+    pendingValuesRef.current.set(pendingKey, {
+      id: params.id,
+      field: params.field,
+      value: nextValue,
+    });
+    onReplaceValue?.(params, nextValue);
+    flushPendingValue(pendingKey);
+    clearPendingLater(pendingKey);
+    return true;
+  }, [
+    apiRef,
+    canStartEdit,
+    clearPendingLater,
+    flushPendingValue,
+    onBeforeEdit,
+    onReplaceValue,
+    setRowModesModel,
+  ]);
+
+  const startEditFromF2 = useCallback((
+    params: GridCellParams<Row>,
+    event: React.KeyboardEvent,
+  ): boolean => {
+    const keyboardEvent = event as DataGridKeyboardEvent;
+    if (
+      keyboardEvent.key !== 'F2'
+      || keyboardEvent.altKey
+      || keyboardEvent.ctrlKey
+      || keyboardEvent.metaKey
+      || !startEdit(params)
+    ) {
+      return false;
+    }
+
+    markMuiEventHandled(keyboardEvent);
+    return true;
+  }, [startEdit]);
+
+  return {
+    startEditFromPrintableKey,
+    startEditFromF2,
+  };
+}

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
@@ -11,6 +11,7 @@ import {
   focusKeyboardNavigableCell,
   getKeyboardNavigationTarget,
 } from "../../data-grid/keyboardNavigation";
+import { useSpreadsheetEditStarter } from "../../data-grid/keyboardEditing";
 import type { HierarchyRow } from "../utils/types";
 
 type HierarchyKeyboardEvent = React.KeyboardEvent & {
@@ -26,6 +27,7 @@ interface HierarchyGridKeyboardApi {
   isCellEditable?: (params: GridCellParams<HierarchyRow>) => boolean;
   scrollToIndexes?: (indexes: { rowIndex?: number; colIndex?: number }) => void;
   setCellFocus?: (id: GridRowId, field: string) => void;
+  setEditCellValue?: (params: { id: GridRowId; field: string; value: unknown }) => Promise<boolean> | boolean | void;
 }
 
 interface UseHierarchyGridKeyboardParams {
@@ -73,14 +75,13 @@ const isRowEditing = (rowModesModel: GridRowModesModel, rowId: GridRowId): boole
 const getEditingRowId = (rowModesModel: GridRowModesModel): string | undefined =>
   Object.entries(rowModesModel).find(([, mode]) => mode.mode === GridRowModes.Edit)?.[0];
 
-const shouldSuppressPrintableViewEdit = (
+const shouldSuppressModifiedPrintableViewEdit = (
   event: HierarchyKeyboardEvent,
   rowModesModel: GridRowModesModel,
   rowId: GridRowId,
 ): boolean => (
   event.key.length === 1
-  && !event.ctrlKey
-  && !event.metaKey
+  && event.altKey
   && !isRowEditing(rowModesModel, rowId)
 );
 
@@ -102,6 +103,27 @@ export function useHierarchyGridKeyboard({
   setTreeActive,
   toggleExpand,
 }: UseHierarchyGridKeyboardParams): UseHierarchyGridKeyboardResult {
+  const spreadsheetEditStarter = useSpreadsheetEditStarter<HierarchyRow>({
+    apiRef: gridApiRef,
+    rowModesModel,
+    setRowModesModel,
+    isCellEditable: (params) => {
+      if (!params.isEditable) {
+        return false;
+      }
+      if (!params.row || !('type' in params.row)) {
+        return true;
+      }
+      return params.field !== "notes" && isCellFocusable(params.row, params.field);
+    },
+    onBeforeEdit: (params) => {
+      rememberFocusedField(params.field);
+      rememberRowSnapshot(params.id);
+      selectRow(params.id);
+      setTreeActive(true);
+    },
+  });
+
   const navigateCell = useCallback((
     params: GridCellParams<HierarchyRow>,
     event: HierarchyKeyboardEvent,
@@ -248,7 +270,15 @@ export function useHierarchyGridKeyboard({
       keyboardEvent.defaultMuiPrevented = true;
     }
 
-    if (shouldSuppressPrintableViewEdit(keyboardEvent, rowModesModel, params.id)) {
+    if (spreadsheetEditStarter.startEditFromF2(params, keyboardEvent)) {
+      return;
+    }
+
+    if (spreadsheetEditStarter.startEditFromPrintableKey(params, keyboardEvent)) {
+      return;
+    }
+
+    if (shouldSuppressModifiedPrintableViewEdit(keyboardEvent, rowModesModel, params.id)) {
       keyboardEvent.defaultMuiPrevented = true;
     }
 
@@ -275,6 +305,7 @@ export function useHierarchyGridKeyboard({
     rememberFocusedField,
     rowModesModel,
     rows,
+    spreadsheetEditStarter,
     toggleExpand,
   ]);
 


### PR DESCRIPTION
## Summary
- Add a shared spreadsheet-style edit starter for row-editing DataGrid tables.
- Start edit mode from focused editable cells when users type printable keys, replacing the current value while preserving fast key bursts.
- Keep F2, Enter, shortcut keys, readonly cells, hierarchy space handling, and Alt navigation behavior intact.
- Cover the shared EditableDataGrid and hierarchy grid keyboard behavior with regression tests.

## Checks
- `npm test -- --run src/__tests__/EditableDataGrid.test.tsx src/__tests__/useHierarchyGridKeyboard.test.ts src/__tests__/FieldsBedsHierarchy.navigation.test.tsx`
- `npm run build`
- `npm test` (110 files, 993 tests)
- `npx eslint src/components/data-grid/keyboardEditing.ts src/components/data-grid/DataGrid.tsx src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts` (passes with one existing warning in DataGrid.tsx)

Note: full `npm run lint` still fails on the current baseline with unrelated existing React hook/refresh lint errors across older files/tests.