### PR TITLE
fix: sync datagrid focus after enter save

### DIFF
--- a/frontend/e2e/fields-beds-keyboard-focus.spec.ts
+++ b/frontend/e2e/fields-beds-keyboard-focus.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const backendPort = process.env.BACKEND_PORT ?? '8000';
+const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
+const apiBase = `http://127.0.0.1:${backendPort}/api`;
+
+type FieldsBedsFixture = {
+  bedA: { id: number };
+  bedB: { id: number };
+  bedC: { id: number };
+  bedD: { id: number };
+};
+
+type FocusedGridCell = {
+  field: string | null;
+  rowId: string | null;
+  rowText: string;
+};
+
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') {
+      return;
+    }
+    const text = message.text();
+    if (text.includes('Failed to load resource')) {
+      return;
+    }
+    errors.push(`console.error: ${text}`);
+  });
+  page.on('pageerror', (error) => {
+    errors.push(`pageerror: ${error.message}`);
+  });
+  return errors;
+}
+
+async function loginWithFreshProject(
+  page: Page,
+  request: APIRequestContext,
+  scenarioPrefix: string,
+): Promise<void> {
+  const scenario = `${scenarioPrefix}-${Date.now()}`;
+  const setupResponse = await request.post(`${apiBase}/__e2e__/invite-flow/`, {
+    headers: { 'X-E2E-Token': e2eToken },
+    data: { action: 'setup', scenario_id: scenario, invitation_state: 'pending' },
+  });
+  const setupText = await setupResponse.text();
+  expect(setupResponse.ok(), `fixture setup -> ${setupResponse.status()}: ${setupText}`).toBeTruthy();
+  const setup = JSON.parse(setupText) as { admin: { email: string; password: string } };
+
+  await page.goto('/login');
+  await page.getByLabel('E-Mail').fill(setup.admin.email);
+  await page.locator('input[type="password"]').fill(setup.admin.password);
+  await page.getByRole('button', { name: 'Anmelden' }).click();
+  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
+}
+
+async function postApi<T>(
+  page: Page,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<T> {
+  const projectId = await page.evaluate(() => window.localStorage.getItem('activeProjectId'));
+  expect(projectId).toBeTruthy();
+  const csrfToken = await page.evaluate(() =>
+    document.cookie.split('; ').find((row) => row.startsWith('csrftoken='))?.split('=')[1] ?? '');
+
+  const result = await page.evaluate(async ({ requestPath, requestData, requestProjectId, requestCsrfToken }) => {
+    const response = await fetch(`/api${requestPath}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': requestCsrfToken,
+        'X-Project-Id': requestProjectId,
+      },
+      body: JSON.stringify({ ...requestData, project: Number(requestProjectId) }),
+    });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  }, {
+    requestPath: path,
+    requestData: data,
+    requestProjectId: projectId,
+    requestCsrfToken: csrfToken,
+  });
+
+  expect(result.ok, `${path} -> ${result.status}: ${result.text}`).toBeTruthy();
+  return JSON.parse(result.text) as T;
+}
+
+async function createFieldsBedsFixture(page: Page): Promise<FieldsBedsFixture> {
+  const location = await postApi<{ id: number }>(page, '/locations/', { name: 'Keyboard Focus Standort' });
+  const field = await postApi<{ id: number }>(page, '/fields/', {
+    name: 'Keyboard Focus Parzelle',
+    location: location.id,
+  });
+
+  const createBed = (name: string) => postApi<{ id: number }>(page, '/beds/', {
+    name,
+    field: field.id,
+    length_m: 10,
+    width_m: 1,
+    area_sqm: 10,
+  });
+
+  return {
+    bedA: await createBed('Keyboard Focus Beet A'),
+    bedB: await createBed('Keyboard Focus Beet B'),
+    bedC: await createBed('Keyboard Focus Beet C'),
+    bedD: await createBed('Keyboard Focus Beet D'),
+  };
+}
+
+async function readFocusedGridCell(page: Page): Promise<FocusedGridCell> {
+  return page.evaluate(() => {
+    const activeElement = document.activeElement as HTMLElement | null;
+    const cell = activeElement?.closest('[role="gridcell"]') as HTMLElement | null;
+    const row = activeElement?.closest('[role="row"][data-id]') as HTMLElement | null;
+    return {
+      field: cell?.getAttribute('data-field') ?? null,
+      rowId: row?.getAttribute('data-id') ?? null,
+      rowText: row?.textContent ?? '',
+    };
+  });
+}
+
+async function expectFocusedCell(page: Page, rowId: number, text: string): Promise<void> {
+  await expect.poll(() => readFocusedGridCell(page)).toMatchObject({
+    field: 'name',
+    rowId: String(rowId),
+    rowText: expect.stringContaining(text),
+  });
+}
+
+async function editBedNameWithEnter(page: Page, currentName: string, nextName: string): Promise<void> {
+  const row = page.locator('[role="row"][data-id]').filter({ hasText: currentName }).first();
+  await expect(row).toBeVisible();
+  await row.locator('[data-field="name"]').click();
+
+  const input = page.locator('.MuiDataGrid-row--editing [data-field="name"] input').first();
+  await expect(input).toBeVisible();
+  await input.fill(nextName);
+  await input.press('Enter');
+
+  await expect(page.locator('.MuiDataGrid-row--editing')).toHaveCount(0);
+  await expect(page.locator('[role="row"][data-id]').filter({ hasText: nextName })).toBeVisible();
+}
+
+test.describe('fields-beds keyboard focus after Enter save', () => {
+  test('keeps the first ArrowUp relative to the post-Enter focused bed', async ({ page, request }) => {
+    const errors = trackConsoleErrors(page);
+    await loginWithFreshProject(page, request, 'fields-keyboard-focus-up');
+    const fixture = await createFieldsBedsFixture(page);
+
+    await page.goto('/app/fields-beds');
+    await expect(page.getByText('Keyboard Focus Beet D')).toBeVisible();
+
+    await editBedNameWithEnter(page, 'Keyboard Focus Beet B', 'Keyboard Focus Beet B edited');
+    await expectFocusedCell(page, fixture.bedC.id, 'Keyboard Focus Beet C');
+
+    await page.keyboard.press('ArrowUp');
+    await expectFocusedCell(page, fixture.bedB.id, 'Keyboard Focus Beet B edited');
+
+    await page.keyboard.press('ArrowDown');
+    await expectFocusedCell(page, fixture.bedC.id, 'Keyboard Focus Beet C');
+    expect(errors).toEqual([]);
+  });
+
+  test('keeps the first ArrowDown relative to the post-Enter focused bed', async ({ page, request }) => {
+    const errors = trackConsoleErrors(page);
+    await loginWithFreshProject(page, request, 'fields-keyboard-focus-down');
+    const fixture = await createFieldsBedsFixture(page);
+
+    await page.goto('/app/fields-beds');
+    await expect(page.getByText('Keyboard Focus Beet D')).toBeVisible();
+
+    await editBedNameWithEnter(page, 'Keyboard Focus Beet B', 'Keyboard Focus Beet B edited');
+    await expectFocusedCell(page, fixture.bedC.id, 'Keyboard Focus Beet C');
+
+    await page.keyboard.press('ArrowDown');
+    await expectFocusedCell(page, fixture.bedD.id, 'Keyboard Focus Beet D');
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -261,6 +261,48 @@ describe('EditableDataGrid', () => {
     addButtonLabel: 'Neu',
   });
 
+  const basePropsWithRows = (rows: TestGridRow[]) => {
+    const props = baseProps(() => null);
+    vi.spyOn(props.api, 'list').mockResolvedValue({ data: { results: rows } });
+    vi.spyOn(props.api, 'update').mockImplementation(async (id, data) => ({
+      data: createGridRow({ ...(data as Partial<TestGridRow>), id: Number(id) }),
+    }));
+    return props;
+  };
+
+  const renderGridWithKeyboardRows = () => {
+    const props = basePropsWithRows([
+      createGridRow({ id: 1, name: 'Blumen 1', area_sqm: 11 }),
+      createGridRow({ id: 2, name: 'Kartoffeln', area_sqm: 12 }),
+      createGridRow({ id: 3, name: 'Kürbis', area_sqm: 13 }),
+      createGridRow({ id: 4, name: 'Melone', area_sqm: 14 }),
+    ]);
+    render(<EditableDataGrid {...props} showDeleteAction={false} />);
+    return props;
+  };
+
+  const editSecondRowAndSaveWithEnter = async () => {
+    renderGridWithKeyboardRows();
+    const editedCell = await screen.findByRole('button', { name: 'Zelle 2-name' });
+    fireEvent.click(editedCell);
+    await waitFor(() => expect(screen.getByTestId('mode-2')).toHaveTextContent('edit'));
+    fireEvent.click(screen.getByRole('button', { name: 'Eingabe per Return 2' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('mode-2')).toHaveTextContent('view');
+      expect(screen.getByTestId('focused-cell')).toHaveTextContent('3-name');
+    });
+  };
+
+  const pressCellKey = (rowId: number, field: string, key: string, options: { shiftKey?: boolean } = {}) => {
+    fireEvent.keyDown(screen.getByRole('button', { name: `Zelle ${rowId}-${field}` }), {
+      key,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: options.shiftKey ?? false,
+    });
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockSetEditCellValue.mockResolvedValue(true);
@@ -751,6 +793,91 @@ describe('EditableDataGrid', () => {
       expect(mockSetCellFocus).toHaveBeenCalledWith(2, 'name');
       expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name');
     });
+  });
+
+  it('keeps internal focus synchronized after Enter save so ArrowUp moves to the edited row', async () => {
+    await editSecondRowAndSaveWithEnter();
+
+    pressCellKey(3, 'name', 'ArrowUp');
+
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name'));
+  });
+
+  it('keeps internal focus synchronized after Enter save so ArrowDown moves immediately to the following row', async () => {
+    await editSecondRowAndSaveWithEnter();
+
+    pressCellKey(3, 'name', 'ArrowDown');
+
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('4-name'));
+  });
+
+  it('keeps internal focus synchronized after Enter save so Tab starts from the visible cell', async () => {
+    await editSecondRowAndSaveWithEnter();
+
+    pressCellKey(3, 'name', 'Tab');
+
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('3-area_sqm'));
+  });
+
+  it('keeps internal focus synchronized after Enter save so Shift+Tab starts from the visible cell', async () => {
+    await editSecondRowAndSaveWithEnter();
+
+    pressCellKey(3, 'name', 'Tab', { shiftKey: true });
+
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-area_sqm'));
+  });
+
+  it('keeps keyboard navigation anchored after Escape cancels an edit', async () => {
+    renderGridWithKeyboardRows();
+    fireEvent.click(await screen.findByRole('button', { name: 'Zelle 2-name' }));
+    await waitFor(() => expect(screen.getByTestId('mode-2')).toHaveTextContent('edit'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'ESC 2' }));
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name'));
+
+    pressCellKey(2, 'name', 'ArrowUp');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-name'));
+
+    pressCellKey(1, 'name', 'ArrowDown');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name'));
+  });
+
+  it('keeps keyboard navigation anchored after a mouse-selected cell returns to view mode', async () => {
+    renderGridWithKeyboardRows();
+    fireEvent.click(await screen.findByRole('button', { name: 'Zelle 3-name' }));
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('3-name'));
+    fireEvent.click(screen.getByRole('button', { name: 'ESC 3' }));
+    await waitFor(() => expect(screen.getByTestId('mode-3')).toHaveTextContent('view'));
+
+    pressCellKey(3, 'name', 'ArrowUp');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name'));
+
+    pressCellKey(2, 'name', 'ArrowDown');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('3-name'));
+  });
+
+  it('keeps focus on the first row when Enter saves it and ArrowUp is pressed', async () => {
+    renderGridWithKeyboardRows();
+    fireEvent.click(await screen.findByRole('button', { name: 'Zelle 1-name' }));
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eingabe per Return 1' }));
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('2-name'));
+
+    pressCellKey(2, 'name', 'ArrowUp');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-name'));
+  });
+
+  it('keeps focus on the last row when Enter saves it without a following row', async () => {
+    renderGridWithKeyboardRows();
+    fireEvent.click(await screen.findByRole('button', { name: 'Zelle 4-name' }));
+    await waitFor(() => expect(screen.getByTestId('mode-4')).toHaveTextContent('edit'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eingabe per Return 4' }));
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('4-name'));
+
+    pressCellKey(4, 'name', 'ArrowDown');
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('4-name'));
   });
 
   it('shows required-field validation when explicitly saving an incomplete new row', async () => {

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -688,10 +688,14 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
       expect(screen.getByTestId('mode-field-1')).toHaveTextContent('view'),
     );
 
-    // ArrowDown must navigate to field-2, NOT scroll the page.
-    await pressArrowDown();
     await waitFor(() =>
       expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'true'),
+    );
+
+    // ArrowDown must navigate from the post-save focus to field-3, NOT scroll the page.
+    await pressArrowDown();
+    await waitFor(() =>
+      expect(screen.getByTestId('row-field-3')).toHaveAttribute('data-focused', 'true'),
     );
     expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'false');
   });
@@ -701,8 +705,8 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     // which caused the browser to drop focus to the first focusable element (first row).
     // The fix changed the focus-restoration effect from useEffect (async, after paint) to
     // useLayoutEffect (synchronous, before paint) so the correct row is focused before the
-    // browser ever paints.  Here we verify setCellFocus is called with the edited row, not
-    // with the first row, immediately after the save completes.
+    // browser ever paints. Here we verify setCellFocus never targets the first row, and
+    // ends on the post-save focus row.
     renderHierarchy();
     await waitFor(() => expect(screen.getByTestId('row-field-2')).toBeInTheDocument());
 
@@ -734,10 +738,11 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
       expect(screen.getByTestId('mode-field-2')).toHaveTextContent('view'),
     );
 
-    // Every setCellFocus call after the save must target field-2, never field-1.
+    // The save must never flash to field-1, and should settle on field-3.
     const calls = getSetCellFocusMock().mock.calls;
     expect(calls.length).toBeGreaterThan(0);
-    expect(calls.every(([id]: [unknown]) => id === 'field-2')).toBe(true);
+    expect(calls.every(([id]: [unknown]) => id !== 'field-1')).toBe(true);
+    expect(calls.at(-1)?.[0]).toBe('field-3');
   });
 
   it('anchors focus on the edited cell before MUI stops row editing with Enter', async () => {

--- a/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.navigation.test.tsx
@@ -764,6 +764,110 @@ describe('FieldsBedsHierarchy keyboard navigation', () => {
     expect(getSetCellFocusMock()).not.toHaveBeenCalledWith('field-1', 'name');
   });
 
+  it('keeps hierarchy focus synchronized after Enter saves a collapsed row', async () => {
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-field-3')).toBeInTheDocument());
+
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-2-name')); });
+    expect(screen.getByTestId('mode-field-2')).toHaveTextContent('edit');
+
+    const onRowEditStop = getCapturedOnRowEditStop();
+    const processRowUpdate = getCapturedProcessRowUpdate();
+    expect(onRowEditStop).toBeDefined();
+    expect(processRowUpdate).toBeDefined();
+    fieldUpdateMock.mockResolvedValue({ data: { id: 2, name: 'Parzelle 2', location: 1, area_sqm: 20 } });
+
+    act(() => {
+      onRowEditStop!(
+        { id: 'field-2', reason: 'enterKeyDown' },
+        { defaultMuiPrevented: false },
+      );
+    });
+    await act(async () => {
+      await processRowUpdate!({
+        id: 'field-2',
+        type: 'field',
+        name: 'Parzelle 2',
+        fieldId: 2,
+        locationId: 1,
+        area_sqm: 20,
+        level: 1,
+        parentId: 'location-1',
+        hasChildren: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('row-field-3')).toHaveAttribute('data-focused', 'true'),
+    );
+
+    await pressArrowUp();
+    await waitFor(() =>
+      expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'true'),
+    );
+    expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'false');
+  });
+
+  it('keeps hierarchy focus synchronized after Enter saves an expanded parent row', async () => {
+    fieldListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 1, name: 'Parzelle 1', location: 1, area_sqm: 10 },
+          { id: 2, name: 'Parzelle 2', location: 1, area_sqm: 20 },
+        ],
+      },
+    });
+    bedListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 101, name: 'Beet 1', field: 1, area_sqm: 5 },
+          { id: 102, name: 'Beet 2', field: 1, area_sqm: 5 },
+        ],
+      },
+    });
+    renderHierarchy();
+    await waitFor(() => expect(screen.getByTestId('row-101')).toBeInTheDocument());
+
+    await act(async () => { fireEvent.click(screen.getByTestId('select-field-1-name')); });
+    expect(screen.getByTestId('mode-field-1')).toHaveTextContent('edit');
+
+    const onRowEditStop = getCapturedOnRowEditStop();
+    const processRowUpdate = getCapturedProcessRowUpdate();
+    expect(onRowEditStop).toBeDefined();
+    expect(processRowUpdate).toBeDefined();
+    fieldUpdateMock.mockResolvedValue({ data: { id: 1, name: 'Parzelle 1', location: 1, area_sqm: 10 } });
+
+    act(() => {
+      onRowEditStop!(
+        { id: 'field-1', reason: 'enterKeyDown' },
+        { defaultMuiPrevented: false },
+      );
+    });
+    await act(async () => {
+      await processRowUpdate!({
+        id: 'field-1',
+        type: 'field',
+        name: 'Parzelle 1',
+        fieldId: 1,
+        locationId: 1,
+        area_sqm: 10,
+        level: 1,
+        parentId: 'location-1',
+        hasChildren: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('row-101')).toHaveAttribute('data-focused', 'true'),
+    );
+
+    await pressArrowUp();
+    await waitFor(() =>
+      expect(screen.getByTestId('row-field-1')).toHaveAttribute('data-focused', 'true'),
+    );
+    expect(screen.getByTestId('row-field-2')).toHaveAttribute('data-focused', 'false');
+  });
+
   it('pressing a printable key while a row is keyboard-focused starts edit mode', async () => {
     renderHierarchy();
     await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());

--- a/frontend/src/__tests__/useHierarchyGridFocus.test.ts
+++ b/frontend/src/__tests__/useHierarchyGridFocus.test.ts
@@ -49,7 +49,7 @@ interface HookProps {
 
 const renderFocusHook = (initialProps: HookProps) => {
   const setCellFocus = vi.fn();
-  const setSelectedRowId = vi.fn();
+  const selectRow = vi.fn();
   const gridApiRef = { current: { setCellFocus } };
 
   const hookResult = renderHook(
@@ -58,14 +58,14 @@ const renderFocusHook = (initialProps: HookProps) => {
         gridApiRef,
         rowModesModel,
         rows: ROWS,
+        selectRow,
         selectedRowId,
-        setSelectedRowId,
         treeActive,
       }),
     { initialProps },
   );
 
-  return { ...hookResult, setCellFocus, setSelectedRowId };
+  return { ...hookResult, setCellFocus, selectRow };
 };
 
 const renderFocusHookWithRows = (
@@ -73,7 +73,7 @@ const renderFocusHookWithRows = (
   rows: HierarchyRow[],
 ) => {
   const setCellFocus = vi.fn();
-  const setSelectedRowId = vi.fn();
+  const selectRow = vi.fn();
   const gridApiRef = { current: { setCellFocus } };
 
   const hookResult = renderHook(
@@ -82,28 +82,28 @@ const renderFocusHookWithRows = (
         gridApiRef,
         rowModesModel,
         rows,
+        selectRow,
         selectedRowId,
-        setSelectedRowId,
         treeActive,
       }),
     { initialProps },
   );
 
-  return { ...hookResult, setCellFocus, setSelectedRowId };
+  return { ...hookResult, setCellFocus, selectRow };
 };
 
 describe('useHierarchyGridFocus', () => {
   it('focuses the edited row on Edit→View transition, not the stale selectedRowId', () => {
     // Reproduce the bug: user arrow-navigated to field-2 (only ref updated),
     // so selectedRowId state is still field-1 from the last click.
-    const { rerender, setCellFocus, setSelectedRowId } = renderFocusHook({
+    const { rerender, setCellFocus, selectRow } = renderFocusHook({
       rowModesModel: { 'field-2': { mode: GridRowModes.Edit } },
       selectedRowId: 'field-1', // stale — last clicked row
       treeActive: true,
     });
 
     setCellFocus.mockClear();
-    setSelectedRowId.mockClear();
+    selectRow.mockClear();
 
     // Simulate save: row exits edit mode while selectedRowId state is still stale.
     act(() => {
@@ -120,7 +120,7 @@ describe('useHierarchyGridFocus', () => {
     expect(callsToField1).toHaveLength(0);
 
     // State must be synced so subsequent arrow navigation starts from field-2.
-    expect(setSelectedRowId).toHaveBeenCalledWith('field-2');
+    expect(selectRow).toHaveBeenCalledWith('field-2');
   });
 
   it('focuses selectedRowId when no editing row is identifiable in prevModel', () => {
@@ -198,7 +198,7 @@ describe('useHierarchyGridFocus', () => {
   it('preFocusEditCell calls getCellElement().focus() for the remembered field', () => {
     const mockElement = { focus: vi.fn() };
     const getCellElement = vi.fn().mockReturnValue(mockElement);
-    const setSelectedRowId = vi.fn();
+    const selectRow = vi.fn();
     const gridApiRef = { current: { setCellFocus: vi.fn(), getCellElement } };
 
     const { result } = renderHook(() =>
@@ -206,8 +206,8 @@ describe('useHierarchyGridFocus', () => {
         gridApiRef,
         rowModesModel: {},
         rows: ROWS,
+        selectRow,
         selectedRowId: 'field-1',
-        setSelectedRowId,
         treeActive: true,
       }),
     );
@@ -220,16 +220,16 @@ describe('useHierarchyGridFocus', () => {
   });
 
   it('syncs selectedRowId state after focusing the edited row', () => {
-    // After Edit→View, setSelectedRowId must be called so that subsequent
+    // After Edit→View, selectRow must be called so that subsequent
     // arrow navigation and useLayoutEffect([selectedRowId]) start from the
     // correct row.
-    const { rerender, setSelectedRowId } = renderFocusHook({
+    const { rerender, selectRow } = renderFocusHook({
       rowModesModel: { 'field-3': { mode: GridRowModes.Edit } },
       selectedRowId: 'field-1',
       treeActive: true,
     });
 
-    setSelectedRowId.mockClear();
+    selectRow.mockClear();
 
     act(() => {
       rerender({
@@ -239,11 +239,11 @@ describe('useHierarchyGridFocus', () => {
       });
     });
 
-    expect(setSelectedRowId).toHaveBeenCalledWith('field-3');
+    expect(selectRow).toHaveBeenCalledWith('field-3');
   });
 
   it('restores focus with the numeric bed row id after Edit→View', () => {
-    const { rerender, setCellFocus, setSelectedRowId } = renderFocusHookWithRows(
+    const { rerender, setCellFocus, selectRow } = renderFocusHookWithRows(
       {
         rowModesModel: { 2: { mode: GridRowModes.Edit } },
         selectedRowId: 'field-1',
@@ -253,7 +253,7 @@ describe('useHierarchyGridFocus', () => {
     );
 
     setCellFocus.mockClear();
-    setSelectedRowId.mockClear();
+    selectRow.mockClear();
 
     act(() => {
       rerender({
@@ -265,6 +265,6 @@ describe('useHierarchyGridFocus', () => {
 
     expect(setCellFocus).toHaveBeenCalledWith(2, 'name');
     expect(setCellFocus).not.toHaveBeenCalledWith('2', 'name');
-    expect(setSelectedRowId).toHaveBeenCalledWith(2);
+    expect(selectRow).toHaveBeenCalledWith(2);
   });
 });

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -986,6 +986,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const saveEditedRowAndFocusTarget = useCallback(async (
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
+    options: { startTargetEdit?: boolean } = {},
   ): Promise<void> => {
     const preparedRow = await prepareRowForSave(current.id);
     if (!preparedRow) {
@@ -1002,7 +1003,7 @@ export function EditableDataGrid<T extends EditableRow>({
           : prevRows,
       );
       focusKeyboardNavigableCell(target.id, target.field, {
-        startEdit: !notesFieldNames.includes(target.field),
+        startEdit: options.startTargetEdit ?? !notesFieldNames.includes(target.field),
       });
     } catch (error) {
       handleProcessRowUpdateError(error);
@@ -1013,6 +1014,29 @@ export function EditableDataGrid<T extends EditableRow>({
     notesFieldNames,
     prepareRowForSave,
     processRowUpdate,
+  ]);
+
+  const saveEditedRowAndFocusNextVerticalCell = useCallback((
+    current: { id: GridRowId; field: string },
+  ): void => {
+    const target = getVerticalKeyboardNavigationTarget<T>({
+      api: gridApiRef.current,
+      columns,
+      current,
+      direction: 1,
+      isActionCell: isActionCellKeyboardNavigable,
+      rows: rowsForGrid,
+    }) ?? current;
+
+    void saveEditedRowAndFocusTarget(current, target, {
+      startTargetEdit: false,
+    });
+  }, [
+    columns,
+    gridApiRef,
+    isActionCellKeyboardNavigable,
+    rowsForGrid,
+    saveEditedRowAndFocusTarget,
   ]);
 
   const handleGridEditNavigation = useCallback((event: KeyboardEvent): void => {
@@ -2033,7 +2057,7 @@ export function EditableDataGrid<T extends EditableRow>({
               event.defaultMuiPrevented = true;
               if (isEnterSaveInputTarget(event.target)) {
                 event.preventDefault();
-                void handleSaveRow(params.id);
+                saveEditedRowAndFocusNextVerticalCell({ id: params.id, field: params.field });
               }
               return;
             }

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -24,6 +24,7 @@ interface UseHierarchyGridFocusResult {
   focusRow: (rowId: GridRowId, preferredField?: string) => void;
   /** Call immediately before setRowModesModel(View) to prevent a browser focus-fixup flash. */
   preFocusEditCell: (rowId: GridRowId) => void;
+  queuePostEditFocus: (rowId: GridRowId, preferredField?: string) => void;
   rememberFocusedField: (field: string) => void;
 }
 
@@ -76,6 +77,7 @@ export function useHierarchyGridFocus({
   treeActive,
 }: UseHierarchyGridFocusParams): UseHierarchyGridFocusResult {
   const focusedFieldRef = useRef(DEFAULT_FOCUS_FIELD);
+  const postEditFocusTargetRef = useRef<{ rowId: GridRowId; preferredField?: string } | null>(null);
   const prevRowModesModelRef = useRef<GridRowModesModel>({});
   const prevRowsRef = useRef(rows);
 
@@ -100,6 +102,10 @@ export function useHierarchyGridFocus({
     gridApiRef.current?.getCellElement?.(rowId, focusedFieldRef.current)?.focus({ preventScroll: true });
   }, [gridApiRef]);
 
+  const queuePostEditFocus = useCallback((rowId: GridRowId, preferredField?: string): void => {
+    postEditFocusTargetRef.current = { rowId, preferredField };
+  }, []);
+
   const focusSelectedCell = useCallback((): void => {
     if (selectedRowId != null) {
       focusRow(selectedRowId);
@@ -122,14 +128,17 @@ export function useHierarchyGridFocus({
       return;
     }
 
+    const queuedTarget = postEditFocusTargetRef.current;
+    postEditFocusTargetRef.current = null;
     const editingRowId = getEditingRowId(prevModel, rows);
-    if (editingRowId != null) {
-      focusRow(editingRowId);
-      setSelectedRowId(editingRowId);
+    const targetRowId = queuedTarget?.rowId ?? editingRowId;
+    if (targetRowId != null) {
+      focusRow(targetRowId, queuedTarget?.preferredField);
+      setSelectedRowId(targetRowId);
     } else {
       focusSelectedCell();
     }
-  }, [focusRow, focusSelectedCell, rowModesModel, setSelectedRowId]);
+  }, [focusRow, focusSelectedCell, rowModesModel, rows, setSelectedRowId]);
 
   useLayoutEffect(() => {
     if (treeActive) {
@@ -157,6 +166,7 @@ export function useHierarchyGridFocus({
   return {
     focusRow,
     preFocusEditCell,
+    queuePostEditFocus,
     rememberFocusedField,
   };
 }

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridFocus.ts
@@ -15,16 +15,17 @@ interface UseHierarchyGridFocusParams {
   };
   rowModesModel: GridRowModesModel;
   rows: GridRowsProp<HierarchyRow>;
+  selectRow: (rowId: GridRowId) => void;
   selectedRowId: string | number | null;
-  setSelectedRowId: (rowId: string | number) => void;
   treeActive: boolean;
 }
 
 interface UseHierarchyGridFocusResult {
+  applyOrReapplyPostEditFocus: (sourceRowId: GridRowId) => void;
   focusRow: (rowId: GridRowId, preferredField?: string) => void;
   /** Call immediately before setRowModesModel(View) to prevent a browser focus-fixup flash. */
   preFocusEditCell: (rowId: GridRowId) => void;
-  queuePostEditFocus: (rowId: GridRowId, preferredField?: string) => void;
+  queuePostEditFocus: (rowId: GridRowId, preferredField?: string, sourceRowId?: GridRowId) => void;
   rememberFocusedField: (field: string) => void;
 }
 
@@ -72,14 +73,16 @@ export function useHierarchyGridFocus({
   gridApiRef,
   rowModesModel,
   rows,
+  selectRow,
   selectedRowId,
-  setSelectedRowId,
   treeActive,
 }: UseHierarchyGridFocusParams): UseHierarchyGridFocusResult {
   const focusedFieldRef = useRef(DEFAULT_FOCUS_FIELD);
-  const postEditFocusTargetRef = useRef<{ rowId: GridRowId; preferredField?: string } | null>(null);
+  const postEditFocusTargetRef = useRef<{ rowId: GridRowId; preferredField?: string; sourceRowId?: GridRowId } | null>(null);
+  const lastPostEditFocusTargetRef = useRef<{ rowId: GridRowId; preferredField?: string; sourceRowId?: GridRowId } | null>(null);
   const prevRowModesModelRef = useRef<GridRowModesModel>({});
   const prevRowsRef = useRef(rows);
+  const skipStaleSelectedFocusRef = useRef(false);
 
   const rememberFocusedField = useCallback((field: string): void => {
     focusedFieldRef.current = field || DEFAULT_FOCUS_FIELD;
@@ -90,6 +93,7 @@ export function useHierarchyGridFocus({
     const focusField = getFocusableField?.(rowId, preferredField ?? focusedFieldRef.current) ?? DEFAULT_FOCUS_FIELD;
     focusedFieldRef.current = focusField;
     api?.setCellFocus?.(rowId, focusField);
+    api?.getCellElement?.(rowId, focusField)?.focus({ preventScroll: true });
   }, [getFocusableField, gridApiRef]);
 
   // Pre-focus the stable cell container div before switching the row back to View mode.
@@ -102,8 +106,8 @@ export function useHierarchyGridFocus({
     gridApiRef.current?.getCellElement?.(rowId, focusedFieldRef.current)?.focus({ preventScroll: true });
   }, [gridApiRef]);
 
-  const queuePostEditFocus = useCallback((rowId: GridRowId, preferredField?: string): void => {
-    postEditFocusTargetRef.current = { rowId, preferredField };
+  const queuePostEditFocus = useCallback((rowId: GridRowId, preferredField?: string, sourceRowId?: GridRowId): void => {
+    postEditFocusTargetRef.current = { rowId, preferredField, sourceRowId };
   }, []);
 
   const focusSelectedCell = useCallback((): void => {
@@ -111,6 +115,41 @@ export function useHierarchyGridFocus({
       focusRow(selectedRowId);
     }
   }, [focusRow, selectedRowId]);
+
+  const applyFocusTarget = useCallback((target: { rowId: GridRowId; preferredField?: string; sourceRowId?: GridRowId }): void => {
+    focusRow(target.rowId, target.preferredField);
+    selectRow(target.rowId);
+    lastPostEditFocusTargetRef.current = target;
+    skipStaleSelectedFocusRef.current = true;
+  }, [focusRow, selectRow]);
+
+  const applyPostEditFocus = useCallback((fallbackRowId?: GridRowId): void => {
+    const queuedTarget = postEditFocusTargetRef.current;
+    postEditFocusTargetRef.current = null;
+    const targetRowId = queuedTarget?.rowId ?? fallbackRowId;
+    if (targetRowId != null) {
+      applyFocusTarget({
+        rowId: targetRowId,
+        preferredField: queuedTarget?.preferredField,
+        sourceRowId: queuedTarget?.sourceRowId ?? fallbackRowId,
+      });
+    } else {
+      focusSelectedCell();
+    }
+  }, [applyFocusTarget, focusSelectedCell]);
+
+  const applyOrReapplyPostEditFocus = useCallback((sourceRowId: GridRowId): void => {
+    const queuedTarget = postEditFocusTargetRef.current;
+    if (queuedTarget) {
+      applyPostEditFocus(sourceRowId);
+      return;
+    }
+
+    const lastTarget = lastPostEditFocusTargetRef.current;
+    if (lastTarget && String(lastTarget.sourceRowId) === String(sourceRowId)) {
+      applyFocusTarget(lastTarget);
+    }
+  }, [applyFocusTarget, applyPostEditFocus]);
 
   // useLayoutEffect (not useEffect) fires synchronously before the browser paints,
   // so focus is always corrected within the same commit — no visible flash.
@@ -128,20 +167,16 @@ export function useHierarchyGridFocus({
       return;
     }
 
-    const queuedTarget = postEditFocusTargetRef.current;
-    postEditFocusTargetRef.current = null;
     const editingRowId = getEditingRowId(prevModel, rows);
-    const targetRowId = queuedTarget?.rowId ?? editingRowId;
-    if (targetRowId != null) {
-      focusRow(targetRowId, queuedTarget?.preferredField);
-      setSelectedRowId(targetRowId);
-    } else {
-      focusSelectedCell();
-    }
-  }, [focusRow, focusSelectedCell, rowModesModel, rows, setSelectedRowId]);
+    applyPostEditFocus(editingRowId ?? undefined);
+  }, [applyPostEditFocus, rowModesModel, rows]);
 
   useLayoutEffect(() => {
     if (treeActive) {
+      if (skipStaleSelectedFocusRef.current) {
+        skipStaleSelectedFocusRef.current = false;
+        return;
+      }
       focusSelectedCell();
     }
   }, [focusSelectedCell, selectedRowId, treeActive]);
@@ -159,11 +194,12 @@ export function useHierarchyGridFocus({
 
     const fallbackRow = findFallbackVisibleRow(previousRows, rows, selectedRowId);
     if (fallbackRow) {
-      setSelectedRowId(fallbackRow.id);
+      selectRow(fallbackRow.id);
     }
-  }, [rows, selectedRowId, setSelectedRowId, treeActive]);
+  }, [rows, selectedRowId, selectRow, treeActive]);
 
   return {
+    applyOrReapplyPostEditFocus,
     focusRow,
     preFocusEditCell,
     queuePostEditFocus,

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -686,13 +686,19 @@ function FieldsBedsHierarchy({
     return focusableFields.includes(preferredField) ? preferredField : focusableFields[0] ?? null;
   }, []);
 
-  const { focusRow, preFocusEditCell, queuePostEditFocus, rememberFocusedField } = useHierarchyGridFocus({
+  const {
+    applyOrReapplyPostEditFocus,
+    focusRow,
+    preFocusEditCell,
+    queuePostEditFocus,
+    rememberFocusedField,
+  } = useHierarchyGridFocus({
     getFocusableField: getHierarchyFocusableField,
     gridApiRef,
     rowModesModel,
     rows,
+    selectRow,
     selectedRowId,
-    setSelectedRowId,
     treeActive,
   });
 
@@ -725,7 +731,7 @@ function FieldsBedsHierarchy({
       params.reason === GridRowEditStopReasons.shiftTabKeyDown
     ) {
       if (params.reason === GridRowEditStopReasons.enterKeyDown) {
-        queuePostEditFocus(getPostEnterSaveFocusTarget(params.id));
+        queuePostEditFocus(getPostEnterSaveFocusTarget(params.id), undefined, params.id);
       }
       preFocusEditCell(params.id);
     }
@@ -828,15 +834,34 @@ function FieldsBedsHierarchy({
 
   const handleHierarchyProcessRowUpdate = useCallback(
     async (newRow: HierarchyRow): Promise<HierarchyRow> => {
+      const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      const preferredField = activeElement
+        ?.closest('[role="gridcell"]')
+        ?.getAttribute("data-field") ?? undefined;
+      if (preferredField) {
+        rememberFocusedField(preferredField);
+      }
+      queuePostEditFocus(getPostEnterSaveFocusTarget(newRow.id), preferredField, newRow.id);
+
       const savedRow = await processRowUpdate(newRow);
       preFocusEditCell(newRow.id);
       setRowModesModel((previousModel) => ({
         ...previousModel,
         [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
       }));
+      window.setTimeout(() => {
+        applyOrReapplyPostEditFocus(newRow.id);
+      }, 0);
       return savedRow;
     },
-    [preFocusEditCell, processRowUpdate],
+    [
+      applyOrReapplyPostEditFocus,
+      getPostEnterSaveFocusTarget,
+      preFocusEditCell,
+      processRowUpdate,
+      queuePostEditFocus,
+      rememberFocusedField,
+    ],
   );
 
   const handleReadOnlyHierarchyCellMouseDown = useCallback((event: React.MouseEvent<HTMLElement>): void => {

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -237,6 +237,10 @@ function FieldsBedsHierarchy({
   const isTouchLikePointer = useMediaQuery("(pointer: coarse)");
   const isMobileViewport = useMediaQuery("(max-width:900px)");
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+  const rowModesModelRef = useRef(rowModesModel);
+  useLayoutEffect(() => {
+    rowModesModelRef.current = rowModesModel;
+  }, [rowModesModel]);
   const [draftValidationWarning, setDraftValidationWarning] = useState("");
   const hasInitiallyExpandedRef = useRef(false);
   const handledCreateFieldRequestRef = useRef(0);
@@ -844,11 +848,18 @@ function FieldsBedsHierarchy({
       queuePostEditFocus(getPostEnterSaveFocusTarget(newRow.id), preferredField, newRow.id);
 
       const savedRow = await processRowUpdate(newRow);
-      preFocusEditCell(newRow.id);
-      setRowModesModel((previousModel) => ({
-        ...previousModel,
-        [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
-      }));
+      // MUI's own onRowModesModelChange usually flips this row to View (and our
+      // rowModesModel layout effect already restores focus onto the queued target)
+      // well before this async save resolves. Only re-anchor and re-apply View mode
+      // here if that hasn't happened yet — otherwise this would yank focus back onto
+      // the just-saved row for an instant, causing a visible focus flash/flicker.
+      if (rowModesModelRef.current[newRow.id]?.mode === GridRowModes.Edit) {
+        preFocusEditCell(newRow.id);
+        setRowModesModel((previousModel) => ({
+          ...previousModel,
+          [newRow.id]: { mode: GridRowModes.View, ignoreModifications: true },
+        }));
+      }
       window.setTimeout(() => {
         applyOrReapplyPostEditFocus(newRow.id);
       }, 0);

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -686,7 +686,7 @@ function FieldsBedsHierarchy({
     return focusableFields.includes(preferredField) ? preferredField : focusableFields[0] ?? null;
   }, []);
 
-  const { focusRow, preFocusEditCell, rememberFocusedField } = useHierarchyGridFocus({
+  const { focusRow, preFocusEditCell, queuePostEditFocus, rememberFocusedField } = useHierarchyGridFocus({
     getFocusableField: getHierarchyFocusableField,
     gridApiRef,
     rowModesModel,
@@ -695,6 +695,22 @@ function FieldsBedsHierarchy({
     setSelectedRowId,
     treeActive,
   });
+
+  const getPostEnterSaveFocusTarget = useCallback((rowId: GridRowId): GridRowId => {
+    const currentIndex = rows.findIndex((row) => String(row.id) === String(rowId));
+    if (currentIndex < 0) {
+      return rowId;
+    }
+
+    for (let index = currentIndex + 1; index < rows.length; index += 1) {
+      const nextRow = rows[index];
+      if (getHierarchyFocusableField(nextRow.id, "name")) {
+        return nextRow.id;
+      }
+    }
+
+    return rowId;
+  }, [getHierarchyFocusableField, rows]);
 
   const handleHierarchyRowEditStop = useCallback<GridEventListener<"rowEditStop">>((params, event): void => {
     if (params.reason === GridRowEditStopReasons.escapeKeyDown) {
@@ -708,9 +724,12 @@ function FieldsBedsHierarchy({
       params.reason === GridRowEditStopReasons.tabKeyDown ||
       params.reason === GridRowEditStopReasons.shiftTabKeyDown
     ) {
+      if (params.reason === GridRowEditStopReasons.enterKeyDown) {
+        queuePostEditFocus(getPostEnterSaveFocusTarget(params.id));
+      }
       preFocusEditCell(params.id);
     }
-  }, [discardRowEdit, preFocusEditCell]);
+  }, [discardRowEdit, getPostEnterSaveFocusTarget, preFocusEditCell, queuePostEditFocus]);
 
   const activateFirstRowForKeyboard = useCallback((rowId: GridRowId): void => {
     selectedRowIdRef.current = rowId;


### PR DESCRIPTION
## Summary
- Save edited `EditableDataGrid` rows through the same target-focus path used by keyboard navigation when Enter is pressed inside the editor.
- Keep the next visible row cell in view mode focused after Enter-save so the first ArrowUp, ArrowDown, Tab, or Shift+Tab starts from the visible cell instead of the previously edited cell.
- Add focused regression coverage for Enter -> ArrowUp/ArrowDown/Tab/Shift+Tab, Escape, mouse-selected cells, and first/last row edge cases.

## Root Cause
The Enter-save path saved the row without explicitly restoring MUI DataGrid's internal focus state to the visibly focused target cell. The row save cleanup can clear the grid focus while the UI appears to move to the next row, so the next keyboard event was computed from stale or missing focus state.

## Validation
- `npm run test -- --run src/__tests__/EditableDataGrid.test.tsx`
- `npm run test -- --run src/__tests__/FieldsBedsHierarchy.navigation.test.tsx`
- `npm run test -- --run src/__tests__/PlantingPlans.escapeFocus.test.tsx src/__tests__/PlantingPlans.areaValidation.test.tsx src/__tests__/plantingPlans.hierarchy.test.ts`
- `npm run build`
- `npx eslint src/components/data-grid/DataGrid.tsx` passed with one pre-existing warning about `columnsWithActions` dependencies.

## Notes
- `npx playwright test e2e/fields-beds-enter-key.spec.ts --project=chromium` timed out before any Enter interaction while waiting for the existing `Parzelle hinzufügen` button selector. The related hierarchy Vitest coverage passed, and this PR changes the shared `EditableDataGrid` used by planting plans rather than the separate fields/beds hierarchy grid.