### PR TITLE
perf(hierarchy): keep the Anbauflächen table scrollable, virtualized, and full-width at scale

### DIFF
--- a/frontend/src/__tests__/FieldsBedsHierarchy.scalability.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsHierarchy.scalability.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Verifies the initial-expansion behavior introduced for very large
+ * hierarchies: small projects still fully expand (locations + fields,
+ * revealing every bed) on first load, while projects above
+ * HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD only expand locations, leaving fields
+ * (and their beds) collapsed for a scannable initial overview.
+ *
+ * The DataGrid is mocked to a plain row list (no MUI internals), since the
+ * behavior under test is which rows the page decides are visible — not
+ * DataGrid's own rendering/virtualization.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import FieldsBedsHierarchy from '../pages/FieldsBedsHierarchy';
+import { mockT } from './helpers/testI18n';
+
+const { bedListMock, fieldListMock, locationListMock } = vi.hoisted(() => ({
+  bedListMock: vi.fn(),
+  fieldListMock: vi.fn(),
+  locationListMock: vi.fn(),
+}));
+
+vi.mock('../i18n', () => ({ useTranslation: () => ({ t: mockT }) }));
+vi.mock('../commands/useCommandContext', () => ({
+  useCommandContextTag: vi.fn(),
+  useRegisterCommands: vi.fn(),
+}));
+vi.mock('../hooks/autosave', () => ({ useNavigationBlocker: vi.fn() }));
+
+vi.mock('../api/api', async () => {
+  const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
+  return {
+    ...actual,
+    bedAPI: { create: vi.fn(), delete: vi.fn(), list: bedListMock, update: vi.fn() },
+    fieldAPI: { create: vi.fn(), delete: vi.fn(), list: fieldListMock, update: vi.fn() },
+    locationAPI: { create: vi.fn(), delete: vi.fn(), list: locationListMock, update: vi.fn() },
+  };
+});
+
+vi.mock('@mui/x-data-grid', async () => {
+  const ReactModule = await import('react');
+  const useGridApiRef = vi.fn(() => ReactModule.useRef({}));
+
+  const DataGrid = ({ rows }: { rows: Array<{ id: string | number; type: string }> }) => (
+    <div data-testid="hierarchy-grid">
+      {rows.map((row) => (
+        <div data-testid={`row-${row.id}`} key={String(row.id)} role="row">
+          {String(row.id)}
+        </div>
+      ))}
+    </div>
+  );
+
+  return {
+    DataGrid,
+    GridRowModes: { Edit: 'edit', View: 'view' },
+    GridRowEditStopReasons: {
+      escapeKeyDown: 'escapeKeyDown',
+      enterKeyDown: 'enterKeyDown',
+      rowFocusOut: 'rowFocusOut',
+      shiftTabKeyDown: 'shiftTabKeyDown',
+      tabKeyDown: 'tabKeyDown',
+    },
+    useGridApiRef,
+  };
+});
+
+const renderHierarchy = () =>
+  render(
+    <MemoryRouter initialEntries={['/app/fields-beds']}>
+      <FieldsBedsHierarchy showTitle={false} />
+    </MemoryRouter>,
+  );
+
+describe('FieldsBedsHierarchy initial expansion at scale', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fully expands a small hierarchy (below the threshold), showing beds by default', async () => {
+    locationListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Standort A' }] } });
+    fieldListMock.mockResolvedValue({
+      data: {
+        results: Array.from({ length: 3 }, (_, i) => ({
+          id: i + 1, name: `Parzelle ${i + 1}`, location: 1, area_sqm: 10,
+        })),
+      },
+    });
+    bedListMock.mockResolvedValue({
+      data: {
+        results: Array.from({ length: 5 }, (_, i) => ({
+          id: i + 1, name: `Beet ${i + 1}`, field: 1, area_sqm: 2,
+        })),
+      },
+    });
+
+    renderHierarchy();
+
+    await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());
+    expect(screen.getByTestId(`row-${1}`)).toBeInTheDocument();
+  });
+
+  it('only expands locations for a very large hierarchy, leaving beds collapsed', async () => {
+    const FIELD_COUNT = 250;
+    locationListMock.mockResolvedValue({ data: { results: [{ id: 1, name: 'Standort A' }] } });
+    fieldListMock.mockResolvedValue({
+      data: {
+        results: Array.from({ length: FIELD_COUNT }, (_, i) => ({
+          id: i + 1, name: `Parzelle ${i + 1}`, location: 1, area_sqm: 10,
+        })),
+      },
+    });
+    bedListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Beet 1', field: 1, area_sqm: 2 }] },
+    });
+
+    renderHierarchy();
+
+    await waitFor(() => expect(screen.getByTestId('row-field-1')).toBeInTheDocument());
+    // Fields are visible (locations expanded)…
+    expect(screen.getByTestId('row-field-1')).toBeInTheDocument();
+    expect(screen.getByTestId(`row-field-${FIELD_COUNT}`)).toBeInTheDocument();
+    // …but beds stay hidden behind their (collapsed) field.
+    expect(screen.queryByTestId(`row-${1}`)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -121,24 +121,33 @@ interface HierarchyRowAction {
 const HIERARCHY_SELECTED_VIEW_ROW_SELECTOR =
   "& .MuiDataGrid-row.Mui-selected:not(.MuiDataGrid-row--editing)";
 
+// Above this many combined locations/fields/beds, fully expanding the tree on
+// first load produces an unwieldy wall of rows before the user has done
+// anything. Below it, full expansion (the long-standing default) is more
+// useful than hiding everything behind a chevron — mirrors the same
+// size-based fallback used for the occupancy tree in GanttChart.tsx.
+const HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD = 200;
+
+// Bottom breathing room left below the table when it's sized to the
+// available viewport height (see the tableWrapper measurement effect below),
+// and a floor so it never collapses to something unusably short.
+const TABLE_BOTTOM_MARGIN_PX = 24;
+const TABLE_MIN_HEIGHT_PX = 240;
+
 const HIERARCHY_DATA_GRID_SX = {
   ...dataGridSx,
-  width: "fit-content",
-  minWidth: 0,
+  // Intentionally no width: "fit-content" here (see git history/#50296dd7 for
+  // why it existed) — the name/dimension/area columns still keep their
+  // compact, content-based widths, but forcing the whole grid to shrink-wrap
+  // them fought the notes column's own flex: 1 (HierarchyColumns.tsx), which
+  // is designed to absorb whatever width is left over. Letting the grid fill
+  // its container lets notes do that job, so a horizontal scrollbar only
+  // shows up when the fixed columns genuinely don't fit (narrow viewports).
   "& .MuiDataGrid-filler": {
     display: "none",
   },
   "& .MuiDataGrid-scrollbarFiller": {
     display: "none",
-  },
-  "& .MuiDataGrid-main": {
-    width: "fit-content",
-  },
-  "& .MuiDataGrid-virtualScrollerContent": {
-    width: "fit-content !important",
-  },
-  "& .MuiDataGrid-columnHeaders": {
-    width: "fit-content !important",
   },
   "& .MuiDataGrid-columnHeader": {
     py: 0.25,
@@ -485,7 +494,16 @@ function FieldsBedsHierarchy({
   });
 
   /**
-   * Expand all rows when data is loaded (only once on initial load)
+   * Expand all rows when data is loaded (only once on initial load).
+   *
+   * Below HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD combined entities, this fully
+   * expands the tree (locations and fields, revealing every bed) — the
+   * long-standing default. Above it, only locations are expanded, leaving
+   * fields (and their beds) collapsed, so opening a very large project shows
+   * a scannable top-level overview instead of a wall of thousands of rows.
+   * Single-location projects render fields as root rows (see
+   * hierarchyTreeNodes below), so they're always visible regardless of this
+   * threshold — only their bed children are affected.
    */
   useEffect(() => {
     if (
@@ -494,6 +512,8 @@ function FieldsBedsHierarchy({
       locations.length > 0 &&
       fields.length > 0
     ) {
+      const canFullyExpand =
+        locations.length + fields.length + beds.length <= HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD;
       const allRowIds = new Set<string | number>();
 
       // Add all location IDs
@@ -501,15 +521,17 @@ function FieldsBedsHierarchy({
         allRowIds.add(`location-${location.id}`);
       });
 
-      // Add all field IDs
-      fields.forEach((field) => {
-        allRowIds.add(`field-${field.id}`);
-      });
+      if (canFullyExpand) {
+        // Add all field IDs
+        fields.forEach((field) => {
+          allRowIds.add(`field-${field.id}`);
+        });
+      }
 
       expandAll(Array.from(allRowIds));
       hasInitiallyExpandedRef.current = true;
     }
-  }, [expandAll, fields, hasPersistedState, locations]);
+  }, [beds.length, expandAll, fields, hasPersistedState, locations]);
 
   // Flat {id, parentId} view of the tree for the shared "Tiefe" depth
   // control (see HierarchyDepthControl / useHierarchyDepthControl).
@@ -1231,6 +1253,24 @@ function FieldsBedsHierarchy({
     return BED_ROW_HEIGHT;
   }, []);
 
+  // Exact height the grid would need to show every current row without its
+  // own scrollbar. Combined with availableTableHeight (measured below) via
+  // Math.min, this lets the table size snugly to its content for small
+  // hierarchies while filling the available viewport height (and internally
+  // scrolling/virtualizing) for large ones — instead of always reserving a
+  // fixed max height regardless of how much screen space is actually there.
+  const tableContentHeight = useMemo(() => (
+    HEADER_ROW_HEIGHT + rows.reduce((sum, row) => {
+      if (row.type === "location") {
+        return sum + LOCATION_ROW_HEIGHT;
+      }
+      if (row.type === "field") {
+        return sum + FIELD_ROW_HEIGHT;
+      }
+      return sum + BED_ROW_HEIGHT;
+    }, 0)
+  ), [rows]);
+
   const shouldShowMissingDimensionsHint = useMemo(() => {
     const hasBeds = beds.length > 0;
     const allBedsMissingLengthAndWidth = beds.every((bed) => {
@@ -1244,6 +1284,41 @@ function FieldsBedsHierarchy({
 
     return hasBeds && allBedsMissingLengthAndWidth;
   }, [beds]);
+
+  // How much vertical space is available below the table's own top edge,
+  // measured against the real viewport (not a fixed svh/px guess) so the
+  // table reaches close to the bottom of the visible app area regardless of
+  // how much the title/alerts/hints/toggle above it currently take up.
+  // Skipped on mobile, where the table keeps using autoHeight and the page
+  // itself scrolls (see the DataGrid props below).
+  const [availableTableHeight, setAvailableTableHeight] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    if (isMobileViewport) {
+      return;
+    }
+
+    const measure = (): void => {
+      const wrapper = tableWrapperRef.current;
+      if (!wrapper) {
+        return;
+      }
+      const top = wrapper.getBoundingClientRect().top;
+      setAvailableTableHeight(
+        Math.max(TABLE_MIN_HEIGHT_PX, window.innerHeight - top - TABLE_BOTTOM_MARGIN_PX),
+      );
+    };
+
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [
+    isMobileViewport,
+    error,
+    draftValidationWarning,
+    showContextMenuHint,
+    shouldShowMissingDimensionsHint,
+    shouldShowHierarchyTable,
+  ]);
 
   const hasUnsavedInvalidNewRows = useMemo(() => (
     beds.some((bed) => isPartiallyFilledNamelessNewHierarchyRow({
@@ -1369,10 +1444,6 @@ function FieldsBedsHierarchy({
             sx={{
               width: "100%",
               maxWidth: "100%",
-              minWidth: 1,
-              overflowX: "auto",
-              overflowY: "visible",
-              display: "block",
               '& [role="row"][data-id]': {
                 WebkitTouchCallout: "none",
               },
@@ -1385,7 +1456,6 @@ function FieldsBedsHierarchy({
             onTouchEnd={handleGridTouchEnd}
             onTouchCancel={handleGridTouchEnd}
           >
-            <Box sx={{ display: "inline-block", minWidth: "100%" }}>
             <DataGrid
               rows={rows}
               columns={columns}
@@ -1403,21 +1473,27 @@ function FieldsBedsHierarchy({
               onProcessRowUpdateError={handleProcessRowUpdateError}
               loading={loading}
               editMode="row"
-              autoHeight
+              autoHeight={isMobileViewport}
               hideFooter={true}
               sortingMode="server"
               sortModel={sortModel}
               onSortModelChange={setSortModel}
               isRowSelectable={() => true}
               isCellEditable={isCellEditable}
-              sx={HIERARCHY_DATA_GRID_SX}
+              sx={
+                isMobileViewport
+                  ? HIERARCHY_DATA_GRID_SX
+                  : {
+                    ...HIERARCHY_DATA_GRID_SX,
+                    height: `${Math.min(tableContentHeight, availableTableHeight ?? tableContentHeight)}px`,
+                  }
+              }
               disableRowSelectionOnClick
               onCellClick={handleHierarchyCellClick}
               onCellKeyDown={handleHierarchyCellKeyDown}
               localeText={germanDataGridLocaleText}
               apiRef={gridApiRef}
             />
-            </Box>
           </Box>
         ) : null}
       </Box>


### PR DESCRIPTION
## Summary
Analysis of the Anbauflächen (fields/beds hierarchy) page for very large projects turned up two compounding problems in the DataGrid setup, both fixed without introducing pagination or changing the Standort → Parzelle → Beet tree structure:

- **`autoHeight` disabled MUI's own row virtualization.** Confirmed directly in `@mui/x-data-grid`'s virtualization state initializer: `enabledForRows` is `false` whenever `autoHeight` is `true`. Combined with the page always fully expanding every location and field on first load, a large project rendered every row into the DOM and the page grew arbitrarily long.
- **A forced `width: "fit-content"`** on the grid (plus matching `virtualScroller`/`columnHeaders` overrides) fought the notes column's own pre-existing `flex: 1`, which could produce an unnecessary horizontal scrollbar instead of letting notes absorb the remaining width.

## Changes
- Desktop table now gets a real internal vertical scroll region instead of `autoHeight`: height is `Math.min(exact content height, actual available viewport height)` — the latter measured from the table's real position (not a fixed vh/px guess), recalculated on resize. Small hierarchies still size snugly to their content; large ones scroll internally with genuine virtualization and MUI's native sticky header. Mobile is unchanged (still `autoHeight`, whole page scrolls).
- Above `HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD` (200) combined locations/fields/beds, only locations expand on first load instead of the whole tree — mirrors the existing size-based fallback already used for the occupancy tree in `GanttChart.tsx`. Below the threshold, the long-standing fully-expanded default is unchanged.
- Removed the `fit-content` forcing so the grid fills its container width; the notes column (already `flex: 1`) absorbs the remaining space. Horizontal scroll now only appears when the fixed columns genuinely don't fit.
- Existing expand/collapse, keyboard navigation, inline editing, notes column, and responsive (mobile) behavior are all unchanged — none of that logic was touched.

## Test plan
- [x] `npx vitest run` — all `FieldsBedsHierarchy.*` suites pass (63 tests), including a new `FieldsBedsHierarchy.scalability.test.tsx` covering the auto-expand threshold at both a small and a very large (250-field) hierarchy.
- [x] `npx tsc --noEmit` — no errors.
- [x] `npx eslint` — no new issues (pre-existing unrelated warnings untouched).
- [x] **Manual verification** against a seeded throwaway project (3 locations, 120 fields, 720 beds, cleaned up afterward):
  - No horizontal overflow at 1024px/1280px/1440px desktop widths.
  - Table reaches to within the intended bottom margin of an 900px-tall viewport (876/900px).
  - Internal vertical scrolling works with the header staying fixed while rows scroll (scroller content 4253px vs 685px visible viewport).
  - Expand/collapse still works correctly; large dataset defaulted to only-locations-expanded as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)