### PR TITLE
fix: make password visibility toggles keyboard accessible

### DIFF
--- a/frontend/src/__tests__/LoginPageDeletionFlow.test.tsx
+++ b/frontend/src/__tests__/LoginPageDeletionFlow.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import LoginPage from '../pages/auth/LoginPage';
 import { AuthApiError } from '../auth/authApi';
@@ -15,6 +16,17 @@ vi.mock('../auth/useAuth', () => ({
   }),
 }));
 
+vi.mock('../api/api', async () => {
+  const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
+  return {
+    ...actual,
+    projectAPI: {
+      ...actual.projectAPI,
+      getPendingInvitation: vi.fn(async () => ({ data: { code: 'no_pending_invitation' } })),
+    },
+  };
+});
+
 describe('LoginPage deletion flow', () => {
   it('shows restore option for account_pending_deletion', async () => {
     loginMock.mockRejectedValueOnce(new AuthApiError('pending', 'account_pending_deletion', new Date().toISOString()));
@@ -28,5 +40,30 @@ describe('LoginPage deletion flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Anmelden' }));
 
     expect(await screen.findByRole('button', { name: 'Konto wiederherstellen' })).toBeInTheDocument();
+  });
+
+  it('lets keyboard users toggle password visibility without moving focus', async () => {
+    const user = userEvent.setup();
+
+    render(<MemoryRouter><LoginPage /></MemoryRouter>);
+
+    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    const toggleButton = screen.getByRole('button', { name: 'Passwort anzeigen' });
+
+    await user.tab();
+    await user.tab();
+    await user.tab();
+
+    expect(toggleButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(passwordInput.type).toBe('text');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort ausblenden');
+
+    await user.keyboard(' ');
+    expect(passwordInput.type).toBe('password');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort anzeigen');
   });
 });

--- a/frontend/src/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/__tests__/RegisterPage.test.tsx
@@ -5,23 +5,24 @@ import { MemoryRouter } from 'react-router-dom';
 import RegisterPage from '../pages/auth/RegisterPage';
 
 const logoutMock = vi.fn(async () => undefined);
+let authUser: unknown = {
+  id: 1,
+  email: 'test@example.com',
+  display_name: 'Test',
+  display_label: 'test@example.com',
+  is_active: true,
+  default_project_id: 1,
+  last_project_id: 1,
+  resolved_project_id: 1,
+  needs_project_selection: false,
+  memberships: [],
+  account_pending_deletion: false,
+  scheduled_deletion_at: null,
+};
 
 vi.mock('../auth/useAuth', () => ({
   useAuth: () => ({
-    user: {
-      id: 1,
-      email: 'test@example.com',
-      display_name: 'Test',
-      display_label: 'test@example.com',
-      is_active: true,
-      default_project_id: 1,
-      last_project_id: 1,
-      resolved_project_id: 1,
-      needs_project_selection: false,
-      memberships: [],
-      account_pending_deletion: false,
-      scheduled_deletion_at: null,
-    },
+    user: authUser,
     register: vi.fn(),
     resendActivation: vi.fn(),
     logout: logoutMock,
@@ -52,7 +53,7 @@ vi.mock('../i18n', () => ({
         'auth:register.resendActivation': 'Aktivierungs-E-Mail erneut senden',
         'auth:register.hasAccount': 'Bereits ein Konto? Anmelden',
         'auth:register.showPassword': 'Passwort anzeigen',
-        'auth:register.hidePassword': 'Passwort verbergen',
+        'auth:register.hidePassword': 'Passwort ausblenden',
       };
       return map[key] ?? key;
     },
@@ -62,9 +63,25 @@ vi.mock('../i18n', () => ({
 describe('RegisterPage', () => {
   beforeEach(() => {
     logoutMock.mockClear();
+    authUser = {
+      id: 1,
+      email: 'test@example.com',
+      display_name: 'Test',
+      display_label: 'test@example.com',
+      is_active: true,
+      default_project_id: 1,
+      last_project_id: 1,
+      resolved_project_id: 1,
+      needs_project_selection: false,
+      memberships: [],
+      account_pending_deletion: false,
+      scheduled_deletion_at: null,
+    };
   });
 
   it('password toggle buttons use translated German aria-labels (BUG-M02 regression guard)', () => {
+    authUser = null;
+
     render(
       <MemoryRouter initialEntries={['/register']}>
         <RegisterPage />
@@ -80,6 +97,8 @@ describe('RegisterPage', () => {
   });
 
   it('password fields carry autocomplete="new-password" (BUG-L02 regression guard)', () => {
+    authUser = null;
+
     render(
       <MemoryRouter initialEntries={['/register']}>
         <RegisterPage />
@@ -93,6 +112,37 @@ describe('RegisterPage', () => {
     passwordInputs.forEach((input) => {
       expect(input).toHaveAttribute('autocomplete', 'new-password');
     });
+  });
+
+  it('keeps password visibility toggles keyboard accessible', async () => {
+    authUser = null;
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/register']}>
+        <RegisterPage />
+      </MemoryRouter>,
+    );
+
+    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    const toggleButton = screen.getAllByRole('button', { name: 'Passwort anzeigen' })[0];
+
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    await user.tab();
+
+    expect(toggleButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(passwordInput.type).toBe('text');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort ausblenden');
+
+    await user.keyboard(' ');
+    expect(passwordInput.type).toBe('password');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort anzeigen');
   });
 
   it('shows logged-in info banner and account-switch actions instead of redirecting', async () => {

--- a/frontend/src/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend/src/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ResetPasswordPage from '../pages/auth/ResetPasswordPage';
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({
+    confirmPasswordReset: vi.fn(),
+  }),
+}));
+
+describe('ResetPasswordPage', () => {
+  it('lets keyboard users toggle new-password visibility without moving focus', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/reset-password?uid=uid&token=token']}>
+        <Routes>
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const passwordInput = document.querySelector('input[type="password"]') as HTMLInputElement;
+    const toggleButton = screen.getAllByRole('button', { name: 'Passwort anzeigen' })[0];
+
+    await user.tab();
+    await user.tab();
+
+    expect(toggleButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(passwordInput.type).toBe('text');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort ausblenden');
+
+    await user.keyboard(' ');
+    expect(passwordInput.type).toBe('password');
+    expect(toggleButton).toHaveFocus();
+    expect(toggleButton).toHaveAccessibleName('Passwort anzeigen');
+  });
+});

--- a/frontend/src/components/inputs/PasswordVisibilityToggle.tsx
+++ b/frontend/src/components/inputs/PasswordVisibilityToggle.tsx
@@ -1,0 +1,30 @@
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { IconButton } from '@mui/material';
+
+interface PasswordVisibilityToggleProps {
+  isVisible: boolean;
+  showLabel: string;
+  hideLabel: string;
+  onToggle: () => void;
+  disabled?: boolean;
+}
+
+export default function PasswordVisibilityToggle({
+  isVisible,
+  showLabel,
+  hideLabel,
+  onToggle,
+  disabled = false,
+}: PasswordVisibilityToggleProps) {
+  return (
+    <IconButton
+      aria-label={isVisible ? hideLabel : showLabel}
+      edge="end"
+      disabled={disabled}
+      onClick={onToggle}
+    >
+      {isVisible ? <VisibilityOff /> : <Visibility />}
+    </IconButton>
+  );
+}

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -12,7 +12,7 @@
     "restoreAccount": "Konto wiederherstellen",
     "restoreFailed": "Wiederherstellung fehlgeschlagen.",
     "showPassword": "Passwort anzeigen",
-    "hidePassword": "Passwort verbergen"
+    "hidePassword": "Passwort ausblenden"
   },
   "register": {
     "title": "Registrieren",
@@ -31,7 +31,7 @@
     "resendActivation": "Aktivierungs-E-Mail erneut senden",
     "hasAccount": "Bereits ein Konto? Anmelden",
     "showPassword": "Passwort anzeigen",
-    "hidePassword": "Passwort verbergen"
+    "hidePassword": "Passwort ausblenden"
   },
   "activate": {
     "title": "Konto aktivieren",
@@ -52,6 +52,8 @@
     "title": "Passwort zurücksetzen",
     "password": "Neues Passwort",
     "passwordConfirm": "Neues Passwort bestätigen",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort ausblenden",
     "submit": "Passwort zurücksetzen",
     "backToLogin": "Zurück zur Anmeldung",
     "failed": "Zurücksetzen fehlgeschlagen."

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,4 @@
-import { Alert, Box, Button, Container, IconButton, InputAdornment, Stack, TextField, Typography } from '@mui/material';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { Alert, Box, Button, Container, InputAdornment, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link as RouterLink, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -8,6 +6,7 @@ import { projectAPI, type InvitationPublicStatus } from '../../api/api';
 import { useAuth } from '../../auth/useAuth';
 import { AuthApiError } from '../../auth/authApi';
 import { useTranslation } from '../../i18n';
+import PasswordVisibilityToggle from '../../components/inputs/PasswordVisibilityToggle';
 import { getNextFromSearch } from '../invitationAcceptance';
 
 export default function LoginPage() {
@@ -111,15 +110,12 @@ export default function LoginPage() {
               input: {
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton
-                      aria-label={t(showPassword ? 'auth:login.hidePassword' : 'auth:login.showPassword')}
-                      edge="end"
-                      tabIndex={-1}
-                      onClick={() => setShowPassword((current) => !current)}
-                      onMouseDown={(event) => event.preventDefault()}
-                    >
-                      {showPassword ? <VisibilityOff /> : <Visibility />}
-                    </IconButton>
+                    <PasswordVisibilityToggle
+                      isVisible={showPassword}
+                      showLabel={t('auth:login.showPassword')}
+                      hideLabel={t('auth:login.hidePassword')}
+                      onToggle={() => setShowPassword((current) => !current)}
+                    />
                   </InputAdornment>
                 ),
               },

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,11 +1,10 @@
-import { Alert, Box, Button, Container, IconButton, InputAdornment, Stack, TextField, Typography } from '@mui/material';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { Alert, Box, Button, Container, InputAdornment, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import { projectAPI, type InvitationPublicStatus } from '../../api/api';
 import { useAuth } from '../../auth/useAuth';
+import PasswordVisibilityToggle from '../../components/inputs/PasswordVisibilityToggle';
 import { useTranslation } from '../../i18n';
 import { getNextFromSearch, getTokenFromNextPath, storeInvitationRedirect } from '../invitationAcceptance';
 
@@ -142,15 +141,13 @@ export default function RegisterPage() {
               input: {
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton
-                      aria-label={t(showPassword ? 'auth:register.hidePassword' : 'auth:register.showPassword')}
-                      edge="end"
-                      tabIndex={-1}
-                      onClick={() => setShowPassword((current) => !current)}
-                      onMouseDown={(event) => event.preventDefault()}
-                    >
-                      {showPassword ? <VisibilityOff /> : <Visibility />}
-                    </IconButton>
+                    <PasswordVisibilityToggle
+                      isVisible={showPassword}
+                      showLabel={t('auth:register.showPassword')}
+                      hideLabel={t('auth:register.hidePassword')}
+                      onToggle={() => setShowPassword((current) => !current)}
+                      disabled={isLoggedIn}
+                    />
                   </InputAdornment>
                 ),
               },
@@ -168,15 +165,13 @@ export default function RegisterPage() {
               input: {
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton
-                      aria-label={t(showPasswordConfirm ? 'auth:register.hidePassword' : 'auth:register.showPassword')}
-                      edge="end"
-                      tabIndex={-1}
-                      onClick={() => setShowPasswordConfirm((current) => !current)}
-                      onMouseDown={(event) => event.preventDefault()}
-                    >
-                      {showPasswordConfirm ? <VisibilityOff /> : <Visibility />}
-                    </IconButton>
+                    <PasswordVisibilityToggle
+                      isVisible={showPasswordConfirm}
+                      showLabel={t('auth:register.showPassword')}
+                      hideLabel={t('auth:register.hidePassword')}
+                      onToggle={() => setShowPasswordConfirm((current) => !current)}
+                      disabled={isLoggedIn}
+                    />
                   </InputAdornment>
                 ),
               },

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,8 +1,9 @@
-import { Alert, Box, Button, Container, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Container, InputAdornment, Stack, TextField, Typography } from '@mui/material';
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../auth/useAuth';
+import PasswordVisibilityToggle from '../../components/inputs/PasswordVisibilityToggle';
 import { useTranslation } from '../../i18n';
 
 export default function ResetPasswordPage() {
@@ -11,6 +12,8 @@ export default function ResetPasswordPage() {
   const { t } = useTranslation('auth');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,8 +38,50 @@ export default function ResetPasswordPage() {
         <Stack spacing={2}>
           {message ? <Alert severity="success">{message}</Alert> : null}
           {error ? <Alert severity="error">{error}</Alert> : null}
-          <TextField label={t('resetPassword.password')} type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-          <TextField label={t('resetPassword.passwordConfirm')} type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required />
+          <TextField
+            label={t('resetPassword.password')}
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <PasswordVisibilityToggle
+                      isVisible={showPassword}
+                      showLabel={t('resetPassword.showPassword')}
+                      hideLabel={t('resetPassword.hidePassword')}
+                      onToggle={() => setShowPassword((current) => !current)}
+                    />
+                  </InputAdornment>
+                ),
+              },
+              htmlInput: { autoComplete: 'new-password' },
+            }}
+          />
+          <TextField
+            label={t('resetPassword.passwordConfirm')}
+            type={showPasswordConfirm ? 'text' : 'password'}
+            value={passwordConfirm}
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+            required
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <PasswordVisibilityToggle
+                      isVisible={showPasswordConfirm}
+                      showLabel={t('resetPassword.showPassword')}
+                      hideLabel={t('resetPassword.hidePassword')}
+                      onToggle={() => setShowPasswordConfirm((current) => !current)}
+                    />
+                  </InputAdornment>
+                ),
+              },
+              htmlInput: { autoComplete: 'new-password' },
+            }}
+          />
           <Button type="submit" variant="contained">{t('resetPassword.submit')}</Button>
           <Button component={RouterLink} to="/login">{t('resetPassword.backToLogin')}</Button>
         </Stack>


### PR DESCRIPTION
## Summary
- Add a shared password visibility toggle component built on a real MUI `IconButton`.
- Make password toggles in login and registration reachable via Tab and operable with Enter/Space.
- Add the same visibility toggles to reset-password fields.
- Use dynamic German aria labels: `Passwort anzeigen` and `Passwort ausblenden`.

## Why
The existing login/register password toggles were real buttons but had `tabIndex={-1}`, so keyboard users could not reach them. Reset-password fields had no visibility toggle. The shared component keeps native button semantics and MUI focus-visible styling, so focus remains on the button after toggling and mouse behavior stays unchanged.

## Validation
- `npm test -- --run src/__tests__/LoginPageDeletionFlow.test.tsx src/__tests__/LoginPageNextRedirect.test.tsx src/__tests__/RegisterPage.test.tsx src/__tests__/ResetPasswordPage.test.tsx`
- `npx eslint src/pages/auth/LoginPage.tsx src/pages/auth/RegisterPage.tsx src/pages/auth/ResetPasswordPage.tsx src/components/inputs/PasswordVisibilityToggle.tsx src/__tests__/LoginPageDeletionFlow.test.tsx src/__tests__/RegisterPage.test.tsx src/__tests__/ResetPasswordPage.test.tsx`
- `npm run build`
