### PR TITLE
fix: use shared seed_units conversion helpers in seed demand view

### DIFF
--- a/backend/farm/seed_units.py
+++ b/backend/farm/seed_units.py
@@ -29,11 +29,9 @@ class SeedAmount:
     unit: str
 
 
-# NOTE: SeedDemandListView (backend/farm/views.py) currently reimplements this
-# TKG conversion inline rather than calling these functions. The formulas agree
-# today, but if you change the conversion rule, update both places (or refactor
-# the view to call these instead of duplicating them). See
-# docs/seed-demand-calculation.md ("A known internal inconsistency").
+# These are the single source of truth for TKG conversion — SeedDemandListView
+# (backend/farm/views.py, _convert_requirement_to_unit) calls them rather than
+# reimplementing the formula. See docs/seed-demand-calculation.md.
 def seeds_to_grams(seeds: Decimal, thousand_kernel_weight_g: Decimal) -> Decimal:
     """
     Convert seed count to grams using TKG.

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -91,6 +91,9 @@ from .seed_units import (
     SEED_RATE_UNIT_SEEDS_PER_LFM,
     SEED_RATE_UNIT_SEEDS_PER_M2,
     SEED_RATE_UNIT_SEEDS_PER_PLANT,
+    are_units_convertible,
+    grams_to_seeds,
+    seeds_to_grams,
 )
 from .services.public_cultures import (
     DuplicatePublicCultureError,
@@ -2244,14 +2247,19 @@ class SeedDemandListView(ProjectScopedMixin, generics.ListAPIView):
 
     @staticmethod
     def _convert_requirement_to_unit(*, requirement_value: Decimal, requirement_unit: str, target_unit: str, tkg: Decimal | None) -> tuple[Decimal | None, str | None]:
+        # Delegates to seed_units.py's shared TKG conversion helpers rather than
+        # reimplementing the formula here, so there is a single place to change
+        # it. See docs/seed-demand-calculation.md.
         if requirement_unit == target_unit:
             return requirement_value, None
         if not tkg or tkg <= 0:
             return None, 'Missing thousand-kernel weight for unit conversion.'
+        if not are_units_convertible(requirement_unit, target_unit):
+            return None, 'Cannot convert between required amount and package unit.'
         if requirement_unit == SEED_PACKAGE_UNIT_SEEDS and target_unit == SEED_PACKAGE_UNIT_GRAMS:
-            return (requirement_value * tkg) / Decimal('1000'), None
+            return seeds_to_grams(requirement_value, tkg), None
         if requirement_unit == SEED_PACKAGE_UNIT_GRAMS and target_unit == SEED_PACKAGE_UNIT_SEEDS:
-            return (requirement_value / tkg) * Decimal('1000'), None
+            return grams_to_seeds(requirement_value, tkg), None
         return None, 'Cannot convert between required amount and package unit.'
 
     @classmethod

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -67,8 +67,8 @@ docs/                  # This documentation
   living in view methods.
 - Physical measurements (area, spacing, seed rates) are stored in SI units
   internally (m², m, g) and converted only at API/serializer boundaries —
-  see [seed-demand-calculation.md](./seed-demand-calculation.md) for where
-  this convention is and isn't consistently followed.
+  see [seed-demand-calculation.md](./seed-demand-calculation.md) for the
+  seed-amount/package-unit conversion specifically.
 
 ## Frontend structure
 

--- a/docs/seed-demand-calculation.md
+++ b/docs/seed-demand-calculation.md
@@ -145,16 +145,13 @@ package suggestion next to a "missing TKG" warning in the same row.
   so there's no point-in-time "what would this have cost last season"
   calculation.
 
-## A known internal inconsistency (documented, not hidden)
+## Unit conversion implementation
 
-`backend/farm/seed_units.py` defines reusable conversion helpers
-(`seeds_to_grams`, `grams_to_seeds`, `are_units_convertible`) that implement
-the same TKG formula described above — but the actual runtime conversion
-path in `SeedDemandListView` is a hand-rolled duplicate of that formula
-inline in the view, not a call to these functions. The formulas agree today,
-but if you need to change the conversion formula, **both places must be
-updated together**, or better: refactor the view to call the shared helper
-instead of leaving the duplication in place.
+`backend/farm/seed_units.py` defines the reusable TKG conversion helpers
+(`seeds_to_grams`, `grams_to_seeds`, `are_units_convertible`), and
+`SeedDemandListView._convert_requirement_to_unit` calls them directly rather
+than reimplementing the formula — there is one place to change the
+conversion rule if it ever needs to change.
 
 ## Unclear / needs check
 


### PR DESCRIPTION
## Summary

- `SeedDemandListView._convert_requirement_to_unit` (`backend/farm/views.py`) reimplemented the seeds↔grams thousand-kernel-weight (TKG) conversion formula inline instead of calling `backend/farm/seed_units.py`'s `seeds_to_grams`/`grams_to_seeds` — the same math existed in two places with no guarantee they'd stay in sync.
- Refactored the view to call the shared helpers directly (plus `are_units_convertible` for the existing "can these units convert" guard), so there's a single source of truth for the conversion formula.
- Updated `docs/seed-demand-calculation.md` and `docs/architecture-overview.md`, which had documented this as a known inconsistency, to reflect that it's now resolved.
- Pure refactor — no behavior change.

## Test plan

- [x] Full backend suite: `pdm run test` — 348 passed, 12 pre-existing failures (`accounts/tests/test_auth_api.py`, `crops/tests/test_views.py`), confirmed identical count/set to `main` before this change.
- [x] Targeted: `farm/tests/test_seed_demand.py`, `test_seed_demand_supplier_selection.py`, `test_seed_package_suggestion.py` — all pass.
- [x] `python -m py_compile` / AST parse on changed files — no syntax errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_