### PR TITLE
docs: add architecture, data model, and feature documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,32 @@
 - Update AGENTS.md only when project architecture or developer workflow changes significantly.
 - Do not update AGENTS.md for small implementation details.
 
+### Before making a non-trivial change
+1. Read [`docs/index.md`](docs/index.md) to find the relevant deep-dive doc
+   (architecture, data model, or a specific complex feature such as the
+   DataGrid layer, keyboard navigation, Gantt/occupancy hierarchy, Crop
+   Library, seed demand calculation, or versioning/history) before touching
+   that area — these docs record *why* something works the way it does,
+   not just what the code does, and re-deriving that from scratch risks
+   redoing a decision that was already made deliberately.
+2. Do not change an existing, working UX behavior (interaction pattern,
+   wording, confirmation flow, keyboard shortcut, etc.) unless the task
+   explicitly asks for that change — see "Architecture Safety Rules" and
+   "UX Consistency Rules" below. If a task's scope is ambiguous about
+   whether a UX change is wanted, ask rather than assume.
+3. If the change touches architecture, the data model, or a documented
+   complex feature's behavior, update the corresponding file under `docs/`
+   (or the relevant top-level `*_IMPLEMENTATION.md`/`*_GUIDE.md` doc) in the
+   same change — don't leave documentation describing the old behavior.
+4. Do not fold an unrelated large-scale refactor into a feature/fix change,
+   even if you notice something that could be improved — see "Refactoring
+   Rules" below; flag it separately instead.
+5. Run the tests/lint relevant to what changed before considering the task
+   done:
+   - Backend: `cd backend && pdm run test` (and `pdm run makemigrations`/`pdm run migrate` if models changed).
+   - Frontend: `cd frontend && npm run lint && npm run test` (add `npm run test:e2e` for user-facing flows with existing E2E coverage).
+   - Or run `./scripts/quality.sh` from the repo root to execute the same gates CI uses.
+
 ## Project Structure
 - `backend/` contains the Django backend. The main apps are `accounts/` and `farm/`, with project settings in `config/`, app-local tests under each app, backend helper scripts in `backend/scripts/`, and generated media under `backend/media/`.
 - `frontend/` contains the React + TypeScript app. Application code lives in `frontend/src/`, with pages, components, hooks, API clients, i18n resources, and frontend tests following the existing folder layout. Playwright end-to-end tests live in `frontend/e2e/`.

--- a/AUTOSAVE_IMPLEMENTATION.md
+++ b/AUTOSAVE_IMPLEMENTATION.md
@@ -4,6 +4,8 @@
 
 This document describes the spreadsheet-like autosave functionality implemented across the OpenFarmPlanner frontend.
 
+> **Status note (2026-07):** the hooks and utilities below (`useAutosaveDraft`, `useNavigationBlocker`, `src/hooks/validation.ts`) are still current. The "Applied To" section further down, however, predates later refactors — `Locations.tsx` and `CultureForm.tsx` no longer use `useAutosaveDraft` (both moved to explicit dialog Save/Cancel forms), and `Beds.tsx`/`Fields.tsx` no longer exist as separate pages (merged into `FieldsBedsPage.tsx`/`FieldsBedsHierarchy.tsx`, which use a raw MUI `DataGrid`, not `EditableDataGrid`). Today, `useAutosaveDraft` is consumed only from `frontend/src/components/data-grid/DataGrid.tsx` (`EditableDataGrid`), whose current sole page user is `PlantingPlans.tsx`. See [`docs/datagrid-architecture.md`](./docs/datagrid-architecture.md) for the current, accurate picture of which grids use this pattern.
+
 ## Features
 
 ### Core Functionality
@@ -139,20 +141,17 @@ const result = validateFields(data, validations);
 
 ## Applied To
 
+> This section describes the state of the feature **as originally implemented**. As of 2026-07 it is only partially accurate — see the status note at the top of this file and [`docs/datagrid-architecture.md`](./docs/datagrid-architecture.md) for what's current.
+
 ### Forms
 
-#### CultureForm (`src/components/CultureForm.tsx`)
+#### CultureForm (`src/cultures/CultureForm.tsx`)
 
-- **Before**: Required clicking "Save" button or pressing Enter
-- **After**: Each field saves on blur if valid
-- **Navigation**: Blocked if there are unsaved invalid changes
-- **Notifications**: Success/error snackbar messages
+Originally moved to save-on-blur; **currently uses an explicit dialog Save/Cancel flow instead** (its own code comments say "Local form state (no autosave)"). If you need blur-based autosave for a form again, `useAutosaveDraft`/`useNavigationBlocker` are still the hooks to reach for — just verify current form behavior in the component before assuming it still applies here.
 
 ### Data Grids
 
-#### EditableDataGrid (`src/components/data-grid/EditableDataGrid.tsx`)
-
-Shared component used by multiple pages:
+#### EditableDataGrid (`src/components/data-grid/DataGrid.tsx`)
 
 - **Before**: Required pressing Enter to save row
 - **After**: Row saves automatically on:
@@ -163,19 +162,11 @@ Shared component used by multiple pages:
 - **Validation**: Invalid rows cannot be saved (error shown to user, row stays in edit mode)
 - **Data Protection**: Navigation is blocked when required fields are missing, preventing data loss
 
-**Pages Using EditableDataGrid:**
-1. **Locations** (`src/pages/Locations.tsx`) - Location management
-2. **PlantingPlans** (`src/pages/PlantingPlans.tsx`) - Planting plan schedules
-3. **FieldsBedsHierarchy** (`src/pages/FieldsBedsHierarchy.tsx`) - Hierarchical field/bed view
-
-All these pages now have autosave-on-blur behavior and validation error navigation blocking.
+**Pages currently using `EditableDataGrid`:** `PlantingPlans.tsx` is the only page using it today. `Locations.tsx` moved to a card/dialog form (not a grid), and `FieldsBedsHierarchy.tsx` renders a raw MUI `DataGrid` directly (see [`docs/datagrid-architecture.md`](./docs/datagrid-architecture.md)) rather than `EditableDataGrid`, so it does not get this autosave behavior automatically.
 
 ### Not Changed
 
-The following pages retain their original behavior (manual save button):
-
-- **Beds** (`src/pages/Beds.tsx`) - Simple create form
-- **Fields** (`src/pages/Fields.tsx`) - Simple create form
+`Beds.tsx`/`Fields.tsx` as separate pages no longer exist — fields and beds are now managed through `FieldsBedsPage.tsx`/`FieldsBedsHierarchy.tsx`/`GraphicalFields.tsx`.
 
 These are simple create-only forms where the manual save button provides clear user intent without the complexity of autosave.
 

--- a/FIELD_BED_AREA_IMPLEMENTATION.md
+++ b/FIELD_BED_AREA_IMPLEMENTATION.md
@@ -3,6 +3,8 @@
 ## Overview
 This document summarizes the implementation of area-only storage for Field and Bed entities in v1, preparing for future polygon/geometry support.
 
+> **Status note (2026-07):** the model/validation details below are still current (see `backend/farm/models.py`). The frontend section references `frontend/src/pages/Beds.tsx`, which no longer exists as a standalone page — field/bed management now lives in `FieldsBedsPage.tsx`/`FieldsBedsHierarchy.tsx`/`GraphicalFields.tsx`. See [`docs/data-model.md`](./docs/data-model.md#2-farm-structure-locations--fields--beds) for the current farm-structure model overview.
+
 ## Issue Requirements
 - ✅ Only the area (sqm) is stored in v1
 - ✅ Prepare for later support of polygons/geometry

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Safety behavior:
 - `frontend/README.md` – frontend-specific development details
 - `frontend/e2e/README.md` – E2E testing notes
 - `CONTRIBUTING.md` – commit conventions and contribution expectations
+- `AGENTS.md` – rules AI coding agents must follow in this repository
+- **[`docs/index.md`](docs/index.md)** – technical documentation index: architecture overview, data model, and deep dives into complex features (DataGrid, keyboard navigation, Gantt/occupancy hierarchy, Crop Library, seed demand calculation, versioning/history)
 
 ## Deployment / Operations
 

--- a/backend/farm/project_context.py
+++ b/backend/farm/project_context.py
@@ -44,6 +44,11 @@ def get_active_project_or_400(request: Request) -> Project:
     agent_mode = bool(request.session.get('agent_mode'))
     agent_project_id = request.session.get('agent_project_id')
 
+    # Agent-mode sessions (created via AgentLoginToken, for automation/AI-agent
+    # access) are hard-locked to whichever project the token was issued for.
+    # The X-Project-Id header is still accepted but must match that binding —
+    # this is what stops an agent session from escalating to other projects
+    # the underlying user happens to belong to, just by changing a header.
     if agent_mode and agent_project_id is not None:
         try:
             bound_project_id = int(agent_project_id)

--- a/backend/farm/seed_units.py
+++ b/backend/farm/seed_units.py
@@ -29,6 +29,11 @@ class SeedAmount:
     unit: str
 
 
+# NOTE: SeedDemandListView (backend/farm/views.py) currently reimplements this
+# TKG conversion inline rather than calling these functions. The formulas agree
+# today, but if you change the conversion rule, update both places (or refactor
+# the view to call these instead of duplicating them). See
+# docs/seed-demand-calculation.md ("A known internal inconsistency").
 def seeds_to_grams(seeds: Decimal, thousand_kernel_weight_g: Decimal) -> Decimal:
     """
     Convert seed count to grams using TKG.

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -2342,6 +2342,10 @@ class SeedDemandListView(ProjectScopedMixin, generics.ListAPIView):
                     'culture': culture,
                 },
             )
+            # Once one plan for this culture fails to compute a requirement, every
+            # later plan for the same culture is skipped too (not just the failing
+            # one) — the row shows a single warning rather than a partial total that
+            # would understate demand without saying so. See docs/seed-demand-calculation.md.
             if entry['warning']:
                 continue
             requirement_value, requirement_unit = self._compute_plan_requirement(plan)

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,191 @@
+# Architecture Overview
+
+OpenFarmPlanner is a Django REST Framework backend plus a React/TypeScript
+single-page frontend, in one repository. This doc gives a developer or AI
+agent enough of a mental model to navigate the codebase and reason about
+where a change belongs. For setup/commands see the root
+[`README.md`](../README.md); for the data model see
+[data-model.md](./data-model.md).
+
+## Tech stack
+
+**Backend** (`backend/`)
+- Python 3.12+, Django 5.2, Django REST Framework
+- SQLite by default in development, PostgreSQL supported via env config
+- PDM for dependency/script management (no `pip`/`requirements.txt`)
+
+**Frontend** (`frontend/`)
+- React 19 + TypeScript, built with Vite
+- Material UI (MUI + MUI X DataGrid)
+- React Router (data router API, `createBrowserRouter`)
+- Plain `async`/`await` + component-local `useState`/`useEffect` for data
+  fetching — there is no React Query/SWR/RTK-Query layer
+- Vitest + Testing Library (unit/integration), Playwright (E2E)
+
+## Repository layout
+
+```text
+backend/
+  accounts/     # User account lifecycle: activation, password reset, deletion, consent
+  farm/         # The core domain app: locations/fields/beds, cultures, planting plans, seed demand, history
+  crops/        # Thin, read-only app for the future public Crop Library (see crop-library-architecture.md)
+  config/       # Django settings, URL roots
+frontend/
+  src/
+    pages/            # One file (or small cluster) per route/screen
+    components/       # Shared UI, including the custom data-grid layer
+    api/               # httpClient (axios) + per-domain API modules + shared types
+    auth/              # Session/auth context, CSRF handling, ProtectedRoute
+    focus/, commands/  # Keyboard focus regions and the command/shortcut system
+    cultures/, crops/  # Culture domain UI vs. the (not yet public) Crop Library UI
+    i18n/              # Translation resources (German is complete; English is partial)
+    gantt-chart/       # Vendored third-party Gantt component (MIT, see its own README)
+  e2e/                 # Playwright end-to-end tests
+docs/                  # This documentation
+```
+
+## Backend structure
+
+- **`farm`** is the main domain app: nearly every model and viewset for
+  locations, fields, beds, cultures, suppliers, planting plans, tasks, seed
+  demand, and history/versioning lives here (`backend/farm/models.py`,
+  `views.py`, `serializers.py`).
+- **`accounts`** owns the Django `User` lifecycle: registration/activation,
+  password reset, per-user project settings (`UserProjectSettings`:
+  default/last project), account deletion with a grace period, and
+  document-consent tracking. There is no custom `AUTH_USER_MODEL`.
+- **`crops`** is a real Django app but defines **no models** — it's a
+  read-only API surface (`/api/crops/`) over `farm.PublicCulture`, kept
+  deliberately one-directional (crops never imports from farm) in
+  preparation for a future public Crop Library. It exists *alongside* the
+  older `/api/public-cultures/` endpoint, which the frontend still uses
+  today. Full reasoning: [crop-library-architecture.md](./crop-library-architecture.md).
+- Views follow a thin-view convention (AGENTS.md): business logic goes into
+  `backend/farm/services/*.py` (e.g. `services_area.py` for bed-area
+  math, `services/seed_packages.py` for the seed-package optimizer,
+  `services/public_cultures.py` for the publish/import bridge) rather than
+  living in view methods.
+- Physical measurements (area, spacing, seed rates) are stored in SI units
+  internally (m², m, g) and converted only at API/serializer boundaries —
+  see [seed-demand-calculation.md](./seed-demand-calculation.md) for where
+  this convention is and isn't consistently followed.
+
+## Frontend structure
+
+- **Routing** (`App.tsx`): a single data router. Public routes
+  (`pages/public/` — landing/imprint/privacy, `pages/auth/` —
+  login/register/activation/password reset) render outside any auth check.
+  Everything under `/app/*` is nested inside a single `<ProtectedRoute />`
+  element, which gates on auth-loading state, redirects unauthenticated
+  users to `/login`, and — before rendering the app — forces acceptance of
+  any pending legal consents via `<ConsentGate />`.
+- **Pages** (`frontend/src/pages/`), one per main route:
+
+  | Page | Route | Purpose |
+  |---|---|---|
+  | `Dashboard.tsx` | `/app/dashboard` | Landing page / setup checklist |
+  | `Locations.tsx` | `/app/locations` | Manage farm locations (Standorte) |
+  | `FieldsBedsPage.tsx` / `FieldsBedsHierarchy.tsx` / `GraphicalFields.tsx` | `/app/fields-beds` | Fields & beds: hierarchy (tree) view and graphical (map) view |
+  | `Cultures.tsx` | `/app/cultures` | Manage project cultures; Public Culture Library import/export and version history |
+  | `PlantingPlans.tsx` | `/app/anbauplaene` (alias `/app/planting-plans`) | Spreadsheet-like editable grid of planting schedules |
+  | `GanttChart.tsx` | `/app/gantt-chart` | Bed-occupancy timeline / seedling calendar |
+  | `YieldOverview.tsx` | `/app/yield-overview` | Aggregated harvest/yield overview |
+  | `SeedDemand.tsx` | `/app/seed-demand` | Seed quantity/package requirement per culture |
+  | `Suppliers.tsx` | `/app/suppliers` | Manage seed/plant suppliers |
+  | `ProjectSelectionPage.tsx` | `/app/project-selection` | Pick/create/restore a project |
+  | `ProjectSettingsPage.tsx` | `/app/project-settings` | Rename/delete project, manage members & invitations |
+  | `AccountSettingsPage.tsx` | `/app/account-settings` | Account details, email/password change, deletion |
+
+  `pages/InvitationPage.tsx` looks unrouted/superseded by
+  `InvitationAcceptPage.tsx` — **unclear/needs check** before assuming it's
+  dead code.
+
+- **API layer** (`frontend/src/api/`): `httpClient.ts` is the one shared
+  axios instance; a single request interceptor attaches `X-Project-Id`
+  (read fresh from `localStorage` per request) and `X-CSRFToken`.
+  `api.ts` groups REST calls into per-domain objects (`cultureAPI`,
+  `plantingPlanAPI`, `seedDemandAPI`, ...) on top of that client.
+  `auth/authApi.ts` is a **separate**, hand-rolled `fetch`-based client used
+  only for auth endpoints (login/register/session), independent of the
+  project-header interceptor. This means there are two independent
+  error-message-normalization implementations (`api/errors.ts` for the
+  axios client, `authApi.ts`'s own for the auth client) — a known
+  duplication, not a bug, if you're looking for "the" error handler.
+- **i18n**: one JSON namespace per feature area under
+  `frontend/src/i18n/locales/{de,en}/`. German is complete (16 namespaces);
+  English is partial (8 namespaces) and falls back to German for anything
+  missing (`fallbackLng: 'de'`). Treat English as "started, not shipped."
+- **Keyboard navigation & commands**: a focus-region model plus a
+  shortcut/command system — see
+  [keyboard-architecture.md](./keyboard-architecture.md).
+- **The custom DataGrid layer**: most editable tables use a shared
+  `EditableDataGrid` wrapper around MUI X DataGrid with inline editing,
+  autosave-on-blur, row actions, and notes — see
+  [datagrid-architecture.md](./datagrid-architecture.md). Not every grid
+  page uses it — `FieldsBedsHierarchy.tsx` renders a raw MUI `DataGrid`
+  directly with its own, independently-implemented context-menu and
+  keyboard-navigation logic; treat the two as parallel, not shared,
+  implementations when changing either one.
+
+## Project, user, and permission model
+
+- A `Project` is the tenant boundary; a `User` gets access only via a
+  `ProjectMembership` (role: `admin` or `member` — no finer-grained
+  permission system exists).
+- Every project-scoped API request must carry an `X-Project-Id` header.
+  `ProjectScopedMixin` (`backend/farm/views.py`) resolves and validates it
+  once per request, then auto-scopes the queryset and auto-injects the
+  project on create — this is the actual multi-tenancy enforcement point,
+  not something each view re-implements.
+- On the frontend, the active project id is tracked in `AuthContext`
+  (seeded from the server-resolved `resolved_project_id` on login/refresh),
+  persisted to `localStorage['activeProjectId']`, and read fresh by the
+  axios interceptor on every request. Switching projects
+  (`switchActiveProject`) calls a dedicated endpoint, updates that storage
+  key, and then does a full `window.location.reload()` — a deliberate
+  choice to guarantee no page holds stale cross-project state, rather than
+  relying on React state propagation alone.
+- A rare **agent-mode** session type (`AgentLoginToken`, superuser-created)
+  locks a session to one specific project regardless of the `X-Project-Id`
+  header sent, and is explicitly never treated as admin even if the
+  underlying user is one — used for automation/agent tooling access, not
+  regular users.
+- Full model relationships: [data-model.md](./data-model.md#1-projects-users-and-access).
+
+## Notable architecture & UX decisions worth knowing before changing things
+
+These are decisions already made deliberately — see AGENTS.md's
+"Architecture Safety Rules": don't change established UX behavior without
+an explicit request, and search for the existing pattern before introducing
+a new one.
+
+- **History is snapshot-based, not event-sourced.** `EntityRevision`
+  stores full JSON snapshots per mutation, not deltas to replay. See
+  [versioning-and-history.md](./versioning-and-history.md).
+- **The Crop Library split already exists in the data model** (`Culture` is
+  project-owned, `PublicCulture` is shared) but is only partially exposed
+  as its own app/route today — see
+  [crop-library-architecture.md](./crop-library-architecture.md) before
+  assuming `/api/public-cultures/` can be renamed or removed.
+- **Large datasets use windowed rendering, not virtualization inside the
+  vendored Gantt library** (which doesn't virtualize on its own) — see
+  [large-dataset-rendering.md](./large-dataset-rendering.md).
+- **Column visibility is now handled entirely by MUI's native columns
+  panel**, not a custom show/hide menu — a custom implementation was
+  deliberately removed in favor of it (see
+  [datagrid-architecture.md](./datagrid-architecture.md#column-visibility)).
+  Don't reintroduce a bespoke column-visibility UI on `EditableDataGrid`.
+- **Deployment/infrastructure live in a separate repository**
+  (`OpenFarmPlanner-ops`) — this repo intentionally has no Dockerfile,
+  deploy scripts, or cron config for production use.
+
+## Unclear / needs check
+
+- Whether `ProjectMembership.role` gates any *frontend* UI beyond simple
+  display (no explicit role-based conditionals were found in the pages
+  reviewed while writing this doc) — verify before documenting a frontend
+  permission model that doesn't actually exist yet.
+- Whether a 401 mid-session (expired Django session while the user is
+  active on an `/app/*` page) triggers any global logout/redirect — no
+  global 401 interceptor was found; this is based on static reading, not an
+  observed runtime session-expiry test.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,157 @@
+# Data Model Overview
+
+This is a conceptual map of OpenFarmPlanner's core Django models
+(`backend/farm/models.py`, `backend/accounts/models.py`) and how they relate.
+It is **not** a full field reference — see the model source for exact fields,
+`help_text`, and validation. The goal here is to help you reason about which
+objects exist, how they're connected, and which relationships matter for
+typical features (a new column on the planting-plan grid, a new report, a
+permission check, ...).
+
+For the frontend/backend split and general architecture, start at
+[architecture-overview.md](./architecture-overview.md).
+
+## 1. Projects, users, and access
+
+Every piece of farm data belongs to exactly one `Project` — projects are the
+tenant boundary. A `User` (Django's built-in auth `User`, no custom user
+model) gets access to a project only via a `ProjectMembership` row.
+
+```mermaid
+erDiagram
+    User ||--o{ ProjectMembership : "has memberships"
+    Project ||--o{ ProjectMembership : "has members"
+    User ||--o{ ProjectInvitation : "invited_by / accepted_by / revoked_by"
+    Project ||--o{ ProjectInvitation : "has invitations"
+    User ||--o| UserProjectSettings : "1:1"
+    Project ||--o{ UserProjectSettings : "default_project / last_project"
+    User ||--o| PendingActivation : "1:1 (email activation)"
+    User ||--o| AccountDeletionRequest : "1:1 (deletion grace period)"
+    User ||--o{ AgentLoginToken : "created_by (superuser tooling)"
+    Project ||--o{ AgentLoginToken : "scoped to"
+```
+
+- **`ProjectMembership.role`** is either `admin` or `member` — this is the
+  *entire* permission model. There is no per-object or field-level
+  permission system, no "read-only" role. Ordinary CRUD on farm data
+  (locations, fields, beds, cultures, planting plans, tasks, ...) only
+  requires *any* membership; a short list of destructive/irreversible or
+  membership-changing actions (delete/restore project, change a member's
+  role, remove a member, send invitations, restore-from-history) requires
+  the `admin` role — enforced in view code (`require_project_admin()` in
+  `backend/farm/project_context.py`), not a DB constraint.
+- Every API request that touches project-scoped data must send an
+  `X-Project-Id` header; `ProjectScopedMixin` (`backend/farm/views.py`)
+  resolves and validates it once per request (`initial()`), then
+  auto-filters `get_queryset()` by `project=request.active_project` for any
+  model that has a `project` field, and auto-injects `project` on create.
+  This is the actual multi-tenancy enforcement point — see
+  [architecture-overview.md](./architecture-overview.md#project-user-and-permission-model)
+  for the full request-time flow.
+- **Unclear / needs check**: the invariant "a project always has at least
+  one admin" is enforced only in `ProjectMembersView` view logic, not at the
+  database level.
+
+## 2. Farm structure: locations → fields → beds
+
+```mermaid
+erDiagram
+    Project ||--o{ Location : has
+    Location ||--o{ Field : "has (Parzelle)"
+    Field ||--o{ Bed : "has (Beet)"
+    Bed ||--o| BedLayout : "1:1 map position"
+    Field ||--o| FieldLayout : "1:1 map position"
+```
+
+- `Location` → `Field` → `Bed` is a strict three-level physical hierarchy
+  ("Standort" → "Parzelle" → "Beet" in the UI). Only *area* (`area_sqm`) is
+  stored for fields/beds today, no polygon geometry — see
+  `FIELD_BED_AREA_IMPLEMENTATION.md` for the historical rationale and the
+  intended future geometry extension path.
+- `BedLayout`/`FieldLayout` hold persisted x/y coordinates for the
+  graphical/map layout view (`GraphicalFields.tsx`) — they're optional,
+  separate rows from `Bed`/`Field` themselves, not embedded fields.
+- `Field`, `Bed`, and most other project-scoped models below also carry a
+  **direct, denormalized `project` FK** in addition to their natural parent
+  (e.g. `Bed.project` in addition to `Bed.field`). This is deliberate — it's
+  what lets `ProjectScopedMixin` filter *any* scoped model uniformly by
+  `project`, without walking the parent chain. Don't treat it as redundant
+  data to clean up.
+
+## 3. Crop / culture domain and the seed supply chain
+
+```mermaid
+erDiagram
+    Project ||--o{ Culture : owns
+    Project ||--o{ Supplier : has
+    Culture ||--o{ CultureSupplierData : "per-supplier seed data"
+    Supplier ||--o{ CultureSupplierData : supplies
+    Culture ||--o{ SeedPackage : "package sizes (supplier-agnostic)"
+    Supplier ||--o{ Culture : "preferred supplier of (nullable)"
+    Supplier ||--o{ Culture : "seed-demand supplier of (nullable)"
+    PublicCulture ||--o{ Culture : "import lineage (optional, nullable)"
+    Culture ||--o{ PublicCulture : "publish lineage (optional, nullable)"
+```
+
+- **`Culture`** is project-owned: every project has its own private copy of
+  every variety it grows, including growing parameters and history. It's
+  soft-deletable (`deleted_at`); the default manager (`objects`) hides
+  soft-deleted rows, `all_objects` doesn't (used by restore flows).
+- **`PublicCulture`** is the shared, cross-project "crop library" — it has
+  no owning `Project`, only optional *provenance* links back to the project
+  and culture it was published from. See
+  [crop-library-architecture.md](./crop-library-architecture.md) for the
+  full story of how this split is formalized into the `crops` Django app.
+- **`CultureSupplierData`** is the join between one `Culture` and one
+  `Supplier`: supplier-specific product data (price, packaging sizes,
+  germination rate, thousand-kernel-weight). `SeedPackage` is a simpler,
+  supplier-agnostic "this culture comes in these package sizes" record.
+  `Culture.selected_seed_demand_supplier` is a *separate* nullable FK from
+  `Culture.supplier` (the general "preferred supplier") — it specifically
+  drives which supplier's data feeds the Seed Demand calculation. See
+  [seed-demand-calculation.md](./seed-demand-calculation.md) for how these
+  pieces combine into an actual quantity.
+
+## 4. Planning and operations
+
+```mermaid
+erDiagram
+    Culture ||--o{ PlantingPlan : "planted as"
+    Bed ||--o{ PlantingPlan : "scheduled on"
+    PlantingPlan ||--o{ Task : "optional related task"
+    PlantingPlan ||--o{ NoteAttachment : "photo notes"
+```
+
+- **`PlantingPlan`** is the central operational record: one culture, on one
+  bed, with a planting date and computed harvest date(s). It drives the
+  Gantt/occupancy calendar, the seed demand view, and the yield overview.
+- There is no separate `Note` model. Free-text notes are plain `notes` text
+  fields directly on `Location`, `Field`, `Bed`, `Culture`,
+  `CultureSupplierData`, `PublicCulture`, and `PlantingPlan`.
+  `NoteAttachment` only stores *photo attachments*, and only for
+  `PlantingPlan` — see
+  [datagrid-architecture.md](./datagrid-architecture.md#notes--markdown-cells)
+  for how these render as rich markdown+photo notes in the grid.
+
+## 5. History and versioning
+
+```mermaid
+erDiagram
+    Project ||--o{ EntityRevision : "generic audit trail"
+```
+
+`EntityRevision` is the current, generic history mechanism: one row per
+mutation of *any* trackable entity (`entity_type` + `object_id`, a full
+JSON `snapshot`, and a diff-style `changed_fields` list). It superseded two
+now-deprecated, drain-only models, `CultureRevision` and `ProjectRevision`
+(culture-only and whole-project-JSON-blob designs that didn't scale). See
+[versioning-and-history.md](./versioning-and-history.md) for how this
+powers project history and restore.
+
+## Unclear / needs check
+
+- The exact session lifecycle of `AgentLoginToken` (how `agent_mode` /
+  `agent_project_id` get set in the session on token consumption) wasn't
+  traced end-to-end while writing this doc.
+- Whether any code path other than `require_project_admin()` gates
+  behavior by role — a full audit of every view wasn't performed.

--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -1,0 +1,244 @@
+# DataGrid Architecture
+
+OpenFarmPlanner builds most editable tables on `EditableDataGrid`
+(`frontend/src/components/data-grid/DataGrid.tsx`), a wrapper around MUI X
+`<DataGrid>`. This doc covers what OpenFarmPlanner *added* on top of the
+stock grid. It intentionally does not repeat:
+
+- keyboard focus regions and the global shortcut system —
+  [keyboard-architecture.md](./keyboard-architecture.md)
+- autosave-on-blur mechanics — `AUTOSAVE_IMPLEMENTATION.md`
+- the Standort/Parzelle/Beet tree view (a *different*, raw `<DataGrid>`
+  page, not `EditableDataGrid`) — [occupancy-tree-hierarchy.md](./occupancy-tree-hierarchy.md)
+
+**Not every table uses `EditableDataGrid`.** `FieldsBedsHierarchy.tsx`
+renders a raw MUI `<DataGrid>` with its own, independently-implemented
+context menu and keyboard navigation (`useHierarchyContextMenu.ts`). It
+duplicates rather than reuses the patterns below — when you change one,
+check whether the other needs the same fix, but don't assume the code is
+shared.
+
+## File map
+
+```text
+frontend/src/components/data-grid/
+  DataGrid.tsx            EditableDataGrid<T> — the main wrapper component
+  index.ts                Public barrel export
+  hooks/
+    useDataGridCommandApi.ts     builds the imperative EditableDataGridCommandApi
+    useDataGridRowCommands.ts    addRow/editSelectedRow/openRowById/focusTable
+    useDataGridDelete.ts         delete + optional undo-snackbar flow
+    useDataGridRowActionMenu.ts  right-click / long-press / keyboard row menu
+  keyboardEditing.ts       "just start typing" / F2 spreadsheet-edit-start behavior
+  keyboardNavigation.ts    Tab/Arrow cell navigation rules, grid-API-agnostic
+  contextMenuFocus.ts      Arrow/Home/End/Enter/Esc navigation *inside* an open menu
+  AreaM2EditCell.tsx, DateEditCell.tsx, GermanDateEditCell.tsx,
+  PlantsCountEditCell.tsx, SearchableSelectEditCell.tsx   custom edit cells
+  NotesCell.tsx, NotesDrawer.tsx, NotesPreviewPopover.tsx,
+  useNotesEditor.ts, useNotesPreview.ts, markdown.ts,
+  noteAttachmentsCache.ts               rich markdown notes + photo attachments
+  tableClipboard.ts, TableCopyMenuItems.tsx   copy row/table as TSV
+  columns.tsx, calculatedColumns.tsx    column builders (select, computed)
+  dataGridUtils.tsx, handlers.ts, styles.ts, localeText.ts   shared helpers
+```
+
+## Imperative API (`EditableDataGridCommandApi`)
+
+A page passes a `commandApiRef` into `EditableDataGrid`; the grid populates
+it on mount (`hooks/useDataGridCommandApi.ts`):
+
+```ts
+interface EditableDataGridCommandApi {
+  addRow, editSelectedRow, deleteSelectedRow, deleteRow(rowId),
+  getSelectedRowId, setDraftValues(rowId, values), commitDraftValues(rowId, values),
+  reload, focusTable, openRowById(rowId, { startEdit? }),
+}
+```
+
+`openRowById(rowId, { startEdit })` is the deep-link entry point: it scrolls
+to and selects a row, optionally opening edit mode. Today only
+`PlantingPlans.tsx` uses it — the Gantt calendar's context menu
+("Anbauplan öffnen" / "bearbeiten") navigates to
+`/app/planting-plans?planId=<id>&edit=true`, and `PlantingPlans.tsx` resolves
+that param to `openRowById(planId, { startEdit: true })`. This deliberately
+replaced an earlier `initialRow`-based approach, which always prefilled a
+**new draft row** — clicking "open" on an existing task used to silently
+create a duplicate-looking blank plan instead of opening the one clicked.
+If you add deep-linking into another grid page, this is the reference
+pattern to follow, not a one-off to reinvent.
+
+`setDraftValues`/`commitDraftValues` let external code push field values
+into a row that's already mid-edit (e.g. a calculated side-effect from
+another field), either staying in edit mode or committing immediately.
+
+## Custom edit cells
+
+MUI's stock edit cells didn't fit a few OpenFarmPlanner-specific needs:
+
+- **`AreaM2EditCell` / `PlantsCountEditCell`** — both preserve the raw text
+  the user is typing (including a mid-typed decimal separator or a
+  temporarily invalid/partial value) instead of coercing on every
+  keystroke like MUI's built-in number editor does; normalization happens
+  at save time, not on each keypress.
+- **`DateEditCell`** (the default for any `type: 'date'` column, applied
+  automatically by `dataGridUtils.tsx`'s `applyDefaultDateEditCell`) — a
+  from-scratch segmented `TT.MM.JJJJ` editor: per-segment cursor tracking,
+  Up/Down arrows increment/decrement the active day/month/year segment
+  (with correct month-length/rollover handling), Left/Right move between
+  segments, plus a hidden native `<input type="date">` behind a calendar
+  icon as a picker fallback.
+- **`GermanDateEditCell`** is a simpler, non-segmented sibling (single text
+  field, parses on every change). `DateEditCell` also imports its
+  `parseGermanDateText`/`formatDateAsGerman` helpers. **Unclear/needs
+  check**: confirm whether any column still explicitly uses
+  `GermanDateEditCell` as `renderEditCell` before treating it as dead code
+  — `DateEditCell` is the default today.
+- **`SearchableSelectEditCell`** wraps an MUI Autocomplete for single-select
+  columns with large option lists (cultures, suppliers) that a plain
+  `singleSelect` dropdown wouldn't make browsable; `columns.tsx` also
+  exposes a `createSingleSelectColumn` builder (plain dropdown) for
+  short option lists — pick whichever builder matches the option-list size,
+  don't default to the searchable one everywhere.
+
+## Keyboard editing/navigation inside the grid
+
+`docs/keyboard-architecture.md` still lists "applying the region-shortcut
+pattern to DataGrid" as future work for the *page-level* keyboard model —
+that's still true. But cell-level Tab/Arrow/Enter/F2 navigation
+(`keyboardEditing.ts` + `keyboardNavigation.ts`) is fully implemented:
+
+- **`keyboardNavigation.ts`** — pure helpers (grid-API-agnostic, easy to
+  unit test) for stepping Tab/Shift+Tab/Left/Right across visible, editable
+  columns, and Up/Down across rows — falling back to the nearest navigable
+  cell in the target row if the same column isn't editable there (so Enter
+  after editing one column doesn't get stuck on a read-only next-row cell).
+- **`keyboardEditing.ts`**'s `useSpreadsheetEditStarter` implements
+  Excel-like "just start typing" (a printable keydown on a non-editing
+  cell immediately opens edit mode and *replaces* the cell's value with the
+  typed character, buffering rapid keystrokes typed before the edit-cell
+  component has actually mounted) and F2 (opens edit mode *without*
+  altering the value — the standard spreadsheet distinction between the
+  two).
+- Notes cells (see below) are deliberately excluded from both spreadsheet
+  auto-edit-start and the F2 flow — Enter/Space on a notes cell opens the
+  notes drawer instead.
+
+## Hover actions / row actions / context menu
+
+Triggers: right-click, the `ContextMenu` keyboard key / `Shift+F10`, and a
+550ms touch long-press (with a `.ofp-row-long-press` visual affordance
+during the hold). All three funnel into the same
+`hooks/useDataGridRowActionMenu.ts` state machine, positioned either at the
+mouse coordinates or the focused cell's bounding rect. Menu contents:
+caller-supplied row actions (duplicate/delete by default) plus
+"copy row"/"copy table" (see below). Closing the menu restores keyboard
+focus to whatever opened it.
+
+A first-run **discovery hint** (`ContextMenuHint.tsx` /
+`useContextMenuHint.ts`) shows a small "right-click a row" banner once,
+only on fine-pointer desktop viewports, persisted per-user in
+`localStorage` and synced across tabs — this is UX polish, not
+functionality; don't remove the dismissal persistence when touching it.
+
+Separately, `renderInlineActionCell` overlays icon buttons directly inside
+one cell on row hover — this is the "hover actions" surface distinct from
+the right-click menu.
+
+**`FieldsBedsHierarchy.tsx`'s `useHierarchyContextMenu.ts` is a second,
+hand-rolled implementation of the same right-click/long-press pattern**,
+built directly on the same lower-level shared primitives
+(`contextMenuFocus.ts`, `utils/contextMenu.ts`) but not on
+`useDataGridRowActionMenu.ts` itself, because that page uses a raw
+`<DataGrid>`, not `EditableDataGrid`. Treat a UX fix to one as *not*
+automatically fixing the other.
+
+## Notes / markdown cells
+
+Any column listed in `EditableDataGrid`'s `notes` prop renders through
+`NotesCell.tsx` instead of a normal edit cell: an icon, a plain-text
+excerpt, and (unless `compactIndicator`) a hover/focus/touch-triggered
+preview popover (`NotesPreviewPopover.tsx` — one shared popover instance
+per grid, not one per row, opened after a 250ms hover delay). Notes are
+*not* edited inline — clicking opens `NotesDrawer.tsx`, a full markdown
+editor (Edit/Preview tabs, a formatting toolbar) that additionally supports
+photo attachments when the column has an `attachmentNoteIdField`: capture
+or pick a photo, crop it with a hand-rolled pointer-drag crop tool, and
+downscale/re-encode to WebP (falling back to JPEG) client-side before
+upload. `noteAttachmentsCache.ts` caches attachment fetches per note id so
+re-hovering a row doesn't refetch; the drawer explicitly invalidates that
+cache after upload/delete.
+
+`markdown.ts`'s `stripCitationMarkers` strips AI-citation markers of the
+form `【digits†identifier】` from note text. **Unclear/needs check**: trace
+where such markers actually get inserted (an LLM-assisted import/enrichment
+path elsewhere in the app, presumably) before documenting the "why" further
+— it wasn't found in the files reviewed for this doc.
+
+## Copy/paste
+
+Copy-only today (no paste-in). `tableClipboard.ts` formats selected rows as
+tab/newline-delimited text (dates localized `de-DE`, arrays joined with
+`, `); `TableCopyMenuItems.tsx` adds "Copy row" (header + the right-clicked
+row) and "Copy table" (header + every currently loaded/filtered/sorted row)
+to the row-action menu — both paste directly into Excel/Sheets.
+
+## Column visibility
+
+Column show/hide is handled entirely by **MUI's native columns panel**
+today. A custom show/hide menu and a separate ResizeObserver-driven
+"autofit" responsive-hiding feature both existed earlier and were
+deliberately removed in favor of it (see the git history around
+`Replace custom column show/hide menu with MUI's native columns panel` and
+`Fold responsive column hiding into the native visibility model`) — do not
+reintroduce a bespoke visibility UI. `EditableDataGrid` only passes
+`columnVisibilityModel`/`onColumnVisibilityModelChange` straight through to
+the underlying MUI grid; the actual state lives in the page via
+`useColumnVisibility(...)` (`frontend/src/hooks/useColumnVisibility.ts`),
+which persists to `localStorage` under `tableColumns.<tableKey>` and
+supports a `defaultHiddenFieldsOnSmallScreen` list that only applies until
+the user makes their *first* explicit visibility choice — after that, the
+user's choice always wins regardless of screen size.
+
+`FieldsBedsHierarchy.tsx` (raw `<DataGrid>`) has **no column-visibility
+feature at all** today — this was an explicit scope cut when the feature
+was migrated to the native panel elsewhere, not an oversight to "fix" as a
+drive-by change.
+
+## Row history / versioning — not a grid feature
+
+Culture version history (backed by the generic `EntityRevision` model, see
+[versioning-and-history.md](./versioning-and-history.md)) is shown in a
+**standalone MUI `Dialog`** on `Cultures.tsx`, populated via
+`cultureAPI.history(...)`. It does not surface inside any grid cell,
+row-action menu, or notes drawer — if you're asked to "show history in the
+grid," that's new work, not exposing something that already half-exists.
+
+## Cross-cutting utilities
+
+- `dataGridUtils.tsx` — `isUnsavedDraftRow` (heuristic for local-only,
+  not-yet-saved rows), `SaveBlockedError` (lets `onBeforeSaveRow` silently
+  keep a row in edit mode without surfacing an error), `prepareDataGridColumn`
+  (applies the default date edit cell and makes unsaved draft rows immune
+  to active column filters), `getSortedRowIds`/`orderRowsByStableIds`
+  (rows are kept in a stable client-side order rather than trusting the
+  grid's own post-edit row order).
+- `handlers.ts` — `handleRowEditStop` deliberately suppresses MUI's default
+  Escape-triggers-save-attempt behavior so Escape reliably means "cancel";
+  see `AUTOSAVE_IMPLEMENTATION.md` for how the blur-triggered save itself
+  works.
+- `styles.ts` — the single `dataGridSx` object defining every `ofp-*` CSS
+  class referenced above (`.ofp-row-editing`, `.ofp-cell-dirty`,
+  `.ofp-cell-error`, `.ofp-row-long-press`, ...).
+
+## What to check before changing this layer
+
+- If you change row-action-menu or keyboard-navigation behavior, check
+  whether `FieldsBedsHierarchy.tsx`'s parallel implementation needs the
+  same change (see above) — it will not pick up the fix automatically.
+- Keep new edit cells consistent with the "preserve raw input text, defer
+  normalization to save time" pattern used by the existing custom edit
+  cells, rather than coercing on every keystroke.
+- Don't reintroduce a custom column-visibility UI; extend
+  `useColumnVisibility`/the native panel instead.
+- Notes columns must stay `editable: false` and excluded from the
+  spreadsheet auto-edit-start/F2 flow — they have their own editor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# OpenFarmPlanner Technical Documentation
+
+This is the technical documentation for OpenFarmPlanner, aimed at
+developers and AI coding agents working in this repository. For setup
+instructions and quick start, see the root [`README.md`](../README.md).
+For contribution/commit conventions, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+For rules AI agents must follow when changing code, see [`AGENTS.md`](../AGENTS.md).
+
+## Start here
+
+- **[Architecture Overview](./architecture-overview.md)** — tech stack,
+  backend/frontend structure, the project/user/permission model, and the
+  main architecture/UX decisions worth knowing before changing things.
+- **[Data Model](./data-model.md)** — the core domain objects and how they
+  relate, with Mermaid diagrams. Not a full field reference.
+
+## Complex features
+
+- **[DataGrid Architecture](./datagrid-architecture.md)** — the custom
+  layer OpenFarmPlanner built on top of MUI X DataGrid: inline editing,
+  row actions, notes/markdown cells, copy/paste, column visibility.
+- **[Keyboard Navigation Architecture](./keyboard-architecture.md)** — the
+  focus-region model and the shortcut/command system.
+- **[Occupancy Tree / Gantt Hierarchy](./occupancy-tree-hierarchy.md)** —
+  the Standort → Parzelle → Beet tree in the bed-occupancy calendar, plus
+  the Gantt calendar's context menu, drag-and-drop, and row-height model.
+- **[Crop Library Architecture](./crop-library-architecture.md)** — the
+  project-owned `Culture` vs. shared `PublicCulture` split, and the `crops`
+  Django app that prepares (but doesn't yet expose) a public Crop Library.
+- **[Seed Demand Calculation](./seed-demand-calculation.md)** — how
+  required seed amounts and package suggestions are computed, with worked
+  examples.
+- **[Versioning and History](./versioning-and-history.md)** — the
+  `EntityRevision` audit trail and how culture/project restore works.
+- **[Large-Dataset Rendering](./large-dataset-rendering.md)** — pagination,
+  bulk-read limits, and scroll-driven windowing for large projects.
+- **[`AUTOSAVE_IMPLEMENTATION.md`](../AUTOSAVE_IMPLEMENTATION.md)** —
+  save-on-blur, validation-before-save, and navigation-blocking hooks
+  (`useAutosaveDraft`, `useNavigationBlocker`).
+
+## Process / QA
+
+- [`qa-strategy.md`](./qa-strategy.md) — when to do a full vs. targeted
+  exploratory QA sweep.
+- [`qa-coverage-2026-06-30.md`](./qa-coverage-2026-06-30.md) (or a later
+  `qa-coverage-*.md`, if one exists — use the most recent date) — what was
+  last tested, at which commit.
+- [`qa-excluded-issues.md`](./qa-excluded-issues.md) — known, intentional
+  behavior that looks like a bug but isn't; don't re-report these.
+- [`keyboard-shortcuts-audit.md`](./keyboard-shortcuts-audit.md) — shortcut
+  inventory audit.
+
+## Conventions used across these docs
+
+- Mermaid diagrams for relationships/flows where they help; plain prose
+  otherwise.
+- A point marked **"unclear / needs check"** means the author could not
+  verify it from the code alone — treat it as a question, not a fact.
+- These docs describe *why* things are the way they are, not just *what*
+  the code does — the code itself, plus inline comments at the specific
+  non-obvious spots, is the source of truth for exact behavior.

--- a/docs/seed-demand-calculation.md
+++ b/docs/seed-demand-calculation.md
@@ -1,0 +1,162 @@
+# Seed Demand Calculation (Saatgutbedarf)
+
+The Seed Demand page (`/app/seed-demand`, `frontend/src/pages/SeedDemand.tsx`)
+answers: *for each culture, across all its planting plans in the active
+project, how much seed do we need, and how many packages (of which sizes)
+should we buy?*
+
+**The calculation happens entirely on the backend.** The frontend only
+renders the result and lets the user pick a supplier per culture.
+
+## Purpose and user interaction
+
+One row per culture, aggregated across every planting plan of that culture
+in the project — there's no per-plan or per-project drill-down UI. The only
+interaction that changes the underlying data is choosing a supplier from a
+per-row dropdown (only shown when a culture has more than one supplier with
+seed data); everything else (amount, package suggestion) is read-only,
+computed server-side. `frontend/src/pages/requirementFlow.ts`, despite the
+name, is *not* part of the calculation — it only decides which "you're
+missing setup step X" empty-state card to show when the project has no
+fields/beds/cultures/plans yet.
+
+## Where the logic lives
+
+| Piece | File |
+|---|---|
+| Per-plan requirement + aggregation + supplier/TKG resolution | `backend/farm/views.py`, `SeedDemandListView` (`GET`/`POST /seed-demand/`) |
+| Package-count optimizer | `backend/farm/services/seed_packages.py`, `compute_seed_package_suggestion()` |
+| Unit constants (seed-rate units, package units) | `backend/farm/seed_units.py` |
+| Read-only response shape | `backend/farm/serializers.py`, `SeedDemandSerializer` |
+| Display + supplier selection UI | `frontend/src/pages/SeedDemand.tsx` |
+
+## Calculation, step by step
+
+For each culture with at least one planting plan:
+
+1. **Per-plan requirement.** Pick the seed rate for the plan's
+   `cultivation_type` (direct sowing vs. pre-cultivation have separate rate
+   fields; falls back to a generic `seed_rate_by_cultivation` map, then to a
+   legacy single rate field). Convert to a quantity using whichever unit the
+   rate is expressed in:
+   - `g_per_m2` / `seeds_per_m2` → `plan.area_usage_sqm × rate`
+   - `g_per_lfm` / `seeds_per_lfm` → `(area_usage_sqm / culture.row_spacing_m) × rate`
+   - `seeds_per_plant` → `plan.quantity × rate`
+
+   If the plan's `cultivation_type` is set but isn't (or is no longer) one of
+   the culture's enabled `cultivation_types`, the plan is silently excluded
+   from the rate lookup.
+
+2. **Safety margin.** A per-cultivation-type safety-margin percentage
+   (`sowing_calculation_safety_percent_direct` / `_pre_cultivation`, or a
+   generic fallback) is applied **per plan, before summing**:
+   `required += requirement × (1 + margin_percent / 100)`.
+
+3. **Sum across all of a culture's plans**, keeping grams and seed-count
+   totals in separate buckets (a culture can have plans using either unit).
+   **Important quirk**: if any single plan fails to compute a requirement
+   (missing row spacing, missing quantity, etc.), the *entire culture's row*
+   for that request stops accumulating further plans — one bad plan doesn't
+   just get skipped, it poisons the rest of that culture's total for this
+   request.
+
+4. **Supplier resolution**, in priority order: an explicit
+   `?supplier_selection=cultureId:supplierId` query param (read-only, used
+   by the same GET that also displays the result) → the persisted
+   `culture.selected_seed_demand_supplier` → if there's exactly one supplier
+   option, auto-use it for display **without persisting it** (confirmed by
+   a dedicated regression test — see below).
+
+5. **Thousand-kernel-weight (TKG) resolution**: the *selected supplier's*
+   `CultureSupplierData.thousand_kernel_weight_g` takes priority over the
+   *culture's own* `thousand_kernel_weight_g`. Changing the selected
+   supplier can therefore change the effective TKG, and with it both the
+   displayed gram total and the package suggestion — this is intentional,
+   not a bug, if a value looks like it "changed for no reason" after a
+   supplier switch.
+
+6. **Display amount** is always normalized to grams via the TKG conversion
+   above. If the native rate was in seeds and no TKG is available anywhere,
+   the amount can't be computed: `required_amount_value = None`,
+   `required_amount_warning = 'missing_tkg'` — the UI shows a specific
+   "missing TKG" message instead of `0` or a dash.
+
+7. **Package suggestion** (`compute_seed_package_suggestion`): only
+   attempted if the selected supplier has `packaging_sizes`. Converts the
+   required amount into whichever unit the packages use (grams preferred if
+   any package is in grams), then searches combinations of pack counts for
+   one that **always rounds up** to at least the required amount — no
+   fractional packages are ever suggested. Among valid combinations, it
+   prefers (in order): fewer total packages, fewer/no "excessive" small
+   packages, fewer distinct sizes, and only then minimal overage — a
+   scoring tradeoff, not a pure "minimize waste" search. If package sizing
+   uses a *different* unit than the native seed-rate unit and no TKG is
+   available for that conversion, `required_amount_value` can be `None`
+   while a `package_suggestion` is still present (or vice versa) — this
+   inconsistent-looking pairing is expected, see the "missing TKG" example
+   below.
+
+## Worked examples (from `backend/farm/tests/test_seed_demand.py`)
+
+**A — safety margin, single package size ("Carrot").**
+Seed rate `10 g/m²`, safety margin `10%` (direct sowing). Two planting
+plans, 5 m² each → 10 m² total.
+`10 m² × 10 g/m² = 100 g`, `× 1.10 = 110 g` → `required_amount_value = 110.0`.
+Supplier package: 25 g each → `ceil(110 / 25) = 5` packages (125 g total,
+15 g overage).
+
+**B — cross-unit conversion via TKG ("Spinach").**
+Seed rate `20 g/m²`, no margin, 5 m² → `100 g` required.
+Culture's own TKG = 10 g/1000 seeds, but the **selected supplier's**
+`thousand_kernel_weight_g = 2` — this overrides the culture's TKG.
+Supplier packages are sized in **seeds** (5000/pack), so the 100 g
+requirement is converted to seed count using the supplier's TKG:
+`100 g / 2 g × 1000 = 50,000 seeds` → `ceil(50000 / 5000) = 10` packages.
+This is the clearest example of "supplier TKG overrides culture TKG,"
+because the same 100 g requirement would need a very different package
+count with the culture's own TKG of 10.
+
+**C — missing TKG ("Beetroot" / "Kresse").**
+Seed rate is `seeds_per_m2`, but no TKG exists anywhere (neither culture nor
+supplier). Result: `required_amount_value = None`,
+`required_amount_unit = 'g'` (the display unit is fixed even though the
+value couldn't be computed), `required_amount_warning = 'missing_tkg'`. A
+package suggestion can *still* be produced if the supplier's packages are
+sized directly in seeds (no conversion needed) — so it's normal to see a
+package suggestion next to a "missing TKG" warning in the same row.
+
+## Edge cases
+
+- **No supplier data at all** → warning `"Keine Lieferantendaten
+  vorhanden."`, no package suggestion; the UI links to editing the culture.
+- **Multiple suppliers, none selected** → the frontend forces an explicit
+  choice; nothing is auto-computed or persisted until the user picks one.
+- **Exactly one supplier** → auto-used for the calculation but never
+  written to the database (there's no interaction available to trigger a
+  write in that state anyway).
+- **`CultureSupplierData.germination_rate` is stored but currently
+  unused** in the quantity calculation — worth knowing if you're asked to
+  "why doesn't a low germination rate increase the suggested amount," since
+  the field exists but isn't wired into this formula.
+- **Historical package-size changes are not considered.** The calculation
+  always reads the *current* `CultureSupplierData.packaging_sizes` and
+  current culture/supplier fields — `CultureRevision` (deprecated, see
+  [versioning-and-history.md](./versioning-and-history.md)) is not consulted,
+  so there's no point-in-time "what would this have cost last season"
+  calculation.
+
+## A known internal inconsistency (documented, not hidden)
+
+`backend/farm/seed_units.py` defines reusable conversion helpers
+(`seeds_to_grams`, `grams_to_seeds`, `are_units_convertible`) that implement
+the same TKG formula described above — but the actual runtime conversion
+path in `SeedDemandListView` is a hand-rolled duplicate of that formula
+inline in the view, not a call to these functions. The formulas agree today,
+but if you need to change the conversion formula, **both places must be
+updated together**, or better: refactor the view to call the shared helper
+instead of leaving the duplication in place.
+
+## Unclear / needs check
+
+- Whether `germination_rate` is intended to factor into required-amount
+  math in a future iteration, or is deliberately display-only for now.

--- a/docs/versioning-and-history.md
+++ b/docs/versioning-and-history.md
@@ -1,0 +1,98 @@
+# Versioning and History (`EntityRevision`)
+
+OpenFarmPlanner keeps an audit trail and supports restoring cultures and
+whole projects to a past point in time. This is **snapshot-based**, not
+event-sourced: each history row is a full point-in-time copy of one
+entity's fields, not a delta to replay.
+
+## The model
+
+`EntityRevision` (`backend/farm/models.py`) is the current, generic
+mechanism: one row per `(entity_type, object_id)` per mutation
+(`created` / `updated` / `deleted` / `restored`), holding a full JSON
+`snapshot` of the entity's fields at that moment plus a `changed_fields`
+list for diff display. It replaced two now-deprecated models:
+
+- `CultureRevision` — the original culture-only history table.
+- `ProjectRevision` — snapshotted the *entire project* as one JSON blob per
+  mutation, which didn't scale as projects grew.
+
+Both are retained only so existing rows can drain via the `cleanup_history`
+management command — **no new rows are written to either**. If you're
+adding history for a new entity type, extend `EntityRevision`, not the old
+models.
+
+Why per-entity instead of per-project: write cost now scales with the size
+of the single changed entity, not with the size of the whole project, since
+every mutation only writes one small `EntityRevision` row rather than
+re-serializing everything the project contains.
+
+## Writing revisions
+
+`record_entity_revision(...)` (`backend/farm/views.py`) is the single
+write path — it just creates an `EntityRevision` row. It's called:
+
+- **Automatically** inside `Culture.save()` on every create/update, so
+  culture history requires no explicit call from view code.
+- **Explicitly** from view code for other mutation paths (soft-delete,
+  restore, project-level restore) — look for `culture._history_action = ...`
+  assignments before `.save()` calls in `backend/farm/views.py`; this is
+  how a save is tagged as a delete/restore action rather than a plain
+  update for history purposes.
+
+## Reading history
+
+- `GlobalHistoryListView` (`GET`, culture-only) and `ProjectHistoryListView`
+  (`GET`, all entity types) return the last 30 days of revisions for the
+  active project. `GlobalHistoryListView` additionally computes a
+  human-readable diff (`_build_entity_revision_changes`) between each
+  revision's snapshot and the *previous* revision for the same object,
+  skipping internal/denormalized fields (`id`, timestamps, `project_id`,
+  `*_normalized` fields, ...).
+- On the frontend, this only surfaces today as a standalone history
+  **dialog** on `Cultures.tsx` (see
+  [datagrid-architecture.md](./datagrid-architecture.md#row-history--versioning--not-a-grid-feature))
+  — it is not wired into the grid itself.
+
+## Restoring
+
+Two restore paths, both admin-only (`require_project_admin`):
+
+- **`GlobalHistoryRestoreView`** restores a *single culture* from one of its
+  own past revisions: copies every allowed field from that revision's
+  snapshot onto the (possibly soft-deleted — looked up via
+  `Culture.all_objects`, not the default manager) culture row, clears
+  `deleted_at`, and saves with `_history_action = ACTION_RESTORED`.
+- **`ProjectHistoryRestoreView`** restores the *whole project* to a target
+  timestamp (`_restore_project_state_at`): for every restorable entity
+  type, it deletes all current rows of that type in the project and
+  bulk-recreates them from `_entity_states_at(project, entity_type,
+  target_time)` — which, for each `object_id`, takes the most recent
+  revision at or before `target_time` (a `None` snapshot, i.e. the entity
+  was deleted by then, means it's simply not recreated). Entity types are
+  deleted in **reverse** dependency order before being recreated in forward
+  order, to avoid FK constraint errors during the rebuild.
+  `_restore_project_state_at` tolerates schema drift: a snapshot may carry
+  fields the current model no longer has (from before a field was renamed
+  or removed), and those are silently dropped rather than raising.
+
+## What to check before changing this
+
+- If you add a new project-scoped model that should participate in
+  project-wide point-in-time restore, add it to the restorable-entity-type
+  list used by `_restore_project_state_at` and make sure something calls
+  `record_entity_revision` for it — being project-scoped alone does not
+  give a model history for free.
+- Don't write new rows to `CultureRevision`/`ProjectRevision` — they're
+  drain-only.
+- Remember `EntityRevision.object_id` is a plain integer, not a real FK —
+  there's no DB-level referential-integrity guarantee tying a revision back
+  to its live entity table; this is an intentional generic-relation-like
+  pattern, not an oversight.
+
+## Unclear / needs check
+
+- The exact list backing `_RESTORABLE_ENTITY_TYPES` (which models
+  participate in whole-project restore) should be read directly from
+  `backend/farm/views.py` before assuming a given model is or isn't
+  covered — it wasn't fully enumerated in this doc.

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -106,6 +106,11 @@ httpClient.interceptors.request.use((config) => {
     }
   }
 
+  // Read fresh from localStorage on every request (not from React state) so a
+  // project switch takes effect immediately for any request in flight, and so
+  // this stays correct across the full-page reload that AuthContext triggers
+  // after switchActiveProject(). See docs/architecture-overview.md
+  // ("Project, user, and permission model").
   const activeProjectId = window.localStorage.getItem('activeProjectId');
   if (activeProjectId) {
     config.headers = config.headers ?? {};

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -13,6 +13,12 @@
  * Changes are saved through the row save action.
  * Keyboard navigation commits edit values locally without calling the API.
  * Navigation is blocked if there are unsaved changes (row in edit mode).
+ *
+ * See docs/datagrid-architecture.md for the full picture of what this adds on
+ * top of MUI X DataGrid (imperative command API, custom edit cells, row-action
+ * menu, notes cells, copy/paste, column visibility) — note that not every grid
+ * page uses this component (FieldsBedsHierarchy.tsx renders a raw MUI
+ * DataGrid with its own parallel implementation of several of these patterns).
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo, type KeyboardEvent, type ReactNode } from 'react';

--- a/frontend/src/components/data-grid/keyboardEditing.ts
+++ b/frontend/src/components/data-grid/keyboardEditing.ts
@@ -1,3 +1,6 @@
+// Excel-like "just start typing" (replace cell value) and F2 (edit in place)
+// entry points for EditableDataGrid. See docs/datagrid-architecture.md
+// ("Keyboard editing/navigation inside the grid") for the broader picture.
 import { useCallback, useEffect, useRef } from 'react';
 import type React from 'react';
 import { flushSync } from 'react-dom';
@@ -159,6 +162,12 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
     if (!pendingValue) {
       onBeforeEdit?.(params);
       apiRef.current?.setCellFocus?.(params.id, params.field);
+      // flushSync forces the row-mode change to commit synchronously so the edit
+      // cell exists in the DOM before we try to seed its value below. Without it,
+      // fast typing can race ahead of React's own render and the first keystroke
+      // (or several, on a slow render) would land before there's an input to type
+      // into — the pendingValuesRef buffer below exists specifically to survive
+      // that gap regardless, but flushSync keeps the common case tight.
       flushSync(() => {
         setRowModesModel((oldModel) => ({
           ...oldModel,

--- a/frontend/src/components/data-grid/markdown.ts
+++ b/frontend/src/components/data-grid/markdown.ts
@@ -10,6 +10,11 @@ const CITATION_MARKER_RE = /\s*【[^】]*†[^】]*】/g;
 /**
  * Remove AI-generated citation markers (e.g. 【941131680077198†L4162-L4178】) from text.
  * These are internal retrieval references that should not be shown to users.
+ *
+ * Kept even though the AI enrichment feature that used to generate these markers
+ * was removed (see git history: "Remove AI enrichment feature") — existing notes
+ * saved while that feature was active can still contain markers, so this stays a
+ * defensive display-time cleanup rather than dead code.
  */
 export function stripCitationMarkers(text: string): string {
   if (!text) return text;

--- a/frontend/src/components/hierarchy/hooks/useHierarchyContextMenu.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyContextMenu.ts
@@ -1,3 +1,9 @@
+// Right-click/long-press row-action menu for FieldsBedsHierarchy's raw MUI
+// DataGrid. This is a parallel, hand-rolled implementation of the same UX as
+// EditableDataGrid's useDataGridRowActionMenu — they share the lower-level
+// contextMenuFocus/utils/contextMenu primitives but not this state machine.
+// See docs/datagrid-architecture.md ("Hover actions / row actions / context
+// menu"). A fix here does not automatically apply to useDataGridRowActionMenu.
 import { useCallback, useRef, useState } from "react";
 import type { HierarchyRow } from "../utils/types";
 import {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,51 @@
+# Optional MkDocs Material configuration for browsing docs/ as a static site.
+#
+# Not currently built or deployed as part of this project — this file only
+# prepares the docs/ structure to be usable with MkDocs Material later,
+# without adding a dependency or a build step today. To try it locally:
+#   pip install mkdocs-material
+#   mkdocs serve
+#
+# Only files under docs/ are included in the nav below. Root-level docs
+# (README.md, AGENTS.md, CONTRIBUTING.md, backend/README.md,
+# frontend/README.md, *_IMPLEMENTATION.md) are intentionally left out of
+# this site config; they remain the canonical, GitHub-browsable entry
+# points and are cross-linked from docs/index.md instead.
+
+site_name: OpenFarmPlanner Technical Documentation
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - admonition
+  - tables
+
+nav:
+  - Home: index.md
+  - Architecture:
+      - Overview: architecture-overview.md
+      - Data Model: data-model.md
+  - Features:
+      - DataGrid Architecture: datagrid-architecture.md
+      - Keyboard Navigation: keyboard-architecture.md
+      - Occupancy Tree / Gantt Hierarchy: occupancy-tree-hierarchy.md
+      - Crop Library Architecture: crop-library-architecture.md
+      - Seed Demand Calculation: seed-demand-calculation.md
+      - Versioning and History: versioning-and-history.md
+      - Large-Dataset Rendering: large-dataset-rendering.md
+  - QA / Process:
+      - QA Strategy: qa-strategy.md
+      - Excluded Issues: qa-excluded-issues.md
+      - Keyboard Shortcuts Audit: keyboard-shortcuts-audit.md


### PR DESCRIPTION
## Summary

- Adds `docs/index.md` as a documentation entry point, plus new deep-dive docs: `architecture-overview.md` (tech stack, backend/frontend structure, project/user/permission model, key architecture/UX decisions), `data-model.md` (core domain objects with Mermaid ER diagrams), `datagrid-architecture.md` (the custom layer built on MUI X DataGrid), `seed-demand-calculation.md` (with worked numeric examples from existing tests), and `versioning-and-history.md` (the `EntityRevision` audit/restore system).
- Corrects stale claims found while researching: `AUTOSAVE_IMPLEMENTATION.md` and `FIELD_BED_AREA_IMPLEMENTATION.md` referenced pages/components (`Locations.tsx` autosave, `CultureForm.tsx` autosave, standalone `Beds.tsx`/`Fields.tsx`) that no longer match current code — both were updated in place with clear status notes rather than rewritten wholesale.
- Links the new docs from the root `README.md`'s Documentation Map, and adds a short pre-change checklist to `AGENTS.md` (which docs to read first, don't change existing UX without being asked, update docs alongside architecture/data-model/complex-feature changes, no drive-by refactors, which tests/lint to run).
- Adds a minimal `mkdocs.yml` so `docs/` can optionally be served with MkDocs Material later — no new dependency installed, no site built.
- Adds a small number of targeted code comments where the "why" wasn't otherwise evident (seed-demand per-culture error propagation in `views.py`, the agent-mode project lock in `project_context.py`, the `seed_units.py`/`views.py` conversion-logic duplication, the `flushSync` rationale in the spreadsheet edit-start hook, and short pointers from a few complex files to their matching docs). No behavior changes.

## Notes for reviewers

- Several points in the new docs are explicitly marked "unclear / needs check" rather than guessed at (e.g. the `AgentLoginToken` session lifecycle, whether `ProjectMembership.role` gates any frontend UI, whether a mid-session 401 triggers a global logout).
- `docs/architecture-overview.md` and `docs/datagrid-architecture.md` call out that `FieldsBedsHierarchy.tsx` uses a raw MUI `DataGrid` with its own parallel context-menu/keyboard implementation rather than `EditableDataGrid` — worth double-checking that characterization if it's since changed.

## Test plan

- [x] Backend: `pdm run test` (full suite) — 348 passed, 12 pre-existing failures (`accounts/tests/test_auth_api.py`, `crops/tests/test_views.py`) confirmed present on `main` before this change too (verified via `git stash`), unrelated to this diff.
- [x] Backend: targeted `farm/tests/test_seed_demand*.py`, `test_agent_login.py`, `test_culture_history.py`, `test_projects_api.py` — all passed.
- [x] Frontend: `npx tsc --noEmit` — no errors.
- [x] Frontend: `npm run lint` — pre-existing errors only, in files this PR doesn't touch.
- [x] Frontend: targeted Vitest runs (`EditableDataGrid`, `dataGridHandlers`, `dataGridUtils`, hierarchy components/navigation, `httpClient`, `markdown`) — all passed.
- [x] Markdown relative links checked programmatically (no missing targets).
- [x] Mermaid diagrams reviewed for cardinality-syntax consistency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_