### PR TITLE
fix: use openfarmplanner URL prefix in crops API tests

### DIFF
--- a/backend/crops/tests/test_views.py
+++ b/backend/crops/tests/test_views.py
@@ -21,12 +21,12 @@ class CropViewSetTest(DRFAPITestCase):
         )
 
     def test_requires_authentication(self):
-        response = self.client.get('/api/crops/')
+        response = self.client.get('/openfarmplanner/api/crops/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_lists_only_published_crops(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get('/api/crops/')
+        response = self.client.get('/openfarmplanner/api/crops/')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         names = [item['name'] for item in response.data['results']]
@@ -35,7 +35,7 @@ class CropViewSetTest(DRFAPITestCase):
 
     def test_filters_by_free_text_query(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get('/api/crops/', {'q': 'lett'})
+        response = self.client.get('/openfarmplanner/api/crops/', {'q': 'lett'})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 1)
@@ -43,7 +43,7 @@ class CropViewSetTest(DRFAPITestCase):
 
     def test_retrieves_a_single_published_crop(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get(f'/api/crops/{self.published.id}/')
+        response = self.client.get(f'/openfarmplanner/api/crops/{self.published.id}/')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], 'Lettuce')
@@ -55,13 +55,13 @@ class CropViewSetTest(DRFAPITestCase):
 
     def test_retrieving_an_unpublished_crop_404s(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get(f'/api/crops/{self.draft.id}/')
+        response = self.client.get(f'/openfarmplanner/api/crops/{self.draft.id}/')
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_match_finds_an_exact_normalized_match(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get('/api/crops/match/', {'name': 'lettuce', 'variety': 'bijella'})
+        response = self.client.get('/openfarmplanner/api/crops/match/', {'name': 'lettuce', 'variety': 'bijella'})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['exists'])
@@ -69,7 +69,7 @@ class CropViewSetTest(DRFAPITestCase):
 
     def test_match_reports_no_match(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.get('/api/crops/match/', {'name': 'Kohlrabi', 'variety': 'Superschmelz'})
+        response = self.client.get('/openfarmplanner/api/crops/match/', {'name': 'Kohlrabi', 'variety': 'Superschmelz'})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['exists'])
@@ -77,6 +77,6 @@ class CropViewSetTest(DRFAPITestCase):
 
     def test_write_methods_are_not_allowed(self):
         self.client.force_authenticate(user=self.user)
-        response = self.client.post('/api/crops/', {'name': 'X', 'variety': 'Y'})
+        response = self.client.post('/openfarmplanner/api/crops/', {'name': 'X', 'variety': 'Y'})
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
## Summary

- `crops/tests/test_views.py` called `/api/crops/...` without the `openfarmplanner/` prefix, while every other test file in the backend consistently uses `/openfarmplanner/api/...` (confirmed via a project-wide grep: 100% of other API-calling test files use the prefixed form, matching the checked-in `backend/.env.example` default of `URL_PREFIX=openfarmplanner`).
- Root-caused via `django.urls.resolve('/api/crops/')` under `config.settings_test`: it 404s because every route is mounted under `openfarmplanner/...` in this configuration, and only `crops/tests/test_views.py` didn't account for that.
- As a result, 6 of 8 tests in this file failed outright, and `test_retrieving_an_unpublished_crop_404s` was a **false-positive pass** — it expected 404 and got one, but for the wrong reason (route not found at all, not "draft crop correctly hidden").
- Fixed by updating every request in the file to use the `/openfarmplanner/api/crops/...` prefix, consistent with the rest of the suite. No production code changed — `/api/crops/` itself was never broken; only these tests called the wrong path for this project's default URL configuration.

## Note for reviewers

While investigating this I also found that the 5 `accounts/tests/test_auth_api.py` failures I'd separately reported as "pre-existing" were actually a local sandbox artifact (missing `gettext`/uncompiled `.mo` translation files — the project's own CI installs `gettext` explicitly and `backend/README.md` documents `pdm run compilemessages`), not a real bug. With `gettext` installed and messages compiled, plus this fix, the **entire backend suite is now 360/360 passing** with zero known failures.

## Test plan

- [x] `crops/tests/test_views.py` — 8/8 passed (all previously failing tests now pass for the right reason).
- [x] Full backend suite: `pdm run test` — 360 passed, 0 failed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_