### PR TITLE
fix: Alt+T only focuses first cell, plus DataGrid command hook cleanup

### DIFF
--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -1291,12 +1291,10 @@ export function EditableDataGrid<T extends EditableRow>({
     if (!api) return;
     const targetId = selectedRowIds[0] ?? api.getAllRowIds()[0];
     if (targetId == null) return;
-    setSelectedRowIds([targetId]);
     scrollAndFocusRow(api, targetId);
   }, [
     gridApiRef,
     selectedRowIds,
-    setSelectedRowIds,
   ]);
 
   const handleStartRowEdit = useCallback((rowId: GridRowId, field?: string): void => {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -53,6 +53,7 @@ import { useContextMenuHint } from './useContextMenuHint';
 import { useDataGridCommandApi } from './hooks/useDataGridCommandApi';
 import { useDataGridDelete } from './hooks/useDataGridDelete';
 import { useDataGridRowActionMenu } from './hooks/useDataGridRowActionMenu';
+import { useDataGridRowCommands } from './hooks/useDataGridRowCommands';
 import {
   getSortedRowIds,
   isSaveBlockedError,
@@ -108,35 +109,6 @@ const isComboboxInteractionTarget = (target: EventTarget | null): boolean => {
 
 const isEnterSaveInputTarget = (target: EventTarget | null): boolean =>
   target instanceof HTMLInputElement && !isComboboxInteractionTarget(target);
-
-interface ScrollFocusGridApi {
-  getVisibleColumns: () => { field: string }[];
-  getRowIndexRelativeToVisibleRows: (id: GridRowId) => number;
-  getColumnIndexRelativeToVisibleColumns: (field: string) => number;
-  scrollToIndexes: (params: { rowIndex?: number; colIndex?: number }) => void;
-  setCellFocus: (id: GridRowId, field: string) => void;
-}
-
-// Scrolls a row into view and, unless `focus: false`, moves keyboard focus
-// onto its first non-action column — deferred to the next animation frame
-// since the row may not exist in the grid's virtualized viewport until
-// after the current render pass (e.g. right after an expand/select state
-// change). Shared by focusTable and openRowById below.
-function scrollAndFocusRow(api: ScrollFocusGridApi, rowId: GridRowId, options: { focus?: boolean } = {}): void {
-  const firstField = api.getVisibleColumns()
-    .find((col) => col.field !== 'actions' && col.field !== 'rowEditActions')?.field;
-  requestAnimationFrame(() => {
-    api.scrollToIndexes(firstField
-      ? {
-          rowIndex: api.getRowIndexRelativeToVisibleRows(rowId),
-          colIndex: api.getColumnIndexRelativeToVisibleColumns(firstField),
-        }
-      : { rowIndex: api.getRowIndexRelativeToVisibleRows(rowId) });
-    if (options.focus !== false && firstField) {
-      api.setCellFocus(rowId, firstField);
-    }
-  });
-}
 
 export function EditableDataGrid<T extends EditableRow>({
   columns,
@@ -309,6 +281,20 @@ export function EditableDataGrid<T extends EditableRow>({
   const rowsById = useMemo(() => {
     return new Map(rows.map((row) => [String(row.id), row]));
   }, [rows]);
+  const {
+    handleEditSelectedRow,
+    handleStartRowEdit,
+    focusTable,
+    openRowById,
+  } = useDataGridRowCommands<T>({
+    gridApiRef,
+    rowsById,
+    columns,
+    selectedRowIds,
+    setSelectedRowIds,
+    setRowModesModel,
+    rowSnapshotRef,
+  });
   const handleSortModelChange = useCallback((nextSortModel: GridSortModel): void => {
     setSortModel(nextSortModel);
     refreshStableRowOrder(rows as T[], nextSortModel);
@@ -1122,18 +1108,6 @@ export function EditableDataGrid<T extends EditableRow>({
     }
   }, [dirtyRowIds, handleSaveRow, prepareRowForSave, rowModesModel]);
 
-  const handleEditSelectedRow = useCallback((): void => {
-    const selectedRowId = selectedRowIds[0];
-    if (!selectedRowId) {
-      return;
-    }
-
-    setRowModesModel((oldModel) => ({
-      ...oldModel,
-      [selectedRowId]: { mode: GridRowModes.Edit, fieldToFocus: columns[0]?.field },
-    }));
-  }, [columns, selectedRowIds]);
-
   const rememberRowSnapshotForCellEdit = useCallback((params: GridCellParams<T>): void => {
     const rowKey = String(params.id);
     if (rowSnapshotRef.current.has(rowKey)) {
@@ -1285,51 +1259,6 @@ export function EditableDataGrid<T extends EditableRow>({
 
     handleDeleteClick(selectedRowId)();
   }, [handleDeleteClick, selectedRowIds]);
-
-  const focusTable = useCallback((): void => {
-    const api = gridApiRef.current;
-    if (!api) return;
-    const targetId = selectedRowIds[0] ?? api.getAllRowIds()[0];
-    if (targetId == null) return;
-    scrollAndFocusRow(api, targetId);
-  }, [
-    gridApiRef,
-    selectedRowIds,
-  ]);
-
-  const handleStartRowEdit = useCallback((rowId: GridRowId, field?: string): void => {
-    const rowKey = String(rowId);
-    if (!rowSnapshotRef.current.has(rowKey)) {
-      const row = rowsById.get(rowKey);
-      if (row) {
-        rowSnapshotRef.current.set(rowKey, row as T);
-      }
-    }
-
-    const fieldToFocus = field ?? columns.find((column) => column.editable !== false)?.field ?? columns[0]?.field;
-    setRowModesModel((oldModel) => ({
-      ...oldModel,
-      [rowId]: { mode: GridRowModes.Edit, fieldToFocus },
-    }));
-  }, [columns, rowsById]);
-
-  // Scrolls to and selects a specific row by id, optionally opening edit
-  // mode on it — used by pages that deep-link into this grid (e.g.
-  // "Anbauplan öffnen"/"bearbeiten" from the Gantt calendar's context menu)
-  // instead of just prefilling a brand-new draft row via `initialRow`.
-  const openRowById = useCallback((rowId: GridRowId, options?: { startEdit?: boolean }): void => {
-    const api = gridApiRef.current;
-    if (!api || !rowsById.has(String(rowId))) return;
-    const shouldStartEdit = options?.startEdit !== false;
-    setSelectedRowIds([rowId]);
-    // Edit mode moves focus into its own input via handleStartRowEdit's
-    // `fieldToFocus` below; only move keyboard focus here for the
-    // view-only (non-edit) case.
-    scrollAndFocusRow(api, rowId, { focus: !shouldStartEdit });
-    if (shouldStartEdit) {
-      handleStartRowEdit(rowId);
-    }
-  }, [gridApiRef, handleStartRowEdit, rowsById, setSelectedRowIds]);
 
   useDataGridCommandApi<T>({
     commandApiRef,

--- a/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { GridRowModes } from '@mui/x-data-grid';
-import type { GridApiCommunity } from '@mui/x-data-grid';
-import type { GridColDef, GridRowId, GridRowModesModel } from '@mui/x-data-grid';
+import type { GridApi, GridColDef, GridRowId, GridRowModesModel } from '@mui/x-data-grid';
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from 'react';
 import type { EditableRow } from '../types';
 
@@ -35,7 +34,7 @@ function scrollAndFocusRow(api: ScrollFocusGridApi, rowId: GridRowId, options: {
 }
 
 interface UseDataGridRowCommandsParams<T extends EditableRow> {
-  gridApiRef: RefObject<GridApiCommunity | null>;
+  gridApiRef: RefObject<GridApi | null>;
   rowsById: Map<string, T>;
   columns: GridColDef[];
   selectedRowIds: GridRowId[];

--- a/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
@@ -1,0 +1,116 @@
+import { useCallback } from 'react';
+import { GridRowModes } from '@mui/x-data-grid';
+import type { GridApiCommunity } from '@mui/x-data-grid';
+import type { GridColDef, GridRowId, GridRowModesModel } from '@mui/x-data-grid';
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from 'react';
+import type { EditableRow } from '../types';
+
+interface ScrollFocusGridApi {
+  getVisibleColumns: () => { field: string }[];
+  getRowIndexRelativeToVisibleRows: (id: GridRowId) => number;
+  getColumnIndexRelativeToVisibleColumns: (field: string) => number;
+  scrollToIndexes: (params: { rowIndex?: number; colIndex?: number }) => void;
+  setCellFocus: (id: GridRowId, field: string) => void;
+}
+
+// Scrolls a row into view and, unless `focus: false`, moves keyboard focus
+// onto its first non-action column — deferred to the next animation frame
+// since the row may not exist in the grid's virtualized viewport until
+// after the current render pass (e.g. right after an expand/select state
+// change). Shared by focusTable and openRowById below.
+function scrollAndFocusRow(api: ScrollFocusGridApi, rowId: GridRowId, options: { focus?: boolean } = {}): void {
+  const firstField = api.getVisibleColumns()
+    .find((col) => col.field !== 'actions' && col.field !== 'rowEditActions')?.field;
+  requestAnimationFrame(() => {
+    api.scrollToIndexes(firstField
+      ? {
+          rowIndex: api.getRowIndexRelativeToVisibleRows(rowId),
+          colIndex: api.getColumnIndexRelativeToVisibleColumns(firstField),
+        }
+      : { rowIndex: api.getRowIndexRelativeToVisibleRows(rowId) });
+    if (options.focus !== false && firstField) {
+      api.setCellFocus(rowId, firstField);
+    }
+  });
+}
+
+interface UseDataGridRowCommandsParams<T extends EditableRow> {
+  gridApiRef: RefObject<GridApiCommunity | null>;
+  rowsById: Map<string, T>;
+  columns: GridColDef[];
+  selectedRowIds: GridRowId[];
+  setSelectedRowIds: Dispatch<SetStateAction<GridRowId[]>>;
+  setRowModesModel: Dispatch<SetStateAction<GridRowModesModel>>;
+  rowSnapshotRef: MutableRefObject<Map<string, T>>;
+}
+
+export function useDataGridRowCommands<T extends EditableRow>({
+  gridApiRef,
+  rowsById,
+  columns,
+  selectedRowIds,
+  setSelectedRowIds,
+  setRowModesModel,
+  rowSnapshotRef,
+}: UseDataGridRowCommandsParams<T>) {
+  const handleEditSelectedRow = useCallback((): void => {
+    const selectedRowId = selectedRowIds[0];
+    if (!selectedRowId) {
+      return;
+    }
+
+    setRowModesModel((oldModel) => ({
+      ...oldModel,
+      [selectedRowId]: { mode: GridRowModes.Edit, fieldToFocus: columns[0]?.field },
+    }));
+  }, [columns, selectedRowIds, setRowModesModel]);
+
+  const handleStartRowEdit = useCallback((rowId: GridRowId, field?: string): void => {
+    const rowKey = String(rowId);
+    if (!rowSnapshotRef.current.has(rowKey)) {
+      const row = rowsById.get(rowKey);
+      if (row) {
+        rowSnapshotRef.current.set(rowKey, row);
+      }
+    }
+
+    const fieldToFocus = field ?? columns.find((column) => column.editable !== false)?.field ?? columns[0]?.field;
+    setRowModesModel((oldModel) => ({
+      ...oldModel,
+      [rowId]: { mode: GridRowModes.Edit, fieldToFocus },
+    }));
+  }, [columns, rowSnapshotRef, rowsById, setRowModesModel]);
+
+  const focusTable = useCallback((): void => {
+    const api = gridApiRef.current;
+    if (!api) return;
+    const targetId = selectedRowIds[0] ?? api.getAllRowIds()[0];
+    if (targetId == null) return;
+    scrollAndFocusRow(api, targetId);
+  }, [gridApiRef, selectedRowIds]);
+
+  // Scrolls to and selects a specific row by id, optionally opening edit
+  // mode on it — used by pages that deep-link into this grid (e.g.
+  // "Anbauplan öffnen"/"bearbeiten" from the Gantt calendar's context menu)
+  // instead of just prefilling a brand-new draft row via `initialRow`.
+  const openRowById = useCallback((rowId: GridRowId, options?: { startEdit?: boolean }): void => {
+    const api = gridApiRef.current;
+    if (!api || !rowsById.has(String(rowId))) return;
+    const shouldStartEdit = options?.startEdit !== false;
+    setSelectedRowIds([rowId]);
+    // Edit mode moves focus into its own input via handleStartRowEdit's
+    // `fieldToFocus` below; only move keyboard focus here for the
+    // view-only (non-edit) case.
+    scrollAndFocusRow(api, rowId, { focus: !shouldStartEdit });
+    if (shouldStartEdit) {
+      handleStartRowEdit(rowId);
+    }
+  }, [gridApiRef, handleStartRowEdit, rowsById, setSelectedRowIds]);
+
+  return {
+    handleEditSelectedRow,
+    handleStartRowEdit,
+    focusTable,
+    openRowById,
+  };
+}


### PR DESCRIPTION
## Summary
- `Alt+T` on the Anbaupläne (planting plans) table was calling `setSelectedRowIds`, which drove the DataGrid's `rowSelectionModel` and visually highlighted the entire first row instead of just moving keyboard focus to the first cell.
- Along the way, extracted the row focus/edit command logic (`focusTable`, `openRowById`, `handleStartRowEdit`, `handleEditSelectedRow`, and the `scrollAndFocusRow` helper) out of the already very large `EditableDataGrid` component into a new `useDataGridRowCommands` hook, matching the existing `useDataGridDelete` / `useDataGridRowActionMenu` hook-extraction pattern in `frontend/src/components/data-grid/hooks/`. No behavior change from the refactor itself.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes (no new warnings/errors)
- [x] `npx vitest run` on `EditableDataGrid`, `PlantingPlans.*`, and hierarchy/mobile tests — 89 tests pass
- [ ] Manual check: open Anbaupläne, press Alt+T, confirm only the first cell is focused (no full-row highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)