### PR TITLE
fix: compact mobile calendar filters

### DIFF
--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -182,6 +182,31 @@ async function readStoredLeftColumnWidth(page: Page): Promise<number | null> {
   });
 }
 
+async function expectResizeHandleStartsAtTimelineBody(page: Page): Promise<void> {
+  const bounds = await page.evaluate(() => {
+    const handle = document.querySelector<HTMLElement>('[role="separator"][aria-orientation="vertical"]');
+    const body = document.querySelector<HTMLElement>('.gantt-container-wrapper .rmg-container');
+    const chart = document.querySelector<HTMLElement>('.gantt-container-wrapper .rmg-gantt-chart');
+    if (!handle || !body || !chart) {
+      throw new Error('Missing resize handle or Gantt body');
+    }
+    const handleRect = handle.getBoundingClientRect();
+    const bodyRect = body.getBoundingClientRect();
+    const chartRect = chart.getBoundingClientRect();
+    return {
+      handleTop: handleRect.top,
+      handleBottom: handleRect.bottom,
+      bodyTop: bodyRect.top,
+      bodyBottom: bodyRect.bottom,
+      chartTop: chartRect.top,
+    };
+  });
+
+  expect(bounds.handleTop).toBeGreaterThan(bounds.chartTop + 8);
+  expect(Math.abs(bounds.handleTop - bounds.bodyTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(bounds.handleBottom - bounds.bodyBottom)).toBeLessThanOrEqual(1);
+}
+
 async function expectMobilePageScrollsCalendar(page: Page, viewport: { width: number; height: number }): Promise<void> {
   await page.setViewportSize(viewport);
   await page.goto('/app/gantt-chart');
@@ -237,6 +262,7 @@ test.describe('Gantt calendar layout', () => {
     await expect.poll(() => readTaskListWidth(page)).toBeCloseTo(240, 0);
     const handle = page.getByRole('separator', { name: 'Seitenleiste verbreitern oder verkleinern' });
     await expect(handle).toBeVisible();
+    await expectResizeHandleStartsAtTimelineBody(page);
 
     const handleBox = await handle.boundingBox();
     expect(handleBox).not.toBeNull();
@@ -255,6 +281,7 @@ test.describe('Gantt calendar layout', () => {
     await page.reload();
     await expect(page.getByText('Layout Kultur').first()).toBeVisible({ timeout: 10_000 });
     await expect.poll(() => readTaskListWidth(page)).toBeCloseTo(330, 0);
+    await expectResizeHandleStartsAtTimelineBody(page);
   });
 });
 

--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -152,6 +152,31 @@ async function expectCalendarLayout(page: Page, path: string): Promise<void> {
   expect(metrics.timelineOverflowStyleY).toBe('hidden');
 }
 
+async function readTaskListWidth(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const taskList = document.querySelector<HTMLElement>('.gantt-container-wrapper .rmg-task-list');
+    if (!taskList) {
+      throw new Error('Missing Gantt task list');
+    }
+    return taskList.getBoundingClientRect().width;
+  });
+}
+
+async function readStoredLeftColumnWidth(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const activeProjectId = window.localStorage.getItem('activeProjectId');
+    if (!activeProjectId) {
+      throw new Error('Missing active project id');
+    }
+    const rawState = window.localStorage.getItem(`openfarmplanner:gantt:${activeProjectId}:state`);
+    if (!rawState) {
+      return null;
+    }
+    const parsed = JSON.parse(rawState) as { leftColumnWidth?: unknown };
+    return typeof parsed.leftColumnWidth === 'number' ? parsed.leftColumnWidth : null;
+  });
+}
+
 test.describe('Gantt calendar layout', () => {
   test('keeps horizontal scrolling on the timeline and short calendars sized to content', async ({ page, request }) => {
     await loginWithFreshProject(page, request, 'gantt-layout-desktop');
@@ -169,6 +194,35 @@ test.describe('Gantt calendar layout', () => {
       await expectCalendarLayout(page, '/app/gantt-chart');
       await expectCalendarLayout(page, '/app/gantt-chart?view=seedlings');
     }
+  });
+
+  test('persists a resized desktop sidebar across reloads', async ({ page, request }) => {
+    await loginWithFreshProject(page, request, 'gantt-layout-sidebar-resize');
+    await createCalendarFixture(page);
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await expectCalendarLayout(page, '/app/gantt-chart');
+
+    await expect.poll(() => readTaskListWidth(page)).toBeCloseTo(240, 0);
+    const handle = page.getByRole('separator', { name: 'Seitenleiste verbreitern oder verkleinern' });
+    await expect(handle).toBeVisible();
+
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    if (!handleBox) {
+      throw new Error('Missing sidebar resize handle bounds');
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + 30);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 90, handleBox.y + 30, { steps: 6 });
+    await page.mouse.up();
+
+    await expect.poll(() => readTaskListWidth(page)).toBeCloseTo(330, 0);
+    await expect.poll(() => readStoredLeftColumnWidth(page)).toBe(330);
+
+    await page.reload();
+    await expect(page.getByText('Layout Kultur').first()).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => readTaskListWidth(page)).toBeCloseTo(330, 0);
   });
 });
 

--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -12,6 +12,7 @@ type LayoutMetrics = {
   viewportBottomGap: number;
   viewportHeight: number;
   viewportOverflowY: number;
+  pageOverflowY: number;
   wrapperOverflowStyleX: string;
   timelineOverflowStyleX: string;
   timelineOverflowStyleY: string;
@@ -36,7 +37,7 @@ async function loginWithFreshProject(page: Page, request: APIRequestContext, sce
   await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
 }
 
-async function createCalendarFixture(page: Page): Promise<void> {
+async function createCalendarFixture(page: Page, options: { bedCount?: number } = {}): Promise<void> {
   const activeProjectId = await page.evaluate(() => window.localStorage.getItem('activeProjectId'));
   expect(activeProjectId).toBeTruthy();
   const projectId = Number(activeProjectId);
@@ -73,13 +74,6 @@ async function createCalendarFixture(page: Page): Promise<void> {
 
   const location = await api<{ id: number }>('/locations/', { name: 'Layout Testhof' });
   const field = await api<{ id: number }>('/fields/', { name: 'Layout Testfeld', location: location.id });
-  const bed = await api<{ id: number }>('/beds/', {
-    name: 'Layout Testbeet',
-    field: field.id,
-    length_m: 10,
-    width_m: 1,
-    area_sqm: 10,
-  });
   const culture = await api<{ id: number }>('/cultures/', {
     name: 'Layout Kultur',
     propagation_duration_days: 21,
@@ -87,14 +81,24 @@ async function createCalendarFixture(page: Page): Promise<void> {
     cultivation_types: ['pre_cultivation'],
     plants_per_m2: 4,
   });
-  await api('/planting-plans/', {
-    bed: bed.id,
-    culture: culture.id,
-    cultivation_type: 'pre_cultivation',
-    planting_date: '2026-04-01',
-    harvest_date: '2026-05-01',
-    area_usage_sqm: 2,
-  });
+  const bedCount = options.bedCount ?? 1;
+  for (let index = 0; index < bedCount; index += 1) {
+    const bed = await api<{ id: number }>('/beds/', {
+      name: index === 0 ? 'Layout Testbeet' : `Layout Testbeet ${index + 1}`,
+      field: field.id,
+      length_m: 10,
+      width_m: 1,
+      area_sqm: 10,
+    });
+    await api('/planting-plans/', {
+      bed: bed.id,
+      culture: culture.id,
+      cultivation_type: 'pre_cultivation',
+      planting_date: '2026-04-01',
+      harvest_date: '2026-05-01',
+      area_usage_sqm: 2,
+    });
+  }
 }
 
 async function readLayoutMetrics(page: Page): Promise<LayoutMetrics> {
@@ -126,6 +130,7 @@ async function readLayoutMetrics(page: Page): Promise<LayoutMetrics> {
       viewportBottomGap: viewportRect.bottom - lastRowBottom,
       viewportHeight: viewportRect.height,
       viewportOverflowY: viewport.scrollHeight - viewport.clientHeight,
+      pageOverflowY: document.documentElement.scrollHeight - window.innerHeight,
       wrapperOverflowStyleX: getComputedStyle(wrapper).overflowX,
       timelineOverflowStyleX: timelineStyle.overflowX,
       timelineOverflowStyleY: timelineStyle.overflowY,
@@ -175,6 +180,33 @@ async function readStoredLeftColumnWidth(page: Page): Promise<number | null> {
     const parsed = JSON.parse(rawState) as { leftColumnWidth?: unknown };
     return typeof parsed.leftColumnWidth === 'number' ? parsed.leftColumnWidth : null;
   });
+}
+
+async function expectMobilePageScrollsCalendar(page: Page, viewport: { width: number; height: number }): Promise<void> {
+  await page.setViewportSize(viewport);
+  await page.goto('/app/gantt-chart');
+  await expect(page.getByText('Layout Kultur').first()).toBeVisible({ timeout: 10_000 });
+
+  const metrics = await readLayoutMetrics(page);
+  expect(metrics.documentOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.bodyOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.wrapperOverflowX).toBeLessThanOrEqual(1);
+  expect(metrics.timelineOverflowX).toBeGreaterThan(0);
+  expect(metrics.viewportOverflowY).toBeLessThanOrEqual(1);
+  expect(metrics.pageOverflowY).toBeGreaterThan(80);
+  expect(metrics.timelineOverflowStyleX).toBe('auto');
+  expect(metrics.timelineOverflowStyleY).toBe('hidden');
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const filters = page.getByTestId('occupancy-tree-filters');
+  const initialTop = await filters.evaluate((element) => element.getBoundingClientRect().top);
+  await page.mouse.wheel(0, 220);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(80);
+  const scrolledTop = await filters.evaluate((element) => element.getBoundingClientRect().top);
+  expect(scrolledTop).toBeLessThan(initialTop - 80);
+  if (viewport.width > viewport.height) {
+    expect(scrolledTop).toBeLessThan(0);
+  }
 }
 
 test.describe('Gantt calendar layout', () => {
@@ -236,5 +268,23 @@ test.describe('Gantt calendar layout on touch devices', () => {
 
     const metrics = await readLayoutMetrics(page);
     expect(metrics.timelineScrollbarWidth).toBe('none');
+  });
+});
+
+test.describe('Gantt calendar mobile page scrolling', () => {
+  test.use({ isMobile: true, hasTouch: true });
+
+  test('uses the page as the vertical scroller in portrait and landscape', async ({ page, request }) => {
+    await loginWithFreshProject(page, request, 'gantt-layout-mobile-page-scroll');
+    await createCalendarFixture(page, { bedCount: 16 });
+
+    for (const viewport of [
+      { width: 320, height: 568 },
+      { width: 568, height: 320 },
+      { width: 844, height: 390 },
+      { width: 768, height: 900 },
+    ]) {
+      await expectMobilePageScrollsCalendar(page, viewport);
+    }
   });
 });

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -719,6 +719,25 @@ describe('GanttChartPage', () => {
     }
   });
 
+  it('uses page scrolling instead of the virtualized Gantt viewport on mobile', async () => {
+    const restoreViewport = withMobileCalendarViewport();
+    try {
+      window.localStorage.setItem(GANTT_STATE_STORAGE_KEY, JSON.stringify({
+        rowScrollTop: 144,
+      }));
+
+      renderWithAuth();
+
+      const virtualViewport = await screen.findByTestId('gantt-virtual-viewport');
+      await waitFor(() => {
+        expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.leftColumnWidth).toBe(220);
+      });
+      expect(virtualViewport.scrollTop).toBe(0);
+    } finally {
+      restoreViewport();
+    }
+  });
+
   it('renders the chart flush with the top of the viewport when a stale row-scroll offset exceeds the actual scrollable range', async () => {
     // Simulates a real browser: the stored offset (e.g. saved while a different
     // calendar mode/project had many more rows) exceeds what's actually

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -1399,7 +1399,7 @@ describe('GanttChartPage', () => {
         expect(screen.queryByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…')).not.toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Suchen' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Filter (1)' })).toBeInTheDocument();
-        expect(screen.getByText('Nur belegte Beete')).toBeInTheDocument();
+        expect(screen.queryByText('Nur belegte Beete')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('button', { name: 'Suchen' }));
         fireEvent.change(await screen.findByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…'), {
@@ -1407,11 +1407,13 @@ describe('GanttChartPage', () => {
         });
 
         await waitFor(() => {
-          expect(screen.getByText('Suche: Karotte')).toBeInTheDocument();
+          expect(screen.getByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…')).toHaveValue('Karotte');
+          expect(screen.queryByText('Suche: Karotte')).not.toBeInTheDocument();
           expect(screen.queryByText('Tomatenbeet')).not.toBeInTheDocument();
         });
 
         fireEvent.click(screen.getByRole('button', { name: 'Filter (1)' }));
+        expect(await screen.findByText('Nur belegte Beete')).toBeInTheDocument();
         fireEvent.mouseDown(await screen.findByLabelText('Standort'));
         fireEvent.click(await screen.findByRole('option', { name: 'Pacht' }));
 

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -83,6 +83,31 @@ const renderWithAuth = (): ReturnType<typeof render> => render(
   </MemoryRouter>,
 );
 
+const withMobileCalendarViewport = (): (() => void) => {
+  const originalMatchMedia = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('max-width:899.95px'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  };
+};
+
 vi.mock('../api/api', async () => {
   const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
   return {
@@ -1362,6 +1387,41 @@ describe('GanttChartPage', () => {
       await waitFor(() => {
         expect(screen.getByText('Leerbeet')).toBeInTheDocument();
       });
+    });
+
+    it('uses compact search and filter controls on mobile', async () => {
+      const restoreViewport = withMobileCalendarViewport();
+      try {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+        expect(screen.queryByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Suchen' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Filter (1)' })).toBeInTheDocument();
+        expect(screen.getByText('Nur belegte Beete')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Suchen' }));
+        fireEvent.change(await screen.findByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…'), {
+          target: { value: 'Karotte' },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText('Suche: Karotte')).toBeInTheDocument();
+          expect(screen.queryByText('Tomatenbeet')).not.toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Filter (1)' }));
+        fireEvent.mouseDown(await screen.findByLabelText('Standort'));
+        fireEvent.click(await screen.findByRole('option', { name: 'Pacht' }));
+
+        await waitFor(() => {
+          expect(screen.getAllByText('Pacht').length).toBeGreaterThanOrEqual(2);
+          expect(screen.getByText('Filter (2)')).toBeInTheDocument();
+        });
+      } finally {
+        restoreViewport();
+      }
     });
   });
 

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -663,6 +663,22 @@ describe('GanttChartPage', () => {
   });
 
   it('resizes the desktop Gantt sidebar and stores the selected width', async () => {
+    mocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 10,
+            culture: 5,
+            culture_name: 'Salat',
+            bed: 3,
+            planting_date: '2026-04-01',
+            harvest_date: '2026-05-01',
+          },
+        ],
+      },
+    });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
+
     renderWithAuth();
 
     const resizeHandle = await screen.findByRole('separator', {
@@ -685,6 +701,21 @@ describe('GanttChartPage', () => {
   });
 
   it('restores the stored desktop Gantt sidebar width', async () => {
+    mocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 10,
+            culture: 5,
+            culture_name: 'Salat',
+            bed: 3,
+            planting_date: '2026-04-01',
+            harvest_date: '2026-05-01',
+          },
+        ],
+      },
+    });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
     window.localStorage.setItem(GANTT_STATE_STORAGE_KEY, JSON.stringify({
       leftColumnWidth: 360,
     }));

--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -186,6 +186,7 @@ vi.mock('../gantt-chart/src', () => ({
       showViewModeSelector: boolean;
     }) => ReactNode;
     viewMode?: string;
+    leftColumnWidth?: number;
     focusMode?: boolean;
     locale?: string;
     localeText?: { title?: string } & Record<string, unknown>;
@@ -659,6 +660,63 @@ describe('GanttChartPage', () => {
     expect(getTopbarAction('calendar-view-mode-seedlings')).toMatchObject({
       active: true,
     });
+  });
+
+  it('resizes the desktop Gantt sidebar and stores the selected width', async () => {
+    renderWithAuth();
+
+    const resizeHandle = await screen.findByRole('separator', {
+      name: 'Seitenleiste verbreitern oder verkleinern',
+    });
+    await waitFor(() => {
+      expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.leftColumnWidth).toBe(240);
+    });
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 240 });
+    fireEvent.mouseMove(window, { clientX: 310 });
+    fireEvent.mouseUp(window);
+
+    await waitFor(() => {
+      expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.leftColumnWidth).toBe(310);
+    });
+    expect(JSON.parse(window.localStorage.getItem(GANTT_STATE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      leftColumnWidth: 310,
+    });
+  });
+
+  it('restores the stored desktop Gantt sidebar width', async () => {
+    window.localStorage.setItem(GANTT_STATE_STORAGE_KEY, JSON.stringify({
+      leftColumnWidth: 360,
+    }));
+
+    renderWithAuth();
+
+    const resizeHandle = await screen.findByRole('separator', {
+      name: 'Seitenleiste verbreitern oder verkleinern',
+    });
+    await waitFor(() => {
+      expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.leftColumnWidth).toBe(360);
+    });
+    expect(resizeHandle).toHaveAttribute('aria-valuenow', '360');
+  });
+
+  it('does not show the Gantt sidebar resize handle on mobile', async () => {
+    const restoreViewport = withMobileCalendarViewport();
+    try {
+      window.localStorage.setItem(GANTT_STATE_STORAGE_KEY, JSON.stringify({
+        leftColumnWidth: 360,
+      }));
+
+      renderWithAuth();
+
+      await screen.findByTestId('mock-gantt');
+      expect(screen.queryByRole('separator', {
+        name: 'Seitenleiste verbreitern oder verkleinern',
+      })).not.toBeInTheDocument();
+      expect(mocks.ganttProps.mock.calls.at(-1)?.[0]?.leftColumnWidth).toBe(220);
+    } finally {
+      restoreViewport();
+    }
   });
 
   it('renders the chart flush with the top of the viewport when a stale row-scroll offset exceeds the actual scrollable range', async () => {

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -169,10 +169,7 @@
     "locationLabel": "Standort",
     "fieldLabel": "Parzelle",
     "resetFilters": "Filter zurücksetzen",
-    "clearSearch": "Suche löschen",
-    "searchChip": "Suche: {{query}}",
-    "selectedLocationFallback": "Standort",
-    "selectedFieldFallback": "Parzelle"
+    "clearSearch": "Suche löschen"
   },
   "contextMenu": {
     "openPlan": "Anbauplan öffnen",

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -163,7 +163,16 @@
     "searchPlaceholderSeedlings": "Suche nach Kultur…",
     "allLocations": "Alle Standorte",
     "allFields": "Alle Parzellen",
-    "onlyOccupiedBeds": "Nur belegte Beete"
+    "onlyOccupiedBeds": "Nur belegte Beete",
+    "filterButton": "Filter",
+    "filterButtonWithCount": "Filter ({{count}})",
+    "locationLabel": "Standort",
+    "fieldLabel": "Parzelle",
+    "resetFilters": "Filter zurücksetzen",
+    "clearSearch": "Suche löschen",
+    "searchChip": "Suche: {{query}}",
+    "selectedLocationFallback": "Standort",
+    "selectedFieldFallback": "Parzelle"
   },
   "contextMenu": {
     "openPlan": "Anbauplan öffnen",

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -158,6 +158,9 @@
       "createPlan": "Anbauplan hinzufügen"
     }
   },
+  "sidebar": {
+    "resizeHandle": "Seitenleiste verbreitern oder verkleinern"
+  },
   "treeFilters": {
     "searchPlaceholder": "Suche nach Kultur, Beet, Parzelle oder Standort…",
     "searchPlaceholderSeedlings": "Suche nach Kultur…",

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -103,7 +103,12 @@ const CALENDAR_VIEW_STORAGE_KEY = 'openFarmPlanner.ganttChart.view';
 const CALENDAR_TIMELINE_VIEW_MODE_STORAGE_KEY = 'openFarmPlanner.ganttChart.timelineViewMode';
 const GANTT_STATE_STORAGE_PREFIX = 'openfarmplanner:gantt';
 const DEFAULT_TIMELINE_VIEW_MODE = ViewMode.MONTH;
-const GANTT_LEFT_COLUMN_WIDTH = 220;
+const GANTT_LEFT_COLUMN_MIN_WIDTH = 190;
+const GANTT_LEFT_COLUMN_DEFAULT_WIDTH = 240;
+const GANTT_LEFT_COLUMN_MOBILE_WIDTH = 220;
+const GANTT_LEFT_COLUMN_MAX_WIDTH = 400;
+const GANTT_SIDEBAR_RESIZE_HANDLE_HITBOX_WIDTH = 12;
+const GANTT_SIDEBAR_RESIZE_KEYBOARD_STEP = 10;
 const GANTT_ROW_HEIGHT = 32;
 const GANTT_VIEWPORT_MAX_HEIGHT_SX = { xs: '70svh', sm: '72svh', lg: '76svh' } as const;
 // Above this many combined location+field+bed nodes, default to
@@ -136,12 +141,19 @@ const GANTT_UNIT_WIDTH_BY_VIEW_MODE: Record<ViewMode, number> = {
   [ViewMode.YEAR]: 200,
 };
 
-function getCalendarGanttRowHeight(group: GanttTaskGroup, viewMode: ViewMode): number {
+function clampGanttLeftColumnWidth(width: number): number {
+  return Math.min(
+    GANTT_LEFT_COLUMN_MAX_WIDTH,
+    Math.max(GANTT_LEFT_COLUMN_MIN_WIDTH, Math.round(width)),
+  );
+}
+
+function getCalendarGanttRowHeight(group: GanttTaskGroup, viewMode: ViewMode, leftColumnWidth: number): number {
   if (group.rowHeightOverride !== undefined) {
     return group.rowHeightOverride;
   }
 
-  const estimatedLabelHeight = estimateTaskGroupLabelHeight(group, GANTT_LEFT_COLUMN_WIDTH);
+  const estimatedLabelHeight = estimateTaskGroupLabelHeight(group, leftColumnWidth);
   const taskRows = CollisionService.detectOverlaps(group.tasks, viewMode);
   return Math.max(estimatedLabelHeight, taskRows.length * GANTT_ROW_HEIGHT + 12);
 }
@@ -159,6 +171,7 @@ interface StoredGanttState {
   timelineViewMode?: ViewMode;
   referenceDate?: string;
   rowScrollTop?: number;
+  leftColumnWidth?: number;
 }
 
 function getCalendarModeFromViewParam(viewParam: string | null): CalendarMode {
@@ -228,6 +241,9 @@ function getStoredGanttState(storageKey: string | null): StoredGanttState | null
       referenceDate: typeof parsed.referenceDate === 'string' ? parsed.referenceDate : undefined,
       rowScrollTop: typeof parsed.rowScrollTop === 'number' && Number.isFinite(parsed.rowScrollTop)
         ? parsed.rowScrollTop
+        : undefined,
+      leftColumnWidth: typeof parsed.leftColumnWidth === 'number' && Number.isFinite(parsed.leftColumnWidth)
+        ? clampGanttLeftColumnWidth(parsed.leftColumnWidth)
         : undefined,
     };
   } catch {
@@ -313,9 +329,16 @@ function getDatePosition(date: Date, viewMode: ViewMode, startDate: Date): numbe
   }
 }
 
-function getReferenceDateFromScroll(scrollLeft: number, containerWidth: number, viewMode: ViewMode, startDate: Date, endDate: Date): Date {
+function getReferenceDateFromScroll(
+  scrollLeft: number,
+  containerWidth: number,
+  viewMode: ViewMode,
+  startDate: Date,
+  endDate: Date,
+  leftColumnWidth: number,
+): Date {
   const unitWidth = getGanttUnitWidth(viewMode);
-  const timelineViewportWidth = Math.max(0, containerWidth - GANTT_LEFT_COLUMN_WIDTH);
+  const timelineViewportWidth = Math.max(0, containerWidth - leftColumnWidth);
   const centerPosition = Math.max(0, scrollLeft + timelineViewportWidth / 2);
   const start = new Date(startDate);
   start.setHours(0, 0, 0, 0);
@@ -344,9 +367,15 @@ function getReferenceDateFromScroll(scrollLeft: number, containerWidth: number, 
   return clampDate(nextDate, startDate, endDate);
 }
 
-function getTimelineScrollLeftForDate(date: Date, viewMode: ViewMode, startDate: Date, container: HTMLElement): number {
+function getTimelineScrollLeftForDate(
+  date: Date,
+  viewMode: ViewMode,
+  startDate: Date,
+  container: HTMLElement,
+  leftColumnWidth: number,
+): number {
   const position = getDatePosition(date, viewMode, startDate);
-  const timelineViewportWidth = Math.max(0, container.clientWidth - GANTT_LEFT_COLUMN_WIDTH);
+  const timelineViewportWidth = Math.max(0, container.clientWidth - leftColumnWidth);
   const maxScroll = Math.max(0, container.scrollWidth - container.clientWidth);
   return Math.max(0, Math.min(maxScroll, position - timelineViewportWidth / 2));
 }
@@ -541,6 +570,7 @@ function GanttChartPage() {
   const [ganttScrollTop, setGanttScrollTop] = useState(0);
   const [ganttViewportHeight, setGanttViewportHeight] = useState(640);
   const ganttViewportRef = useRef<HTMLDivElement | null>(null);
+  const ganttSidebarWidthFrameRef = useRef<number | null>(null);
   const hasRestoredTimelineRef = useRef(false);
   const latestReferenceDateRef = useRef<Date | null>(null);
   const currentYear = new Date().getFullYear();
@@ -556,6 +586,10 @@ function GanttChartPage() {
     () => getStoredGanttState(ganttStateStorageKey),
     [ganttStateStorageKey],
   );
+  const [ganttLeftColumnWidth, setGanttLeftColumnWidth] = useState(
+    storedGanttState?.leftColumnWidth ?? GANTT_LEFT_COLUMN_DEFAULT_WIDTH,
+  );
+  const [isResizingGanttSidebar, setIsResizingGanttSidebar] = useState(false);
   const calendarViewStorageKey = useMemo(
     () => (canUseStoredCalendarView ? getCalendarViewStorageKey(activeProjectId) : null),
     [activeProjectId, canUseStoredCalendarView],
@@ -577,10 +611,28 @@ function GanttChartPage() {
   const [timelineViewMode, setTimelineViewMode] = useState<ViewMode>(() => (
     getStoredTimelineViewModeFromState(storedGanttState) ?? DEFAULT_TIMELINE_VIEW_MODE
   ));
+  const activeGanttLeftColumnWidth = useMobileFilterLayout
+    ? GANTT_LEFT_COLUMN_MOBILE_WIDTH
+    : ganttLeftColumnWidth;
+  const activeGanttLeftColumnWidthRef = useRef(activeGanttLeftColumnWidth);
   const [editMode, setEditMode] = useState(false);
   const outletContext = useOutletContext<RootLayoutOutletContext | null>();
   const setTopbarContextActions = outletContext?.setTopbarContextActions;
   const setTopbarTitleActions = outletContext?.setTopbarTitleActions;
+
+  useEffect(() => {
+    setGanttLeftColumnWidth(storedGanttState?.leftColumnWidth ?? GANTT_LEFT_COLUMN_DEFAULT_WIDTH);
+  }, [ganttStateStorageKey, storedGanttState?.leftColumnWidth]);
+
+  useEffect(() => () => {
+    if (ganttSidebarWidthFrameRef.current !== null) {
+      window.cancelAnimationFrame(ganttSidebarWidthFrameRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    activeGanttLeftColumnWidthRef.current = activeGanttLeftColumnWidth;
+  }, [activeGanttLeftColumnWidth]);
 
   useEffect(() => {
     const viewParam = searchParams.get('view');
@@ -644,7 +696,14 @@ function GanttChartPage() {
   ) => {
     const scrollContainer = ganttViewportRef.current?.querySelector<HTMLElement>('.rmg-container') ?? null;
     const currentReferenceDate = scrollContainer
-      ? getReferenceDateFromScroll(scrollContainer.scrollLeft, scrollContainer.clientWidth, timelineViewMode, startDate, endDate)
+      ? getReferenceDateFromScroll(
+        scrollContainer.scrollLeft,
+        scrollContainer.clientWidth,
+        timelineViewMode,
+        startDate,
+        endDate,
+        activeGanttLeftColumnWidth,
+      )
       : latestReferenceDateRef.current;
     setTimelineViewMode(nextViewMode);
     if (timelineViewModeStorageKey) {
@@ -656,7 +715,7 @@ function GanttChartPage() {
     });
     hasRestoredTimelineRef.current = false;
     applyViewModeChange(nextViewMode);
-  }, [endDate, ganttStateStorageKey, startDate, storedGanttState, timelineViewMode, timelineViewModeStorageKey]);
+  }, [activeGanttLeftColumnWidth, endDate, ganttStateStorageKey, startDate, storedGanttState, timelineViewMode, timelineViewModeStorageKey]);
 
   const getCurrentTimelineReferenceDate = useCallback((): Date => {
     const scrollContainer = ganttViewportRef.current?.querySelector<HTMLElement>('.rmg-container') ?? null;
@@ -667,12 +726,13 @@ function GanttChartPage() {
         timelineViewMode,
         startDate,
         endDate,
+        activeGanttLeftColumnWidth,
       );
     }
 
     return latestReferenceDateRef.current
       ?? getInitialTimelineReferenceDate(getStoredGanttState(ganttStateStorageKey), startDate, endDate);
-  }, [endDate, ganttStateStorageKey, startDate, timelineViewMode]);
+  }, [activeGanttLeftColumnWidth, endDate, ganttStateStorageKey, startDate, timelineViewMode]);
 
   const scrollToTimelineReferenceDate = useCallback((date: Date): void => {
     const referenceDate = clampDate(date, startDate, endDate);
@@ -688,8 +748,14 @@ function GanttChartPage() {
       return;
     }
 
-    scrollContainer.scrollLeft = getTimelineScrollLeftForDate(referenceDate, timelineViewMode, startDate, scrollContainer);
-  }, [calendarMode, endDate, ganttStateStorageKey, startDate, timelineViewMode]);
+    scrollContainer.scrollLeft = getTimelineScrollLeftForDate(
+      referenceDate,
+      timelineViewMode,
+      startDate,
+      scrollContainer,
+      activeGanttLeftColumnWidth,
+    );
+  }, [activeGanttLeftColumnWidth, calendarMode, endDate, ganttStateStorageKey, startDate, timelineViewMode]);
 
   const handleShortcutTimelineViewModeChange = useCallback((nextViewMode: ViewMode): void => {
     const referenceDate = getCurrentTimelineReferenceDate();
@@ -1090,6 +1156,85 @@ function GanttChartPage() {
     }
     setMobileSearchOpen(false);
   }, [calendarMode]);
+  const persistGanttLeftColumnWidth = useCallback((width: number) => {
+    storeGanttState(ganttStateStorageKey, {
+      leftColumnWidth: clampGanttLeftColumnWidth(width),
+    });
+  }, [ganttStateStorageKey]);
+  const handleGanttSidebarResizeStart = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    if (useMobileFilterLayout) {
+      return;
+    }
+
+    event.preventDefault();
+    const startClientX = event.clientX;
+    const startWidth = ganttLeftColumnWidth;
+    let pendingWidth = startWidth;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    const applyPendingWidth = (): void => {
+      ganttSidebarWidthFrameRef.current = null;
+      setGanttLeftColumnWidth(pendingWidth);
+    };
+
+    const queueWidthUpdate = (width: number): void => {
+      pendingWidth = clampGanttLeftColumnWidth(width);
+      if (ganttSidebarWidthFrameRef.current === null) {
+        ganttSidebarWidthFrameRef.current = window.requestAnimationFrame(applyPendingWidth);
+      }
+    };
+
+    const finishResize = (): void => {
+      if (ganttSidebarWidthFrameRef.current !== null) {
+        window.cancelAnimationFrame(ganttSidebarWidthFrameRef.current);
+        ganttSidebarWidthFrameRef.current = null;
+      }
+      setGanttLeftColumnWidth(pendingWidth);
+      persistGanttLeftColumnWidth(pendingWidth);
+      setIsResizingGanttSidebar(false);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', finishResize);
+    };
+
+    const handleMouseMove = (moveEvent: MouseEvent): void => {
+      moveEvent.preventDefault();
+      queueWidthUpdate(startWidth + moveEvent.clientX - startClientX);
+    };
+
+    setIsResizingGanttSidebar(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', finishResize);
+  }, [ganttLeftColumnWidth, persistGanttLeftColumnWidth, useMobileFilterLayout]);
+  const handleGanttSidebarResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (useMobileFilterLayout) {
+      return;
+    }
+
+    let nextWidth: number | null = null;
+    if (event.key === 'ArrowLeft') {
+      nextWidth = ganttLeftColumnWidth - GANTT_SIDEBAR_RESIZE_KEYBOARD_STEP;
+    } else if (event.key === 'ArrowRight') {
+      nextWidth = ganttLeftColumnWidth + GANTT_SIDEBAR_RESIZE_KEYBOARD_STEP;
+    } else if (event.key === 'Home') {
+      nextWidth = GANTT_LEFT_COLUMN_MIN_WIDTH;
+    } else if (event.key === 'End') {
+      nextWidth = GANTT_LEFT_COLUMN_MAX_WIDTH;
+    }
+
+    if (nextWidth === null) {
+      return;
+    }
+
+    event.preventDefault();
+    const clampedWidth = clampGanttLeftColumnWidth(nextWidth);
+    setGanttLeftColumnWidth(clampedWidth);
+    persistGanttLeftColumnWidth(clampedWidth);
+  }, [ganttLeftColumnWidth, persistGanttLeftColumnWidth, useMobileFilterLayout]);
 
   const occupancyTaskGroups = useMemo<GanttTaskGroup[]>(() => {
     // Structural filter: "only occupied beds" removes empty beds (and any
@@ -1404,8 +1549,8 @@ function GanttChartPage() {
 
   const activeTaskGroups = calendarMode === 'occupancy' ? occupancyTaskGroups : seedlingTaskGroups;
   const getActiveGanttRowHeight = useCallback(
-    (group: GanttTaskGroup): number => getCalendarGanttRowHeight(group, timelineViewMode),
-    [timelineViewMode],
+    (group: GanttTaskGroup): number => getCalendarGanttRowHeight(group, timelineViewMode, activeGanttLeftColumnWidth),
+    [activeGanttLeftColumnWidth, timelineViewMode],
   );
   const renderWindow = useMemo(
     () => getGanttRenderWindow(
@@ -1640,7 +1785,13 @@ function GanttChartPage() {
           startDate,
           endDate,
         );
-        const nextScrollLeft = getTimelineScrollLeftForDate(referenceDate, timelineViewMode, startDate, scrollContainer);
+        const nextScrollLeft = getTimelineScrollLeftForDate(
+          referenceDate,
+          timelineViewMode,
+          startDate,
+          scrollContainer,
+          activeGanttLeftColumnWidthRef.current,
+        );
         const previousScrollBehavior = scrollContainer.style.scrollBehavior;
         scrollContainer.style.scrollBehavior = 'auto';
         scrollContainer.scrollLeft = nextScrollLeft;
@@ -1704,6 +1855,7 @@ function GanttChartPage() {
         timelineViewMode,
         startDate,
         endDate,
+        activeGanttLeftColumnWidth,
       );
       latestReferenceDateRef.current = referenceDate;
       storeGanttState(ganttStateStorageKey, {
@@ -1715,7 +1867,7 @@ function GanttChartPage() {
 
     scrollContainer.addEventListener('scroll', handleTimelineScroll, { passive: true });
     return () => scrollContainer.removeEventListener('scroll', handleTimelineScroll);
-  }, [calendarMode, endDate, ganttStateStorageKey, hasCalendarRequirements, loading, startDate, timelineViewMode]);
+  }, [activeGanttLeftColumnWidth, calendarMode, endDate, ganttStateStorageKey, hasCalendarRequirements, loading, startDate, timelineViewMode]);
 
   useEffect(() => {
     if (loading || !hasCalendarRequirements || calendarMode !== 'occupancy' || !editMode) {
@@ -1964,7 +2116,7 @@ function GanttChartPage() {
         locale={resolvedLocale}
         localeText={ganttLocaleText}
         viewMode={timelineViewMode}
-        leftColumnWidth={GANTT_LEFT_COLUMN_WIDTH}
+        leftColumnWidth={activeGanttLeftColumnWidth}
         rowHeight={GANTT_ROW_HEIGHT}
         startDate={startDate}
         endDate={endDate}
@@ -2388,39 +2540,96 @@ function GanttChartPage() {
             }}
           >
             <Box
-              ref={ganttViewportRef}
-              data-testid="gantt-virtual-viewport"
-              onScroll={(event) => {
-                const nextScrollTop = event.currentTarget.scrollTop;
-                setGanttScrollTop(nextScrollTop);
-                storeGanttState(ganttStateStorageKey, {
-                  calendarMode,
-                  timelineViewMode,
-                  rowScrollTop: nextScrollTop,
-                });
-              }}
               sx={{
                 position: 'relative',
-                maxHeight: GANTT_VIEWPORT_MAX_HEIGHT_SX,
-                overflowY: 'auto',
-                overflowX: 'hidden',
-                overscrollBehavior: 'contain',
               }}
             >
-              {isGanttRenderWindowVirtualized ? (
-                <Box sx={{ height: renderWindow.totalHeight, position: 'relative' }}>
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      top: ganttScrollTop,
-                      left: 0,
-                      right: 0,
-                    }}
-                  >
-                    {calendarGanttChart}
+              <Box
+                ref={ganttViewportRef}
+                data-testid="gantt-virtual-viewport"
+                onScroll={(event) => {
+                  const nextScrollTop = event.currentTarget.scrollTop;
+                  setGanttScrollTop(nextScrollTop);
+                  storeGanttState(ganttStateStorageKey, {
+                    calendarMode,
+                    timelineViewMode,
+                    rowScrollTop: nextScrollTop,
+                  });
+                }}
+                sx={{
+                  position: 'relative',
+                  maxHeight: GANTT_VIEWPORT_MAX_HEIGHT_SX,
+                  overflowY: 'auto',
+                  overflowX: 'hidden',
+                  overscrollBehavior: 'contain',
+                }}
+              >
+                {isGanttRenderWindowVirtualized ? (
+                  <Box sx={{ height: renderWindow.totalHeight, position: 'relative' }}>
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        top: ganttScrollTop,
+                        left: 0,
+                        right: 0,
+                      }}
+                    >
+                      {calendarGanttChart}
+                    </Box>
                   </Box>
-                </Box>
-              ) : calendarGanttChart}
+                ) : calendarGanttChart}
+              </Box>
+              {!useMobileFilterLayout ? (
+                <Box
+                  component="button"
+                  type="button"
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label={t('ganttChart:sidebar.resizeHandle')}
+                  aria-valuemin={GANTT_LEFT_COLUMN_MIN_WIDTH}
+                  aria-valuemax={GANTT_LEFT_COLUMN_MAX_WIDTH}
+                  aria-valuenow={ganttLeftColumnWidth}
+                  onMouseDown={handleGanttSidebarResizeStart}
+                  onKeyDown={handleGanttSidebarResizeKeyDown}
+                  sx={{
+                    position: 'absolute',
+                    top: 0,
+                    bottom: 0,
+                    left: `${activeGanttLeftColumnWidth - GANTT_SIDEBAR_RESIZE_HANDLE_HITBOX_WIDTH / 2}px`,
+                    zIndex: 360,
+                    width: GANTT_SIDEBAR_RESIZE_HANDLE_HITBOX_WIDTH,
+                    p: 0,
+                    m: 0,
+                    border: 0,
+                    borderRadius: 0,
+                    bgcolor: 'transparent',
+                    cursor: 'col-resize',
+                    touchAction: 'none',
+                    '&::before': {
+                      content: '""',
+                      position: 'absolute',
+                      top: 0,
+                      bottom: 0,
+                      left: '50%',
+                      width: isResizingGanttSidebar ? 2 : 1,
+                      transform: 'translateX(-50%)',
+                      bgcolor: isResizingGanttSidebar ? 'text.secondary' : 'divider',
+                      opacity: isResizingGanttSidebar ? 1 : 0.7,
+                      transition: 'background-color 120ms ease, opacity 120ms ease, width 120ms ease',
+                    },
+                    '&:hover::before, &:focus-visible::before': {
+                      width: 2,
+                      bgcolor: 'text.secondary',
+                      opacity: 1,
+                    },
+                    '&:focus-visible': {
+                      outline: '2px solid',
+                      outlineColor: 'primary.main',
+                      outlineOffset: -2,
+                    },
+                  }}
+                />
+              ) : null}
             </Box>
           </Box>
           </PageSurface>

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -10,7 +10,9 @@
 import React, { useState, useEffect, useMemo, useCallback, useContext, useRef } from 'react';
 import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import CloseIcon from '@mui/icons-material/Close';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import TuneIcon from '@mui/icons-material/Tune';
 import { useTranslation } from '../i18n';
 import {
   Alert,
@@ -18,15 +20,23 @@ import {
   Button,
   ButtonGroup,
   Checkbox,
+  Chip,
   Divider,
+  FormControl,
   FormControlLabel,
+  IconButton,
   InputAdornment,
+  InputLabel,
   Menu,
   MenuItem,
+  Popover,
   Select,
+  Stack,
   TextField,
   Tooltip,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import {
@@ -467,6 +477,8 @@ function dispatchSyntheticMouseEvent(
 
 function GanttChartPage() {
   const { t, i18n } = useTranslation(['ganttChart', 'common']);
+  const theme = useTheme();
+  const useMobileFilterLayout = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const authContext = useContext(AuthContext);
@@ -493,12 +505,27 @@ function GanttChartPage() {
   // Seedling (Anzucht) view: search-only, no hierarchy/location filters —
   // it's a flat, culture-grouped list, not tied to a specific bed/field.
   const [seedlingSearchText, setSeedlingSearchText] = useState('');
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+  const [calendarFilterAnchorEl, setCalendarFilterAnchorEl] = useState<HTMLElement | null>(null);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const focusSearch = useCallback(() => {
+    if (useMobileFilterLayout) {
+      setMobileSearchOpen(true);
+    }
     searchInputRef.current?.focus();
     searchInputRef.current?.select();
-  }, []);
+  }, [useMobileFilterLayout]);
+  useEffect(() => {
+    if (!mobileSearchOpen) {
+      return undefined;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [mobileSearchOpen]);
 
   const occupancyTreeStorageKey = activeProjectId
     ? `occupancyTree.${activeProjectId}`
@@ -1043,6 +1070,90 @@ function GanttChartPage() {
         (node) => node.type === 'field' && node.locationId === occupancyLocationFilter,
       )),
     [occupancyHierarchyNodes, occupancyLocationFilter],
+  );
+  const selectedLocationName = useMemo(
+    () => (occupancyLocationFilter === 'all'
+      ? null
+      : locations.find((location) => location.id === occupancyLocationFilter)?.name ?? null),
+    [locations, occupancyLocationFilter],
+  );
+  const selectedFieldName = useMemo(
+    () => (occupancyFieldFilter === 'all'
+      ? null
+      : occupancyHierarchyNodes.find(
+        (node) => node.type === 'field' && node.fieldId === occupancyFieldFilter,
+      )?.name ?? null),
+    [occupancyFieldFilter, occupancyHierarchyNodes],
+  );
+  const activeHierarchyFilterCount = [
+    occupancyLocationFilter !== 'all',
+    occupancyFieldFilter !== 'all',
+    onlyOccupiedBeds,
+  ].filter(Boolean).length;
+  const activeSearchText = calendarMode === 'occupancy' ? occupancySearchText.trim() : seedlingSearchText.trim();
+  const isCalendarFilterPopoverOpen = Boolean(calendarFilterAnchorEl);
+  const resetOccupancyHierarchyFilters = useCallback(() => {
+    setOccupancyLocationFilter('all');
+    setOccupancyFieldFilter('all');
+    setOnlyOccupiedBeds(false);
+  }, []);
+  const clearActiveSearch = useCallback(() => {
+    if (calendarMode === 'occupancy') {
+      setOccupancySearchText('');
+    } else {
+      setSeedlingSearchText('');
+    }
+    setMobileSearchOpen(false);
+  }, [calendarMode]);
+  const activeMobileFilterChips = useMemo(
+    () => {
+      const chips: Array<{ key: string; label: string; onDelete: () => void }> = [];
+      if (activeSearchText) {
+        chips.push({
+          key: 'search',
+          label: t('ganttChart:treeFilters.searchChip', { query: activeSearchText }),
+          onDelete: clearActiveSearch,
+        });
+      }
+      if (calendarMode === 'occupancy') {
+        if (occupancyLocationFilter !== 'all') {
+          chips.push({
+            key: 'location',
+            label: selectedLocationName ?? t('ganttChart:treeFilters.selectedLocationFallback'),
+            onDelete: () => {
+              setOccupancyLocationFilter('all');
+              setOccupancyFieldFilter('all');
+            },
+          });
+        }
+        if (occupancyFieldFilter !== 'all') {
+          chips.push({
+            key: 'field',
+            label: selectedFieldName ?? t('ganttChart:treeFilters.selectedFieldFallback'),
+            onDelete: () => setOccupancyFieldFilter('all'),
+          });
+        }
+        if (onlyOccupiedBeds) {
+          chips.push({
+            key: 'only-occupied',
+            label: t('ganttChart:treeFilters.onlyOccupiedBeds'),
+            onDelete: () => setOnlyOccupiedBeds(false),
+          });
+        }
+      }
+      return chips;
+    },
+    [
+      activeSearchText,
+      calendarMode,
+      clearActiveSearch,
+      occupancyFieldFilter,
+      occupancyLocationFilter,
+      onlyOccupiedBeds,
+      selectedFieldName,
+      selectedLocationName,
+      t,
+    ],
   );
 
   const occupancyTaskGroups = useMemo<GanttTaskGroup[]>(() => {
@@ -2018,100 +2129,333 @@ function GanttChartPage() {
             <Box
               data-testid="occupancy-tree-filters"
               sx={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 1.5,
-                alignItems: 'center',
-                mb: 1.5,
+                mb: { xs: 0.75, md: 1.5 },
               }}
             >
-              <TextField
-                size="small"
-                placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
-                value={occupancySearchText}
-                onChange={(event) => setOccupancySearchText(event.target.value)}
-                inputRef={searchInputRef}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <SearchIcon fontSize="small" />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-                sx={{ minWidth: 240, flex: '1 1 240px' }}
-              />
-              <Select
-                size="small"
-                value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
-                onChange={(event) => {
-                  const { value } = event.target;
-                  setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
-                  setOccupancyFieldFilter('all');
-                }}
-                sx={{ minWidth: 160 }}
-              >
-                <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
-                {locations.filter((location) => location.id).map((location) => (
-                  <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
-                ))}
-              </Select>
-              <Select
-                size="small"
-                value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
-                onChange={(event) => {
-                  const { value } = event.target;
-                  setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
-                }}
-                disabled={occupancyLocationFilter === 'all'}
-                sx={{ minWidth: 160 }}
-              >
-                <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
-                {occupancyFieldOptions.map((field) => (
-                  <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
-                ))}
-              </Select>
-              <FormControlLabel
-                control={(
-                  <Checkbox
+              {useMobileFilterLayout ? (
+                <Stack spacing={0.75}>
+                  {mobileSearchOpen || activeSearchText ? (
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <TextField
+                        size="small"
+                        placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
+                        value={occupancySearchText}
+                        onChange={(event) => setOccupancySearchText(event.target.value)}
+                        inputRef={searchInputRef}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <SearchIcon fontSize="small" />
+                              </InputAdornment>
+                            ),
+                          },
+                        }}
+                        sx={{ flex: '1 1 auto', minWidth: 0 }}
+                      />
+                      <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
+                        <IconButton
+                          size="small"
+                          aria-label={t('ganttChart:treeFilters.clearSearch')}
+                          onClick={clearActiveSearch}
+                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+                        >
+                          <CloseIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Button
+                        size="small"
+                        variant={activeHierarchyFilterCount > 0 ? 'contained' : 'outlined'}
+                        color={activeHierarchyFilterCount > 0 ? 'success' : 'inherit'}
+                        startIcon={<TuneIcon fontSize="small" />}
+                        onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
+                        aria-expanded={isCalendarFilterPopoverOpen}
+                        aria-haspopup="dialog"
+                        aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
+                        sx={{ minHeight: 40, minWidth: 0, px: 1, whiteSpace: 'nowrap' }}
+                      >
+                        {activeHierarchyFilterCount > 0
+                          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
+                          : t('ganttChart:treeFilters.filterButton')}
+                      </Button>
+                    </Stack>
+                  ) : (
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <Tooltip title={t('common:actions.search')}>
+                        <IconButton
+                          size="small"
+                          aria-label={t('common:actions.search')}
+                          onClick={() => setMobileSearchOpen(true)}
+                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+                        >
+                          <SearchIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Button
+                        size="small"
+                        variant={activeHierarchyFilterCount > 0 ? 'contained' : 'outlined'}
+                        color={activeHierarchyFilterCount > 0 ? 'success' : 'inherit'}
+                        startIcon={<TuneIcon fontSize="small" />}
+                        onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
+                        aria-expanded={isCalendarFilterPopoverOpen}
+                        aria-haspopup="dialog"
+                        aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
+                        sx={{ minHeight: 40, whiteSpace: 'nowrap' }}
+                      >
+                        {activeHierarchyFilterCount > 0
+                          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
+                          : t('ganttChart:treeFilters.filterButton')}
+                      </Button>
+                    </Stack>
+                  )}
+                  {activeMobileFilterChips.length > 0 ? (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxWidth: '100%', overflow: 'hidden' }}>
+                      {activeMobileFilterChips.map((chip) => (
+                        <Chip
+                          key={chip.key}
+                          size="small"
+                          variant="outlined"
+                          label={chip.label}
+                          onDelete={chip.onDelete}
+                          sx={{ maxWidth: '100%', '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' } }}
+                        />
+                      ))}
+                    </Box>
+                  ) : null}
+                  <Popover
+                    id="calendar-filters-popover"
+                    open={isCalendarFilterPopoverOpen}
+                    anchorEl={calendarFilterAnchorEl}
+                    onClose={() => setCalendarFilterAnchorEl(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                    PaperProps={{ sx: { width: 'min(92vw, 360px)', p: 1.5 } }}
+                  >
+                    <Stack spacing={1.25}>
+                      <FormControl size="small" sx={{ minWidth: '100%' }}>
+                        <InputLabel id="calendar-location-filter-label">{t('ganttChart:treeFilters.locationLabel')}</InputLabel>
+                        <Select
+                          labelId="calendar-location-filter-label"
+                          value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
+                          label={t('ganttChart:treeFilters.locationLabel')}
+                          onChange={(event) => {
+                            const { value } = event.target;
+                            setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
+                            setOccupancyFieldFilter('all');
+                          }}
+                        >
+                          <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
+                          {locations.filter((location) => location.id).map((location) => (
+                            <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <FormControl size="small" sx={{ minWidth: '100%' }}>
+                        <InputLabel id="calendar-field-filter-label">{t('ganttChart:treeFilters.fieldLabel')}</InputLabel>
+                        <Select
+                          labelId="calendar-field-filter-label"
+                          value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
+                          label={t('ganttChart:treeFilters.fieldLabel')}
+                          onChange={(event) => {
+                            const { value } = event.target;
+                            setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
+                          }}
+                          disabled={occupancyLocationFilter === 'all'}
+                        >
+                          <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
+                          {occupancyFieldOptions.map((field) => (
+                            <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <FormControlLabel
+                        control={(
+                          <Checkbox
+                            size="small"
+                            checked={onlyOccupiedBeds}
+                            onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
+                          />
+                        )}
+                        label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
+                      />
+                      <Button
+                        variant="text"
+                        size="small"
+                        onClick={() => {
+                          resetOccupancyHierarchyFilters();
+                          setCalendarFilterAnchorEl(null);
+                        }}
+                        sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
+                      >
+                        {t('ganttChart:treeFilters.resetFilters')}
+                      </Button>
+                    </Stack>
+                  </Popover>
+                </Stack>
+              ) : (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1.5,
+                    alignItems: 'center',
+                  }}
+                >
+                  <TextField
                     size="small"
-                    checked={onlyOccupiedBeds}
-                    onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
+                    placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
+                    value={occupancySearchText}
+                    onChange={(event) => setOccupancySearchText(event.target.value)}
+                    inputRef={searchInputRef}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <SearchIcon fontSize="small" />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                    sx={{ minWidth: 240, flex: '1 1 240px' }}
                   />
-                )}
-                label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
-              />
+                  <Select
+                    size="small"
+                    value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
+                      setOccupancyFieldFilter('all');
+                    }}
+                    sx={{ minWidth: 160 }}
+                  >
+                    <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
+                    {locations.filter((location) => location.id).map((location) => (
+                      <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
+                    ))}
+                  </Select>
+                  <Select
+                    size="small"
+                    value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
+                    onChange={(event) => {
+                      const { value } = event.target;
+                      setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
+                    }}
+                    disabled={occupancyLocationFilter === 'all'}
+                    sx={{ minWidth: 160 }}
+                  >
+                    <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
+                    {occupancyFieldOptions.map((field) => (
+                      <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
+                    ))}
+                  </Select>
+                  <FormControlLabel
+                    control={(
+                      <Checkbox
+                        size="small"
+                        checked={onlyOccupiedBeds}
+                        onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
+                      />
+                    )}
+                    label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
+                  />
+                </Box>
+              )}
             </Box>
           )}
           {calendarMode === 'seedlings' && (
             <Box
               data-testid="seedling-filters"
               sx={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 1.5,
-                alignItems: 'center',
-                mb: 1.5,
+                mb: { xs: 0.75, md: 1.5 },
               }}
             >
-              <TextField
-                size="small"
-                placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
-                value={seedlingSearchText}
-                onChange={(event) => setSeedlingSearchText(event.target.value)}
-                inputRef={searchInputRef}
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
+              {useMobileFilterLayout ? (
+                <Stack spacing={0.75}>
+                  {mobileSearchOpen || activeSearchText ? (
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <TextField
+                        size="small"
+                        placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
+                        value={seedlingSearchText}
+                        onChange={(event) => setSeedlingSearchText(event.target.value)}
+                        inputRef={searchInputRef}
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <SearchIcon fontSize="small" />
+                              </InputAdornment>
+                            ),
+                          },
+                        }}
+                        sx={{ flex: '1 1 auto', minWidth: 0 }}
+                      />
+                      <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
+                        <IconButton
+                          size="small"
+                          aria-label={t('ganttChart:treeFilters.clearSearch')}
+                          onClick={clearActiveSearch}
+                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+                        >
+                          <CloseIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                  ) : (
+                    <Tooltip title={t('common:actions.search')}>
+                      <IconButton
+                        size="small"
+                        aria-label={t('common:actions.search')}
+                        onClick={() => setMobileSearchOpen(true)}
+                        sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+                      >
                         <SearchIcon fontSize="small" />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-                sx={{ minWidth: 240, flex: '1 1 240px' }}
-              />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  {activeMobileFilterChips.length > 0 ? (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxWidth: '100%', overflow: 'hidden' }}>
+                      {activeMobileFilterChips.map((chip) => (
+                        <Chip
+                          key={chip.key}
+                          size="small"
+                          variant="outlined"
+                          label={chip.label}
+                          onDelete={chip.onDelete}
+                          sx={{ maxWidth: '100%', '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' } }}
+                        />
+                      ))}
+                    </Box>
+                  ) : null}
+                </Stack>
+              ) : (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1.5,
+                    alignItems: 'center',
+                  }}
+                >
+                  <TextField
+                    size="small"
+                    placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
+                    value={seedlingSearchText}
+                    onChange={(event) => setSeedlingSearchText(event.target.value)}
+                    inputRef={searchInputRef}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <SearchIcon fontSize="small" />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                    sx={{ minWidth: 240, flex: '1 1 240px' }}
+                  />
+                </Box>
+              )}
             </Box>
           )}
           <Box

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -110,7 +110,7 @@ const GANTT_LEFT_COLUMN_MAX_WIDTH = 400;
 const GANTT_SIDEBAR_RESIZE_HANDLE_HITBOX_WIDTH = 12;
 const GANTT_SIDEBAR_RESIZE_KEYBOARD_STEP = 10;
 const GANTT_ROW_HEIGHT = 32;
-const GANTT_VIEWPORT_MAX_HEIGHT_SX = { xs: '70svh', sm: '72svh', lg: '76svh' } as const;
+const GANTT_VIEWPORT_MAX_HEIGHT_SX = { md: '72svh', lg: '76svh' } as const;
 // Above this many combined location+field+bed nodes, default to
 // locations-expanded/fields-collapsed instead of fully expanding the tree.
 const OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD = 30;
@@ -614,6 +614,7 @@ function GanttChartPage() {
   const activeGanttLeftColumnWidth = useMobileFilterLayout
     ? GANTT_LEFT_COLUMN_MOBILE_WIDTH
     : ganttLeftColumnWidth;
+  const useWindowedGanttRows = !useMobileFilterLayout;
   const activeGanttLeftColumnWidthRef = useRef(activeGanttLeftColumnWidth);
   const [editMode, setEditMode] = useState(false);
   const outletContext = useOutletContext<RootLayoutOutletContext | null>();
@@ -1553,16 +1554,24 @@ function GanttChartPage() {
     [activeGanttLeftColumnWidth, timelineViewMode],
   );
   const renderWindow = useMemo(
-    () => getGanttRenderWindow(
-      activeTaskGroups,
-      ganttScrollTop,
-      ganttViewportHeight,
-      getActiveGanttRowHeight,
-    ),
-    [activeTaskGroups, ganttScrollTop, ganttViewportHeight, getActiveGanttRowHeight],
+    () => (useWindowedGanttRows
+      ? getGanttRenderWindow(
+        activeTaskGroups,
+        ganttScrollTop,
+        ganttViewportHeight,
+        getActiveGanttRowHeight,
+      )
+      : {
+        groups: activeTaskGroups,
+        startIndex: 0,
+        endIndex: activeTaskGroups.length,
+        totalHeight: activeTaskGroups.reduce((total, group) => total + getActiveGanttRowHeight(group), 0),
+      }),
+    [activeTaskGroups, ganttScrollTop, ganttViewportHeight, getActiveGanttRowHeight, useWindowedGanttRows],
   );
   const renderedTaskGroups = renderWindow.groups;
-  const isGanttRenderWindowVirtualized = renderWindow.startIndex > 0 || renderWindow.endIndex < activeTaskGroups.length;
+  const isGanttRenderWindowVirtualized = useWindowedGanttRows
+    && (renderWindow.startIndex > 0 || renderWindow.endIndex < activeTaskGroups.length);
   const totalTimelineItems = useMemo(
     // For occupancy mode, count tasks across the full tree (every bed),
     // not just the currently visible/expanded rows — collapsing a field
@@ -1737,7 +1746,10 @@ function GanttChartPage() {
   useRegisterCommands('calendar-page', calendarCommands);
 
   useEffect(() => {
-    if (loading || !hasCalendarRequirements) {
+    if (loading || !hasCalendarRequirements || !useWindowedGanttRows) {
+      if (!useWindowedGanttRows) {
+        setGanttScrollTop(0);
+      }
       return;
     }
 
@@ -1757,7 +1769,7 @@ function GanttChartPage() {
     }
     setGanttScrollTop(appliedScrollTop);
     hasRestoredTimelineRef.current = false;
-  }, [activeProjectId, calendarMode, hasCalendarRequirements, loading, storedGanttState?.rowScrollTop]);
+  }, [activeProjectId, calendarMode, hasCalendarRequirements, loading, storedGanttState?.rowScrollTop, useWindowedGanttRows]);
 
   useEffect(() => {
     if (loading || !hasCalendarRequirements) {
@@ -2548,6 +2560,9 @@ function GanttChartPage() {
                 ref={ganttViewportRef}
                 data-testid="gantt-virtual-viewport"
                 onScroll={(event) => {
+                  if (!useWindowedGanttRows) {
+                    return;
+                  }
                   const nextScrollTop = event.currentTarget.scrollTop;
                   setGanttScrollTop(nextScrollTop);
                   storeGanttState(ganttStateStorageKey, {
@@ -2558,10 +2573,10 @@ function GanttChartPage() {
                 }}
                 sx={{
                   position: 'relative',
-                  maxHeight: GANTT_VIEWPORT_MAX_HEIGHT_SX,
-                  overflowY: 'auto',
+                  maxHeight: { xs: 'none', ...GANTT_VIEWPORT_MAX_HEIGHT_SX },
+                  overflowY: { xs: 'visible', md: 'auto' },
                   overflowX: 'hidden',
-                  overscrollBehavior: 'contain',
+                  overscrollBehavior: { xs: 'auto', md: 'contain' },
                 }}
               >
                 {isGanttRenderWindowVirtualized ? (

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -20,7 +20,6 @@ import {
   Button,
   ButtonGroup,
   Checkbox,
-  Chip,
   Divider,
   FormControl,
   FormControlLabel,
@@ -1071,20 +1070,6 @@ function GanttChartPage() {
       )),
     [occupancyHierarchyNodes, occupancyLocationFilter],
   );
-  const selectedLocationName = useMemo(
-    () => (occupancyLocationFilter === 'all'
-      ? null
-      : locations.find((location) => location.id === occupancyLocationFilter)?.name ?? null),
-    [locations, occupancyLocationFilter],
-  );
-  const selectedFieldName = useMemo(
-    () => (occupancyFieldFilter === 'all'
-      ? null
-      : occupancyHierarchyNodes.find(
-        (node) => node.type === 'field' && node.fieldId === occupancyFieldFilter,
-      )?.name ?? null),
-    [occupancyFieldFilter, occupancyHierarchyNodes],
-  );
   const activeHierarchyFilterCount = [
     occupancyLocationFilter !== 'all',
     occupancyFieldFilter !== 'all',
@@ -1105,56 +1090,6 @@ function GanttChartPage() {
     }
     setMobileSearchOpen(false);
   }, [calendarMode]);
-  const activeMobileFilterChips = useMemo(
-    () => {
-      const chips: Array<{ key: string; label: string; onDelete: () => void }> = [];
-      if (activeSearchText) {
-        chips.push({
-          key: 'search',
-          label: t('ganttChart:treeFilters.searchChip', { query: activeSearchText }),
-          onDelete: clearActiveSearch,
-        });
-      }
-      if (calendarMode === 'occupancy') {
-        if (occupancyLocationFilter !== 'all') {
-          chips.push({
-            key: 'location',
-            label: selectedLocationName ?? t('ganttChart:treeFilters.selectedLocationFallback'),
-            onDelete: () => {
-              setOccupancyLocationFilter('all');
-              setOccupancyFieldFilter('all');
-            },
-          });
-        }
-        if (occupancyFieldFilter !== 'all') {
-          chips.push({
-            key: 'field',
-            label: selectedFieldName ?? t('ganttChart:treeFilters.selectedFieldFallback'),
-            onDelete: () => setOccupancyFieldFilter('all'),
-          });
-        }
-        if (onlyOccupiedBeds) {
-          chips.push({
-            key: 'only-occupied',
-            label: t('ganttChart:treeFilters.onlyOccupiedBeds'),
-            onDelete: () => setOnlyOccupiedBeds(false),
-          });
-        }
-      }
-      return chips;
-    },
-    [
-      activeSearchText,
-      calendarMode,
-      clearActiveSearch,
-      occupancyFieldFilter,
-      occupancyLocationFilter,
-      onlyOccupiedBeds,
-      selectedFieldName,
-      selectedLocationName,
-      t,
-    ],
-  );
 
   const occupancyTaskGroups = useMemo<GanttTaskGroup[]>(() => {
     // Structural filter: "only occupied beds" removes empty beds (and any
@@ -2129,11 +2064,11 @@ function GanttChartPage() {
             <Box
               data-testid="occupancy-tree-filters"
               sx={{
-                mb: { xs: 0.75, md: 1.5 },
+                mb: { xs: 0, md: 1.5 },
               }}
             >
               {useMobileFilterLayout ? (
-                <Stack spacing={0.75}>
+                <Stack spacing={0}>
                   {mobileSearchOpen || activeSearchText ? (
                     <Stack direction="row" spacing={0.75} alignItems="center">
                       <TextField
@@ -2165,14 +2100,21 @@ function GanttChartPage() {
                       </Tooltip>
                       <Button
                         size="small"
-                        variant={activeHierarchyFilterCount > 0 ? 'contained' : 'outlined'}
-                        color={activeHierarchyFilterCount > 0 ? 'success' : 'inherit'}
+                        variant="outlined"
+                        color="inherit"
                         startIcon={<TuneIcon fontSize="small" />}
                         onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
                         aria-expanded={isCalendarFilterPopoverOpen}
                         aria-haspopup="dialog"
                         aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
-                        sx={{ minHeight: 40, minWidth: 0, px: 1, whiteSpace: 'nowrap' }}
+                        sx={{
+                          minHeight: 40,
+                          minWidth: 0,
+                          px: 1,
+                          whiteSpace: 'nowrap',
+                          borderColor: activeHierarchyFilterCount > 0 ? 'text.secondary' : 'divider',
+                          bgcolor: activeHierarchyFilterCount > 0 ? 'action.selected' : 'transparent',
+                        }}
                       >
                         {activeHierarchyFilterCount > 0
                           ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
@@ -2193,14 +2135,19 @@ function GanttChartPage() {
                       </Tooltip>
                       <Button
                         size="small"
-                        variant={activeHierarchyFilterCount > 0 ? 'contained' : 'outlined'}
-                        color={activeHierarchyFilterCount > 0 ? 'success' : 'inherit'}
+                        variant="outlined"
+                        color="inherit"
                         startIcon={<TuneIcon fontSize="small" />}
                         onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
                         aria-expanded={isCalendarFilterPopoverOpen}
                         aria-haspopup="dialog"
                         aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
-                        sx={{ minHeight: 40, whiteSpace: 'nowrap' }}
+                        sx={{
+                          minHeight: 40,
+                          whiteSpace: 'nowrap',
+                          borderColor: activeHierarchyFilterCount > 0 ? 'text.secondary' : 'divider',
+                          bgcolor: activeHierarchyFilterCount > 0 ? 'action.selected' : 'transparent',
+                        }}
                       >
                         {activeHierarchyFilterCount > 0
                           ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
@@ -2208,20 +2155,6 @@ function GanttChartPage() {
                       </Button>
                     </Stack>
                   )}
-                  {activeMobileFilterChips.length > 0 ? (
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxWidth: '100%', overflow: 'hidden' }}>
-                      {activeMobileFilterChips.map((chip) => (
-                        <Chip
-                          key={chip.key}
-                          size="small"
-                          variant="outlined"
-                          label={chip.label}
-                          onDelete={chip.onDelete}
-                          sx={{ maxWidth: '100%', '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' } }}
-                        />
-                      ))}
-                    </Box>
-                  ) : null}
                   <Popover
                     id="calendar-filters-popover"
                     open={isCalendarFilterPopoverOpen}
@@ -2366,11 +2299,11 @@ function GanttChartPage() {
             <Box
               data-testid="seedling-filters"
               sx={{
-                mb: { xs: 0.75, md: 1.5 },
+                mb: { xs: 0, md: 1.5 },
               }}
             >
               {useMobileFilterLayout ? (
-                <Stack spacing={0.75}>
+                <Stack spacing={0}>
                   {mobileSearchOpen || activeSearchText ? (
                     <Stack direction="row" spacing={0.75} alignItems="center">
                       <TextField
@@ -2413,20 +2346,6 @@ function GanttChartPage() {
                       </IconButton>
                     </Tooltip>
                   )}
-                  {activeMobileFilterChips.length > 0 ? (
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxWidth: '100%', overflow: 'hidden' }}>
-                      {activeMobileFilterChips.map((chip) => (
-                        <Chip
-                          key={chip.key}
-                          size="small"
-                          variant="outlined"
-                          label={chip.label}
-                          onDelete={chip.onDelete}
-                          sx={{ maxWidth: '100%', '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' } }}
-                        />
-                      ))}
-                    </Box>
-                  ) : null}
                 </Stack>
               ) : (
                 <Box
@@ -2461,6 +2380,7 @@ function GanttChartPage() {
           <Box
             className={`gantt-container-wrapper gantt-container-wrapper--${calendarMode}`}
             sx={{
+              mt: { xs: 0.75, md: 2 },
               border: '1px solid',
               borderColor: 'surface.surfaceSoftBorder',
               borderRadius: 2,

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -7,7 +7,7 @@
  * @returns The Gantt Chart page component
  */
 
-import React, { useState, useEffect, useMemo, useCallback, useContext, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useContext, useRef, useLayoutEffect } from 'react';
 import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CloseIcon from '@mui/icons-material/Close';
@@ -570,6 +570,7 @@ function GanttChartPage() {
   const [ganttScrollTop, setGanttScrollTop] = useState(0);
   const [ganttViewportHeight, setGanttViewportHeight] = useState(640);
   const ganttViewportRef = useRef<HTMLDivElement | null>(null);
+  const [ganttResizeBoundaryNode, setGanttResizeBoundaryNode] = useState<HTMLDivElement | null>(null);
   const ganttSidebarWidthFrameRef = useRef<number | null>(null);
   const hasRestoredTimelineRef = useRef(false);
   const latestReferenceDateRef = useRef<Date | null>(null);
@@ -590,6 +591,7 @@ function GanttChartPage() {
     storedGanttState?.leftColumnWidth ?? GANTT_LEFT_COLUMN_DEFAULT_WIDTH,
   );
   const [isResizingGanttSidebar, setIsResizingGanttSidebar] = useState(false);
+  const [ganttResizeHandleTop, setGanttResizeHandleTop] = useState<number | null>(null);
   const calendarViewStorageKey = useMemo(
     () => (canUseStoredCalendarView ? getCalendarViewStorageKey(activeProjectId) : null),
     [activeProjectId, canUseStoredCalendarView],
@@ -616,6 +618,9 @@ function GanttChartPage() {
     : ganttLeftColumnWidth;
   const useWindowedGanttRows = !useMobileFilterLayout;
   const activeGanttLeftColumnWidthRef = useRef(activeGanttLeftColumnWidth);
+  const handleGanttResizeBoundaryRef = useCallback((node: HTMLDivElement | null): void => {
+    setGanttResizeBoundaryNode(node);
+  }, []);
   const [editMode, setEditMode] = useState(false);
   const outletContext = useOutletContext<RootLayoutOutletContext | null>();
   const setTopbarContextActions = outletContext?.setTopbarContextActions;
@@ -1572,6 +1577,69 @@ function GanttChartPage() {
   const renderedTaskGroups = renderWindow.groups;
   const isGanttRenderWindowVirtualized = useWindowedGanttRows
     && (renderWindow.startIndex > 0 || renderWindow.endIndex < activeTaskGroups.length);
+
+  useLayoutEffect(() => {
+    if (useMobileFilterLayout) {
+      setGanttResizeHandleTop(null);
+      return undefined;
+    }
+
+    const boundary = ganttResizeBoundaryNode;
+    if (!boundary) {
+      return undefined;
+    }
+
+    let animationFrameId: number | null = null;
+    const measureHandleTop = (): void => {
+      animationFrameId = null;
+      const ganttBody = boundary.querySelector<HTMLElement>('.rmg-container');
+      if (!ganttBody) {
+        setGanttResizeHandleTop(null);
+        return;
+      }
+      const boundaryRect = boundary.getBoundingClientRect();
+      const bodyRect = ganttBody.getBoundingClientRect();
+      setGanttResizeHandleTop(Math.max(0, Math.round(bodyRect.top - boundaryRect.top)));
+    };
+    const queueMeasure = (): void => {
+      if (animationFrameId === null) {
+        animationFrameId = window.requestAnimationFrame(measureHandleTop);
+      }
+    };
+
+    measureHandleTop();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', queueMeasure);
+      return () => {
+        window.removeEventListener('resize', queueMeasure);
+        if (animationFrameId !== null) {
+          window.cancelAnimationFrame(animationFrameId);
+        }
+      };
+    }
+
+    const observer = new ResizeObserver(queueMeasure);
+    observer.observe(boundary);
+    const ganttBody = boundary.querySelector<HTMLElement>('.rmg-container');
+    if (ganttBody) {
+      observer.observe(ganttBody);
+    }
+
+    return () => {
+      observer.disconnect();
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [
+    calendarMode,
+    ganttResizeBoundaryNode,
+    renderedTaskGroups.length,
+    timelineViewMode,
+    useMobileFilterLayout,
+  ]);
+
   const totalTimelineItems = useMemo(
     // For occupancy mode, count tasks across the full tree (every bed),
     // not just the currently visible/expanded rows — collapsing a field
@@ -2552,6 +2620,7 @@ function GanttChartPage() {
             }}
           >
             <Box
+              ref={handleGanttResizeBoundaryRef}
               sx={{
                 position: 'relative',
               }}
@@ -2594,7 +2663,7 @@ function GanttChartPage() {
                   </Box>
                 ) : calendarGanttChart}
               </Box>
-              {!useMobileFilterLayout ? (
+              {!useMobileFilterLayout && ganttResizeHandleTop !== null ? (
                 <Box
                   component="button"
                   type="button"
@@ -2608,7 +2677,7 @@ function GanttChartPage() {
                   onKeyDown={handleGanttSidebarResizeKeyDown}
                   sx={{
                     position: 'absolute',
-                    top: 0,
+                    top: `${ganttResizeHandleTop}px`,
                     bottom: 0,
                     left: `${activeGanttLeftColumnWidth - GANTT_SIDEBAR_RESIZE_HANDLE_HITBOX_WIDTH / 2}px`,
                     zIndex: 360,


### PR DESCRIPTION
## Summary

- Compact the mobile Anbaukalender filter area into a search icon and a filter button with active-count state.
- Move Standort, Parzelle, and “Nur belegte Beete” into a mobile MUI Popover using the existing CultureDetail-style filter pattern.
- Show removable active-filter chips for search, Standort, Parzelle, and occupied-bed filters without changing the desktop toolbar layout.
- Add regression coverage for the compact mobile controls.

## Existing pattern reused

The closest existing pattern is `CultureDetail`: a compact filter trigger with active count, MUI Popover contents, reset action, and MUI Chip indicators. The calendar now follows that interaction style on mobile while keeping the existing visible desktop controls.

## Validation

- `npm test -- --run src/__tests__/GanttChart.test.tsx`
- `npx eslint src/pages/GanttChart.tsx src/__tests__/GanttChart.test.tsx`
- `npm run build`
- `npx playwright test e2e/gantt-layout.spec.ts`
