### PR TITLE
chore: remove unused GermanDateEditCell component

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -32,8 +32,10 @@ frontend/src/components/data-grid/
   keyboardEditing.ts       "just start typing" / F2 spreadsheet-edit-start behavior
   keyboardNavigation.ts    Tab/Arrow cell navigation rules, grid-API-agnostic
   contextMenuFocus.ts      Arrow/Home/End/Enter/Esc navigation *inside* an open menu
-  AreaM2EditCell.tsx, DateEditCell.tsx, GermanDateEditCell.tsx,
-  PlantsCountEditCell.tsx, SearchableSelectEditCell.tsx   custom edit cells
+  AreaM2EditCell.tsx, DateEditCell.tsx, PlantsCountEditCell.tsx,
+  SearchableSelectEditCell.tsx                            custom edit cells
+  GermanDateEditCell.tsx   shared German date parse/format helpers only
+                           (its edit-cell component was removed as dead code)
   NotesCell.tsx, NotesDrawer.tsx, NotesPreviewPopover.tsx,
   useNotesEditor.ts, useNotesPreview.ts, markdown.ts,
   noteAttachmentsCache.ts               rich markdown notes + photo attachments
@@ -87,12 +89,11 @@ MUI's stock edit cells didn't fit a few OpenFarmPlanner-specific needs:
   (with correct month-length/rollover handling), Left/Right move between
   segments, plus a hidden native `<input type="date">` behind a calendar
   icon as a picker fallback.
-- **`GermanDateEditCell`** is a simpler, non-segmented sibling (single text
-  field, parses on every change). `DateEditCell` also imports its
-  `parseGermanDateText`/`formatDateAsGerman` helpers. **Unclear/needs
-  check**: confirm whether any column still explicitly uses
-  `GermanDateEditCell` as `renderEditCell` before treating it as dead code
-  — `DateEditCell` is the default today.
+- **`GermanDateEditCell.tsx`** no longer exports an edit-cell component —
+  the component itself was confirmed unused as a `renderEditCell` anywhere
+  and removed. The file now only holds the shared
+  `parseGermanDateText`/`formatDateAsGerman` helpers that `DateEditCell`
+  imports.
 - **`SearchableSelectEditCell`** wraps an MUI Autocomplete for single-select
   columns with large option lists (cultures, suppliers) that a plain
   `singleSelect` dropdown wouldn't make browsable; `columns.tsx` also

--- a/frontend/src/components/data-grid/GermanDateEditCell.tsx
+++ b/frontend/src/components/data-grid/GermanDateEditCell.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
-import { TextField } from '@mui/material';
-import { useGridApiContext } from '@mui/x-data-grid';
-import type { GridRenderEditCellParams } from '@mui/x-data-grid';
-
+// Shared German date-text parse/format helpers used by DateEditCell.tsx (the
+// actual date edit cell in use today - see docs/datagrid-architecture.md).
+// The GermanDateEditCell component that used to live in this file was a
+// simpler, non-segmented edit cell with no remaining renderEditCell usages
+// anywhere in the app; it was removed as dead code, these helpers were not.
 export const parseGermanDateText = (text: string): Date | null => {
   const match = /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/.exec(text.trim());
   if (!match) return null;
@@ -20,40 +20,3 @@ export const formatDateAsGerman = (value: Date | string | null | undefined): str
   const month = String(d.getMonth() + 1).padStart(2, '0');
   return `${day}.${month}.${d.getFullYear()}`;
 };
-
-export function GermanDateEditCell({ id, field, value, hasFocus }: GridRenderEditCellParams) {
-  const apiRef = useGridApiContext();
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const [text, setText] = useState<string>(formatDateAsGerman(value as Date | null));
-
-  useEffect(() => {
-    if (!hasFocus) {
-      setText(formatDateAsGerman(value as Date | null));
-    }
-  }, [hasFocus, value]);
-
-  useEffect(() => {
-    if (hasFocus) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [hasFocus]);
-
-  return (
-    <TextField
-      type="text"
-      inputRef={inputRef}
-      value={text}
-      placeholder="TT.MM.JJJJ"
-      onChange={(e) => {
-        const raw = e.target.value;
-        setText(raw);
-        const parsed = parseGermanDateText(raw);
-        void apiRef.current.setEditCellValue({ id, field, value: parsed ?? (raw === '' ? null : value) });
-      }}
-      slotProps={{ input: { sx: { fontSize: 'inherit' } } }}
-      variant="standard"
-      sx={{ width: '100%', px: 1 }}
-    />
-  );
-}

--- a/frontend/src/components/data-grid/index.ts
+++ b/frontend/src/components/data-grid/index.ts
@@ -33,7 +33,7 @@ export type { AreaM2EditCellProps } from './AreaM2EditCell';
 export { PlantsCountEditCell } from './PlantsCountEditCell';
 export type { PlantsCountEditCellProps } from './PlantsCountEditCell';
 export { DateEditCell, toIsoDateString } from './DateEditCell';
-export { GermanDateEditCell, parseGermanDateText, formatDateAsGerman } from './GermanDateEditCell';
+export { parseGermanDateText, formatDateAsGerman } from './GermanDateEditCell';
 export { SearchableSelectEditCell } from './SearchableSelectEditCell';
 export type { SearchableSelectOption, SearchableSelectEditCellProps } from './SearchableSelectEditCell';
 export { createSearchableSelectColumn, createSingleSelectColumn } from './columns';


### PR DESCRIPTION
## Summary

- `GermanDateEditCell` (`frontend/src/components/data-grid/GermanDateEditCell.tsx`) was a simple, non-segmented date edit cell that turned out to have zero remaining usages as a `renderEditCell` anywhere in the app — `DateEditCell.tsx` is the actual default date edit cell today (applied automatically via `prepareDataGridColumn`), and only imports this file's `parseGermanDateText`/`formatDateAsGerman` helpers from it.
- Removed the unused component and its barrel export (`components/data-grid/index.ts`); kept the two helper functions, which are still actively used.
- Updated `docs/datagrid-architecture.md`, which had flagged this as "unclear/needs check," to reflect the resolved state.

## Test plan

- [x] `npx tsc --noEmit` — no errors.
- [x] `npx eslint` on changed files — no new errors.
- [x] `DateEditCell.test.tsx` (covers the still-used helpers via `DateEditCell`) — 11/11 passed.
- [x] Full frontend Vitest suite — passed (no regressions from removing the unused export).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_