### PR TITLE
feat: add TanStack table spike for growing areas

### DIFF
--- a/docs/table-library-comparison.md
+++ b/docs/table-library-comparison.md
@@ -1,0 +1,147 @@
+# Table Library Comparison
+
+## Compared Options
+
+This document compares three approaches for the Anbauflächen hierarchy table:
+
+- Current solution: MUI DataGrid with OpenFarmPlanner hierarchy projection and custom hooks.
+- AG Grid Community spike: experimental AG Grid Community prototype in the sibling worktree `OpenFarmPlanner-ag-grid-spike`.
+- TanStack Table + TanStack Virtual spike: experimental prototype in this branch.
+
+The comparison focuses on long-term suitability for OpenFarmPlanner, not on immediate migration.
+
+## Summary Table
+
+| Criterion | Current MUI DataGrid | AG Grid Community | TanStack Table + Virtual |
+| --- | --- | --- | --- |
+| Development effort | Already implemented, but complex | Medium-high; many grid features built in | High; headless composition requires custom behavior |
+| Maintainability | Good short-term, selector/API coupling remains | Good for grid-native behavior, but AG-specific | Good if shared primitives are extracted; heavy if page-local |
+| Performance | Good after existing scalability work | Strong built-in row virtualization | Strong explicit virtualization |
+| User experience | Most complete today | Promising, grid-like, dense | Promising, custom, not fully hardened |
+| Keyboard operation | Most mature today | Strong baseline from grid engine | Functional prototype, needs hardening |
+| Hierarchical data | Custom projection | Custom projection; Tree Data is Enterprise-only | Custom projection |
+| Inline editing | Mature row edit lifecycle | Built-in editing, wired to existing save path | Manual row editing; more work required |
+| Sorting | Existing persisted sibling sort | Built-in UI plus existing sort integration | Existing persisted sibling sort |
+| Filtering | Limited in current hierarchy table | Stronger built-in column filters | Simple per-column text filters |
+| Responsive behavior | Mature, known behavior | Good in spike, needs more review | Good in spike, custom layout |
+| Bundle size | Already paid dependency cost | Adds AG Grid packages | Adds small TanStack packages |
+| Extensibility | Moderate; constrained by DataGrid model | High for grid features, lower for custom design | High for custom features |
+| Long-term fit | Safe incremental choice | Good if AG Grid UX is accepted | Best if OpenFarmPlanner wants owned table primitives |
+
+## Development Effort
+
+Current solution: lowest immediate effort because it is already implemented. Further work is mostly incremental fixes.
+
+AG Grid Community: medium-high. The spike is about `1,415` lines and uses AG Grid's editing, virtualization, theming, and column features, but still needs OpenFarmPlanner-specific hierarchy projection and custom context menu handling.
+
+TanStack Table + Virtual: high. The spike is `1,627` lines because the library is headless and OpenFarmPlanner must implement rendering, edit controls, filters, keyboard behavior, resizing, sticky headers, and layout.
+
+## Maintainability
+
+Current solution: maintainable in the short term because it is covered by existing tests and user behavior is known. The downside is accumulated custom DataGrid focus logic and styling selectors.
+
+AG Grid Community: maintainable for standard grid features. Long-term maintainability depends on accepting AG Grid conventions and avoiding Enterprise-only APIs.
+
+TanStack Table + Virtual: maintainable only if the work becomes shared infrastructure. As a page-local implementation, it duplicates table behavior that other pages would also need.
+
+## Performance
+
+Current solution: already optimized for large hierarchies with conditional expansion and DataGrid virtualization.
+
+AG Grid Community: strong performance profile. The AG spike includes a Playwright scenario with 120 beds and asserts that rendered rows stay below 80.
+
+TanStack Table + Virtual: strong performance potential. The TanStack spike uses explicit row virtualization and tests large initial hierarchy behavior. Further Playwright scrolling coverage is still needed.
+
+## User Experience
+
+Current solution: best current UX because it has the most complete edge-case handling: undo, notes, click-away behavior, keyboard focus, deep links, empty states, and responsive behavior.
+
+AG Grid Community: good dense-grid UX. It may feel more like an enterprise grid and require styling work to fully match OpenFarmPlanner.
+
+TanStack Table + Virtual: best design-control potential, but the prototype is not yet as polished in editing and keyboard details.
+
+## Keyboard Operation
+
+Current solution: strongest today. There are existing tests for Enter behavior, focus after save, context menus, and keyboard navigation.
+
+AG Grid Community: strong baseline from AG Grid, with custom handling for hierarchy expand/collapse and row actions.
+
+TanStack Table + Virtual: implements row-level keyboard support, but cell-level parity and async focus restoration need more work.
+
+## Hierarchical Data
+
+Current solution: custom flat hierarchy projection.
+
+AG Grid Community: also custom flat hierarchy projection because AG Grid Tree Data is not available in Community.
+
+TanStack Table + Virtual: custom flat hierarchy projection, which fits the headless model but leaves all tree behavior in application code.
+
+## Inline Editing
+
+Current solution: most complete and already integrated with existing validation and draft handling.
+
+AG Grid Community: built-in cell editing is a useful base and was wired to existing save logic in the spike.
+
+TanStack Table + Virtual: works for name, length, and width, but editing lifecycle is manual and needs more production hardening.
+
+## Sorting
+
+Current solution: uses the existing persisted sort model and sorts siblings in the projected hierarchy.
+
+AG Grid Community: can use AG Grid sort UI, but the spike still needs careful coordination with hierarchy projection to avoid flattening semantics incorrectly.
+
+TanStack Table + Virtual: uses the existing persisted sort model for hierarchy-safe sibling sorting.
+
+## Filtering
+
+Current solution: the hierarchy table has limited filtering.
+
+AG Grid Community: strongest built-in filtering features among the three, though custom hierarchy semantics still need care.
+
+TanStack Table + Virtual: simple per-column text filters are implemented. The spike keeps ancestors visible for matches, which is a good hierarchy-specific behavior.
+
+## Responsive Behavior
+
+Current solution: already tuned for the app's breakpoints.
+
+AG Grid Community: spike includes a mobile-width Playwright check that the center viewport fits without unnecessary horizontal overflow.
+
+TanStack Table + Virtual: custom responsive behavior works in build/tests, with compact notes and dynamic height. It still needs real-device and Playwright scrolling coverage.
+
+## Bundle Size
+
+Current solution: no new dependency if retained. MUI DataGrid is already part of the project.
+
+AG Grid Community: adds `ag-grid-community` and `ag-grid-react` `^36.0.0`. This is likely the largest new dependency option.
+
+TanStack Table + Virtual: adds `@tanstack/react-table` and `@tanstack/react-virtual`. Installed package footprint is smaller than AG Grid, but the current spike branch still includes the original MUI implementation, so the measured page chunk is not the final net migration cost.
+
+Measured TanStack spike build:
+
+- `FieldsBedsPage-ZbuAgp-7.js`: `455.37 kB` raw, `137.57 kB` gzip.
+
+## Extensibility
+
+Current solution: good for features that map to MUI DataGrid; less ideal for custom hierarchy-specific interaction.
+
+AG Grid Community: strong for conventional grid features such as column menus, editing, sizing, and virtualization. We must avoid features reserved for Enterprise.
+
+TanStack Table + Virtual: strongest for custom interaction and design-system ownership, but only after extracting shared primitives.
+
+## Long-Term Suitability For OpenFarmPlanner
+
+Current solution is best for stability and immediate product continuity.
+
+AG Grid Community is a good candidate if OpenFarmPlanner wants a mature grid engine and accepts AG Grid's conventions. Its main drawback is that the most attractive hierarchy feature, Tree Data, is Enterprise-only.
+
+TanStack Table + Virtual is the best candidate if OpenFarmPlanner wants a lightweight, open, custom table foundation. It aligns with a design-system-first direction, but it requires deliberate investment in reusable table infrastructure and accessibility tests.
+
+## Recommendation
+
+Do not migrate immediately.
+
+For the short term, keep the current MUI DataGrid implementation because it is the most functionally complete and has the lowest regression risk.
+
+For the long term, prefer TanStack Table + TanStack Virtual over AG Grid Community if OpenFarmPlanner is willing to build and maintain shared table primitives. The TanStack approach keeps the project fully in control of hierarchy semantics, styling, and future feature design while using small permissive OSS libraries. It is the better strategic fit for OpenFarmPlanner's custom agricultural workflows.
+
+AG Grid Community should remain a fallback candidate if the team decides that mature built-in grid behavior is more important than custom design ownership. Its Community license is acceptable, but the absence of Community Tree Data reduces its advantage for this specific hierarchy table.

--- a/docs/tanstack-table-spike.md
+++ b/docs/tanstack-table-spike.md
@@ -1,0 +1,228 @@
+# TanStack Table + TanStack Virtual Spike
+
+## Scope
+
+This spike replaces only the Anbauflächen hierarchy table with a TanStack Table + TanStack Virtual prototype. It keeps the existing OpenFarmPlanner data model, API calls, hierarchy projection, expansion state, deletion undo, notes drawer, validation, and most shared hooks. The original MUI DataGrid implementation remains in `frontend/src/pages/FieldsBedsHierarchy.tsx` for review and rollback; the page imports the experimental implementation from `FieldsBedsTanStackHierarchy.tsx`.
+
+The spike uses:
+
+- `@tanstack/react-table` `^8.21.3`
+- `@tanstack/react-virtual` `^3.14.5`
+
+Both packages are open-source and permissively licensed.
+
+## Implemented Prototype Features
+
+- Standort -> Parzelle -> Beet hierarchy, rendered as an indented flat tree.
+- Expand/collapse per row and one-level expand/collapse controls in the name header.
+- Inline row editing for name, length, and width.
+- Existing notes drawer integration.
+- Existing delete-with-undo flow and row context menu.
+- Sorting for `name` and `area_sqm` through the existing persisted sort model.
+- Per-column text filters with ancestor rows kept visible for context.
+- Column resizing through TanStack column sizing.
+- Row virtualization through TanStack Virtual.
+- Dynamic height that shrinks for small tables and fills available viewport space for larger tables.
+- Keyboard navigation for row selection, expand/collapse, edit, delete, and context menu.
+- Responsive behavior matching the existing mobile breakpoint and compact notes rendering.
+
+## Known Gaps
+
+- Inline editing is functional but less polished than the MUI DataGrid row-editing engine. The old implementation has deeper handling for cell-level focus restoration after Enter/Tab saves.
+- Filter UI is intentionally simple text filtering. It does not reproduce MUI DataGrid's richer operator model.
+- Sorting is limited to the fields already supported by the existing hierarchy sort model (`name`, `area_sqm`).
+- Column resizing works, but autosize/content measurement is less mature than the current measured name-column logic.
+- The implementation includes a jsdom-safe virtualizer fallback for tests. It is bounded to the first 80 rows only when TanStack Virtual has not produced virtual items yet.
+- No Playwright screenshot baseline was added or updated. This is an experimental spike, and screenshot baselines should only be updated after explicit visual review.
+
+## Development Effort
+
+The prototype required a near full table-surface rewrite because TanStack Table is headless. Existing domain hooks could be reused, but keyboard behavior, virtual row layout, header/filter rows, context menu anchoring, column resizing, edit controls, and responsive sizing all had to be composed manually.
+
+Code size comparison:
+
+- Existing MUI DataGrid hierarchy table: `1,589` lines in `FieldsBedsHierarchy.tsx`.
+- TanStack spike table: `1,627` lines in `FieldsBedsTanStackHierarchy.tsx`.
+- Focused TanStack spike tests: `117` lines.
+
+The result is not smaller than the current implementation because OpenFarmPlanner's required behavior is table-engine-heavy, not just row rendering.
+
+## Code Complexity
+
+TanStack separates row modeling from rendering. That is clean for simple tables, but the Anbauflächen table needs a lot of custom behavior:
+
+- tree projection
+- row-level editing
+- persistent hierarchical expansion
+- calculated area cells
+- notes drawer integration
+- undoable deletion
+- focus and keyboard behavior
+- dynamic viewport measurement
+- filter behavior that keeps ancestors visible
+
+Those pieces now live directly in the spike component. The complexity is explicit and controllable, but OpenFarmPlanner owns more of it.
+
+## Readability
+
+The TanStack version is readable for engineers comfortable with headless table composition. It avoids MUI DataGrid-specific APIs and makes the render tree visible in normal React code.
+
+The downside is volume: behavior that DataGrid previously supplied or coordinated must be implemented in application code. Reading the spike requires understanding both TanStack state and OpenFarmPlanner's hierarchy hooks.
+
+## Maintainability
+
+Maintainability is mixed:
+
+- Positive: no dependency on DataGrid internals for tree projection, focus hacks, or styling selectors.
+- Positive: the rendering model is ordinary React and easier to customize.
+- Negative: OpenFarmPlanner must maintain more table infrastructure itself.
+- Negative: keyboard, editing, and virtualization edge cases become local responsibility.
+
+For long-term use, this approach would need extraction into shared table primitives before migrating other pages.
+
+## Performance
+
+The prototype uses TanStack Virtual and renders only a visible window for large row counts once the scroll element is measured. The focused tests cover:
+
+- small hierarchy default expansion
+- large hierarchy initial collapsed bed rows
+- per-column filtering with ancestor visibility
+
+The build succeeded, and the UI is expected to perform well for large read/browse datasets. Editing performance should also be acceptable because only visible rows render. The main risk is correctness around virtualized keyboard focus and scroll positioning, which needs Playwright coverage before production adoption.
+
+## Bundle Size
+
+Measured with `npm run build` in this spike:
+
+- `FieldsBedsPage-ZbuAgp-7.js`: `455.37 kB` raw, `137.57 kB` gzip.
+
+Installed package footprint in `node_modules`:
+
+- `@tanstack/react-table`: `796K`
+- `@tanstack/table-core`: `3.6M`
+- `@tanstack/react-virtual`: `88K`
+- `@tanstack/virtual-core`: `460K`
+
+The page chunk remains large because the current MUI DataGrid implementation is still present in the branch for comparison and because the Anbauflächen page pulls shared notes, markdown, MUI, and hierarchy code. A final migration branch would need to remove the unused MUI hierarchy import path before measuring the true net delta.
+
+## Virtualization
+
+TanStack Virtual is a good fit. It is small, explicit, and easy to combine with dynamic row heights by row type. The main integration work is layout: sticky headers, filter rows, total height, scroll container ownership, and test-environment behavior all have to be implemented by OpenFarmPlanner.
+
+## Hierarchy Support
+
+TanStack Table does not give OpenFarmPlanner a complete tree grid out of the box. The spike reuses the existing hierarchy projection and renders a flat indented tree. This is similar to the current solution and the AG Grid Community spike because AG Grid Community does not include Enterprise Tree Data.
+
+This approach is flexible and license-safe, but hierarchy behavior remains application code.
+
+## Inline Editing
+
+Inline editing works for the core editable fields and reuses the existing row update validation and API logic. However, MUI DataGrid still has a more complete editing lifecycle. The TanStack version would need more hardening around:
+
+- Tab behavior between cells
+- click-away commit/discard parity
+- focus restoration after async saves
+- partially valid draft preservation
+- screen reader announcements
+
+## Keyboard Operation
+
+The spike supports row-level keyboard behavior:
+
+- Arrow Up/Down moves selection.
+- Arrow Left/Right collapses or expands selected parent rows.
+- Enter starts editing.
+- Delete triggers delete.
+- Shift+F10 or ContextMenu opens the context menu.
+
+This is enough for evaluation, but it is not yet feature-parity with the current DataGrid-focused keyboard suite.
+
+## Sorting
+
+Sorting is integrated with the existing persisted sort model and hierarchy index. This keeps sibling ordering consistent with the current implementation. It is intentionally limited to `name` and `area_sqm`, matching current supported behavior.
+
+## Filtering
+
+Per-column text filters are implemented. Active filters operate on the fully expanded row set and keep ancestor rows visible so matching beds do not appear without their Standort/Parzelle context.
+
+This is useful and predictable, but less powerful than DataGrid-style operator filters or AG Grid's column filter menus.
+
+## Styling Effort
+
+Styling effort is high. TanStack is headless, so all of the following are application-owned:
+
+- header layout
+- sticky header/filter rows
+- column borders
+- row hover/selection states
+- calculated cell background
+- editing controls
+- action overlays
+- responsive scroll behavior
+
+The upside is design-system control. The downside is more local CSS/SX surface area.
+
+## Integration With Existing Architecture
+
+Integration was feasible because existing hierarchy hooks already isolate much of the domain logic. The spike reused:
+
+- `useHierarchyData`
+- `useExpandedState`
+- `useHierarchyLevelToggle`
+- `useBedOperations`
+- `useHierarchyRowUpdate`
+- `useHierarchyDelete`
+- notes drawer utilities
+- persistent sort storage
+
+The strongest fit is at the data/model layer. The weakest fit is at the table interaction layer, where MUI DataGrid-specific focus and edit hooks could not be reused.
+
+## Advantages Over Current Solution
+
+- Smaller, headless table/virtualization dependencies.
+- More direct control over DOM structure and styling.
+- Less reliance on MUI DataGrid internals and selectors.
+- Per-column filtering can be tailored to hierarchy semantics.
+- Virtualization is explicit and library-agnostic.
+
+## Disadvantages Versus Current Solution
+
+- More custom code for editing, focus, keyboard navigation, resizing, and accessibility.
+- Existing MUI DataGrid tests and utilities cannot be reused directly.
+- Feature parity requires significant hardening.
+- Current implementation already has mature behavior for row editing, undo, notes, keyboard edge cases, and height management.
+
+## Advantages Over AG Grid Community
+
+- Headless and easier to align precisely with the OpenFarmPlanner design language.
+- Smaller dependency footprint than AG Grid.
+- No AG Grid-specific theming or module registration.
+- No temptation to depend on Enterprise-only Tree Data or context menu features.
+- React-first composition model fits the existing component style.
+
+## Disadvantages Versus AG Grid Community
+
+- AG Grid Community provides more built-in grid behavior, including robust column sizing, editing infrastructure, keyboard navigation, and virtualization.
+- AG Grid's performance model is more mature for dense data grids.
+- TanStack requires more application code to reach comparable grid affordances.
+
+## Validation
+
+Commands run:
+
+- `npm run test -- FieldsBedsTanStackHierarchy.test.tsx FieldsBedsPage.test.tsx`
+- `npm run build`
+- `FRONTEND_PORT=4178 BACKEND_PORT=8005 npx playwright test e2e/fields-beds-tanstack-spike.spec.ts`
+
+Results:
+
+- 11 focused tests passed.
+- Production build passed.
+- 2 Playwright spike tests passed, covering small-dataset hierarchy/editing/sorting/filtering/keyboard/context-menu/responsive behavior and a 90-bed virtualized scroll scenario.
+- `npm install` reported existing audit findings: 25 vulnerabilities (2 low, 8 moderate, 14 high, 1 critical). These were not introduced through a separate audit remediation in this spike.
+
+## Recommendation From This Spike
+
+TanStack Table + TanStack Virtual is viable for OpenFarmPlanner, but it is not a low-effort replacement for the current Anbauflächen table. It gives the project maximum control and a permissive, lightweight dependency base, but the team must own more grid behavior.
+
+For this specific table, TanStack is the strongest long-term candidate only if OpenFarmPlanner wants a custom, design-system-owned table foundation and is willing to invest in shared table primitives. If the priority is fastest production parity with least custom interaction code, the current MUI DataGrid solution remains safer in the short term.

--- a/frontend/e2e/fields-beds-tanstack-spike.spec.ts
+++ b/frontend/e2e/fields-beds-tanstack-spike.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { loginWithDeterministicProject } from './utils';
+
+async function getProjectContext(page: Page): Promise<{ projectId: number; csrfToken: string }> {
+  const activeProjectId = await page.evaluate(() => window.localStorage.getItem('activeProjectId'));
+  expect(activeProjectId).toBeTruthy();
+  const csrfToken = await page.evaluate(() =>
+    document.cookie.split('; ').find((row) => row.startsWith('csrftoken='))?.split('=')[1] ?? '');
+  expect(csrfToken).toBeTruthy();
+  return { projectId: Number(activeProjectId), csrfToken };
+}
+
+async function postApi<T>(
+  page: Page,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<T> {
+  const { projectId, csrfToken } = await getProjectContext(page);
+  const result = await page.evaluate(async ({ requestPath, requestData, requestProjectId, requestCsrfToken }) => {
+    const response = await fetch(`/api${requestPath}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': requestCsrfToken,
+        'X-Project-Id': String(requestProjectId),
+      },
+      body: JSON.stringify({ ...requestData, project: requestProjectId }),
+    });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  }, {
+    requestPath: path,
+    requestData: data,
+    requestProjectId: projectId,
+    requestCsrfToken: csrfToken,
+  });
+
+  expect(result.ok, `${path} -> ${result.status}: ${result.text}`).toBeTruthy();
+  return JSON.parse(result.text) as T;
+}
+
+async function getApi<T>(page: Page, path: string): Promise<T> {
+  const { projectId } = await getProjectContext(page);
+  const result = await page.evaluate(async ({ requestPath, requestProjectId }) => {
+    const response = await fetch(`/api${requestPath}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { 'X-Project-Id': String(requestProjectId) },
+    });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  }, {
+    requestPath: path,
+    requestProjectId: projectId,
+  });
+
+  expect(result.ok, `${path} -> ${result.status}: ${result.text}`).toBeTruthy();
+  return JSON.parse(result.text) as T;
+}
+
+test.describe('fields-beds TanStack Table spike', () => {
+  test('supports hierarchy, inline editing, sorting, filtering, keyboard, context menu, and responsive width', async ({ page, request }) => {
+    await loginWithDeterministicProject(page, request, 'tanstack-spike-small');
+    await page.waitForLoadState('networkidle');
+    const locations = await getApi<{ results: { id: number }[] }>(page, '/locations/');
+    const location = locations.results[0];
+    if (!location) {
+      throw new Error('Expected the e2e fixture to provide a default location.');
+    }
+    const field = await postApi<{ id: number }>(page, '/fields/', {
+      name: 'TanStack Testfeld',
+      location: location.id,
+      area_sqm: 24,
+      length_m: 6,
+      width_m: 4,
+    });
+    const bed = await postApi<{ id: number }>(page, '/beds/', {
+      name: 'TanStack Testbeet',
+      field: field.id,
+      area_sqm: 6,
+      length_m: 3,
+      width_m: 2,
+    });
+
+    await page.evaluate(() => window.localStorage.setItem('fieldsBedsViewMode', 'table'));
+    await page.goto('/app/fields-beds');
+    const grid = page.getByTestId('tanstack-hierarchy-grid');
+    await expect(grid).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('TanStack Testfeld')).toBeVisible();
+    await expect(page.getByText('TanStack Testbeet')).toBeVisible();
+
+    const fieldRow = page.getByTestId(`tanstack-row-field-${field.id}`);
+    await fieldRow.getByRole('button', { name: 'Eintrag zuklappen' }).click();
+    await expect(page.getByText('TanStack Testbeet')).not.toBeVisible();
+    await fieldRow.getByRole('button', { name: 'Eintrag aufklappen' }).click();
+    await expect(page.getByText('TanStack Testbeet')).toBeVisible();
+
+    await fieldRow.dblclick();
+    const editInput = fieldRow.getByRole('textbox').first();
+    await expect(editInput).toBeVisible();
+    await editInput.fill('TanStack Testfeld bearbeitet');
+    await editInput.press('Enter');
+    await expect(page.getByText('TanStack Testfeld bearbeitet')).toBeVisible({ timeout: 10_000 });
+
+    await grid.focus();
+    await page
+      .getByTestId(`tanstack-row-${bed.id}`)
+      .locator('[data-field="name"]')
+      .click({ position: { x: 20, y: 10 } });
+    await page.keyboard.press('ArrowUp');
+    await expect(fieldRow).toHaveAttribute('aria-selected', 'true');
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByTestId(`tanstack-row-${bed.id}`)).toHaveAttribute('aria-selected', 'true');
+
+    const nameHeader = page.locator('[role="columnheader"][aria-sort]').first();
+    await nameHeader.getByRole('button').first().click();
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+
+    await page.getByRole('textbox').first().fill('Testbeet');
+    await expect(page.getByText('TanStack Testbeet')).toBeVisible();
+    await expect(page.getByText('TanStack Testfeld bearbeitet')).toBeVisible();
+    await page.getByRole('textbox').first().fill('');
+
+    await grid.focus();
+    await page.keyboard.press('Shift+F10');
+    await expect(page.getByRole('menuitem', { name: 'Anbauplan hinzufügen' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Zeile kopieren' })).toBeVisible();
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/app/fields-beds');
+    await expect(grid).toBeVisible({ timeout: 10_000 });
+    const fitsWithoutExtraHorizontalScroll = await grid.evaluate((element) =>
+      element.scrollWidth <= element.clientWidth + 2);
+    expect(fitsWithoutExtraHorizontalScroll).toBe(true);
+  });
+
+  test('keeps a larger expanded hierarchy virtualized while scrolling', async ({ page, request }) => {
+    await loginWithDeterministicProject(page, request, 'tanstack-spike-large');
+    await page.waitForLoadState('networkidle');
+    const locations = await getApi<{ results: { id: number }[] }>(page, '/locations/');
+    const location = locations.results[0];
+    if (!location) {
+      throw new Error('Expected the e2e fixture to provide a default location.');
+    }
+    const field = await postApi<{ id: number }>(page, '/fields/', {
+      name: 'TanStack Large Feld',
+      location: location.id,
+      area_sqm: 1000,
+      length_m: 100,
+      width_m: 10,
+    });
+
+    for (let index = 0; index < 90; index += 1) {
+      await postApi<{ id: number }>(page, '/beds/', {
+        name: `TanStack Large Beet ${String(index + 1).padStart(3, '0')}`,
+        field: field.id,
+        area_sqm: 1,
+        length_m: 1,
+        width_m: 1,
+      });
+    }
+
+    await page.evaluate(() => window.localStorage.setItem('fieldsBedsViewMode', 'table'));
+    const start = Date.now();
+    await page.goto('/app/fields-beds');
+    const grid = page.getByTestId('tanstack-hierarchy-grid');
+    await expect(grid).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('TanStack Large Beet 001')).toBeVisible({ timeout: 10_000 });
+    expect(Date.now() - start).toBeLessThan(10_000);
+
+    const renderedRows = await page.locator('[data-testid^="tanstack-row-"]').count();
+    expect(renderedRows).toBeLessThan(100);
+
+    await grid.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+      element.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    await expect(page.getByText('TanStack Large Beet 090')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@mui/icons-material": "^7.3.6",
         "@mui/material": "^7.3.6",
         "@mui/x-data-grid": "^8.20.0",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.5",
         "axios": "^1.13.2",
         "date-fns": "^4.1.0",
         "html2canvas": "^1.4.1",
@@ -3043,6 +3045,66 @@
       "peerDependencies": {
         "@stryker-mutator/core": "9.5.1",
         "vitest": ">=2.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,8 @@
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",
     "@mui/x-data-grid": "^8.20.0",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "axios": "^1.13.2",
     "date-fns": "^4.1.0",
     "html2canvas": "^1.4.1",

--- a/frontend/src/__tests__/FieldsBedsPage.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsPage.test.tsx
@@ -16,7 +16,7 @@ const projectRequirementState = vi.hoisted(() => ({
   missingProjectReason: null as null | 'no_projects' | 'no_active_project',
 }));
 
-vi.mock('../pages/FieldsBedsHierarchy', () => ({
+vi.mock('../pages/FieldsBedsTanStackHierarchy', () => ({
   default: ({ createFieldRequest }: { createFieldRequest?: number }) => (
     <div>
       <div>Hierarchieansicht</div>

--- a/frontend/src/__tests__/FieldsBedsTanStackHierarchy.test.tsx
+++ b/frontend/src/__tests__/FieldsBedsTanStackHierarchy.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import FieldsBedsTanStackHierarchy from '../pages/FieldsBedsTanStackHierarchy';
+import { mockT } from './helpers/testI18n';
+
+const { bedListMock, fieldListMock, locationListMock } = vi.hoisted(() => ({
+  bedListMock: vi.fn(),
+  fieldListMock: vi.fn(),
+  locationListMock: vi.fn(),
+}));
+
+vi.mock('../i18n', () => ({ useTranslation: () => ({ t: mockT }) }));
+vi.mock('../hooks/autosave', () => ({ useNavigationBlocker: vi.fn() }));
+
+vi.mock('../api/api', async () => {
+  const actual = await vi.importActual<typeof import('../api/api')>('../api/api');
+  return {
+    ...actual,
+    bedAPI: { create: vi.fn(), delete: vi.fn(), list: bedListMock, update: vi.fn() },
+    fieldAPI: { create: vi.fn(), delete: vi.fn(), list: fieldListMock, update: vi.fn() },
+    locationAPI: { create: vi.fn(), delete: vi.fn(), list: locationListMock, update: vi.fn() },
+  };
+});
+
+const renderHierarchy = () =>
+  render(
+    <MemoryRouter initialEntries={['/app/fields-beds']}>
+      <FieldsBedsTanStackHierarchy showTitle={false} suppressContextMenuHint />
+    </MemoryRouter>,
+  );
+
+describe('FieldsBedsTanStackHierarchy spike', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 900 });
+  });
+
+  it('fully expands small multi-location hierarchies by default', async () => {
+    locationListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Hofstelle' }, { id: 2, name: 'Aussenfeld' }] },
+    });
+    fieldListMock.mockResolvedValue({
+      data: { results: [{ id: 10, name: 'Nord', location: 1, area_sqm: 100 }] },
+    });
+    bedListMock.mockResolvedValue({
+      data: { results: [{ id: 100, name: 'Nordbeet', field: 10, area_sqm: 20 }] },
+    });
+
+    renderHierarchy();
+
+    await waitFor(() => expect(screen.getByTestId('tanstack-row-location-1')).toBeInTheDocument());
+    expect(screen.getByTestId('tanstack-row-field-10')).toBeInTheDocument();
+    expect(screen.getByTestId('tanstack-row-100')).toBeInTheDocument();
+  });
+
+  it('keeps large hierarchies scannable by leaving bed rows collapsed initially', async () => {
+    const FIELD_COUNT = 250;
+    locationListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Hofstelle' }, { id: 2, name: 'Aussenfeld' }] },
+    });
+    fieldListMock.mockResolvedValue({
+      data: {
+        results: Array.from({ length: FIELD_COUNT }, (_, index) => ({
+          id: index + 1,
+          name: `Parzelle ${index + 1}`,
+          location: 1,
+          area_sqm: 100,
+        })),
+      },
+    });
+    bedListMock.mockResolvedValue({
+      data: { results: [{ id: 100, name: 'Beet 1', field: 1, area_sqm: 20 }] },
+    });
+
+    renderHierarchy();
+
+    await waitFor(() => expect(screen.getByTestId('tanstack-row-location-1')).toBeInTheDocument());
+    expect(screen.getByTestId('tanstack-row-field-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('tanstack-row-100')).not.toBeInTheDocument();
+  });
+
+  it('filters per column while keeping ancestor rows visible for context', async () => {
+    const user = userEvent.setup();
+    locationListMock.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Hofstelle' }, { id: 2, name: 'Aussenfeld' }] },
+    });
+    fieldListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 10, name: 'Nord', location: 1, area_sqm: 100 },
+          { id: 20, name: 'Sued', location: 2, area_sqm: 100 },
+        ],
+      },
+    });
+    bedListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 100, name: 'Nordbeet', field: 10, area_sqm: 20 },
+          { id: 200, name: 'Suedbeet', field: 20, area_sqm: 20 },
+        ],
+      },
+    });
+
+    renderHierarchy();
+
+    await waitFor(() => expect(screen.getByTestId('tanstack-row-100')).toBeInTheDocument());
+    await user.type(screen.getAllByRole('textbox')[0], 'Suedbeet');
+
+    await waitFor(() => expect(screen.queryByTestId('tanstack-row-100')).not.toBeInTheDocument());
+    expect(screen.getByTestId('tanstack-row-location-2')).toBeInTheDocument();
+    expect(screen.getByTestId('tanstack-row-field-20')).toBeInTheDocument();
+    expect(screen.getByTestId('tanstack-row-200')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -1,7 +1,7 @@
 import { Alert, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Link, TextField, Typography, useMediaQuery } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
-import FieldsBedsHierarchy from './FieldsBedsHierarchy';
+import FieldsBedsHierarchy from './FieldsBedsTanStackHierarchy';
 import GraphicalFields from './GraphicalFields';
 import { AddBedIcon } from '../components/hierarchy/AddBedIcon';
 import { HierarchyAddIcon } from '../components/hierarchy/HierarchyAddIcon';

--- a/frontend/src/pages/FieldsBedsTanStackHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsTanStackHierarchy.tsx
@@ -1,0 +1,1640 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type ColumnSizingState,
+  type SortingState,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { GridRowModes, type GridRowModesModel } from "@mui/x-data-grid";
+import {
+  Alert,
+  Box,
+  IconButton,
+  InputBase,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from "@mui/material";
+import Divider from "@mui/material/Divider";
+import AddIcon from "@mui/icons-material/Add";
+import AgricultureIcon from "@mui/icons-material/Agriculture";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import DeleteIcon from "@mui/icons-material/Delete";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import SaveIcon from "@mui/icons-material/Save";
+import CloseIcon from "@mui/icons-material/Close";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import EmptyStateCard from "../components/project/EmptyStateCard";
+import {
+  ContextMenuHint,
+  DeleteUndoSnackbar,
+  NotesCell,
+  NotesDrawer,
+  TableCopyMenuItems,
+  getPlainExcerpt,
+  useContextMenuHint,
+  useNotesEditor,
+} from "../components/data-grid";
+import { handleContextMenuKeyboardNavigation } from "../components/data-grid/contextMenuFocus";
+import { useNavigationBlocker } from "../hooks/autosave";
+import { usePersistentSortModel } from "../hooks/usePersistentSortModel";
+import { useTranslation } from "../i18n";
+import { bedAPI, fieldAPI, locationAPI, type Field } from "../api/api";
+import { useBedOperations } from "../components/hierarchy/hooks/useBedOperations";
+import { useExpandedState } from "../components/hierarchy/hooks/useExpandedState";
+import { useHierarchyData, type HierarchyDataState } from "../components/hierarchy/hooks/useHierarchyData";
+import { useHierarchyDelete } from "../components/hierarchy/hooks/useHierarchyDelete";
+import { useHierarchyLevelToggle } from "../components/hierarchy/hooks/useHierarchyLevelToggle";
+import { useHierarchyRowUpdate } from "../components/hierarchy/hooks/useHierarchyRowUpdate";
+import { HierarchyAddIcon } from "../components/hierarchy/HierarchyAddIcon";
+import { HierarchyLevelButtons } from "../components/hierarchy/HierarchyLevelToggle";
+import {
+  buildHierarchyIndex,
+  createHierarchyRowsProjector,
+  hasPersistedEntityId,
+  type HierarchySortConfig,
+} from "../components/hierarchy/utils/hierarchyUtils";
+import {
+  isPartiallyFilledNamelessNewHierarchyRow,
+} from "../components/hierarchy/utils/hierarchyRowDraft";
+import {
+  normalizeAreaValue,
+  parseAreaValue,
+  parseDimensionValue,
+} from "../components/hierarchy/utils/hierarchyAreaParsing";
+import type { TreeRowNode } from "../components/hierarchy/utils/treeRows";
+import type { HierarchyRow } from "../components/hierarchy/utils/types";
+
+interface FieldsBedsTanStackHierarchyProps {
+  showTitle?: boolean;
+  createFieldRequest?: number;
+  onCreateFieldRequestHandled?: () => void;
+  hierarchyData?: HierarchyDataState;
+  onPendingDeletionCountChange?: (count: number) => void;
+  suppressContextMenuHint?: boolean;
+}
+
+interface HierarchyRowAction {
+  id: string;
+  label: string;
+  group: "create" | "destructive";
+  color?: "default" | "error";
+  onClick: () => void;
+}
+
+type EditableField = "name" | "length_m" | "width_m";
+
+const HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD = 200;
+const TABLE_BOTTOM_MARGIN_PX = 24;
+const TABLE_MIN_HEIGHT_PX = 240;
+const HEADER_ROW_HEIGHT = 40;
+const FILTER_ROW_HEIGHT = 36;
+const LOCATION_ROW_HEIGHT = 46;
+const FIELD_ROW_HEIGHT = 42;
+const BED_ROW_HEIGHT = 36;
+const TABLE_MIN_WIDTH_PX = 760;
+const FILTERABLE_FIELDS = ["name", "length_m", "width_m", "area_sqm", "notes"] as const;
+
+const defaultColumnSizing: ColumnSizingState = {
+  name: 320,
+  length_m: 120,
+  width_m: 120,
+  area_sqm: 130,
+  notes: 260,
+};
+
+const getRowHeight = (row: HierarchyRow): number => {
+  if (row.type === "location") return LOCATION_ROW_HEIGHT;
+  if (row.type === "field") return FIELD_ROW_HEIGHT;
+  return BED_ROW_HEIGHT;
+};
+
+const getRowKey = (rowId: string | number): string => String(rowId);
+
+const formatHierarchyValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") {
+    return "—";
+  }
+  return String(value);
+};
+
+const getHierarchyAreaValue = (row: HierarchyRow): string => {
+  if (row.type === "location") {
+    return "—";
+  }
+  if (typeof row.length_m === "number" && typeof row.width_m === "number") {
+    return String(Math.round(row.length_m * row.width_m * 10) / 10);
+  }
+  return formatHierarchyValue(row.area_sqm);
+};
+
+const getFilterValue = (row: HierarchyRow, columnId: string): string => {
+  if (columnId === "area_sqm") {
+    return getHierarchyAreaValue(row);
+  }
+  const value = row[columnId];
+  return value === null || value === undefined ? "" : String(value);
+};
+
+const matchesFilters = (row: HierarchyRow, filters: ColumnFiltersState): boolean =>
+  filters.every((filter) => {
+    const filterValue = String(filter.value ?? "").trim().toLocaleLowerCase("de");
+    if (!filterValue) {
+      return true;
+    }
+    return getFilterValue(row, filter.id).toLocaleLowerCase("de").includes(filterValue);
+  });
+
+function applyHierarchyFilters(rows: HierarchyRow[], filters: ColumnFiltersState): HierarchyRow[] {
+  const activeFilters = filters.filter((filter) => String(filter.value ?? "").trim() !== "");
+  if (activeFilters.length === 0) {
+    return rows;
+  }
+
+  const rowsById = new Map(rows.map((row) => [getRowKey(row.id), row]));
+  const visibleIds = new Set<string>();
+
+  rows.forEach((row) => {
+    if (!matchesFilters(row, activeFilters)) {
+      return;
+    }
+
+    let current: HierarchyRow | undefined = row;
+    while (current) {
+      visibleIds.add(getRowKey(current.id));
+      current = current.parentId !== undefined ? rowsById.get(getRowKey(current.parentId)) : undefined;
+    }
+  });
+
+  return rows.filter((row) => visibleIds.has(getRowKey(row.id)));
+}
+
+function getHierarchyRowClipboardValues(row: HierarchyRow): string[] {
+  return [
+    row.name ?? "",
+    row.type === "location" ? "—" : formatHierarchyValue(row.length_m),
+    row.type === "location" ? "—" : formatHierarchyValue(row.width_m),
+    getHierarchyAreaValue(row),
+    getPlainExcerpt(row.notes ?? "", 120),
+  ];
+}
+
+function FieldsBedsTanStackHierarchy({
+  showTitle = true,
+  createFieldRequest = 0,
+  onCreateFieldRequestHandled,
+  hierarchyData,
+  onPendingDeletionCountChange,
+  suppressContextMenuHint = false,
+}: FieldsBedsTanStackHierarchyProps) {
+  const { t } = useTranslation(["hierarchy", "common"]);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isTouchLikePointer = useMediaQuery("(pointer: coarse)");
+  const isMobileViewport = useMediaQuery("(max-width:900px)");
+  const tableWrapperRef = useRef<HTMLDivElement | null>(null);
+  const scrollParentRef = useRef<HTMLDivElement | null>(null);
+  const contextMenuListRef = useRef<HTMLUListElement | null>(null);
+  const scrollToRowRef = useRef<(rowId: string | number) => void>(() => undefined);
+  const hasInitiallyExpandedRef = useRef(false);
+  const handledCreateFieldRequestRef = useRef(0);
+  const highlightClearTimeoutRef = useRef<number | null>(null);
+  const rowSnapshotRef = useRef<Map<string, HierarchyRow>>(new Map());
+
+  const internalHierarchyData = useHierarchyData(hierarchyData === undefined);
+  const {
+    loading,
+    error,
+    setError,
+    locations,
+    setLocations,
+    fields,
+    beds,
+    setBeds,
+    setFields,
+    fetchData,
+  } = hierarchyData ?? internalHierarchyData;
+
+  const {
+    expandedRows,
+    hasPersistedState,
+    toggleExpand,
+    ensureExpanded,
+    expandAll,
+  } = useExpandedState("fieldsBedsHierarchyTanStack");
+
+  const { sortModel, setSortModel } = usePersistentSortModel({
+    tableKey: "fieldsBedsHierarchyTanStack",
+    allowedFields: ["name", "area_sqm"],
+    persistInUrl: true,
+  });
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(defaultColumnSizing);
+  const [selectedRowId, setSelectedRowId] = useState<string | number | null>(null);
+  const [editingRowId, setEditingRowId] = useState<string | number | null>(null);
+  const [editingDraft, setEditingDraft] = useState<HierarchyRow | null>(null);
+  const [draftValidationWarning, setDraftValidationWarning] = useState("");
+  const [highlightedRowId, setHighlightedRowId] = useState<string | number | null>(null);
+  const [contextMenuState, setContextMenuState] = useState<{
+    row: HierarchyRow;
+    mouseX: number;
+    mouseY: number;
+  } | null>(null);
+  const [availableTableHeight, setAvailableTableHeight] = useState<number | null>(null);
+
+  const sorting = useMemo<SortingState>(
+    () => sortModel
+      .filter((item) => item.sort === "asc" || item.sort === "desc")
+      .map((item) => ({ id: item.field, desc: item.sort === "desc" })),
+    [sortModel],
+  );
+
+  const hierarchySortConfig = useMemo<HierarchySortConfig | undefined>(() => {
+    const [firstSort] = sortModel;
+    if (!firstSort || !firstSort.sort) {
+      return undefined;
+    }
+
+    return {
+      field: firstSort.field,
+      direction: firstSort.sort,
+    };
+  }, [sortModel]);
+
+  const { addBed, saveBed, pendingEditRow, setPendingEditRow } =
+    useBedOperations(setBeds, setError, t);
+  const [pendingFieldEditRow, setPendingFieldEditRow] = useState<string | number | null>(null);
+
+  const hierarchyIndex = useMemo(
+    () => buildHierarchyIndex(locations, fields, beds, hierarchySortConfig),
+    [locations, fields, beds, hierarchySortConfig],
+  );
+  const projectRows = useMemo(
+    () => createHierarchyRowsProjector(hierarchyIndex),
+    [hierarchyIndex],
+  );
+
+  const hierarchyTreeNodes = useMemo<TreeRowNode[]>(() => {
+    const nodes: TreeRowNode[] = [];
+    const hasMultipleLocations = locations.length > 1;
+
+    if (hasMultipleLocations) {
+      locations.forEach((locationItem) => {
+        if (!hasPersistedEntityId(locationItem.id)) return;
+        nodes.push({ id: `location-${locationItem.id}`, parentId: null });
+      });
+    }
+
+    fields.forEach((field) => {
+      if (!hasPersistedEntityId(field.id)) return;
+      nodes.push({
+        id: `field-${field.id}`,
+        parentId: hasMultipleLocations ? `location-${field.location}` : null,
+      });
+    });
+
+    beds.forEach((bed) => {
+      if (!hasPersistedEntityId(bed.id) || !hasPersistedEntityId(bed.field)) return;
+      nodes.push({ id: bed.id, parentId: `field-${bed.field}` });
+    });
+
+    return nodes;
+  }, [beds, fields, locations]);
+
+  const allExpandableIds = useMemo(
+    () => hierarchyTreeNodes.map((node) => node.id),
+    [hierarchyTreeNodes],
+  );
+
+  const rawRows = useMemo(
+    () => projectRows(expandedRows),
+    [expandedRows, projectRows],
+  );
+  const allRows = useMemo(
+    () => projectRows(new Set(allExpandableIds)),
+    [allExpandableIds, projectRows],
+  );
+  const hasActiveFilters = columnFilters.some((filter) => String(filter.value ?? "").trim() !== "");
+  const rows = useMemo(
+    () => applyHierarchyFilters(hasActiveFilters ? allRows : rawRows, columnFilters),
+    [allRows, columnFilters, hasActiveFilters, rawRows],
+  );
+  const rowsRef = useRef(rows);
+  useLayoutEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
+
+  const rowsById = useMemo(() => {
+    const nextRowsById = new Map<string, HierarchyRow>();
+    rows.forEach((row) => nextRowsById.set(getRowKey(row.id), row));
+    return nextRowsById;
+  }, [rows]);
+
+  const getDraftRow = useCallback((rowId: string | number): HierarchyRow | null => {
+    if (editingDraft && getRowKey(editingDraft.id) === getRowKey(rowId)) {
+      return editingDraft;
+    }
+    return rowsById.get(getRowKey(rowId)) ?? null;
+  }, [editingDraft, rowsById]);
+
+  const noopSetRowModesModel = useCallback((_value: React.SetStateAction<GridRowModesModel>): void => undefined, []);
+
+  const {
+    discardRowEdit,
+    processRowUpdate,
+    handleProcessRowUpdateError,
+  } = useHierarchyRowUpdate({
+    getDraftRow,
+    rowModesModel: editingRowId === null ? {} : { [editingRowId]: { mode: GridRowModes.Edit } },
+    rowsById,
+    beds,
+    fields,
+    locations,
+    setBeds,
+    setFields,
+    setLocations,
+    rowSnapshotRef,
+    setRowModesModel: noopSetRowModesModel,
+    setError,
+    setDraftValidationWarning,
+    fetchData,
+    saveBed,
+    t,
+  });
+
+  const {
+    pendingDeletions,
+    deleteHierarchyRowWithUndo,
+    undoPendingDeletion,
+    closePendingDeletionSnackbar,
+  } = useHierarchyDelete({
+    locations,
+    fields,
+    beds,
+    expandedRows,
+    fetchData,
+    expandAll,
+    setLocations,
+    setFields,
+    setBeds,
+    setSelectedRowId,
+    setError,
+    onPendingDeletionCountChange,
+    t,
+    rowSnapshotRef,
+    setDraftValidationWarning,
+  });
+
+  const shouldShowHierarchyTable =
+    hierarchyIndex.hasMultipleLocations || fields.length > 0 || createFieldRequest > 0;
+  const hasUsableHierarchyRows = shouldShowHierarchyTable && (
+    rows.length > 0 ||
+    locations.length > 0 ||
+    fields.length > 0 ||
+    beds.length > 0
+  );
+  const { showContextMenuHint, closeContextMenuHint, markContextMenuHintUsed } = useContextMenuHint({
+    enabled: !suppressContextMenuHint,
+    isLoading: loading,
+    hasRows: hasUsableHierarchyRows,
+  });
+
+  const hierarchyLevelToggle = useHierarchyLevelToggle(hierarchyTreeNodes, expandedRows, expandAll);
+
+  const notesEditor = useNotesEditor<HierarchyRow>({
+    rows,
+    onSave: async ({ row, value }) => {
+      if (!row.name) {
+        throw new Error(t("validation.nameRequired"));
+      }
+
+      const parsedArea = parseAreaValue(row.area_sqm);
+
+      if (row.type === "bed" && row.bedId) {
+        await bedAPI.update(row.bedId, {
+          name: row.name,
+          field: row.field!,
+          area_sqm: normalizeAreaValue(parsedArea),
+          length_m: parseDimensionValue(row.length_m),
+          width_m: parseDimensionValue(row.width_m),
+          notes: value,
+        });
+        setBeds((previousBeds) =>
+          previousBeds.map((bed) => (bed.id === row.bedId ? { ...bed, notes: value } : bed)),
+        );
+      } else if (row.type === "field" && row.fieldId) {
+        await fieldAPI.update(row.fieldId, {
+          name: row.name,
+          location: row.locationId!,
+          area_sqm: normalizeAreaValue(parsedArea),
+          length_m: parseDimensionValue(row.length_m),
+          width_m: parseDimensionValue(row.width_m),
+          notes: value,
+        });
+        setFields((previousFields) =>
+          previousFields.map((field) => (field.id === row.fieldId ? { ...field, notes: value } : field)),
+        );
+      } else if (row.type === "location" && row.locationId) {
+        const locationItem = locations.find((item) => item.id === row.locationId);
+        if (!locationItem) return;
+        await locationAPI.update(row.locationId, { ...locationItem, notes: value });
+        setLocations((previousLocations) =>
+          previousLocations.map((item) => (item.id === row.locationId ? { ...item, notes: value } : item)),
+        );
+      }
+    },
+    onError: setError,
+  });
+
+  useEffect(() => {
+    if (
+      !hasPersistedState &&
+      !hasInitiallyExpandedRef.current &&
+      locations.length > 0 &&
+      fields.length > 0
+    ) {
+      const canFullyExpand =
+        locations.length + fields.length + beds.length <= HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD;
+      const expandedIds = new Set<string | number>();
+      locations.forEach((locationItem) => expandedIds.add(`location-${locationItem.id}`));
+      if (canFullyExpand) {
+        fields.forEach((field) => expandedIds.add(`field-${field.id}`));
+      }
+      expandAll(Array.from(expandedIds));
+      hasInitiallyExpandedRef.current = true;
+    }
+  }, [beds.length, expandAll, fields, hasPersistedState, locations]);
+
+  useEffect(() => {
+    if (pendingEditRow === null) return;
+    const row = rows.find((item) => item.id === pendingEditRow);
+    if (!row) return;
+    setEditingRowId(row.id);
+    setEditingDraft(row);
+    setSelectedRowId(row.id);
+    setPendingEditRow(null);
+  }, [pendingEditRow, rows, setPendingEditRow]);
+
+  useEffect(() => {
+    if (pendingFieldEditRow === null) return;
+    const row = rows.find((item) => item.id === pendingFieldEditRow);
+    if (!row) return;
+    setEditingRowId(row.id);
+    setEditingDraft(row);
+    setSelectedRowId(row.id);
+    setPendingFieldEditRow(null);
+  }, [pendingFieldEditRow, rows]);
+
+  const handleAddField = useCallback((locationId: number): void => {
+    const locationItem = locations.find((item) => item.id === locationId);
+    if (!locationItem) return;
+
+    const newFieldId = -Date.now();
+    const newField: Field = {
+      id: newFieldId,
+      name: "",
+      location: locationId,
+      area_sqm: undefined,
+      length_m: null,
+      width_m: null,
+      notes: "",
+    };
+
+    ensureExpanded(`location-${locationId}`);
+    setFields((previousFields) => [newField, ...previousFields]);
+    setPendingFieldEditRow(`field-${newFieldId}`);
+  }, [ensureExpanded, locations, setFields]);
+
+  const handleAddBed = useCallback((fieldId: number): void => {
+    const field = fields.find((item) => item.id === fieldId);
+    if (!field) return;
+    ensureExpanded(`field-${fieldId}`);
+    setPendingEditRow(addBed(fieldId));
+  }, [addBed, ensureExpanded, fields, setPendingEditRow]);
+
+  useEffect(() => {
+    if (!location.pathname.startsWith("/app/fields-beds")) return;
+
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get("createBed") !== "true" || loading) return;
+
+    const firstField = fields.find((field) => field.id !== undefined);
+    if (firstField?.id !== undefined) {
+      handleAddBed(firstField.id);
+    }
+
+    searchParams.delete("createBed");
+    const nextSearch = searchParams.toString();
+    navigate({ pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : "" }, { replace: true });
+  }, [fields, handleAddBed, loading, location.pathname, location.search, navigate]);
+
+  useEffect(() => {
+    if (
+      createFieldRequest <= 0 ||
+      loading ||
+      createFieldRequest <= handledCreateFieldRequestRef.current
+    ) {
+      return;
+    }
+
+    const hasActiveFieldDraft = fields.some((field) => typeof field.id === "number" && field.id < 0);
+    const firstLocationId = locations.find((locationItem) => locationItem.id !== undefined)?.id;
+    if (!hasActiveFieldDraft && firstLocationId === undefined) {
+      return;
+    }
+
+    handledCreateFieldRequestRef.current = createFieldRequest;
+    if (!hasActiveFieldDraft && firstLocationId !== undefined) {
+      handleAddField(firstLocationId);
+    }
+    onCreateFieldRequestHandled?.();
+  }, [createFieldRequest, fields, handleAddField, loading, locations, onCreateFieldRequestHandled]);
+
+  useEffect(() => () => {
+    if (highlightClearTimeoutRef.current !== null) {
+      window.clearTimeout(highlightClearTimeoutRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!location.pathname.startsWith("/app/fields-beds")) return;
+
+    const searchParams = new URLSearchParams(location.search);
+    const highlightParam = searchParams.get("highlight");
+    if (!highlightParam || loading) return;
+
+    const [highlightType, highlightIdRaw] = highlightParam.split(":");
+    const highlightId = Number(highlightIdRaw);
+    let targetRowId: string | number | null = null;
+    let locationIdToExpand: number | undefined;
+    let fieldIdToExpand: number | undefined;
+
+    if (Number.isFinite(highlightId)) {
+      if (highlightType === "location") {
+        targetRowId = `location-${highlightId}`;
+      } else if (highlightType === "field") {
+        const field = fields.find((entry) => entry.id === highlightId);
+        targetRowId = `field-${highlightId}`;
+        locationIdToExpand = field?.location;
+      } else if (highlightType === "bed") {
+        const bed = beds.find((entry) => entry.id === highlightId);
+        const field = bed ? fields.find((entry) => entry.id === bed.field) : undefined;
+        targetRowId = highlightId;
+        fieldIdToExpand = bed?.field;
+        locationIdToExpand = field?.location;
+      }
+    }
+
+    if (targetRowId !== null) {
+      if (locationIdToExpand !== undefined) ensureExpanded(`location-${locationIdToExpand}`);
+      if (fieldIdToExpand !== undefined) ensureExpanded(`field-${fieldIdToExpand}`);
+      setSelectedRowId(targetRowId);
+      setHighlightedRowId(targetRowId);
+      requestAnimationFrame(() => scrollToRowRef.current(targetRowId));
+
+      if (highlightClearTimeoutRef.current !== null) {
+        window.clearTimeout(highlightClearTimeoutRef.current);
+      }
+      highlightClearTimeoutRef.current = window.setTimeout(() => {
+        setHighlightedRowId(null);
+        highlightClearTimeoutRef.current = null;
+      }, 2500);
+    }
+
+    searchParams.delete("highlight");
+    const nextSearch = searchParams.toString();
+    navigate({ pathname: location.pathname, search: nextSearch ? `?${nextSearch}` : "" }, { replace: true });
+  }, [beds, ensureExpanded, fields, loading, location.pathname, location.search, navigate]);
+
+  useLayoutEffect(() => {
+    if (isMobileViewport) {
+      setAvailableTableHeight(null);
+      return;
+    }
+
+    const measure = (): void => {
+      const wrapper = tableWrapperRef.current;
+      if (!wrapper) return;
+      const top = wrapper.getBoundingClientRect().top;
+      setAvailableTableHeight(Math.max(TABLE_MIN_HEIGHT_PX, window.innerHeight - top - TABLE_BOTTOM_MARGIN_PX));
+    };
+
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [
+    isMobileViewport,
+    error,
+    draftValidationWarning,
+    showContextMenuHint,
+    shouldShowHierarchyTable,
+  ]);
+
+  const tableContentHeight = useMemo(
+    () => HEADER_ROW_HEIGHT + FILTER_ROW_HEIGHT + rows.reduce((sum, row) => sum + getRowHeight(row), 0),
+    [rows],
+  );
+  const tableHeight = isMobileViewport
+    ? tableContentHeight
+    : Math.min(tableContentHeight, availableTableHeight ?? tableContentHeight);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollParentRef.current,
+    estimateSize: (index) => getRowHeight(rows[index] ?? { type: "bed" } as HierarchyRow),
+    initialRect: {
+      width: TABLE_MIN_WIDTH_PX,
+      height: Math.max(TABLE_MIN_HEIGHT_PX, tableHeight),
+    },
+    overscan: 10,
+    getItemKey: (index) => rows[index]?.id ?? index,
+  });
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const renderedVirtualItems = virtualItems.length > 0
+    ? virtualItems
+    : rows.slice(0, Math.min(rows.length, 80)).map((row, index) => {
+      const start = rows.slice(0, index).reduce((sum, currentRow) => sum + getRowHeight(currentRow), 0);
+      return {
+        index,
+        key: row.id,
+        start,
+        end: start + getRowHeight(row),
+        size: getRowHeight(row),
+        lane: 0,
+      };
+    });
+
+  const scrollToRow = useCallback((rowId: string | number): void => {
+    const index = rowsRef.current.findIndex((row) => getRowKey(row.id) === getRowKey(rowId));
+    if (index >= 0) {
+      rowVirtualizer.scrollToIndex(index, { align: "center" });
+    }
+  }, [rowVirtualizer]);
+
+  useLayoutEffect(() => {
+    scrollToRowRef.current = scrollToRow;
+  }, [scrollToRow]);
+
+  const startEdit = useCallback((row: HierarchyRow): void => {
+    if (row.type === "location" || row.type === "field" || row.type === "bed") {
+      rowSnapshotRef.current.set(getRowKey(row.id), row);
+      setEditingRowId(row.id);
+      setEditingDraft(row);
+      setSelectedRowId(row.id);
+    }
+  }, []);
+
+  const cancelEdit = useCallback((): void => {
+    if (editingRowId !== null) {
+      discardRowEdit(editingRowId);
+    }
+    setEditingRowId(null);
+    setEditingDraft(null);
+  }, [discardRowEdit, editingRowId]);
+
+  const saveEdit = useCallback(async (): Promise<void> => {
+    if (!editingDraft) return;
+
+    try {
+      const savedRow = await processRowUpdate(editingDraft);
+      setSelectedRowId(savedRow.id);
+      setEditingRowId(null);
+      setEditingDraft(null);
+      setError("");
+    } catch (err) {
+      handleProcessRowUpdateError(err instanceof Error ? err : new Error(t("errors.save")));
+    }
+  }, [editingDraft, handleProcessRowUpdateError, processRowUpdate, setError, t]);
+
+  const handleDraftChange = useCallback((field: EditableField, value: string): void => {
+    setEditingDraft((currentDraft) => {
+      if (!currentDraft) return currentDraft;
+      return {
+        ...currentDraft,
+        [field]: field === "name" ? value : value === "" ? null : value,
+      };
+    });
+  }, []);
+
+  const handleCreatePlantingPlan = useCallback((bedId: number): void => {
+    navigate(`/app/planting-plans?bedId=${bedId}`);
+  }, [navigate]);
+
+  const closeContextMenu = useCallback((): void => {
+    setContextMenuState(null);
+  }, []);
+
+  const openContextMenu = useCallback((
+    event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+    row: HierarchyRow,
+  ): void => {
+    event.preventDefault();
+    markContextMenuHintUsed();
+    setSelectedRowId(row.id);
+
+    if ("clientX" in event && event.clientX !== 0) {
+      setContextMenuState({ row, mouseX: event.clientX + 2, mouseY: event.clientY - 6 });
+      return;
+    }
+
+    const element = event.currentTarget;
+    const rect = element.getBoundingClientRect();
+    setContextMenuState({ row, mouseX: rect.left + 24, mouseY: rect.top + 24 });
+  }, [markContextMenuHintUsed]);
+
+  const getHierarchyRowActions = useCallback((row: HierarchyRow): HierarchyRowAction[] => {
+    const createActions: HierarchyRowAction[] = [];
+
+    if (row.type === "location" && row.locationId) {
+      createActions.push({
+        id: "add-field",
+        label: t("actions.addField"),
+        group: "create",
+        onClick: () => handleAddField(row.locationId!),
+      });
+    }
+
+    if (row.type === "field" && row.fieldId) {
+      createActions.push({
+        id: "add-bed",
+        label: t("actions.addBed"),
+        group: "create",
+        onClick: () => handleAddBed(row.fieldId!),
+      });
+    }
+
+    if (row.type === "bed" && row.bedId) {
+      createActions.push({
+        id: "create-planting-plan",
+        label: t("createPlantingPlan"),
+        group: "create",
+        onClick: () => handleCreatePlantingPlan(row.bedId!),
+      });
+    }
+
+    return [
+      ...createActions,
+      {
+        id: "delete",
+        label: t("common:actions.delete"),
+        group: "destructive",
+        color: "error",
+        onClick: () => {
+          void deleteHierarchyRowWithUndo(row);
+        },
+      },
+    ];
+  }, [deleteHierarchyRowWithUndo, handleAddBed, handleAddField, handleCreatePlantingPlan, t]);
+
+  const contextMenuActions = contextMenuState ? getHierarchyRowActions(contextMenuState.row) : [];
+
+  const updateSorting = useCallback((columnId: string): void => {
+    const current = sorting[0];
+    if (current?.id !== columnId) {
+      setSortModel([{ field: columnId, sort: "asc" }]);
+      return;
+    }
+    if (!current.desc) {
+      setSortModel([{ field: columnId, sort: "desc" }]);
+      return;
+    }
+    setSortModel([]);
+  }, [setSortModel, sorting]);
+
+  const handleColumnFilterChange = useCallback((columnId: string, value: string): void => {
+    setColumnFilters((currentFilters) => {
+      const nextFilters = currentFilters.filter((filter) => filter.id !== columnId);
+      if (value.trim() !== "") {
+        nextFilters.push({ id: columnId, value });
+      }
+      return nextFilters;
+    });
+  }, []);
+
+  const columns = useMemo<ColumnDef<HierarchyRow>[]>(() => [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: () => (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, minWidth: 0 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>{t("columns.name")}</Typography>
+          {!isMobileViewport ? (
+            <HierarchyLevelButtons
+              canExpand={hierarchyLevelToggle.canExpand}
+              canCollapse={hierarchyLevelToggle.canCollapse}
+              onExpandOneLevel={hierarchyLevelToggle.expandOneLevel}
+              onCollapseOneLevel={hierarchyLevelToggle.collapseOneLevel}
+            />
+          ) : null}
+        </Box>
+      ),
+      size: defaultColumnSizing.name,
+      minSize: 220,
+      enableSorting: true,
+      enableColumnFilter: true,
+    },
+    {
+      id: "length_m",
+      accessorKey: "length_m",
+      header: () => t("columns.length"),
+      size: defaultColumnSizing.length_m,
+      minSize: 92,
+      enableSorting: false,
+      enableColumnFilter: true,
+    },
+    {
+      id: "width_m",
+      accessorKey: "width_m",
+      header: () => t("columns.width"),
+      size: defaultColumnSizing.width_m,
+      minSize: 92,
+      enableSorting: false,
+      enableColumnFilter: true,
+    },
+    {
+      id: "area_sqm",
+      accessorFn: getHierarchyAreaValue,
+      header: () => t("columns.area"),
+      size: defaultColumnSizing.area_sqm,
+      minSize: 112,
+      enableSorting: true,
+      enableColumnFilter: true,
+    },
+    {
+      id: "notes",
+      accessorKey: "notes",
+      header: () => t("common:fields.notes"),
+      size: defaultColumnSizing.notes,
+      minSize: 180,
+      enableSorting: false,
+      enableColumnFilter: true,
+    },
+  ], [
+    hierarchyLevelToggle.canCollapse,
+    hierarchyLevelToggle.canExpand,
+    hierarchyLevelToggle.collapseOneLevel,
+    hierarchyLevelToggle.expandOneLevel,
+    isMobileViewport,
+    t,
+  ]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      sorting,
+      columnFilters,
+      columnSizing,
+    },
+    columnResizeMode: "onChange",
+    onColumnSizingChange: setColumnSizing,
+    manualSorting: true,
+    manualFiltering: true,
+  });
+
+  const visibleColumns = table.getVisibleLeafColumns();
+  const gridTemplateColumns = useMemo(() => {
+    if (isMobileViewport) {
+      return "minmax(140px, 1.6fr) minmax(52px, 0.58fr) minmax(52px, 0.58fr) minmax(56px, 0.62fr) minmax(40px, 0.45fr)";
+    }
+
+    const [name, length, width, area] = visibleColumns;
+    const notes = visibleColumns[4];
+    return [
+      `${name?.getSize() ?? defaultColumnSizing.name}px`,
+      `${length?.getSize() ?? defaultColumnSizing.length_m}px`,
+      `${width?.getSize() ?? defaultColumnSizing.width_m}px`,
+      `${area?.getSize() ?? defaultColumnSizing.area_sqm}px`,
+      `minmax(${notes?.columnDef.minSize ?? 180}px, 1fr)`,
+    ].join(" ");
+  }, [isMobileViewport, visibleColumns]);
+
+  const isCellEditable = useCallback((row: HierarchyRow, field: EditableField): boolean => {
+    if (row.type === "location") {
+      return field === "name";
+    }
+    return field === "name" || field === "length_m" || field === "width_m";
+  }, []);
+
+  const renderEditableValue = useCallback((row: HierarchyRow, field: EditableField): React.ReactNode => {
+    const draftRow = editingRowId !== null && getRowKey(editingRowId) === getRowKey(row.id)
+      ? editingDraft
+      : null;
+    if (draftRow && isCellEditable(row, field)) {
+      return (
+        <InputBase
+          autoFocus={field === "name"}
+          value={String(draftRow[field] ?? "")}
+          inputProps={{ "aria-label": String(t(`columns.${field === "length_m" ? "length" : field === "width_m" ? "width" : "name"}`)) }}
+          onChange={(event) => handleDraftChange(field, event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void saveEdit();
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              cancelEdit();
+            }
+          }}
+          sx={{
+            width: "100%",
+            minHeight: 30,
+            px: 0.75,
+            border: "1px solid",
+            borderColor: "primary.main",
+            borderRadius: 1,
+            bgcolor: "background.paper",
+            fontSize: "0.875rem",
+          }}
+        />
+      );
+    }
+
+    if (row.type === "location" && field !== "name") {
+      return "—";
+    }
+    return formatHierarchyValue(row[field]);
+  }, [cancelEdit, editingDraft, editingRowId, handleDraftChange, isCellEditable, saveEdit, t]);
+
+  const renderNameCell = useCallback((row: HierarchyRow): React.ReactNode => {
+    const hasExpandToggle = (row.type === "location" || row.type === "field") && row.hasChildren;
+    const inlineActionsHidden = isTouchLikePointer || isMobileViewport;
+
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", minWidth: 0, width: "100%", gap: 0.5, pl: `${row.level * 24}px` }}>
+        <Box sx={{ width: 32, minWidth: 32, display: "inline-flex", justifyContent: "center" }}>
+          {hasExpandToggle ? (
+            <Tooltip title={row.expanded ? t("tooltips.collapse") : t("tooltips.expand")} disableInteractive>
+              <IconButton
+                size="small"
+                aria-label={row.expanded ? t("tooltips.collapse") : t("tooltips.expand")}
+                tabIndex={-1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  toggleExpand(row.id);
+                }}
+              >
+                {row.expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <Box aria-hidden sx={{ width: 32 }} />
+          )}
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          {renderEditableValue(row, "name")}
+        </Box>
+        {!inlineActionsHidden && editingRowId === null ? (
+          <Box
+            className="ofp-tanstack-row-actions"
+            sx={{ display: "inline-flex", alignItems: "center", gap: 0.25, opacity: 0, transition: "opacity 120ms ease" }}
+          >
+            {row.type === "location" && row.locationId ? (
+              <Tooltip title={t("addField")} disableInteractive>
+                <IconButton size="small" aria-label={t("addField")} tabIndex={-1} onClick={(event) => {
+                  event.stopPropagation();
+                  handleAddField(row.locationId!);
+                }}>
+                  <AddIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+            {row.type === "field" && row.fieldId ? (
+              <Tooltip title={t("addBedToField")} disableInteractive>
+                <IconButton size="small" aria-label={t("addBedToField")} tabIndex={-1} onClick={(event) => {
+                  event.stopPropagation();
+                  handleAddBed(row.fieldId!);
+                }}>
+                  <HierarchyAddIcon interactive={false} ariaHidden sx={{ bgcolor: "transparent" }} />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+            {row.type === "bed" && row.bedId ? (
+              <Tooltip title={t("createPlantingPlan")} disableInteractive>
+                <IconButton size="small" color="primary" aria-label={t("createPlantingPlan")} tabIndex={-1} onClick={(event) => {
+                  event.stopPropagation();
+                  handleCreatePlantingPlan(row.bedId!);
+                }}>
+                  <AgricultureIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+            <Tooltip title={t("common:actions.delete")} disableInteractive>
+              <IconButton size="small" color="error" aria-label={t("common:actions.delete")} tabIndex={-1} onClick={(event) => {
+                event.stopPropagation();
+                void deleteHierarchyRowWithUndo(row);
+              }}>
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t("common:actions.actions")} disableInteractive>
+              <IconButton size="small" aria-label={t("common:actions.actions")} tabIndex={-1} onClick={(event) => openContextMenu(event, row)}>
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        ) : null}
+      </Box>
+    );
+  }, [
+    deleteHierarchyRowWithUndo,
+    editingRowId,
+    handleAddBed,
+    handleAddField,
+    handleCreatePlantingPlan,
+    isMobileViewport,
+    isTouchLikePointer,
+    openContextMenu,
+    renderEditableValue,
+    t,
+    toggleExpand,
+  ]);
+
+  const renderCell = useCallback((row: HierarchyRow, columnId: string): React.ReactNode => {
+    if (columnId === "name") {
+      return renderNameCell(row);
+    }
+    if (columnId === "length_m" || columnId === "width_m") {
+      return renderEditableValue(row, columnId);
+    }
+    if (columnId === "area_sqm") {
+      return getHierarchyAreaValue(row);
+    }
+    if (columnId === "notes") {
+      const rawValue = row.notes ?? "";
+      return (
+        <NotesCell
+          hasValue={rawValue.trim() !== ""}
+          rawValue={rawValue}
+          excerpt={getPlainExcerpt(rawValue, 120)}
+          compactIndicator={isMobileViewport}
+          onOpen={() => notesEditor.handleOpen(row.id, "notes")}
+        />
+      );
+    }
+    return formatHierarchyValue(row[columnId]);
+  }, [isMobileViewport, notesEditor, renderEditableValue, renderNameCell]);
+
+  const moveSelection = useCallback((delta: number): void => {
+    if (rows.length === 0) return;
+    const currentIndex = selectedRowId === null
+      ? -1
+      : rows.findIndex((row) => getRowKey(row.id) === getRowKey(selectedRowId));
+    const nextIndex = Math.max(0, Math.min(rows.length - 1, currentIndex + delta));
+    const nextRow = rows[nextIndex];
+    if (!nextRow) return;
+    setSelectedRowId(nextRow.id);
+    scrollToRow(nextRow.id);
+  }, [rows, scrollToRow, selectedRowId]);
+
+  const handleGridKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>): void => {
+    const target = event.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return;
+    }
+
+    if (editingRowId !== null) {
+      return;
+    }
+
+    const selectedRow = selectedRowId === null ? rows[0] : rowsById.get(getRowKey(selectedRowId));
+    if (!selectedRow) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveSelection(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveSelection(-1);
+    } else if (event.key === "ArrowRight") {
+      if ((selectedRow.type === "location" || selectedRow.type === "field") && selectedRow.hasChildren && !selectedRow.expanded) {
+        event.preventDefault();
+        toggleExpand(selectedRow.id);
+      }
+    } else if (event.key === "ArrowLeft") {
+      if ((selectedRow.type === "location" || selectedRow.type === "field") && selectedRow.expanded) {
+        event.preventDefault();
+        toggleExpand(selectedRow.id);
+      }
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      startEdit(selectedRow);
+    } else if (event.key === "Delete") {
+      event.preventDefault();
+      void deleteHierarchyRowWithUndo(selectedRow);
+    } else if ((event.shiftKey && event.key === "F10") || event.key === "ContextMenu") {
+      event.preventDefault();
+      openContextMenu(event, selectedRow);
+    }
+  }, [
+    deleteHierarchyRowWithUndo,
+    editingRowId,
+    moveSelection,
+    openContextMenu,
+    rows,
+    rowsById,
+    selectedRowId,
+    startEdit,
+    toggleExpand,
+  ]);
+
+  const hasUnsavedInvalidNewRows = useMemo(() => (
+    beds.some((bed) => isPartiallyFilledNamelessNewHierarchyRow({
+      id: bed.id ?? "",
+      type: "bed",
+      level: 0,
+      isNew: typeof bed.id === "number" && bed.id < 0,
+      name: bed.name,
+      field: bed.field,
+      bedId: bed.id,
+      area_sqm: bed.area_sqm,
+      length_m: bed.length_m,
+      width_m: bed.width_m,
+      notes: bed.notes,
+    }))
+  ), [beds]);
+
+  useNavigationBlocker(
+    hasUnsavedInvalidNewRows || editingRowId !== null,
+    hasUnsavedInvalidNewRows
+      ? t("messages.unsavedInvalidRowsNavigationWarning")
+      : t("messages.unsavedRowEditNavigationWarning"),
+  );
+
+  useEffect(() => {
+    if (!hasUnsavedInvalidNewRows) {
+      setDraftValidationWarning("");
+    }
+  }, [hasUnsavedInvalidNewRows]);
+
+  const shouldShowMissingDimensionsHint = useMemo(() => {
+    const hasBeds = beds.length > 0;
+    const allBedsMissingLengthAndWidth = beds.every((bed) => {
+      const length = parseDimensionValue(bed.length_m);
+      const width = parseDimensionValue(bed.width_m);
+      return !Number.isFinite(length ?? NaN) && !Number.isFinite(width ?? NaN);
+    });
+
+    return hasBeds && allBedsMissingLengthAndWidth;
+  }, [beds]);
+
+  const getHierarchyTableClipboardRows = useCallback((): string[][] => [
+    [
+      t("columns.name"),
+      t("columns.length"),
+      t("columns.width"),
+      t("columns.area"),
+      t("common:fields.notes"),
+    ],
+    ...rows.map(getHierarchyRowClipboardValues),
+  ], [rows, t]);
+
+  const renderSortIcon = (columnId: string): React.ReactNode => {
+    const current = sorting[0];
+    if (current?.id !== columnId) {
+      return <UnfoldMoreIcon fontSize="small" color="disabled" />;
+    }
+    return current.desc ? <ArrowDownwardIcon fontSize="small" /> : <ArrowUpwardIcon fontSize="small" />;
+  };
+
+  const renderFilterInput = (columnId: string): React.ReactNode => {
+    const value = columnFilters.find((filter) => filter.id === columnId)?.value ?? "";
+    return (
+      <InputBase
+        value={String(value)}
+        placeholder={t("common:actions.search")}
+        inputProps={{ "aria-label": `${t("common:actions.search")} ${String(table.getColumn(columnId)?.columnDef.header ?? "")}` }}
+        onChange={(event) => handleColumnFilterChange(columnId, event.target.value)}
+        sx={{
+          width: "100%",
+          height: 28,
+          px: 0.75,
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 1,
+          bgcolor: "background.paper",
+          fontSize: "0.8125rem",
+        }}
+      />
+    );
+  };
+
+  return (
+    <div className={showTitle ? "page-container" : undefined}>
+      <Box sx={{ width: "100%", minWidth: 0 }}>
+        {showTitle && <h1>{t("title")}</h1>}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {draftValidationWarning && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {draftValidationWarning}
+          </Alert>
+        )}
+
+        {showContextMenuHint && (
+          <ContextMenuHint
+            message={t("common:messages.contextMenuTableHint")}
+            onClose={closeContextMenuHint}
+            prominent
+            sx={{ mb: 1.5, maxWidth: 560 }}
+          />
+        )}
+
+        {shouldShowMissingDimensionsHint && (
+          <EmptyStateCard
+            title={t("messages.missingDimensionsHint")}
+            description={t("messages.missingDimensionsHintOptional")}
+            containerSx={{ mx: 0 }}
+          />
+        )}
+
+        {shouldShowHierarchyTable ? (
+          <Box
+            ref={tableWrapperRef}
+            sx={{
+              width: "100%",
+              maxWidth: "100%",
+              overflowX: "auto",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              bgcolor: "background.paper",
+            }}
+          >
+            <Box
+              ref={scrollParentRef}
+              role="grid"
+              aria-rowcount={rows.length}
+              tabIndex={0}
+              data-testid="tanstack-hierarchy-grid"
+              onKeyDown={handleGridKeyDown}
+              sx={{
+                height: `${Math.max(TABLE_MIN_HEIGHT_PX, tableHeight)}px`,
+                minWidth: isMobileViewport ? "100%" : `${TABLE_MIN_WIDTH_PX}px`,
+                overflowY: isMobileViewport ? "visible" : "auto",
+                outline: "none",
+                position: "relative",
+              }}
+            >
+              <Box
+                role="rowgroup"
+                sx={{
+                  position: "sticky",
+                  top: 0,
+                  zIndex: 2,
+                  bgcolor: "surface.surfaceBackground",
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                }}
+              >
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <Box
+                    key={headerGroup.id}
+                    role="row"
+                    sx={{
+                      minHeight: HEADER_ROW_HEIGHT,
+                      display: "grid",
+                      gridTemplateColumns,
+                    }}
+                  >
+                    {headerGroup.headers.map((header) => {
+                      const canSort = header.column.getCanSort() && (header.column.id === "name" || header.column.id === "area_sqm");
+                      return (
+                        <Box
+                          key={header.id}
+                          role="columnheader"
+                          aria-sort={
+                            sorting[0]?.id === header.column.id
+                              ? sorting[0].desc ? "descending" : "ascending"
+                              : "none"
+                          }
+                          sx={{
+                            minWidth: 0,
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 0.5,
+                            px: 1,
+                            borderRight: "1px solid",
+                            borderColor: "divider",
+                            fontWeight: 600,
+                            position: "relative",
+                          }}
+                        >
+                          <Box
+                            role={canSort ? "button" : undefined}
+                            tabIndex={canSort ? 0 : undefined}
+                            onClick={canSort ? () => updateSorting(header.column.id) : undefined}
+                            onKeyDown={canSort ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                updateSorting(header.column.id);
+                              }
+                            } : undefined}
+                            sx={{
+                              appearance: "none",
+                              border: 0,
+                              bgcolor: "transparent",
+                              p: 0,
+                              m: 0,
+                              minWidth: 0,
+                              flex: 1,
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 0.5,
+                              color: "inherit",
+                              cursor: canSort ? "pointer" : "default",
+                              textAlign: "left",
+                            }}
+                          >
+                            <Box sx={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              {flexRender(header.column.columnDef.header, header.getContext())}
+                            </Box>
+                            {canSort ? renderSortIcon(header.column.id) : null}
+                          </Box>
+                          {header.column.getCanResize() ? (
+                            <Box
+                              aria-hidden
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              sx={{
+                                position: "absolute",
+                                top: 0,
+                                right: -3,
+                                width: 6,
+                                height: "100%",
+                                cursor: "col-resize",
+                                zIndex: 3,
+                              }}
+                            />
+                          ) : null}
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                ))}
+                <Box
+                  role="row"
+                  sx={{
+                    minHeight: FILTER_ROW_HEIGHT,
+                    display: "grid",
+                    gridTemplateColumns,
+                  }}
+                >
+                  {visibleColumns.map((column) => (
+                    <Box
+                      key={column.id}
+                      role="columnheader"
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        px: 0.75,
+                        py: 0.5,
+                        borderRight: "1px solid",
+                        borderColor: "divider",
+                      }}
+                    >
+                      {FILTERABLE_FIELDS.includes(column.id as typeof FILTERABLE_FIELDS[number]) ? renderFilterInput(column.id) : null}
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+
+              <Box
+                role="rowgroup"
+                sx={{
+                  height: `${rowVirtualizer.getTotalSize()}px`,
+                  minHeight: rows.length === 0 ? 96 : 0,
+                  position: "relative",
+                }}
+              >
+                {loading ? (
+                  <Box sx={{ p: 2 }}>{t("common:messages.loading")}</Box>
+                ) : rows.length === 0 ? (
+                  <Box sx={{ p: 2 }}>{t("common:messages.noData")}</Box>
+                ) : (
+                  renderedVirtualItems.map((virtualRow) => {
+                    const row = rows[virtualRow.index];
+                    if (!row) return null;
+                    const isSelected = selectedRowId !== null && getRowKey(selectedRowId) === getRowKey(row.id);
+                    const isHighlighted = highlightedRowId !== null && getRowKey(highlightedRowId) === getRowKey(row.id);
+                    const isEditing = editingRowId !== null && getRowKey(editingRowId) === getRowKey(row.id);
+
+                    return (
+                      <Box
+                        key={row.id}
+                        role="row"
+                        aria-selected={isSelected}
+                        data-id={row.id}
+                        data-testid={`tanstack-row-${row.id}`}
+                        data-row-type={row.type}
+                        onClick={() => setSelectedRowId(row.id)}
+                        onDoubleClick={() => startEdit(row)}
+                        onContextMenu={(event) => openContextMenu(event, row)}
+                        sx={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          width: "100%",
+                          height: `${virtualRow.size}px`,
+                          transform: `translateY(${virtualRow.start}px)`,
+                          display: "grid",
+                          gridTemplateColumns,
+                          bgcolor: isSelected ? "surface.surfaceBackground" : "background.paper",
+                          boxShadow: isSelected ? "inset 0 0 0 1px rgba(37, 111, 42, 0.24)" : undefined,
+                          animation: isHighlighted ? "ofp-tanstack-row-highlight-flash 2.5s ease-out" : undefined,
+                          "&:hover": {
+                            bgcolor: "surface.surfaceHoverBackground",
+                          },
+                          "&:hover .ofp-tanstack-row-actions": {
+                            opacity: 1,
+                          },
+                          "@keyframes ofp-tanstack-row-highlight-flash": {
+                            "0%": { backgroundColor: "rgba(37, 111, 42, 0.22)" },
+                            "70%": { backgroundColor: "rgba(37, 111, 42, 0.14)" },
+                            "100%": { backgroundColor: "transparent" },
+                          },
+                        }}
+                      >
+                        {visibleColumns.map((column) => (
+                          <Box
+                            key={column.id}
+                            role="gridcell"
+                            data-field={column.id}
+                            sx={{
+                              minWidth: 0,
+                              px: 1,
+                              display: "flex",
+                              alignItems: "center",
+                              borderRight: "1px solid",
+                              borderBottom: "1px solid",
+                              borderColor: "divider",
+                              overflow: "hidden",
+                              color: row.type === "location" ? "text.primary" : undefined,
+                              fontWeight: row.type === "location" ? 600 : row.type === "field" ? 500 : 400,
+                              bgcolor: column.id === "area_sqm" ? "#F5F5F5" : undefined,
+                            }}
+                          >
+                            <Box sx={{ minWidth: 0, width: "100%", overflow: "hidden", textOverflow: "ellipsis" }}>
+                              {renderCell(row, column.id)}
+                            </Box>
+                          </Box>
+                        ))}
+                        {isEditing ? (
+                          <Box
+                            sx={{
+                              position: "absolute",
+                              right: 8,
+                              top: "50%",
+                              transform: "translateY(-50%)",
+                              display: "inline-flex",
+                              gap: 0.5,
+                              bgcolor: "background.paper",
+                              border: "1px solid",
+                              borderColor: "divider",
+                              borderRadius: 1,
+                              boxShadow: 1,
+                            }}
+                          >
+                            <Tooltip title={t("common:actions.saveRow")} disableInteractive>
+                              <IconButton size="small" color="primary" aria-label={t("common:actions.saveRow")} onClick={() => { void saveEdit(); }}>
+                                <SaveIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title={t("common:actions.cancelRowEdit")} disableInteractive>
+                              <IconButton size="small" aria-label={t("common:actions.cancelRowEdit")} onClick={cancelEdit}>
+                                <CloseIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </Box>
+                        ) : null}
+                      </Box>
+                    );
+                  })
+                )}
+              </Box>
+            </Box>
+          </Box>
+        ) : null}
+      </Box>
+
+      <NotesDrawer
+        open={notesEditor.isOpen}
+        title={t("columns.notes")}
+        value={notesEditor.draft}
+        onChange={notesEditor.setDraft}
+        onSave={notesEditor.handleSave}
+        onClose={notesEditor.handleClose}
+        hasUnsavedChanges={Boolean(
+          notesEditor.currentRow &&
+          notesEditor.field &&
+          notesEditor.draft !== ((notesEditor.currentRow[notesEditor.field] as string) || ""),
+        )}
+        loading={notesEditor.isSaving}
+      />
+
+      <Menu
+        open={contextMenuState !== null}
+        onClose={closeContextMenu}
+        hideBackdrop
+        sx={{ pointerEvents: "none" }}
+        autoFocus
+        disableAutoFocusItem={false}
+        slotProps={{
+          paper: {
+            className: "ofp-custom-context-menu",
+            sx: { pointerEvents: "auto" },
+          },
+          list: {
+            autoFocus: true,
+            ref: contextMenuListRef,
+            onKeyDown: (event: React.KeyboardEvent<HTMLUListElement>) => handleContextMenuKeyboardNavigation(event, closeContextMenu),
+          },
+        }}
+        onKeyDown={(event) => handleContextMenuKeyboardNavigation(event, closeContextMenu)}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          contextMenuState !== null
+            ? { top: contextMenuState.mouseY, left: contextMenuState.mouseX }
+            : undefined
+        }
+      >
+        {contextMenuActions.flatMap((action, index) => {
+          const previousAction = contextMenuActions[index - 1];
+          const shouldSeparateGroup = previousAction !== undefined && previousAction.group !== action.group;
+          const menuItem = (
+            <MenuItem
+              key={action.id}
+              onClick={() => {
+                closeContextMenu();
+                action.onClick();
+              }}
+              sx={{ color: action.color === "error" ? "error.main" : undefined }}
+            >
+              {action.label}
+            </MenuItem>
+          );
+
+          return shouldSeparateGroup
+            ? [<Divider key={`${action.id}-divider`} role="separator" />, menuItem]
+            : [menuItem];
+        })}
+        <TableCopyMenuItems
+          rowValues={contextMenuState ? getHierarchyRowClipboardValues(contextMenuState.row) : null}
+          tableRows={getHierarchyTableClipboardRows()}
+          copyRowLabel={t("common:actions.copyRow")}
+          copyTableLabel={t("common:actions.copyTable")}
+          rowCopiedMessage={t("common:messages.rowCopied")}
+          tableCopiedMessage={t("common:messages.tableCopied")}
+          copyErrorMessage={t("common:messages.copyError")}
+          includeDivider={contextMenuActions.length > 0}
+          onClose={closeContextMenu}
+        />
+      </Menu>
+
+      {pendingDeletions.map((deletion, index) => (
+        <DeleteUndoSnackbar
+          key={deletion.id}
+          open={deletion.visible}
+          message={deletion.message}
+          undoLabel={t("actions.undo")}
+          offsetIndex={index}
+          testId="hierarchy-delete-snackbar"
+          onClose={() => closePendingDeletionSnackbar(deletion.id)}
+          onUndo={() => {
+            void undoPendingDeletion(deletion.id);
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default FieldsBedsTanStackHierarchy;


### PR DESCRIPTION
## Experimental spike

This is an experimental spike, not a production migration. It replaces only the growing areas hierarchy table with a TanStack Table + TanStack Virtual prototype so it can be compared objectively with the current MUI DataGrid implementation and the AG Grid Community spike.

## What changed

- Added a TanStack Table + TanStack Virtual prototype for the growing areas hierarchy table.
- Kept the existing data hooks, API calls, hierarchy projection, row operations, notes drawer, and delete undo flow as close to the current architecture as possible.
- Implemented hierarchy display, expand/collapse, inline editing, per-column filters, sorting, column resizing, virtualized rows, dynamic height, keyboard selection/actions, context menu handling, and responsive behavior.
- Added focused Vitest coverage for the TanStack hierarchy behavior.
- Added Playwright coverage for small and larger datasets, virtual scrolling, expand/collapse, inline editing, keyboard behavior, filtering, sorting, and responsive layout.
- Added `docs/tanstack-table-spike.md` and `docs/table-library-comparison.md` with the technical evaluation and recommendation.

## Validation

- `npm run test -- FieldsBedsTanStackHierarchy.test.tsx FieldsBedsPage.test.tsx`
- `npm run build`
- `FRONTEND_PORT=4178 BACKEND_PORT=8005 npx playwright test e2e/fields-beds-tanstack-spike.spec.ts`

## Notes

The recommendation in the docs is to keep the current MUI DataGrid implementation short-term, treat TanStack Table + TanStack Virtual as the strongest long-term candidate if OpenFarmPlanner is willing to own shared table primitives, and avoid assuming AG Grid Community provides full tree-data parity because Tree Data and built-in context menus are Enterprise features.