### PR TITLE
Improve Gantt move-mode tooltip and fix fields/beds help switching

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -830,10 +830,9 @@ function RootLayout() {
     if (location.pathname.startsWith('/app/dashboard')) return { pageKey: 'dashboard' as const, label: t('pageHelp.dashboard') };
     if (location.pathname.startsWith('/app/locations')) return { pageKey: 'locations' as const, label: t('pageHelp.locations') };
     if (location.pathname.startsWith('/app/fields-beds')) {
-      return {
-        pageKey: (isFieldsBedsGraphicalViewActive ? 'graphical' : 'areas') as const,
-        label: t('pageHelp.areas'),
-      };
+      return isFieldsBedsGraphicalViewActive
+        ? { pageKey: 'graphical' as const, label: t('pageHelp.areas') }
+        : { pageKey: 'areas' as const, label: t('pageHelp.areas') };
     }
     if (location.pathname.startsWith('/app/cultures')) return { pageKey: 'cultures' as const, label: t('pageHelp.cultures') };
     if (location.pathname.startsWith('/app/anbauplaene') || location.pathname.startsWith('/app/planting-plans')) return { pageKey: 'plantingPlans' as const, label: t('pageHelp.plantingPlans') };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -629,6 +629,10 @@ function RootLayout() {
     () => topbarContextActions.find((action) => action.id === 'fields-global-add-field') ?? null,
     [topbarContextActions],
   );
+  const isFieldsBedsGraphicalViewActive = useMemo(
+    () => topbarContextActions.some((action) => action.id === 'fields-view-mode-graphical' && action.active),
+    [topbarContextActions],
+  );
   const genericTopbarContextActions = useMemo(
     () => (isCulturesPage ? [] : topbarContextActions.filter((action) => action.id !== 'fields-global-add-field')),
     [isCulturesPage, topbarContextActions],
@@ -825,7 +829,12 @@ function RootLayout() {
   const topbarHelpConfig = useMemo(() => {
     if (location.pathname.startsWith('/app/dashboard')) return { pageKey: 'dashboard' as const, label: t('pageHelp.dashboard') };
     if (location.pathname.startsWith('/app/locations')) return { pageKey: 'locations' as const, label: t('pageHelp.locations') };
-    if (location.pathname.startsWith('/app/fields-beds')) return { pageKey: 'areas' as const, label: t('pageHelp.areas') };
+    if (location.pathname.startsWith('/app/fields-beds')) {
+      return {
+        pageKey: (isFieldsBedsGraphicalViewActive ? 'graphical' : 'areas') as const,
+        label: t('pageHelp.areas'),
+      };
+    }
     if (location.pathname.startsWith('/app/cultures')) return { pageKey: 'cultures' as const, label: t('pageHelp.cultures') };
     if (location.pathname.startsWith('/app/anbauplaene') || location.pathname.startsWith('/app/planting-plans')) return { pageKey: 'plantingPlans' as const, label: t('pageHelp.plantingPlans') };
     if (location.pathname.startsWith('/app/gantt-chart')) return { pageKey: 'calendar' as const, label: t('pageHelp.calendar') };
@@ -833,7 +842,7 @@ function RootLayout() {
     if (location.pathname.startsWith('/app/seed-demand')) return { pageKey: 'seedDemand' as const, label: t('pageHelp.seedDemand') };
     if (location.pathname.startsWith('/app/suppliers')) return { pageKey: 'suppliers' as const, label: t('pageHelp.suppliers') };
     return null;
-  }, [location.pathname, t]);
+  }, [isFieldsBedsGraphicalViewActive, location.pathname, t]);
   const topbarPrimaryAction = useMemo(() => {
     if (activeCreateActions.length > 0) {
       const isSingleCreateAction = activeCreateActions.length === 1;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -630,8 +630,8 @@ function RootLayout() {
     [topbarContextActions],
   );
   const isFieldsBedsGraphicalViewActive = useMemo(
-    () => topbarContextActions.some((action) => action.id === 'fields-view-mode-graphical' && action.active),
-    [topbarContextActions],
+    () => topbarTitleActions.some((action) => action.id === 'fields-view-mode-graphical' && action.active),
+    [topbarTitleActions],
   );
   const genericTopbarContextActions = useMemo(
     () => (isCulturesPage ? [] : topbarContextActions.filter((action) => action.id !== 'fields-global-add-field')),

--- a/frontend/src/__tests__/HelpDialog.test.tsx
+++ b/frontend/src/__tests__/HelpDialog.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HelpDialog } from '../components/help/HelpDialog';
+
+describe('HelpDialog', () => {
+  it('covers every main navigation page and keeps the workflow line untouched', async () => {
+    render(<HelpDialog open onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Überblick: So funktioniert OpenFarmPlanner')).toBeInTheDocument();
+
+    for (const title of [
+      'Übersicht',
+      'Anbauflächen',
+      'Kulturen',
+      'Anbaupläne',
+      'Anbaukalender',
+      'Ertragsübersicht',
+      'Saatgutbedarf',
+      'Lieferanten',
+    ]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+
+    expect(screen.getByText('Anbauflächen → Kulturen → Anbaupläne → Anbaukalender → Saatgutbedarf')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/PageHelp.test.tsx
+++ b/frontend/src/__tests__/PageHelp.test.tsx
@@ -47,6 +47,19 @@ describe('PageHelp', () => {
     expect(screen.queryByText(/•/)).not.toBeInTheDocument();
   });
 
+  it('renders graphical fields help with the per-location edit toggle instead of the obsolete global mode switch', async () => {
+    render(<PageHelp pageKey="graphical" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hilfe anzeigen' }));
+
+    expect(await screen.findByText('Aktiviere „Grafik bearbeiten“ bei einem Standort, um dessen Beete und Parzellen zu verschieben und anzuordnen.', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Grafik bearbeiten: Beete und Parzellen eines Standorts per Drag-and-Drop verschieben und anordnen')).toBeInTheDocument();
+    expect(screen.getByTestId('EditOutlinedIcon')).toBeInTheDocument();
+    expect(screen.queryByText('Modus')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ansicht')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Bearbeiten' })).not.toBeInTheDocument();
+  });
+
   it('renders cultures help with vertical more-actions icon and without separate delete symbol', async () => {
     render(<PageHelp pageKey="cultures" />);
 

--- a/frontend/src/__tests__/PageHelp.test.tsx
+++ b/frontend/src/__tests__/PageHelp.test.tsx
@@ -38,7 +38,9 @@ describe('PageHelp', () => {
     expect(screen.getByText('Neue Standorte, Parzellen und Beete können über das', { exact: false })).toBeInTheDocument();
     expect(screen.getByTestId('AddIcon')).toBeInTheDocument();
     expect(screen.getByText('hinzugefügt werden, das beim Überfahren eines Elements mit der Maus erscheint.', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('Einträge können direkt in der Tabelle bearbeitet werden. Weitere Aktionen wie Umbenennen, Löschen oder das Anlegen von Anbauplänen findest du im Kontextmenü per Rechtsklick.')).toBeInTheDocument();
+    expect(screen.getByText('Einträge können direkt in der Tabelle bearbeitet werden. Über das', { exact: false })).toBeInTheDocument();
+    expect(screen.getByTestId('AgricultureIcon')).toBeInTheDocument();
+    expect(screen.getByText('bei einem Beet legst du direkt einen Anbauplan dafür an. Weitere Aktionen wie Umbenennen oder Löschen findest du im Kontextmenü per Rechtsklick.', { exact: false })).toBeInTheDocument();
     expect(screen.queryByText('Bedienung')).not.toBeInTheDocument();
     expect(screen.queryByText('Zusammenhang mit anderen Seiten')).not.toBeInTheDocument();
     expect(screen.queryByText('Symbole und Bedienelemente')).not.toBeInTheDocument();

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -35,8 +35,6 @@ import {
   ListItemText,
   Popover,
   Stack,
-  ToggleButton,
-  ToggleButtonGroup,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -149,6 +147,7 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
     { key: 'zoomOut', icon: <RemoveIcon fontSize="small" /> },
     { key: 'fit', icon: <FitScreenIcon fontSize="small" /> },
     { key: 'fullscreen', icon: <FullscreenIcon fontSize="small" /> },
+    { key: 'editToggle', icon: <EditOutlinedIcon fontSize="small" sx={{ color: 'success.dark' }} /> },
   ],
 };
 
@@ -388,33 +387,6 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
             <HelpIconRow key={`${pageKey}-symbol-row-${index}`} icon={row.icon} text={row.text} />
           ))}
         </Stack>
-      </Box>
-
-      <Box>
-        <Typography variant="body1" sx={{ fontWeight: 600, mb: 1 }}>
-          {t('pages.graphical.modeTitle')}
-        </Typography>
-        <Box sx={{ display: 'inline-flex', flexDirection: 'column', gap: 1, p: 1.25, borderRadius: 1.5, border: '1px solid', borderColor: 'divider' }}>
-          <Typography variant="caption" sx={{ fontWeight: 600 }}>
-            {t('pages.graphical.modeLabel')}
-          </Typography>
-          <ToggleButtonGroup value="view" exclusive size="small" aria-label={t('pages.graphical.modeLabel')}>
-            <ToggleButton value="view" disabled>
-              {t('pages.graphical.modeView')}
-            </ToggleButton>
-            <ToggleButton value="edit" disabled>
-              {t('pages.graphical.modeEdit')}
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-        <List dense disablePadding sx={{ mt: 1 }}>
-          <ListItem sx={{ py: 0.2, px: 0 }}>
-            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${t('pages.graphical.modeViewDescription')}`} />
-          </ListItem>
-          <ListItem sx={{ py: 0.2, px: 0 }}>
-            <ListItemText slotProps={{ primary: { variant: 'body2' } }} primary={`• ${t('pages.graphical.modeEditDescription')}`} />
-          </ListItem>
-        </List>
       </Box>
     </Stack>
   );

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -113,7 +113,6 @@ const PAGE_SYMBOL_DEFINITIONS: Partial<Record<HelpPageKey, SymbolDefinition[]>> 
     { key: 'createPlan', icon: <AgricultureIcon fontSize="small" sx={{ color: 'primary.main' }} /> },
     { key: 'edit', icon: <EditIcon fontSize="small" sx={{ color: 'rgba(37, 111, 42, 0.86)' }} /> },
     { key: 'more', icon: <MoreVertIcon fontSize="small" sx={{ color: 'text.secondary' }} /> },
-    { key: 'delete', icon: <DeleteIcon fontSize="small" sx={{ color: 'error.main' }} /> },
   ],
   plantingPlans: [
     { key: 'add', icon: <AddIcon fontSize="small" sx={{ color: 'primary.main' }} /> },

--- a/frontend/src/components/help/PageHelp.tsx
+++ b/frontend/src/components/help/PageHelp.tsx
@@ -245,7 +245,7 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
   };
 
   const renderHelpTextContent = (text: string): ReactElement | string => {
-    const tokens = text.split(/({{addIcon}}|{{moreIcon}})/);
+    const tokens = text.split(/({{addIcon}}|{{moreIcon}}|{{createPlanIcon}})/);
     if (tokens.length === 1) {
       return text;
     }
@@ -275,6 +275,20 @@ export default function PageHelp({ pageKey, ariaLabel, tooltip }: PageHelpProps)
                 sx={{
                   mx: 0.25,
                   color: 'text.secondary',
+                  verticalAlign: 'text-bottom',
+                }}
+              />
+            );
+          }
+          if (token === '{{createPlanIcon}}') {
+            return (
+              <AgricultureIcon
+                key={`${token}-${index}`}
+                aria-hidden
+                fontSize="small"
+                sx={{
+                  mx: 0.25,
+                  color: 'primary.main',
                   verticalAlign: 'text-bottom',
                 }}
               />

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -63,7 +63,7 @@
   "moveModeCommandDeactivate": "Zeitraum verschieben deaktivieren",
   "modeViewTooltip": "Ansichtsmodus: Kalender ansehen und navigieren. Keine Änderungen per Drag & Drop.",
   "moveModeTooltip": "Verschiebemodus aktivieren: Anbauzeiträume können per Drag-and-Drop verschoben werden.",
-  "moveModeActiveTooltip": "Verschiebemodus aktiv: Anbauzeiträume können per Drag-and-Drop verschoben werden.",
+  "moveModeActiveTooltipDescription": "Ziehe einen Zeitraum nach links oder rechts, um den gesamten Anbauplan zeitlich zu verschieben.",
   "viewMode": "Ansichtsmodus",
   "viewSelectorAriaLabel": "Kalenderansicht auswählen",
   "chartLocaleText": {

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -62,7 +62,7 @@
   "moveModeCommandActivate": "Zeitraum verschieben aktivieren",
   "moveModeCommandDeactivate": "Zeitraum verschieben deaktivieren",
   "modeViewTooltip": "Ansichtsmodus: Kalender ansehen und navigieren. Keine Änderungen per Drag & Drop.",
-  "moveModeTooltip": "Verschiebemodus aktivieren: Anbauzeiträume können per Drag-and-Drop verschoben werden.",
+  "moveModeTooltipDescription": "Aktiviere den Verschiebemodus, um Anbauzeiträume per Drag-and-Drop zu verschieben.",
   "moveModeActiveTooltipDescription": "Ziehe einen Zeitraum nach links oder rechts, um den gesamten Anbauplan zeitlich zu verschieben.",
   "viewMode": "Ansichtsmodus",
   "viewSelectorAriaLabel": "Kalenderansicht auswählen",

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -139,8 +139,7 @@
         "library": "Kulturbibliothek öffnen",
         "createPlan": "Anbauplan für diese Kultur hinzufügen",
         "more": "Weitere Aktionen öffnen",
-        "edit": "Kulturdaten bearbeiten",
-        "delete": "Kultur löschen"
+        "edit": "Kulturdaten bearbeiten"
       }
     },
     "plantingPlans": {

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -189,7 +189,7 @@
           "title": "Bedienung",
           "points": [
             "Klicke auf ein Beet oder eine Parzelle, um Details anzuzeigen.",
-            "Verschiebe Elemente im Modus „Bearbeiten“.",
+            "Aktiviere „Grafik bearbeiten“ bei einem Standort, um dessen Beete und Parzellen zu verschieben und anzuordnen.",
             "Ziehe auf eine freie Fläche, um die Ansicht zu verschieben.",
             "Zoome mit Mausrad oder Pinch-Geste."
           ]
@@ -207,14 +207,9 @@
         "zoomIn": "Hineinzoomen",
         "zoomOut": "Herauszoomen",
         "fit": "Gesamte Ansicht einpassen",
-        "fullscreen": "Im Vollbild anzeigen"
-      },
-      "modeTitle": "Modus",
-      "modeLabel": "Modus",
-      "modeView": "Ansicht",
-      "modeEdit": "Bearbeiten",
-      "modeViewDescription": "Nur ansehen, navigieren und zoomen",
-      "modeEditDescription": "Elemente verschieben und anordnen"
+        "fullscreen": "Im Vollbild anzeigen",
+        "editToggle": "Grafik bearbeiten: Beete und Parzellen eines Standorts per Drag-and-Drop verschieben und anordnen"
+      }
     },
     "yieldOverview": {
       "title": "Hilfe: Ertragsübersicht",

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -6,6 +6,12 @@
   "intro": "OpenFarmPlanner besteht aus mehreren Seiten, die zusammenarbeiten:",
   "sections": [
     {
+      "title": "Übersicht",
+      "points": [
+        "Hier siehst du anstehende Termine für Aussaat, Pflanzung, Anzucht und Ernte auf einen Blick."
+      ]
+    },
+    {
       "title": "Anbauflächen",
       "points": [
         "Hier legst du Parzellen und Beete an. Bei Bedarf kannst du zusätzliche Standorte verwenden."
@@ -14,13 +20,13 @@
     {
       "title": "Kulturen",
       "points": [
-        "Hier trägst du deine Kulturdaten ein."
+        "Hier trägst du deine Kulturdaten ein oder greifst auf die öffentliche Kulturbibliothek zurück."
       ]
     },
     {
       "title": "Anbaupläne",
       "points": [
-        "Hier planst du, welche Kultur auf welchem Beet angebaut wird."
+        "Hier planst du, welche Kultur wann auf welchem Beet angebaut wird."
       ]
     },
     {
@@ -30,9 +36,21 @@
       ]
     },
     {
+      "title": "Ertragsübersicht",
+      "points": [
+        "Hier siehst du die aus deinen Anbauplänen erwarteten Erntemengen."
+      ]
+    },
+    {
       "title": "Saatgutbedarf",
       "points": [
         "Daraus wird berechnet, wie viel Saatgut du brauchst."
+      ]
+    },
+    {
+      "title": "Lieferanten",
+      "points": [
+        "Hier verwaltest du deine Lieferanten und kulturspezifische Bezugsquellen."
       ]
     }
   ],

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -50,7 +50,7 @@
     {
       "title": "Lieferanten",
       "points": [
-        "Hier verwaltest du deine Lieferanten und kulturspezifische Bezugsquellen."
+        "Hier trägst du deine Lieferanten ein, um sie bei Kulturen zu hinterlegen."
       ]
     }
   ],
@@ -201,7 +201,7 @@
     },
     "graphical": {
       "title": "Hilfe: Anbauflächen – Grafische Ansicht",
-      "intro": "Hier siehst du Parzellen und Beete räumlich angeordnet. Wenn mehrere Standorte vorhanden sind, zeigt die grafische Ansicht auch die Standortstruktur.",
+      "intro": "Hier siehst du Parzellen und Beete räumlich angeordnet.",
       "sections": [
         {
           "title": "Bedienung",

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -103,7 +103,7 @@
     },
     "areas": {
       "title": "Hilfe: Anbauflächen – Listenansicht",
-      "intro": "Hier verwaltest du die Flächenstruktur deines Betriebs – vom Standort über Parzellen bis zu einzelnen Beeten.\n\nNeue Standorte, Parzellen und Beete können über das {{addIcon}} hinzugefügt werden, das beim Überfahren eines Elements mit der Maus erscheint.\n\nEinträge können direkt in der Tabelle bearbeitet werden. Weitere Aktionen wie Umbenennen, Löschen oder das Anlegen von Anbauplänen findest du im Kontextmenü per Rechtsklick.",
+      "intro": "Hier verwaltest du die Flächenstruktur deines Betriebs – vom Standort über Parzellen bis zu einzelnen Beeten.\n\nNeue Standorte, Parzellen und Beete können über das {{addIcon}} hinzugefügt werden, das beim Überfahren eines Elements mit der Maus erscheint.\n\nEinträge können direkt in der Tabelle bearbeitet werden. Über das {{createPlanIcon}} bei einem Beet legst du direkt einen Anbauplan dafür an. Weitere Aktionen wie Umbenennen oder Löschen findest du im Kontextmenü per Rechtsklick.",
       "symbolsTitle": "Symbole und Bedienelemente",
       "symbols": {
         "expandToggle": "Abschnitt auf- oder zuklappen",

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -1528,17 +1528,17 @@ function GanttChartPage() {
           </Typography>
           {calendarMode === 'occupancy' ? (
             <Tooltip
-              title={editMode ? (
+              title={(
                 <Box component="span" sx={{ display: 'block' }}>
                   <Box component="span" sx={{ display: 'block', fontWeight: 600 }}>
-                    {t('ganttChart:moveModeActiveOption')}
+                    {editMode ? t('ganttChart:moveModeActiveOption') : t('ganttChart:moveModeOption')}
                   </Box>
                   <Box component="span" sx={{ display: 'block' }}>
-                    {t('ganttChart:moveModeActiveTooltipDescription')}
+                    {editMode
+                      ? t('ganttChart:moveModeActiveTooltipDescription')
+                      : t('ganttChart:moveModeTooltipDescription')}
                   </Box>
                 </Box>
-              ) : (
-                t('ganttChart:moveModeOption')
               )}
             >
               <Button

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -1527,7 +1527,20 @@ function GanttChartPage() {
             {title}
           </Typography>
           {calendarMode === 'occupancy' ? (
-            <Tooltip title={t('ganttChart:moveModeOption')}>
+            <Tooltip
+              title={editMode ? (
+                <Box component="span" sx={{ display: 'block' }}>
+                  <Box component="span" sx={{ display: 'block', fontWeight: 600 }}>
+                    {t('ganttChart:moveModeActiveOption')}
+                  </Box>
+                  <Box component="span" sx={{ display: 'block' }}>
+                    {t('ganttChart:moveModeActiveTooltipDescription')}
+                  </Box>
+                </Box>
+              ) : (
+                t('ganttChart:moveModeOption')
+              )}
+            >
               <Button
                 size="small"
                 variant={editMode ? 'contained' : 'outlined'}


### PR DESCRIPTION
## Summary
- Show a title + description tooltip for the "Zeitraum verschieben" / "Zeitraum verschieben aktiv" button in both states (previously only a single-line tooltip that didn't reflect the mode).
- Remove the redundant "Kultur löschen" entry from the Kulturen page help text, since deleting a culture is already covered by the "weitere Aktionen" (⋮ menu) bullet and no longer has its own icon.
- Fix the fields/beds page help popover always showing the list-view help text even when the graphical view is active; it now switches based on the active view mode (fixed a wrong-state lookup along the way: view mode lives in `topbarTitleActions`, not `topbarContextActions`).
- Mention the tractor icon (create planting plan) in the fields/beds list-view help intro instead of only pointing to the right-click context menu.
- Replace the outdated global "Ansicht"/"Bearbeiten" mode-toggle mock in the graphical fields help with a description of the real per-location "Grafik bearbeiten" button (the global toggle is never rendered in production).
- Refresh the global "So funktioniert OpenFarmPlanner" help dialog: add the three pages missing from the overview (Übersicht, Ertragsübersicht, Lieferanten) and update a couple of stale descriptions (Kulturen now mentions the public culture library; Anbaupläne mentions timing). The workflow line/order is untouched.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` for `GanttChart`, `PageHelp`, `HelpDialog`, `i18n`, `App`, `commandProvider`
- [x] `npx eslint` on touched files
- [ ] Manual check in browser: hover the move-mode button in both states, toggle Liste/Grafik on the Anbauflächen page to confirm the help text switches, and open the global help dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)