### PR TITLE
Restore column-visibility toolbar for Anbaupläne

### DIFF
--- a/frontend/src/components/data-grid/ColumnVisibilityMenu.tsx
+++ b/frontend/src/components/data-grid/ColumnVisibilityMenu.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Divider,
+  FormControlLabel,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ViewColumnIcon from '@mui/icons-material/ViewColumn';
+import type { GridColDef, GridColumnVisibilityModel } from '@mui/x-data-grid';
+import { useTranslation } from '../../i18n';
+
+interface ColumnVisibilityMenuProps {
+  columns: GridColDef[];
+  /** Effective visibility model (auto-fit or manual — already resolved). */
+  columnVisibilityModel: GridColumnVisibilityModel;
+  onColumnVisibilityModelChange: (model: GridColumnVisibilityModel) => void;
+  /** Whether Autofit is currently enabled. */
+  autofitEnabled?: boolean;
+  /** Called when the user toggles the Autofit checkbox. */
+  onAutofitChange?: (enabled: boolean) => void;
+}
+
+export function ColumnVisibilityMenu({
+  columns,
+  columnVisibilityModel,
+  onColumnVisibilityModelChange,
+  autofitEnabled = false,
+  onAutofitChange,
+}: ColumnVisibilityMenuProps) {
+  const { t } = useTranslation('common');
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isOpen = Boolean(anchorEl);
+  const handleClose = (): void => setAnchorEl(null);
+
+  const menuColumns = columns.filter((col) => col.hideable !== false);
+
+  const isVisible = (field: string): boolean => columnVisibilityModel[field] !== false;
+
+  const toggleColumn = (field: string) => {
+    onColumnVisibilityModelChange({
+      ...columnVisibilityModel,
+      [field]: !isVisible(field),
+    });
+  };
+
+  const visibleCount = menuColumns.filter((col) => isVisible(col.field)).length;
+  const allVisible = visibleCount === menuColumns.length;
+  const noneVisible = visibleCount === 0;
+
+  const toggleAll = () => {
+    const next: GridColumnVisibilityModel = {};
+    for (const col of menuColumns) {
+      next[col.field] = !allVisible;
+    }
+    onColumnVisibilityModelChange({ ...columnVisibilityModel, ...next });
+  };
+
+  return (
+    <>
+      <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
+        <Tooltip title={t('columnVisibility.buttonTooltip')}>
+          <Button
+            size="small"
+            variant="outlined"
+            color="secondary"
+            startIcon={<ViewColumnIcon fontSize="small" />}
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            aria-label={t('columnVisibility.buttonTooltip')}
+            aria-haspopup="true"
+            aria-expanded={isOpen}
+            sx={{ textTransform: 'none', flexShrink: 0, whiteSpace: 'nowrap', px: 1.25, bgcolor: 'background.paper' }}
+          >
+            {t('columnVisibility.button')}
+          </Button>
+        </Tooltip>
+      </Box>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={handleClose}
+        slotProps={{ paper: { sx: { minWidth: 270, maxHeight: 560 } } }}
+      >
+        {onAutofitChange ? (
+          <Box sx={{ px: 2, py: 1 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={autofitEnabled}
+                  onChange={(e) => onAutofitChange(e.target.checked)}
+                  sx={{ py: 0.5 }}
+                />
+              }
+              label={
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {t('columnVisibility.autofitLabel')}
+                </Typography>
+              }
+            />
+          </Box>
+        ) : null}
+
+        {onAutofitChange ? <Divider /> : null}
+
+        <MenuItem dense onClick={toggleAll}>
+          <ListItemIcon>
+            <Checkbox
+              edge="start"
+              size="small"
+              checked={allVisible}
+              indeterminate={!allVisible && !noneVisible}
+              disableRipple
+              sx={{ p: 0 }}
+            />
+          </ListItemIcon>
+          <ListItemText
+            primary={allVisible ? t('columnVisibility.hideAll') : t('columnVisibility.showAll')}
+            primaryTypographyProps={{ variant: 'body2', fontWeight: 500 }}
+          />
+        </MenuItem>
+
+        <Divider />
+
+        {menuColumns.map((col) => {
+          const visible = isVisible(col.field);
+          return (
+            <MenuItem key={col.field} dense onClick={() => toggleColumn(col.field)}>
+              <ListItemIcon>
+                <Checkbox
+                  edge="start"
+                  size="small"
+                  checked={visible}
+                  disableRipple
+                  sx={{ p: 0 }}
+                />
+              </ListItemIcon>
+              <ListItemText
+                primary={col.headerName ?? col.field}
+                primaryTypographyProps={{ variant: 'body2' }}
+              />
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mui/x-data-grid';
 import { dataGridSx, dataGridFooterSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
-import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRenderCellParams, GridRowParams, GridPaginationModel } from '@mui/x-data-grid';
+import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRenderCellParams, GridRowParams, GridPaginationModel, GridColumnVisibilityModel } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
@@ -46,6 +46,8 @@ import { useNotesEditor } from './useNotesEditor';
 import { extractApiErrorMessage } from '../../api/errors';
 import { germanDataGridLocaleText } from './localeText';
 import { TableCopyMenuItems } from './TableCopyMenuItems';
+import { ColumnVisibilityMenu } from './ColumnVisibilityMenu';
+import { computeAutoFitColumnVisibility } from '../../hooks/useColumnVisibility';
 import { formatClipboardValue, type TableClipboardRow } from './tableClipboard';
 import { handleContextMenuKeyboardNavigation } from './contextMenuFocus';
 import { ContextMenuHint } from './ContextMenuHint';
@@ -148,6 +150,12 @@ export function EditableDataGrid<T extends EditableRow>({
   surfaceSizing,
   paginationPageSizeOptions,
   initialPageSize = 25,
+  columnVisibilityModel,
+  onColumnVisibilityModelChange,
+  showColumnVisibilityButton = false,
+  autoHideColumnPriority,
+  columnVisibilityAutofit = false,
+  onColumnVisibilityAutofitChange,
 }: EditableDataGridProps<T>) {
   const gridApiRef = useGridApiRef();
   const resolvedSurfaceSizing = surfaceSizing ?? 'contentFit';
@@ -1745,6 +1753,73 @@ export function EditableDataGrid<T extends EditableRow>({
     onSelectedRowChange(selectedRow ?? null);
   }, [onSelectedRowChange, selectedRowIds, rows]);
 
+  // Autofit: measure the outer container and hide columns in priority order.
+  const outerContainerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const el = outerContainerRef.current;
+    if (!el || !autoHideColumnPriority?.length || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      // Round to integer pixels to avoid float noise triggering extra renders.
+      const w = Math.round(entry.contentRect.width);
+      setContainerWidth((prev) => (prev === w ? prev : w));
+    });
+    observer.observe(el);
+    setContainerWidth(Math.round(el.clientWidth));
+
+    return () => observer.disconnect();
+  // autoHideColumnPriority identity is stable (array literal from JSX); only
+  // re-attach observer when the array reference changes (unlikely in practice).
+  }, [autoHideColumnPriority]);
+
+  // Conservative fallback shown before the first ResizeObserver measurement:
+  // hide all optional columns so we never flash wide → narrow.
+  const autofitFallbackModel = useMemo<GridColumnVisibilityModel>(() => {
+    if (!autoHideColumnPriority?.length) return {};
+    return Object.fromEntries(autoHideColumnPriority.map((f) => [f, false]));
+  }, [autoHideColumnPriority]);
+
+  // Stable-reference effective model: only creates a new object when the set
+  // of hidden columns actually changes, preventing unnecessary child renders.
+  const prevEffectiveRef = useRef<{ key: string; model: GridColumnVisibilityModel }>({
+    key: '',
+    model: {},
+  });
+
+  const effectiveColumnVisibilityModel = useMemo<GridColumnVisibilityModel>(() => {
+    let computed: GridColumnVisibilityModel;
+
+    if (!autoHideColumnPriority?.length || !columnVisibilityAutofit) {
+      computed = columnVisibilityModel ?? {};
+    } else {
+      computed = computeAutoFitColumnVisibility(
+        columnsWithActions,
+        autoHideColumnPriority,
+        containerWidth,
+        autofitFallbackModel,
+      );
+    }
+
+    // Stabilise reference: reuse previous object when keys/values are unchanged.
+    const key = JSON.stringify(computed);
+    if (key !== prevEffectiveRef.current.key) {
+      prevEffectiveRef.current = { key, model: computed };
+    }
+    return prevEffectiveRef.current.model;
+  }, [autoHideColumnPriority, columnVisibilityAutofit, containerWidth, columnsWithActions, columnVisibilityModel, autofitFallbackModel]);
+
+  // When user disables Autofit from the column menu, capture the current
+  // effective model so visible columns don't jump.
+  const handleAutofitChange = useCallback((enabled: boolean) => {
+    if (!enabled) {
+      onColumnVisibilityModelChange?.(effectiveColumnVisibilityModel);
+    } else {
+      onColumnVisibilityAutofitChange?.(true);
+    }
+  }, [effectiveColumnVisibilityModel, onColumnVisibilityModelChange, onColumnVisibilityAutofitChange]);
+
   return (
     <>
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
@@ -1757,6 +1832,7 @@ export function EditableDataGrid<T extends EditableRow>({
       ) : null}
       
       <Box
+        ref={outerContainerRef}
         sx={{
           position: 'relative',
           width: '100%',
@@ -1777,6 +1853,25 @@ export function EditableDataGrid<T extends EditableRow>({
           }}
         >
           <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: isContentSizedSurface ? 'fit-content' : '100%',
+              minWidth: isContentSizedSurface ? 0 : '100%',
+            }}
+          >
+            {showColumnVisibilityButton && onColumnVisibilityModelChange ? (
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.75 }}>
+                <ColumnVisibilityMenu
+                  columns={columns}
+                  columnVisibilityModel={effectiveColumnVisibilityModel}
+                  onColumnVisibilityModelChange={onColumnVisibilityModelChange}
+                  autofitEnabled={columnVisibilityAutofit}
+                  onAutofitChange={onColumnVisibilityAutofitChange ? handleAutofitChange : undefined}
+                />
+              </Box>
+            ) : null}
+            <Box
             ref={gridSurfaceRef}
             onContextMenu={hasContextualRowActions ? (event) => {
               if (!isRowActionContextMenuTarget(event.target)) {
@@ -1807,6 +1902,7 @@ export function EditableDataGrid<T extends EditableRow>({
             <DataGrid
           rows={rowsForGrid}
           columns={columnsWithActions}
+          columnVisibilityModel={effectiveColumnVisibilityModel}
           rowModesModel={rowModesModel}
           onRowModesModelChange={setRowModesModel}
           onRowEditStop={(params, event, details) => {
@@ -2007,6 +2103,7 @@ export function EditableDataGrid<T extends EditableRow>({
           localeText={germanDataGridLocaleText}
           apiRef={gridApiRef}
           />
+          </Box>
           </Box>
         </Box>
       </Box>

--- a/frontend/src/components/data-grid/NotesCell.tsx
+++ b/frontend/src/components/data-grid/NotesCell.tsx
@@ -102,13 +102,22 @@ export function NotesCell({
 
   if (compactIndicator) {
     return (
-      <Tooltip title={hasValue || hasAttachments ? compactTooltip : '—'} arrow>
+      <Tooltip
+        title={compactTooltip}
+        arrow
+        disableHoverListener={!hasValue && !hasAttachments}
+        disableFocusListener={!hasValue && !hasAttachments}
+        disableTouchListener={!hasValue && !hasAttachments}
+      >
         <Box
           ref={compactTriggerRef}
           role="button"
           tabIndex={hasFocus ? 0 : -1}
           aria-label={compactAriaLabel}
-          onClick={onOpen}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpen();
+          }}
           onKeyDown={(event) => {
             if (event.key === 'Enter' || event.key === ' ') {
               event.preventDefault();
@@ -126,6 +135,10 @@ export function NotesCell({
             gap: 0.25,
             whiteSpace: 'nowrap',
             cursor: 'pointer',
+            outline: 'none',
+            '&:focus, &:focus-visible': {
+              outline: 'none',
+            },
           }}
         >
           {hasValue ? <NotesIcon fontSize="small" color="action" /> : null}

--- a/frontend/src/components/data-grid/types.ts
+++ b/frontend/src/components/data-grid/types.ts
@@ -1,5 +1,5 @@
 import type { MutableRefObject, ReactNode } from 'react';
-import type { GridColDef, GridRowId, GridSortModel } from '@mui/x-data-grid';
+import type { GridColDef, GridColumnVisibilityModel, GridRowId, GridSortModel } from '@mui/x-data-grid';
 
 export interface EditableRow {
   id: number;
@@ -103,4 +103,33 @@ export interface EditableDataGridProps<T extends EditableRow> {
   surfaceSizing?: 'contentFit' | 'fullWorkspace' | 'compact';
   paginationPageSizeOptions?: number[];
   initialPageSize?: number;
+  /**
+   * User's manually-saved visibility model. Pass `columnVisibilityModel` from
+   * `useColumnVisibility`. Only used when `columnVisibilityAutofit` is false.
+   */
+  columnVisibilityModel?: GridColumnVisibilityModel;
+  /**
+   * Called when the user explicitly changes columns via the built-in menu.
+   * Pass `setManualColumnVisibility` from `useColumnVisibility`.
+   * This automatically disables Autofit in the hook.
+   */
+  onColumnVisibilityModelChange?: (model: GridColumnVisibilityModel) => void;
+  /** When true, renders the column-visibility toggle button above the grid. */
+  showColumnVisibilityButton?: boolean;
+  /**
+   * Column fields to auto-hide in priority order (index 0 = first to hide)
+   * when the table width exceeds the container. Requires `columnVisibilityAutofit`.
+   */
+  autoHideColumnPriority?: string[];
+  /**
+   * Pass `autofitEnabled` from `useColumnVisibility`.
+   * When true the grid auto-hides/shows optional columns to fit the container.
+   * When false the `columnVisibilityModel` is used as-is.
+   */
+  columnVisibilityAutofit?: boolean;
+  /**
+   * Called when the user toggles the Autofit checkbox.
+   * Pass `setAutofitEnabled` from `useColumnVisibility`.
+   */
+  onColumnVisibilityAutofitChange?: (enabled: boolean) => void;
 }

--- a/frontend/src/hooks/useColumnVisibility.ts
+++ b/frontend/src/hooks/useColumnVisibility.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState } from 'react';
+import type { GridColDef, GridColumnVisibilityModel } from '@mui/x-data-grid';
+
+const COLUMN_VISIBILITY_PREFIX = 'tableColumns.';
+
+interface StoredState {
+  autofit: boolean;
+  model: GridColumnVisibilityModel;
+}
+
+function loadFromStorage(key: string): StoredState | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+    const obj = parsed as Record<string, unknown>;
+
+    // Current format: { autofit: boolean, model: {...} }
+    if ('autofit' in obj && 'model' in obj && obj.model !== null && typeof obj.model === 'object') {
+      return {
+        autofit: Boolean(obj.autofit),
+        model: obj.model as GridColumnVisibilityModel,
+      };
+    }
+
+    // Legacy format { model, customized }: treat as manual (autofit=false)
+    if ('model' in obj && obj.model !== null && typeof obj.model === 'object') {
+      return { autofit: false, model: obj.model as GridColumnVisibilityModel };
+    }
+
+    // Oldest legacy format: plain visibility model object
+    return { autofit: false, model: obj as GridColumnVisibilityModel };
+  } catch { /* ignore malformed data */ }
+  return null;
+}
+
+function saveToStorage(key: string, state: StoredState): void {
+  localStorage.setItem(key, JSON.stringify(state));
+}
+
+export interface UseColumnVisibilityOptions {
+  tableKey: string;
+}
+
+export function useColumnVisibility({ tableKey }: UseColumnVisibilityOptions): {
+  /** True when Autofit is active (default on first use). */
+  autofitEnabled: boolean;
+  /** The user's manually-saved visibility model (used when autofitEnabled=false). */
+  columnVisibilityModel: GridColumnVisibilityModel;
+  /**
+   * Save a manual column visibility model and disable Autofit.
+   * Call this when the user explicitly toggles a column.
+   */
+  setManualColumnVisibility: (model: GridColumnVisibilityModel) => void;
+  /**
+   * Enable or disable Autofit.
+   * When enabling: resumes auto-hide/show based on container width.
+   * When disabling: call setManualColumnVisibility instead so the current
+   * effective model is captured at the same time.
+   */
+  setAutofitEnabled: (enabled: boolean) => void;
+} {
+  const storageKey = `${COLUMN_VISIBILITY_PREFIX}${tableKey}`;
+
+  const [savedState, setSavedState] = useState<StoredState>(
+    () => loadFromStorage(storageKey) ?? { autofit: true, model: {} },
+  );
+
+  const setManualColumnVisibility = useCallback(
+    (model: GridColumnVisibilityModel) => {
+      const next: StoredState = { autofit: false, model };
+      setSavedState(next);
+      saveToStorage(storageKey, next);
+    },
+    [storageKey],
+  );
+
+  const setAutofitEnabled = useCallback(
+    (enabled: boolean) => {
+      setSavedState((prev) => {
+        const next: StoredState = { ...prev, autofit: enabled };
+        saveToStorage(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  return {
+    autofitEnabled: savedState.autofit,
+    columnVisibilityModel: savedState.model,
+    setManualColumnVisibility,
+    setAutofitEnabled,
+  };
+}
+
+/**
+ * Pure utility: hides columns in `autoHidePriority` order until the total
+ * minimum column width fits within `availableWidth`.
+ *
+ * - Returns `{}` (all visible) when all columns fit.
+ * - Returns `fallbackModel` when `availableWidth <= 0` (not yet measured).
+ *
+ * Suitable for use in `useMemo`.
+ *
+ * @param columns         All rendered column definitions.
+ * @param autoHidePriority Fields to hide, from first-to-hide to last-to-hide.
+ * @param availableWidth  Container width in pixels (from ResizeObserver).
+ * @param fallbackModel   Model to use before the first measurement fires.
+ */
+export function computeAutoFitColumnVisibility(
+  columns: GridColDef[],
+  autoHidePriority: string[],
+  availableWidth: number,
+  fallbackModel: GridColumnVisibilityModel = {},
+): GridColumnVisibilityModel {
+  if (availableWidth <= 0) return fallbackModel;
+
+  const getColMinWidth = (col: GridColDef): number =>
+    col.minWidth ?? (typeof col.width === 'number' ? col.width : 0) ?? 50;
+
+  let remaining = columns.reduce((sum, col) => sum + getColMinWidth(col), 0);
+
+  if (remaining <= availableWidth) return {};
+
+  const model: GridColumnVisibilityModel = {};
+  for (const field of autoHidePriority) {
+    if (remaining <= availableWidth) break;
+    model[field] = false;
+    const col = columns.find(c => c.field === field);
+    if (col) remaining -= getColMinWidth(col);
+  }
+
+  return model;
+}

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -43,6 +43,13 @@
   "columns": {
     "project": "Projekt"
   },
+  "columnVisibility": {
+    "button": "Spalten",
+    "buttonTooltip": "Sichtbare Spalten auswählen",
+    "autofitLabel": "Automatisch an Bildschirmbreite anpassen",
+    "showAll": "Alle einblenden",
+    "hideAll": "Alle ausblenden"
+  },
   "project": "Projekt",
   "setupActions": {
     "createField": "Parzelle hinzufügen",

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -98,6 +98,7 @@ import {
 } from "../commands/useCommandContext";
 import type { CommandSpec } from "../commands/types";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
+import { useColumnVisibility } from "../hooks/useColumnVisibility";
 import { getFirstMissingCultivationPlanRequirement, getProjectSetupAction, getProjectSetupActions } from "./requirementFlow";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
 import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
@@ -467,6 +468,9 @@ function PlantingPlans() {
   const { shouldShowProjectRequiredState, missingProjectReason } = useProjectRequirement();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const { autofitEnabled, columnVisibilityModel, setManualColumnVisibility, setAutofitEnabled } = useColumnVisibility({
+    tableKey: "plantingPlans",
+  });
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
@@ -2215,6 +2219,12 @@ function PlantingPlans() {
           tableKey="plantingPlans"
           defaultSortModel={[{ field: "planting_date", sort: "asc" }]}
           persistSortInUrl={true}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={setManualColumnVisibility}
+          columnVisibilityAutofit={autofitEnabled}
+          onColumnVisibilityAutofitChange={setAutofitEnabled}
+          autoHideColumnPriority={["harvest_date", "harvest_end_date"]}
+          showColumnVisibilityButton={!isMobile}
             notes={{
               fields: [
                 {


### PR DESCRIPTION
## Summary
- Restores the "Spalten" column-visibility toggle button (show/hide columns + auto-hide-on-narrow-screens) for the Anbaupläne table, which was silently lost in a botched stash-merge (`a5fb7628`, 2026-06-22) and never made it into the later regression-fix batches.
- Fixes the toolbar button's alignment so it hugs the table's actual (content-fit) width instead of the full-width page container.
- Fixes a bug in the compact Notizen cell indicator: clicking it to open the notes drawer didn't stop event propagation, so it also selected the row, leaving it highlighted (`.Mui-selected`) after the drawer closed.
- Suppresses the empty tooltip bubble the compact Notizen indicator showed when a row had no notes/attachments, and removes a redundant native focus outline that stacked on top of the grid's own focus ring.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full frontend test suite passes (112 files / 1022 tests)
- [ ] Manually refresh the Anbaupläne page and confirm the "Spalten" button aligns with the table's right edge, opens the menu, and toggling columns works
- [ ] Manually confirm opening/closing notes no longer leaves the row highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)