### PR TITLE
fix: preserve initial typed edit value

### DIFF
--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -59,9 +59,17 @@ vi.mock('@mui/x-data-grid', async () => {
     pageSizeOptions,
   }: unknown) => {
     const [, forceFocusRender] = React.useState(0);
+    const [editValues, setEditValues] = React.useState<Record<string, unknown>>({});
 
     if (apiRef?.current) {
       apiRef.current.state = apiRef.current.state ?? { focus: { cell: null } };
+      apiRef.current.setEditCellValue = (params: { id: string | number; field: string; value: unknown }) => {
+        setEditValues((currentValues) => ({
+          ...currentValues,
+          [`${String(params.id)}-${params.field}`]: params.value,
+        }));
+        return mockSetEditCellValue(params);
+      };
       apiRef.current.getVisibleColumns = () => columns;
       apiRef.current.getAllRowIds = () => rows.map((row: TestGridRow) => row.id);
       apiRef.current.getRowWithUpdatedValues = (id: string | number) =>
@@ -109,6 +117,10 @@ vi.mock('@mui/x-data-grid', async () => {
           >
             <span data-testid={`mode-${row.id}`}>{rowModesModel?.[row.id]?.mode ?? GridRowModes.View}</span>
             {columns.map((col: GridColDef) => {
+              const isEditingCell =
+                rowModesModel?.[row.id]?.mode === GridRowModes.Edit &&
+                rowModesModel?.[row.id]?.fieldToFocus === col.field;
+              const editValueKey = `${String(row.id)}-${col.field}`;
               if (typeof col.getActions === 'function') {
                 return (
                   <div key={`${row.id}-${col.field}`}>
@@ -133,6 +145,14 @@ vi.mock('@mui/x-data-grid', async () => {
                       data-min-width={col.minWidth ?? ''}
                     />
                   )}
+                  {isEditingCell ? (
+                    <input
+                      aria-label={`Editor ${row.id}-${col.field}`}
+                      data-testid={`edit-input-${row.id}-${col.field}`}
+                      readOnly
+                      value={String(editValues[editValueKey] ?? row[col.field as keyof TestGridRow] ?? '')}
+                    />
+                  ) : null}
                   <button
                     type="button"
                     onClick={() => {
@@ -399,6 +419,7 @@ describe('EditableDataGrid', () => {
     await waitFor(() => {
       expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'area_sqm', value: '5' });
     });
+    await waitFor(() => expect(screen.getByTestId('edit-input-1-area_sqm')).toHaveValue('5'));
     expect(mockSetCellFocus).toHaveBeenCalledWith(1, 'area_sqm');
   });
 
@@ -406,12 +427,13 @@ describe('EditableDataGrid', () => {
     render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
 
     const cell = await screen.findByRole('button', { name: 'Zelle 1-name' });
-    fireEvent.keyDown(cell, { key: 'T' });
+    fireEvent.keyDown(cell, { key: 'A' });
 
     await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
     await waitFor(() => {
-      expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'name', value: 'T' });
+      expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'name', value: 'A' });
     });
+    await waitFor(() => expect(screen.getByTestId('edit-input-1-name')).toHaveValue('A'));
   });
 
   it('keeps multiple fast typed characters when starting edit mode', async () => {
@@ -426,6 +448,7 @@ describe('EditableDataGrid', () => {
     await waitFor(() => {
       expect(mockSetEditCellValue).toHaveBeenCalledWith({ id: 1, field: 'area_sqm', value: '123' });
     });
+    await waitFor(() => expect(screen.getByTestId('edit-input-1-area_sqm')).toHaveValue('123'));
   });
 
   it('starts editing with F2 without replacing the existing value', async () => {
@@ -437,6 +460,18 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
     expect(mockSetEditCellValue).not.toHaveBeenCalled();
     expect(mockSetCellFocus).toHaveBeenCalledWith(1, 'name');
+    expect(screen.getByTestId('edit-input-1-name')).toHaveValue('Beet A');
+  });
+
+  it('starts editing from a click without replacing the existing value', async () => {
+    render(<EditableDataGrid {...baseProps()} showDeleteAction={false} />);
+
+    const cell = await screen.findByRole('button', { name: 'Zelle 1-name' });
+    fireEvent.click(cell);
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+    expect(mockSetEditCellValue).not.toHaveBeenCalled();
+    expect(screen.getByTestId('edit-input-1-name')).toHaveValue('Beet A');
   });
 
   it('does not start editing for browser shortcut keys', async () => {

--- a/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridKeyboard.test.ts
@@ -191,6 +191,20 @@ describe('useHierarchyGridKeyboard', () => {
     });
   });
 
+  it('keeps fast typed numeric keys together when starting edit mode', async () => {
+    const { result, setEditCellValue } = renderKeyboardHook();
+
+    act(() => {
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'length_m'), makeKeyboardEvent('1'));
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'length_m'), makeKeyboardEvent('2'));
+      result.current.handleCellKeyDown(makeCellParams('field-1', 'length_m'), makeKeyboardEvent('3'));
+    });
+
+    await waitFor(() => {
+      expect(setEditCellValue).toHaveBeenCalledWith({ id: 'field-1', field: 'length_m', value: '123' });
+    });
+  });
+
   it('suppresses modified printable shortcuts in view mode without entering edit mode', () => {
     const { result, setRowModesModel } = renderKeyboardHook();
     const event = makeKeyboardEvent('T', { altKey: true });

--- a/frontend/src/components/data-grid/keyboardEditing.ts
+++ b/frontend/src/components/data-grid/keyboardEditing.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type React from 'react';
+import { flushSync } from 'react-dom';
 import { GridRowModes } from '@mui/x-data-grid';
 import type { GridCellParams, GridRowId, GridRowModesModel, GridValidRowModel } from '@mui/x-data-grid';
 
@@ -92,7 +93,7 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
   }, []);
 
   const flushPendingValue = useCallback((pendingKey: string): void => {
-    const runFlush = (): void => {
+    const applyPendingValue = (): void => {
       const pendingValue = pendingValuesRef.current.get(pendingKey);
       const api = apiRef.current;
       if (!pendingValue || !api?.setEditCellValue) {
@@ -107,10 +108,11 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
       }));
     };
 
-    queueMicrotask(runFlush);
-    window.setTimeout(runFlush, 0);
+    applyPendingValue();
+    queueMicrotask(applyPendingValue);
+    window.setTimeout(applyPendingValue, 0);
     if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(runFlush);
+      window.requestAnimationFrame(applyPendingValue);
     }
   }, [apiRef]);
 
@@ -157,10 +159,12 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
     if (!pendingValue) {
       onBeforeEdit?.(params);
       apiRef.current?.setCellFocus?.(params.id, params.field);
-      setRowModesModel((oldModel) => ({
-        ...oldModel,
-        [params.id]: { mode: GridRowModes.Edit, fieldToFocus: params.field },
-      }));
+      flushSync(() => {
+        setRowModesModel((oldModel) => ({
+          ...oldModel,
+          [params.id]: { mode: GridRowModes.Edit, fieldToFocus: params.field },
+        }));
+      });
     }
 
     const previousValue = pendingValue?.value ?? '';


### PR DESCRIPTION
## Summary

- Preserve the first typed character when a focused editable grid cell enters edit mode.
- Flush row edit mode synchronously before applying the pending typed value via `setEditCellValue`.
- Keep fast typed sequences buffered so values like `123` arrive intact.
- Strengthen shared grid and hierarchy keyboard tests for typed-start editing, F2/click behavior, and readonly cells.

## Root Cause

The shared spreadsheet-style edit starter only scheduled deferred `setEditCellValue` calls after switching row edit mode. In real MUI DataGrid timing, the initial key could start edit mode without reliably seeding the editor value, so the first character was lost.

## Validation

- `npm test -- --run src/__tests__/EditableDataGrid.test.tsx src/__tests__/useHierarchyGridKeyboard.test.ts src/__tests__/FieldsBedsHierarchy.navigation.test.tsx`
- `npx eslint src/components/data-grid/keyboardEditing.ts src/components/data-grid/DataGrid.tsx src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts` (passes with one existing hook-deps warning in `DataGrid.tsx`)
- `npm run build`
