### PR TITLE
fix: hide layout focus outline after pointer focus

### DIFF
--- a/frontend/e2e/focus-region-outline.spec.ts
+++ b/frontend/e2e/focus-region-outline.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { MAIN_ROUTES, waitForPageStable } from './utils';
+
+const backendPort = process.env.BACKEND_PORT ?? '8000';
+const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
+const apiBase = `http://127.0.0.1:${backendPort}/api`;
+
+const ROUTE_KEYS = ['dashboard', 'kulturen', 'anbauplaene', 'saatgutbedarf', 'lieferanten'] as const;
+const routes = MAIN_ROUTES.filter((route) => ROUTE_KEYS.includes(route.key));
+
+type OutlineSnapshot = {
+  boxShadow: string;
+  focusRegionVisible: string | null;
+  outlineColor: string;
+  outlineStyle: string;
+};
+
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') {
+      return;
+    }
+    const text = message.text();
+    if (text.includes('Failed to load resource')) {
+      return;
+    }
+    errors.push(`console.error: ${text}`);
+  });
+  page.on('pageerror', (error) => {
+    errors.push(`pageerror: ${error.message}`);
+  });
+  return errors;
+}
+
+async function loginWithFreshProject(
+  page: Page,
+  request: APIRequestContext,
+  scenarioPrefix: string,
+): Promise<void> {
+  const scenario = `${scenarioPrefix}-${Date.now()}`;
+  const setupResponse = await request.post(`${apiBase}/__e2e__/invite-flow/`, {
+    headers: { 'X-E2E-Token': e2eToken },
+    data: { action: 'setup', scenario_id: scenario, invitation_state: 'pending' },
+  });
+  const setupText = await setupResponse.text();
+  expect(setupResponse.ok(), `fixture setup -> ${setupResponse.status()}: ${setupText}`).toBeTruthy();
+  const setup = JSON.parse(setupText) as { admin: { email: string; password: string } };
+
+  await page.goto('/login');
+  await page.getByLabel('E-Mail').fill(setup.admin.email);
+  await page.locator('input[type="password"]').fill(setup.admin.password);
+  await page.getByRole('button', { name: 'Anmelden' }).click();
+  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
+}
+
+async function readMainOutline(page: Page): Promise<OutlineSnapshot> {
+  return page.locator('main').evaluate((main) => {
+    const style = window.getComputedStyle(main);
+    return {
+      boxShadow: style.boxShadow,
+      focusRegionVisible: main.getAttribute('data-ofp-focus-region-visible'),
+      outlineColor: style.outlineColor,
+      outlineStyle: style.outlineStyle,
+    };
+  });
+}
+
+test.describe('layout focus regions', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    await loginWithFreshProject(page, request, `focus-region-outline-${testInfo.workerIndex}`);
+  });
+
+  for (const route of routes) {
+    test(`does not show a main-content focus line after clicking empty space on ${route.key}`, async ({ page }) => {
+      const errors = trackConsoleErrors(page);
+      await page.goto(route.path);
+      await waitForPageStable(page, route.ready);
+
+      const main = page.locator('main');
+      await expect(main).toBeVisible();
+      const box = await main.boundingBox();
+      expect(box).toBeTruthy();
+      await main.click({
+        position: {
+          x: Math.max(1, Math.floor((box?.width ?? 2) - 2)),
+          y: Math.max(1, Math.floor((box?.height ?? 2) - 2)),
+        },
+      });
+
+      await expect.poll(() => readMainOutline(page)).toMatchObject({
+        boxShadow: 'none',
+        focusRegionVisible: null,
+        outlineStyle: 'none',
+      });
+      expect(errors).toEqual([]);
+    });
+  }
+});

--- a/frontend/e2e/focus-region-outline.spec.ts
+++ b/frontend/e2e/focus-region-outline.spec.ts
@@ -68,13 +68,11 @@ async function readMainOutline(page: Page): Promise<OutlineSnapshot> {
 }
 
 test.describe('layout focus regions', () => {
-  test.beforeEach(async ({ page, request }, testInfo) => {
+  test('does not show a main-content focus line after clicking empty space', async ({ page, request }, testInfo) => {
+    const errors = trackConsoleErrors(page);
     await loginWithFreshProject(page, request, `focus-region-outline-${testInfo.workerIndex}`);
-  });
 
-  for (const route of routes) {
-    test(`does not show a main-content focus line after clicking empty space on ${route.key}`, async ({ page }) => {
-      const errors = trackConsoleErrors(page);
+    for (const route of routes) {
       await page.goto(route.path);
       await waitForPageStable(page, route.ready);
 
@@ -94,7 +92,8 @@ test.describe('layout focus regions', () => {
         focusRegionVisible: null,
         outlineStyle: 'none',
       });
-      expect(errors).toEqual([]);
-    });
-  }
+    }
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/frontend/e2e/focus-region-outline.spec.ts
+++ b/frontend/e2e/focus-region-outline.spec.ts
@@ -96,4 +96,44 @@ test.describe('layout focus regions', () => {
 
     expect(errors).toEqual([]);
   });
+
+  test('does not show a main-content focus line after a client-side route change', async ({ page, request }, testInfo) => {
+    // Regression test: unlike the scenario above (which reloads via page.goto
+    // for every route), the sidebar's <Link>-based navigation swaps the page
+    // content without remounting the shared <main> region. If the previously
+    // focused descendant unmounts as part of that swap, the browser can
+    // implicitly move DOM focus back onto the (still mounted) <main>
+    // container itself, which is exactly the case the CSS override in
+    // theme.ts's MuiCssBaseline needs to suppress.
+    const errors = trackConsoleErrors(page);
+    await loginWithFreshProject(page, request, `focus-region-outline-nav-${testInfo.workerIndex}`);
+
+    const first = routes[0];
+    const second = routes[1];
+
+    await page.goto(first.path);
+    await waitForPageStable(page, first.ready);
+
+    const main = page.locator('main');
+    await expect(main).toBeVisible();
+    const box = await main.boundingBox();
+    expect(box).toBeTruthy();
+    await main.click({
+      position: {
+        x: Math.max(1, Math.floor((box?.width ?? 2) - 2)),
+        y: Math.max(1, Math.floor((box?.height ?? 2) - 2)),
+      },
+    });
+
+    await page.locator(`a[href="${second.path}"]`).first().click();
+    await waitForPageStable(page, second.ready);
+
+    await expect.poll(() => readMainOutline(page)).toMatchObject({
+      boxShadow: 'none',
+      focusRegionVisible: null,
+      outlineStyle: 'none',
+    });
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/frontend/src/__tests__/focus/FocusManager.test.tsx
+++ b/frontend/src/__tests__/focus/FocusManager.test.tsx
@@ -153,6 +153,25 @@ describe("FocusManager", () => {
     expect(event).toBe(true);
     expect(second).not.toHaveFocus();
   });
+
+  it("only marks a fallback region focus as visible for focus-manager navigation", () => {
+    render(
+      <FocusManagerProvider>
+        <Region id="empty" order={0} buttonCount={0} />
+      </FocusManagerProvider>,
+    );
+
+    const region = screen.getByTestId("region-empty");
+    expect(region).toHaveClass("ofp-focus-region");
+    expect(region).not.toHaveAttribute("data-ofp-focus-region-visible");
+
+    fireEvent.keyDown(window, { key: "F6" });
+    expect(region).toHaveFocus();
+    expect(region).toHaveAttribute("data-ofp-focus-region-visible", "true");
+
+    fireEvent.pointerDown(region);
+    expect(region).not.toHaveAttribute("data-ofp-focus-region-visible");
+  });
 });
 
 function RegionWithShortcut({ id, order }: { id: string; order: number }) {

--- a/frontend/src/focus/FocusManager.tsx
+++ b/frontend/src/focus/FocusManager.tsx
@@ -20,6 +20,9 @@ function focusRegionElement(region: FocusRegionInfo): void {
     return;
   }
   const target = getFirstFocusable(container) ?? container;
+  if (target === container) {
+    container.dataset.ofpFocusRegionVisible = 'true';
+  }
   target.focus();
 }
 

--- a/frontend/src/focus/useFocusManager.ts
+++ b/frontend/src/focus/useFocusManager.ts
@@ -34,14 +34,28 @@ export function useFocusRegion(
   useEffect(() => {
     const container = containerRef.current;
     // Regions need to be focusable as a fallback landing target (e.g. one
-    // with no focusable descendants yet), and get a consistent visible
-    // focus ring — see the `.ofp-focus-region:focus` rule in theme.ts.
+    // with no focusable descendants yet). The visible region focus marker is
+    // opt-in and only applied by FocusManager when it focuses the container.
     if (container && !container.hasAttribute('tabindex')) {
       container.tabIndex = -1;
     }
     container?.classList.add('ofp-focus-region');
 
-    return registerRegion({ id: regionId, label, order, containerRef });
+    const clearVisibleFocusMarker = (): void => {
+      if (container) {
+        delete container.dataset.ofpFocusRegionVisible;
+      }
+    };
+    container?.addEventListener('blur', clearVisibleFocusMarker);
+    container?.addEventListener('pointerdown', clearVisibleFocusMarker);
+
+    const unregisterRegion = registerRegion({ id: regionId, label, order, containerRef });
+    return () => {
+      clearVisibleFocusMarker();
+      container?.removeEventListener('blur', clearVisibleFocusMarker);
+      container?.removeEventListener('pointerdown', clearVisibleFocusMarker);
+      unregisterRegion();
+    };
     // containerRef is a stable ref object; re-registering on every render
     // would thrash the region map for no benefit.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -173,7 +173,15 @@ const theme = createTheme({
         // Focus regions (see src/focus/FocusManager.tsx) may be focused
         // programmatically as F6 fallback targets. Only show the region ring
         // when FocusManager explicitly marks that case; pointer focus on
-        // layout containers must remain invisible.
+        // layout containers must remain invisible. The browser's own
+        // focus-visible heuristic still matches these containers on a plain
+        // mouse click (they're non-interactive divs) and, worse, when a
+        // route change unmounts the previously focused descendant and focus
+        // implicitly lands back on the container — neither case goes through
+        // FocusManager, so the baseline rule above must be overridden here.
+        '.ofp-focus-region:focus-visible': {
+          outline: 'none',
+        },
         '.ofp-focus-region[data-ofp-focus-region-visible="true"]:focus': {
           outline: `2px solid ${theme.palette.primary.main}`,
           outlineOffset: 2,

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -170,10 +170,11 @@ const theme = createTheme({
           outline: `2px solid ${theme.palette.primary.main}`,
           outlineOffset: 2,
         },
-        // Focus regions (see src/focus/FocusManager.tsx) are focused
-        // programmatically (F6), which some browsers don't treat as
-        // ":focus-visible" — so they get a plain ":focus" ring instead.
-        '.ofp-focus-region:focus': {
+        // Focus regions (see src/focus/FocusManager.tsx) may be focused
+        // programmatically as F6 fallback targets. Only show the region ring
+        // when FocusManager explicitly marks that case; pointer focus on
+        // layout containers must remain invisible.
+        '.ofp-focus-region[data-ofp-focus-region-visible="true"]:focus': {
           outline: `2px solid ${theme.palette.primary.main}`,
           outlineOffset: 2,
         },


### PR DESCRIPTION
## Summary
- Gate the layout focus-region outline behind an explicit FocusManager marker instead of plain `:focus`.
- Clear the marker on pointer focus/blur so empty content clicks do not render the green horizontal line.
- Add unit and Playwright regression coverage for the affected multi-page flow.

## Tests
- `npm run test -- --run src/__tests__/focus/FocusManager.test.tsx`
- `npm run build`
- `npx playwright test e2e/focus-region-outline.spec.ts --project=chromium`
- `npx eslint e2e/focus-region-outline.spec.ts src/focus/FocusManager.tsx src/focus/useFocusManager.ts src/theme.ts src/__tests__/focus/FocusManager.test.tsx`

Note: `npm run lint -- e2e/focus-region-outline.spec.ts` currently invokes `eslint .` and fails on existing unrelated frontend lint issues/generated `.vite/deps` files; the touched-file lint command above passes.