### PR TITLE
feat: factor germination rate into seed demand calculation

### DIFF
--- a/backend/farm/tests/test_seed_demand.py
+++ b/backend/farm/tests/test_seed_demand.py
@@ -46,7 +46,13 @@ def _create_plan(culture: Culture, bed: Bed, area: float, quantity: int | None =
     )
 
 
-def _create_supplier_data(culture: Culture, package_size: float, package_unit: str, thousand_kernel_weight_g: float | None = None) -> None:
+def _create_supplier_data(
+    culture: Culture,
+    package_size: float,
+    package_unit: str,
+    thousand_kernel_weight_g: float | None = None,
+    germination_rate: float | None = None,
+) -> None:
     supplier = Supplier.objects.create(
         name=f'Supplier {culture.name}',
         homepage_url=f'https://{culture.name.lower()}.example',
@@ -58,6 +64,7 @@ def _create_supplier_data(culture: Culture, package_size: float, package_unit: s
         project=culture.project,
         packaging_sizes=[{'size_value': package_size, 'size_unit': package_unit}],
         thousand_kernel_weight_g=thousand_kernel_weight_g,
+        germination_rate=germination_rate,
     )
 
 
@@ -83,6 +90,49 @@ def test_seed_demand_applies_safety_margin(api_client: APIClient, bed: Bed):
     assert row['required_amount_value'] == pytest.approx(110.0)
     assert row['required_amount_unit'] == 'g'
     assert row['package_suggestion']['pack_count'] == 5
+
+
+@pytest.mark.django_db
+def test_seed_demand_applies_germination_rate(api_client: APIClient, bed: Bed):
+    culture = Culture.objects.create(
+        name='Radish',
+        growth_duration_days=30,
+        harvest_duration_days=14,
+        cultivation_types=['direct_sowing'],
+        seed_rate_direct_value=10,
+        seed_rate_direct_unit='g_per_m2',
+        project=bed.project,
+    )
+    _create_plan(culture, bed, 10)
+    _create_supplier_data(culture, 25, 'g', germination_rate=80)
+
+    response = api_client.get('/openfarmplanner/api/seed-demand/')
+    row = response.json()['results'][0]
+    assert response.status_code == 200
+    # 10 m² * 10 g/m² = 100g raw, inflated by 100/80 germination rate = 125g.
+    assert row['required_amount_value'] == pytest.approx(125.0)
+    assert row['required_amount_unit'] == 'g'
+    assert row['package_suggestion']['pack_count'] == 5
+
+
+@pytest.mark.django_db
+def test_seed_demand_ignores_missing_germination_rate(api_client: APIClient, bed: Bed):
+    culture = Culture.objects.create(
+        name='Lettuce',
+        growth_duration_days=45,
+        harvest_duration_days=14,
+        cultivation_types=['direct_sowing'],
+        seed_rate_direct_value=10,
+        seed_rate_direct_unit='g_per_m2',
+        project=bed.project,
+    )
+    _create_plan(culture, bed, 10)
+    _create_supplier_data(culture, 25, 'g')
+
+    response = api_client.get('/openfarmplanner/api/seed-demand/')
+    row = response.json()['results'][0]
+    assert response.status_code == 200
+    assert row['required_amount_value'] == pytest.approx(100.0)
 
 
 @pytest.mark.django_db

--- a/backend/farm/views.py
+++ b/backend/farm/views.py
@@ -2285,6 +2285,25 @@ class SeedDemandListView(ProjectScopedMixin, generics.ListAPIView):
             return Decimal(str(selected_supplier.thousand_kernel_weight_g))
         return culture_tkg
 
+    @staticmethod
+    def _apply_germination_rate(
+        amounts_by_unit: dict[str, Decimal],
+        germination_rate: float | None,
+    ) -> dict[str, Decimal]:
+        """Inflate raw seed-amount requirements to account for expected
+        germination loss: a germination_rate of e.g. 80 means only 80% of
+        sown seed is expected to produce a viable plant, so the raw
+        requirement is scaled up by 100/germination_rate to still end up with
+        enough plants. An unknown, zero, or out-of-range rate (the model only
+        validates 0-100) leaves amounts unadjusted rather than raising, since
+        germination_rate is optional per-supplier data. See
+        docs/seed-demand-calculation.md.
+        """
+        if germination_rate is None or germination_rate <= 0 or germination_rate > 100:
+            return amounts_by_unit
+        factor = Decimal('100') / Decimal(str(germination_rate))
+        return {unit: amount * factor for unit, amount in amounts_by_unit.items()}
+
     def _compute_plan_requirement(self, plan: PlantingPlan) -> tuple[Decimal | None, str | None]:
         value, unit = self._select_seed_rate(plan.culture, plan.cultivation_type)
         if value is None or not unit or value <= 0:
@@ -2386,8 +2405,10 @@ class SeedDemandListView(ProjectScopedMixin, generics.ListAPIView):
                 selected_supplier_id = selected_supplier.supplier_id
 
             selected_tkg = self._select_tkg(entry['tkg'], selected_supplier)
+            germination_rate = selected_supplier.germination_rate if selected_supplier else None
+            germination_adjusted_amounts = self._apply_germination_rate(required_amounts_by_unit, germination_rate)
             display_required_amount, required_amount_warning = self._get_required_amount_in_unit(
-                amounts_by_unit=required_amounts_by_unit,
+                amounts_by_unit=germination_adjusted_amounts,
                 target_unit=SEED_PACKAGE_UNIT_GRAMS,
                 tkg=selected_tkg,
             )
@@ -2453,7 +2474,7 @@ class SeedDemandListView(ProjectScopedMixin, generics.ListAPIView):
             )
             same_unit_packages = [pkg for pkg in packages if pkg['size_unit'] == target_unit]
             target_amount, conversion_warning = self._get_required_amount_in_unit(
-                amounts_by_unit=required_amounts_by_unit,
+                amounts_by_unit=germination_adjusted_amounts,
                 target_unit=target_unit,
                 tkg=selected_tkg,
             )

--- a/docs/seed-demand-calculation.md
+++ b/docs/seed-demand-calculation.md
@@ -75,13 +75,26 @@ For each culture with at least one planting plan:
    not a bug, if a value looks like it "changed for no reason" after a
    supplier switch.
 
-6. **Display amount** is always normalized to grams via the TKG conversion
-   above. If the native rate was in seeds and no TKG is available anywhere,
-   the amount can't be computed: `required_amount_value = None`,
+6. **Germination-rate adjustment**: if the selected supplier has a
+   `germination_rate` (0-100%), the margin-adjusted requirement (in whichever
+   unit(s) it's currently in) is scaled up by `100 / germination_rate` —
+   e.g. an 80% germination rate means 100 required plants need
+   `100 / 0.8 = 125` sown seed-equivalents, not 100. This runs *after*
+   summing all of a culture's plans and *after* the supplier is selected
+   (germination rate is per-supplier data, like TKG), so switching the
+   selected supplier can change both the TKG *and* the germination
+   adjustment at once. A missing, zero, or out-of-range rate leaves the
+   amount unadjusted (treated the same as "no germination data yet"), it
+   does not block the calculation or add a warning.
+
+7. **Display amount** is always normalized to grams via the TKG conversion
+   above, using the germination-adjusted amount from step 6. If the native
+   rate was in seeds and no TKG is available anywhere, the amount can't be
+   computed: `required_amount_value = None`,
    `required_amount_warning = 'missing_tkg'` — the UI shows a specific
    "missing TKG" message instead of `0` or a dash.
 
-7. **Package suggestion** (`compute_seed_package_suggestion`): only
+8. **Package suggestion** (`compute_seed_package_suggestion`): only
    attempted if the selected supplier has `packaging_sizes`. Converts the
    required amount into whichever unit the packages use (grams preferred if
    any package is in grams), then searches combinations of pack counts for
@@ -125,6 +138,14 @@ package suggestion can *still* be produced if the supplier's packages are
 sized directly in seeds (no conversion needed) — so it's normal to see a
 package suggestion next to a "missing TKG" warning in the same row.
 
+**D — germination-rate adjustment.**
+Seed rate `10 g/m²`, no margin, 10 m² → `100 g` raw requirement. Selected
+supplier's `germination_rate = 80`. Adjusted requirement:
+`100 g / (80 / 100) = 125 g` → `required_amount_value = 125.0`. A supplier
+with 25 g packages now needs `ceil(125 / 25) = 5` packages instead of the 4
+that the unadjusted 100 g would have needed — the extra pack exists purely
+to cover expected germination loss.
+
 ## Edge cases
 
 - **No supplier data at all** → warning `"Keine Lieferantendaten
@@ -134,10 +155,10 @@ package suggestion next to a "missing TKG" warning in the same row.
 - **Exactly one supplier** → auto-used for the calculation but never
   written to the database (there's no interaction available to trigger a
   write in that state anyway).
-- **`CultureSupplierData.germination_rate` is stored but currently
-  unused** in the quantity calculation — worth knowing if you're asked to
-  "why doesn't a low germination rate increase the suggested amount," since
-  the field exists but isn't wired into this formula.
+- **`CultureSupplierData.germination_rate` inflates the required amount**
+  (see step 6 above and example D) using the *selected supplier's* rate —
+  switching suppliers can change the displayed amount and package
+  suggestion via germination rate as well as via TKG.
 - **Historical package-size changes are not considered.** The calculation
   always reads the *current* `CultureSupplierData.packaging_sizes` and
   current culture/supplier fields — `CultureRevision` (deprecated, see
@@ -158,5 +179,7 @@ instead of leaving the duplication in place.
 
 ## Unclear / needs check
 
-- Whether `germination_rate` is intended to factor into required-amount
-  math in a future iteration, or is deliberately display-only for now.
+- Whether the seed-demand UI should surface *which* rates (TKG,
+  germination) were applied to a given row, since both are now silently
+  supplier-dependent and can make the displayed number change for reasons
+  that aren't visible without opening the culture/supplier data.


### PR DESCRIPTION
## Summary

- `CultureSupplierData.germination_rate` (0-100%) was captured on suppliers but never used in the seed demand calculation (`SeedDemandListView`), even though a lower germination rate should mean more raw seed is needed to end up with the same number of viable plants.
- `SeedDemandListView` now inflates the margin-adjusted requirement by `100 / germination_rate` using the *selected supplier's* rate — resolved the same way TKG already is (per-supplier, chosen with the same supplier-selection priority) — before computing both the displayed `required_amount_value` and the package suggestion.
- A missing, zero, or out-of-range germination rate leaves the amount unadjusted, consistent with how missing TKG/margin data is already handled elsewhere in this view (no hard failure, no warning — treated as "no data yet").
- Documented in `docs/seed-demand-calculation.md` with a new worked example (D) and updated edge cases / step-by-step list.

**Intentional behavior change**: this changes the displayed required amount and package suggestion for any culture whose selected supplier has a `germination_rate` set below 100. That is the fix, not a regression — previously the app silently ignored data users had already entered.

## Test plan

- [x] New backend tests: `test_seed_demand_applies_germination_rate` (80% rate inflates 100g → 125g, 5×25g packages) and `test_seed_demand_ignores_missing_germination_rate` (no rate set → unchanged 100g).
- [x] `farm/tests/test_seed_demand.py`, `test_seed_demand_supplier_selection.py`, `test_seed_package_suggestion.py` — 24 passed.
- [x] Full backend suite: 350 passed, 12 pre-existing failures unrelated to this change (see note below).
- [x] `python -m py_compile` / AST parse on changed files — no syntax errors.

## Note for reviewers

While testing this I root-caused the "12 pre-existing failures" I'd previously reported as identical to `main`: 7 are a genuine, unrelated bug in `crops/tests/test_views.py` (separate PR incoming), but the other 5 (`accounts/tests/test_auth_api.py`) turned out to be a local sandbox artifact — `gettext`/compiled `.mo` translation files weren't present, which the project's own CI (`.github/workflows/ci.yml`) installs explicitly and `backend/README.md` documents (`pdm run compilemessages`). After installing `gettext` and compiling messages, all 48 accounts tests pass. Flagging this for transparency since I'd characterized the failure count incorrectly in an earlier PR description.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_