### PR TITLE
fix: Anbaupläne pagination bug + N+1 queries + labeled add-row action

### DIFF
--- a/backend/farm/serializers.py
+++ b/backend/farm/serializers.py
@@ -801,6 +801,10 @@ class CultureSerializer(serializers.ModelSerializer):
                 return obj.source_public_culture_id
             return None
 
+        prefetched = getattr(obj, '_prefetched_owned_public_cultures', None)
+        if prefetched is not None:
+            return prefetched[0].id if prefetched else None
+
         linked_public = PublicCulture.objects.filter(
             source_project_culture=obj,
             created_by=user,

--- a/backend/farm/tests/test_views.py
+++ b/backend/farm/tests/test_views.py
@@ -368,6 +368,25 @@ class ApiEndpointsTest(DRFAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 1)
 
+    def test_culture_list_query_count_does_not_scale_with_result_count(self):
+        # Regression test: get_queryset() previously dropped the select_related/
+        # prefetch_related applied on the class-level `queryset`, causing one extra
+        # query per culture for `supplier`, `image_file`, `source_public_culture`,
+        # `seed_packages`, and the owned-public-culture lookup.
+        for index in range(5):
+            Culture.objects.create(
+                name=f'Extra Culture {index}',
+                growth_duration_days=7,
+                harvest_duration_days=2,
+                project=self.project,
+                supplier=self.supplier,
+            )
+
+        with self.assertNumQueries(8):
+            response = self.client.get('/openfarmplanner/api/cultures/')
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 6)
+
     def test_culture_detail_returns_all_supplier_data_rows(self):
         supplier_a = Supplier.objects.create(name='Supplier A', homepage_url='https://supplier-a.example', project=self.project)
         supplier_b = Supplier.objects.create(name='Supplier B', homepage_url='https://supplier-b.example', project=self.project)

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -17,7 +17,7 @@ from django.contrib.auth import login
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, transaction
-from django.db.models import Case, When, Value, F, FloatField, IntegerField, ExpressionWrapper, Sum, CharField, Q, Count
+from django.db.models import Case, When, Value, F, FloatField, IntegerField, ExpressionWrapper, Sum, CharField, Q, Count, Prefetch
 from django.db.models.functions import Coalesce, Ceil, Cast
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
@@ -1237,9 +1237,21 @@ class CultureViewSet(ProjectScopedMixin, viewsets.ModelViewSet):
 
     def get_queryset(self):
         include_deleted = self.request.query_params.get('include_deleted') in {'1', 'true', 'True'}
-        if include_deleted:
-            return Culture.all_objects.filter(project=self.request.active_project).prefetch_related('supplier_data__supplier')
-        return Culture.objects.filter(project=self.request.active_project).prefetch_related('supplier_data__supplier')
+        manager = Culture.all_objects if include_deleted else Culture.objects
+        owned_public_cultures_prefetch = Prefetch(
+            'published_public_cultures',
+            queryset=PublicCulture.objects.filter(
+                created_by=self.request.user,
+                status=PublicCulture.STATUS_PUBLISHED,
+            ).order_by('-updated_at', '-id'),
+            to_attr='_prefetched_owned_public_cultures',
+        )
+        return (
+            manager
+            .filter(project=self.request.active_project)
+            .select_related('supplier', 'image_file', 'source_public_culture')
+            .prefetch_related('supplier_data__supplier', 'seed_packages', owned_public_cultures_prefetch)
+        )
 
     @action(detail=False, methods=['get'], url_path='duplicate-check')
     def duplicate_check(self, request):

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -228,8 +228,11 @@ vi.mock('@mui/x-data-grid', async () => {
     );
   };
 
+  const GridPagination = () => <div data-testid="grid-pagination" />;
+
   return {
     DataGrid,
+    GridPagination,
     GridRowModes,
     GridRowEditStopReasons,
     getGridBooleanOperators: getMockFilterOperators,

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -61,6 +61,38 @@ describe('API Client', () => {
     expect(getMock).toHaveBeenNthCalledWith(2, '/planting-plans/?page=2');
   });
 
+  it('strips the host from an absolute pagination `next` URL so requests stay same-origin', async () => {
+    // DRF builds `next` as an absolute URL using the backend's own host (e.g. when the
+    // dev proxy rewrites the request Host header). Following it verbatim would bypass
+    // the frontend's proxy and drop same-origin cookies, so only the query string may be reused.
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          count: 3,
+          next: 'http://127.0.0.1:8000/api/planting-plans/?page=2&page_size=1000',
+          previous: null,
+          results: [{ id: 1 }, { id: 2 }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          count: 3,
+          next: null,
+          previous: '/planting-plans/',
+          results: [{ id: 3 }],
+        },
+      });
+
+    await expect(fetchAllPaginated<{ id: number }>('/planting-plans/')).resolves.toEqual({
+      count: 3,
+      next: null,
+      previous: null,
+      results: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    });
+    expect(getMock).toHaveBeenNthCalledWith(1, '/planting-plans/?page_size=1000');
+    expect(getMock).toHaveBeenNthCalledWith(2, '/planting-plans/?page=2&page_size=1000');
+  });
+
   it('calls all culture endpoints with expected URLs and payloads', () => {
     const cultureData = { name: 'Karotte' };
     const importPreviewData = [{ name: 'Tomate' }];

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -44,7 +44,12 @@ export async function fetchAllPaginated<T>(
     >(nextPath);
     results.push(...response.data.results);
     count = response.data.count;
-    nextPath = response.data.next;
+    // DRF returns an absolute URL for `next`, built from the backend's own host.
+    // Following it directly would bypass the frontend's dev proxy (and drop
+    // same-origin cookies), so only the query string is reused against the
+    // original relative path.
+    const next = response.data.next;
+    nextPath = next ? `${initialPath}?${new URL(next, window.location.origin).searchParams.toString()}` : null;
   }
 
   return {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -18,11 +18,12 @@
 import { useState, useEffect, useCallback, useRef, useMemo, type KeyboardEvent, type ReactNode } from 'react';
 import {
   DataGrid,
+  GridPagination,
   GridRowEditStopReasons,
   GridRowModes,
   useGridApiRef,
 } from '@mui/x-data-grid';
-import { dataGridSx, dataGridFooterSx, deleteIconButtonSx } from './styles';
+import { dataGridSx, dataGridFooterSx, dataGridAddRowButtonSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
 import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRenderCellParams, GridRowParams, GridPaginationModel, GridColumnVisibilityModel } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
@@ -126,6 +127,7 @@ export function EditableDataGrid<T extends EditableRow>({
   deleteErrorMessage,
   deleteConfirmMessage,
   addButtonLabel,
+  addButtonText,
   showDeleteAction = true,
   initialRow,
   tableKey,
@@ -1452,38 +1454,50 @@ export function EditableDataGrid<T extends EditableRow>({
     const hasInvalidCell = hasValidationError || hasInvalidRowInEditMode;
 
     return (
-      <Box sx={dataGridFooterSx}>
-        {showAddAction && (
-          <IconButton
-            onClick={handleAddClick}
-            color="primary"
-            size="small"
-            aria-label={addButtonLabel}
-          >
-            <AddIcon />
-          </IconButton>
-        )}
-        {showFooterEditControls && hasUnsavedChanges && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: showAddAction ? 1 : 0 }}>
-            <Button size="small" variant="contained" onClick={() => void handleSaveAllDirtyRows()}>
-              {t('actions.save')}
-            </Button>
-            <Button
-              size="small"
-              onClick={() => {
-                const editIds = Object.entries(rowModesModel)
-                  .filter(([, mode]) => mode.mode === GridRowModes.Edit)
-                  .map(([id]) => id);
-                for (const id of editIds) {
-                  handleDiscardRowChanges(id);
-                }
-              }}
-            >
-              {t('actions.cancel')}
-            </Button>
-            {hasInvalidCell && <Chip size="small" color="error" label={t('messages.validationErrors')} />}
-          </Box>
-        )}
+      <Box
+        sx={
+          paginationPageSizeOptions
+            ? { ...dataGridFooterSx, justifyContent: 'space-between' }
+            : dataGridFooterSx
+        }
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          {showAddAction && (
+            <Tooltip title={addButtonLabel}>
+              <Button
+                onClick={handleAddClick}
+                size="small"
+                startIcon={<AddIcon fontSize="small" />}
+                aria-label={addButtonLabel}
+                sx={dataGridAddRowButtonSx}
+              >
+                {addButtonText ?? addButtonLabel}
+              </Button>
+            </Tooltip>
+          )}
+          {showFooterEditControls && hasUnsavedChanges && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: showAddAction ? 1 : 0 }}>
+              <Button size="small" variant="contained" onClick={() => void handleSaveAllDirtyRows()}>
+                {t('actions.save')}
+              </Button>
+              <Button
+                size="small"
+                onClick={() => {
+                  const editIds = Object.entries(rowModesModel)
+                    .filter(([, mode]) => mode.mode === GridRowModes.Edit)
+                    .map(([id]) => id);
+                  for (const id of editIds) {
+                    handleDiscardRowChanges(id);
+                  }
+                }}
+              >
+                {t('actions.cancel')}
+              </Button>
+              {hasInvalidCell && <Chip size="small" color="error" label={t('messages.validationErrors')} />}
+            </Box>
+          )}
+        </Box>
+        {paginationPageSizeOptions && <GridPagination />}
       </Box>
     );
   };

--- a/frontend/src/components/data-grid/styles.ts
+++ b/frontend/src/components/data-grid/styles.ts
@@ -254,6 +254,26 @@ export const dataGridFooterSx = {
 };
 
 /**
+ * Subtle, row-like "add" action shown in the DataGrid footer — deliberately not
+ * styled as a primary/contained button so it reads as a table affordance rather
+ * than competing with the page's main call-to-action button.
+ */
+export const dataGridAddRowButtonSx = {
+  color: 'text.secondary',
+  textTransform: 'none',
+  fontWeight: 400,
+  justifyContent: 'flex-start',
+  minHeight: 44,
+  minWidth: 44,
+  px: 1.5,
+  borderRadius: 1,
+  '&:hover': {
+    backgroundColor: 'surface.surfaceHoverBackground',
+    color: 'primary.main',
+  },
+};
+
+/**
  * Common styles for delete action IconButtons
  */
 export const deleteIconButtonSx = {

--- a/frontend/src/components/data-grid/types.ts
+++ b/frontend/src/components/data-grid/types.ts
@@ -75,6 +75,7 @@ export interface EditableDataGridProps<T extends EditableRow> {
   deleteErrorMessage: string;
   deleteConfirmMessage: string;
   addButtonLabel: string;
+  addButtonText?: string;
   showDeleteAction?: boolean;
   initialRow?: Partial<T>;
   tableKey?: string;

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -2195,6 +2195,7 @@ function PlantingPlans() {
           }}
           clipboardColumns={clipboardColumns}
           addButtonLabel={`${t("plantingPlans:addButton")} (Alt+Shift+N)`}
+          addButtonText={t("plantingPlans:addButton")}
           showDeleteAction={false}
           showFooterEditControls={false}
           showRowEditActions={false}

--- a/frontend/src/pages/useCultureImportExport.ts
+++ b/frontend/src/pages/useCultureImportExport.ts
@@ -156,29 +156,15 @@ export function useCultureImportExport({
           const filename = buildSingleCultureFilename(selectedCulture);
           downloadJsonFile(exportPayload, filename);
         } else {
-          const allCultures: Culture[] = [];
-          let nextUrl: string | null = '/cultures/';
-          while (nextUrl) {
-            const response = await cultureAPI.list(nextUrl);
-            allCultures.push(...response.data.results);
-            nextUrl = response.data.next;
-          }
+          const { results: allCultures } = await cultureAPI.listAll();
           const exportPayload = buildAllCulturesExport(allCultures);
           const filename = buildAllCulturesFilename();
           downloadJsonFile(exportPayload, filename);
         }
       } else {
-        const culturesToExport: Culture[] = [];
-        if (scope === 'current' && selectedCulture) {
-          culturesToExport.push(selectedCulture);
-        } else {
-          let nextUrl: string | null = '/cultures/';
-          while (nextUrl) {
-            const response = await cultureAPI.list(nextUrl);
-            culturesToExport.push(...response.data.results);
-            nextUrl = response.data.next;
-          }
-        }
+        const culturesToExport: Culture[] = scope === 'current' && selectedCulture
+          ? [selectedCulture]
+          : (await cultureAPI.listAll()).results;
         const filename = buildSpreadsheetFilename(format, scope === 'current' ? 'single' : 'all', selectedCulture ?? undefined);
         exportCulturesToSpreadsheet(culturesToExport, format, filename);
       }


### PR DESCRIPTION
## Summary
Found while performance-testing a large-data project on localhost.

- **Backend N+1**: `CultureViewSet.get_queryset()` dropped the class-level `select_related`/`prefetch_related`, causing one extra DB query per culture row (~300 queries / ~400ms for 300 cultures → ~10 queries / ~50ms).
- **Pagination 403 bug**: DRF's `next` pagination URL is absolute and (via Vite's `changeOrigin` dev proxy) points at the backend host directly. Following it bypassed the frontend proxy and dropped the session cookie cross-origin, causing a 403 once a resource exceeded `max_page_size` (beds/planting plans) or 100 rows (culture export). Fixed centrally in `fetchAllPaginated`; the culture import/export flows now reuse the fixed `cultureAPI.listAll()` instead of a duplicated (equally buggy) loop.
- **Missing pagination controls**: the DataGrid's custom footer slot never rendered `GridPagination`, so once a table (Anbaupläne) had more rows than fit on one page, there was no way to reach the rest — this is what "not all planting plans are shown" turned out to be.
- **Add-row affordance**: replaced the bare "+" icon button in the Anbaupläne table footer with a labeled, subtle text button ("+ Anbauplan hinzufügen"), styled like a table row (same hover tint as `.MuiDataGrid-row:hover`) rather than duplicating the primary green header button.

## Test plan
- [x] Backend: `pdm run test` (365 passed), new `test_culture_list_query_count_does_not_scale_with_result_count` regression test
- [x] Frontend: `vitest run` on affected files (93 passed), new pagination-absolute-URL regression test in `api.test.ts`
- [x] `tsc --noEmit` clean, `eslint` shows no new issues (verified via stash/pop diff against main)
- [x] Manually verified in a real browser (Playwright): pagination footer renders and paging works (1–25 → 26–50 of 509), add-row button shows/hovers correctly on desktop, mobile view unaffected (uses its own FAB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)