### PR TITLE
fix: refine gantt resize handle visuals

### DIFF
--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -228,21 +228,82 @@ async function expectResizeHandleIsVisuallySubtle(page: Page): Promise<void> {
   const styles = await page.evaluate(() => {
     const handle = document.querySelector<HTMLElement>('[role="separator"][aria-orientation="vertical"]');
     const marker = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-line"]');
-    if (!handle || !marker) {
+    const grip = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-grip"]');
+    if (!handle || !marker || !grip) {
       throw new Error('Missing resize handle');
     }
     const computedStyle = window.getComputedStyle(handle);
     const markerStyle = window.getComputedStyle(marker);
+    const gripStyle = window.getComputedStyle(grip);
     return {
       backgroundColor: computedStyle.backgroundColor,
       hitboxWidth: computedStyle.width,
       markerWidth: markerStyle.width,
+      gripOpacity: gripStyle.opacity,
     };
   });
 
   expect(styles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   expect(Number.parseFloat(styles.hitboxWidth)).toBeGreaterThan(2);
   expect(Number.parseFloat(styles.markerWidth)).toBeLessThanOrEqual(2);
+  expect(Number.parseFloat(styles.gripOpacity)).toBe(0);
+}
+
+async function expectDesktopResizeHandleHoverIsVisible(page: Page): Promise<void> {
+  const handle = page.getByRole('separator', { name: 'Seitenleiste verbreitern oder verkleinern' });
+  await handle.hover();
+
+  await expect.poll(() => page.evaluate(() => {
+    const handleElement = document.querySelector<HTMLElement>('[role="separator"][aria-orientation="vertical"]');
+    const marker = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-line"]');
+    const grip = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-grip"]');
+    if (!handleElement || !marker || !grip) {
+      throw new Error('Missing resize handle');
+    }
+    const handleStyle = window.getComputedStyle(handleElement);
+    const markerStyle = window.getComputedStyle(marker);
+    const gripStyle = window.getComputedStyle(grip);
+    return {
+      cursor: handleStyle.cursor,
+      backgroundColor: handleStyle.backgroundColor,
+      markerWidth: Number.parseFloat(markerStyle.width),
+      markerOpacity: Number.parseFloat(markerStyle.opacity),
+      gripOpacity: Number.parseFloat(gripStyle.opacity),
+    };
+  })).toMatchObject({
+    cursor: 'col-resize',
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    markerWidth: 2,
+    markerOpacity: 1,
+    gripOpacity: 1,
+  });
+}
+
+async function expectResizeHandleDraggingIsVisible(page: Page): Promise<void> {
+  await expect.poll(() => page.evaluate(() => {
+    const handle = document.querySelector<HTMLElement>('[role="separator"][aria-orientation="vertical"]');
+    const marker = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-line"]');
+    const grip = document.querySelector<HTMLElement>('[data-testid="gantt-sidebar-resize-grip"]');
+    if (!handle || !marker || !grip) {
+      throw new Error('Missing resize handle');
+    }
+    const handleStyle = window.getComputedStyle(handle);
+    const markerStyle = window.getComputedStyle(marker);
+    const gripStyle = window.getComputedStyle(grip);
+    return {
+      isResizing: handle.dataset.resizing === 'true',
+      backgroundColor: handleStyle.backgroundColor,
+      markerWidth: Number.parseFloat(markerStyle.width),
+      markerOpacity: Number.parseFloat(markerStyle.opacity),
+      gripOpacity: Number.parseFloat(gripStyle.opacity),
+    };
+  })).toMatchObject({
+    isResizing: true,
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    markerWidth: 2,
+    markerOpacity: 1,
+    gripOpacity: 1,
+  });
 }
 
 async function expectMobilePageScrollsCalendar(page: Page, viewport: { width: number; height: number }): Promise<void> {
@@ -303,6 +364,7 @@ test.describe('Gantt calendar layout', () => {
     await expect(handle).toBeVisible();
     await expectResizeHandleStartsAtTimelineBody(page);
     await expectResizeHandleIsVisuallySubtle(page);
+    await expectDesktopResizeHandleHoverIsVisible(page);
 
     const handleBox = await handle.boundingBox();
     expect(handleBox).not.toBeNull();
@@ -312,6 +374,7 @@ test.describe('Gantt calendar layout', () => {
 
     await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + 30);
     await page.mouse.down();
+    await expectResizeHandleDraggingIsVisible(page);
     await page.mouse.move(handleBox.x + handleBox.width / 2 + 90, handleBox.y + 30, { steps: 6 });
     await page.mouse.up();
 

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -11,6 +11,7 @@ import React, { useState, useEffect, useMemo, useCallback, useContext, useRef, u
 import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CloseIcon from '@mui/icons-material/Close';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import TuneIcon from '@mui/icons-material/Tune';
 import { useTranslation } from '../i18n';
@@ -2743,6 +2744,7 @@ function GanttChartPage() {
                   aria-valuemin={activeGanttLeftColumnMinWidth}
                   aria-valuemax={activeGanttLeftColumnMaxWidth}
                   aria-valuenow={activeGanttLeftColumnWidth}
+                  data-resizing={isResizingGanttSidebar ? 'true' : undefined}
                   onPointerDown={handleGanttSidebarResizeStart}
                   onKeyDown={handleGanttSidebarResizeKeyDown}
                   sx={{
@@ -2763,13 +2765,16 @@ function GanttChartPage() {
                     cursor: { xs: 'default', md: 'col-resize' },
                     touchAction: 'none',
                     WebkitTapHighlightColor: 'transparent',
-                    '&:hover, &:active': {
+                    '&, &:hover, &:active, &[data-resizing="true"]': {
                       bgcolor: 'transparent !important',
                       background: 'transparent !important',
                     },
-                    '&:hover .GanttSidebarResizeHandle-line, &:focus-visible .GanttSidebarResizeHandle-line': {
+                    '&:hover .GanttSidebarResizeHandle-line, &:focus-visible .GanttSidebarResizeHandle-line, &[data-resizing="true"] .GanttSidebarResizeHandle-line': {
                       width: '2px',
                       bgcolor: 'text.secondary',
+                      opacity: 1,
+                    },
+                    '&:hover .GanttSidebarResizeHandle-grip, &:focus-visible .GanttSidebarResizeHandle-grip, &[data-resizing="true"] .GanttSidebarResizeHandle-grip': {
                       opacity: 1,
                     },
                     '&:focus-visible': {
@@ -2795,6 +2800,28 @@ function GanttChartPage() {
                       transition: 'background-color 120ms ease, opacity 120ms ease, width 120ms ease',
                     }}
                   />
+                  <Box
+                    className="GanttSidebarResizeHandle-grip"
+                    data-testid="gantt-sidebar-resize-grip"
+                    aria-hidden="true"
+                    sx={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      display: { xs: 'none', md: 'flex' },
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 16,
+                      height: 24,
+                      transform: 'translate(-50%, -50%)',
+                      color: 'text.secondary',
+                      opacity: isResizingGanttSidebar ? 1 : 0,
+                      pointerEvents: 'none',
+                      transition: 'opacity 120ms ease',
+                    }}
+                  >
+                    <DragIndicatorIcon sx={{ fontSize: 16 }} />
+                  </Box>
                 </Box>
               ) : null}
             </Box>


### PR DESCRIPTION
## Summary
- keep the Gantt sidebar resize hitbox transparent while showing only the subtle vertical line by default
- add a small desktop grip indicator that appears on hover, focus, and dragging without changing layout
- extend the Gantt layout E2E coverage for normal, hover, dragging, mobile resize, and mobile page scrolling states

## Validation
- `npx eslint src/pages/GanttChart.tsx e2e/gantt-layout.spec.ts`
- `npm run test -- --run src/__tests__/GanttChart.test.tsx src/__tests__/gantt-chart/GanttChart.localization.test.tsx`
- `npm run build`
- `npx playwright test e2e/gantt-layout.spec.ts --project=chromium`

Note: `npm run lint` still fails on existing repo-wide issues, including generated `.vite/deps` files and unrelated React lint findings. The changed files pass targeted ESLint.
