### PR TITLE
fix: Anbaukalender scroll resets to top when switching calendar modes

### DIFF
--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -662,6 +662,45 @@ describe('GanttChartPage', () => {
     });
   });
 
+  it('keeps the current row scroll position when switching calendar modes mid-session', async () => {
+    // Regression test: the restore effect used to reapply the `rowScrollTop` value
+    // captured once at mount (via a memoized read of localStorage) whenever
+    // calendarMode changed, snapping the view back to whatever was stored before
+    // the user started scrolling in this session — typically the top.
+    mocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 10,
+            culture: 5,
+            culture_name: 'Salat',
+            bed: 3,
+            planting_date: '2026-04-20',
+            harvest_date: '2026-05-20',
+          },
+        ],
+      },
+    });
+    mocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: 'Salat' }] } });
+
+    renderWithAuth();
+
+    const virtualViewport = await screen.findByTestId('gantt-virtual-viewport');
+    await waitFor(() => expect(topbarContext.latestTitleActions).toHaveLength(2));
+
+    fireEvent.scroll(virtualViewport, { target: { scrollTop: 300 } });
+    await waitFor(() => expect(virtualViewport.scrollTop).toBe(300));
+
+    act(() => {
+      getTopbarAction('calendar-view-mode-seedlings').onClick();
+    });
+
+    await waitFor(() => {
+      expect(getTopbarAction('calendar-view-mode-seedlings')).toMatchObject({ active: true });
+    });
+    expect(virtualViewport.scrollTop).toBe(300);
+  });
+
   it('resizes the desktop Gantt sidebar and stores the selected width', async () => {
     mocks.planList.mockResolvedValue({
       data: {

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -1905,7 +1905,12 @@ function GanttChartPage() {
       return;
     }
 
-    const storedRowScrollTop = storedGanttState?.rowScrollTop;
+    // Read the persisted offset fresh instead of relying on the `storedGanttState`
+    // memo (captured once per storage key): every scroll tick writes the latest
+    // offset to storage via `storeGanttState`, but that memo never re-reads it, so
+    // reusing it here reapplied a stale (often 0) offset on every calendarMode/loading
+    // change, snapping the view back to the top mid-session.
+    const storedRowScrollTop = getStoredGanttState(ganttStateStorageKey)?.rowScrollTop;
     const requestedScrollTop = typeof storedRowScrollTop === 'number' && Number.isFinite(storedRowScrollTop)
       ? Math.max(0, storedRowScrollTop)
       : 0;
@@ -1921,7 +1926,7 @@ function GanttChartPage() {
     }
     setGanttScrollTop(appliedScrollTop);
     hasRestoredTimelineRef.current = false;
-  }, [activeProjectId, calendarMode, hasCalendarRequirements, loading, storedGanttState?.rowScrollTop, useWindowedGanttRows]);
+  }, [activeProjectId, calendarMode, ganttStateStorageKey, hasCalendarRequirements, loading, useWindowedGanttRows]);
 
   useEffect(() => {
     if (loading || !hasCalendarRequirements) {


### PR DESCRIPTION
## Summary
- Reported: scrolling in the Anbaukalender "keeps jumping back to the top".
- Root cause: the row-scroll-restore `useEffect` in `GanttChart.tsx` read `storedGanttState?.rowScrollTop` — a value captured once via `useMemo(() => getStoredGanttState(key), [key])` and never refreshed. Every scroll tick writes the live offset to `localStorage` via `storeGanttState`, but that memo doesn't pick it up. Since `calendarMode` (Feldbelegung ↔ Anzucht) is also a dependency of this effect, switching tabs mid-session reapplied the stale value captured at mount (typically 0), snapping the view back to the top.
- Fix: read the stored offset fresh (`getStoredGanttState(ganttStateStorageKey)`) at the time the effect actually runs, instead of the stale closure.

## Test plan
- [x] New regression test: `keeps the current row scroll position when switching calendar modes mid-session` (fails without the fix, passes with it)
- [x] Full `GanttChart.test.tsx` suite passes (45/45)
- [x] `tsc --noEmit` clean, `eslint` clean
- [x] Manually verified in a real browser via Playwright: scrolled the calendar viewport to 800px, switched Feldbelegung → Anzucht → Feldbelegung, scroll position stayed at 800px (previously reset to 0 on every switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)