### PR TITLE
fix: rename Anbaukalender hierarchy column header to Anbauflächen

### DIFF
--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -549,7 +549,7 @@ describe('GanttChartPage', () => {
     expect(latestProps?.locale).toBe('de-DE');
     expect(latestProps?.localeText).toMatchObject({
       title: 'Feldplanung',
-      resources: 'Beete',
+      resources: 'Anbauflächen',
       today: 'Heute',
     });
     expect(latestProps?.editMode).toBe(false);

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -69,7 +69,7 @@
   "chartLocaleText": {
     "titleOccupancy": "Feldplanung",
     "titleSeedlings": "Anzuchtplanung",
-    "resources": "Beete",
+    "resources": "Anbauflächen",
     "resourcesSeedlings": "Kulturen",
     "today": "Heute",
     "viewModes": {


### PR DESCRIPTION
## Summary
The Anbaukalender's left tree column header said "Beete", but the column shows the full Standort → Parzelle → Beet hierarchy, not just individual beds. Renamed to "Anbauflächen" to match the content and the existing "Anbauflächen" page name.

Checked for other places in the calendar that say "Beete" while meaning the whole hierarchy — found none; the remaining occurrences ("Nur belegte Beete" filter, the per-Parzelle "X Beete · Y belegt" summary) correctly refer to beds specifically and were left unchanged.

Label-only change — no functional/behavioral changes.

## Test plan
- [x] Updated the existing `GanttChart.test.tsx` assertion for the new label
- [x] Full suite still passes (45/45)
- [x] `tsc --noEmit` clean
- [x] Manually verified in a real browser: header now reads "Anbauflächen" on both desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)