### PR TITLE
feat(i18n): complete English translations for all namespaces

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -38,7 +38,7 @@ frontend/
     auth/              # Session/auth context, CSRF handling, ProtectedRoute
     focus/, commands/  # Keyboard focus regions and the command/shortcut system
     cultures/, crops/  # Culture domain UI vs. the (not yet public) Crop Library UI
-    i18n/              # Translation resources (German is complete; English is partial)
+    i18n/              # Translation resources (German + English complete, no switcher UI yet)
     gantt-chart/       # Vendored third-party Gantt component (MIT, see its own README)
   e2e/                 # Playwright end-to-end tests
 docs/                  # This documentation
@@ -112,9 +112,11 @@ docs/                  # This documentation
   axios client, `authApi.ts`'s own for the auth client) — a known
   duplication, not a bug, if you're looking for "the" error handler.
 - **i18n**: one JSON namespace per feature area under
-  `frontend/src/i18n/locales/{de,en}/`. German is complete (16 namespaces);
-  English is partial (8 namespaces) and falls back to German for anything
-  missing (`fallbackLng: 'de'`). Treat English as "started, not shipped."
+  `frontend/src/i18n/locales/{de,en}/`. Both German and English now have all
+  16 namespaces translated with matching key structure. There is no
+  language switcher UI yet, though — German (`lng: 'de'`,
+  `fallbackLng: 'de'`) is still the only language actually shown to users
+  today; the English resources exist ahead of that UI being built.
 - **Keyboard navigation & commands**: a focus-region model plus a
   shortcut/command system — see
   [keyboard-architecture.md](./keyboard-architecture.md).

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -17,21 +17,30 @@ import navigationEN from './locales/en/navigation.json';
 import homeDE from './locales/de/home.json';
 import homeEN from './locales/en/home.json';
 import dashboardDE from './locales/de/dashboard.json';
+import dashboardEN from './locales/en/dashboard.json';
 import locationsDE from './locales/de/locations.json';
+import locationsEN from './locales/en/locations.json';
 import culturesDE from './locales/de/cultures.json';
 import culturesEN from './locales/en/cultures.json';
 import plantingPlansDE from './locales/de/plantingPlans.json';
+import plantingPlansEN from './locales/en/plantingPlans.json';
 import fieldsDE from './locales/de/fields.json';
 import fieldsEN from './locales/en/fields.json';
 import bedsDE from './locales/de/beds.json';
+import bedsEN from './locales/en/beds.json';
 import hierarchyDE from './locales/de/hierarchy.json';
+import hierarchyEN from './locales/en/hierarchy.json';
 import ganttChartDE from './locales/de/ganttChart.json';
+import ganttChartEN from './locales/en/ganttChart.json';
 import yieldOverviewDE from './locales/de/yieldOverview.json';
 import yieldOverviewEN from './locales/en/yieldOverview.json';
 import suppliersDE from './locales/de/suppliers.json';
+import suppliersEN from './locales/en/suppliers.json';
 import helpDE from './locales/de/help.json';
 import authDE from './locales/de/auth.json';
+import authEN from './locales/en/auth.json';
 import accountDE from './locales/de/account.json';
+import accountEN from './locales/en/account.json';
 import projectInvitationsDE from './locales/de/projectInvitations.json';
 import projectInvitationsEN from './locales/en/projectInvitations.json';
 import helpEN from './locales/en/help.json';
@@ -76,10 +85,19 @@ i18n
         common: commonEN,
         navigation: navigationEN,
         home: homeEN,
+        dashboard: dashboardEN,
+        locations: locationsEN,
         cultures: culturesEN,
+        plantingPlans: plantingPlansEN,
         fields: fieldsEN,
-        help: helpEN,
+        beds: bedsEN,
+        hierarchy: hierarchyEN,
+        ganttChart: ganttChartEN,
         yieldOverview: yieldOverviewEN,
+        suppliers: suppliersEN,
+        help: helpEN,
+        auth: authEN,
+        account: accountEN,
         projectInvitations: projectInvitationsEN,
       },
     },

--- a/frontend/src/i18n/locales/en/account.json
+++ b/frontend/src/i18n/locales/en/account.json
@@ -1,0 +1,49 @@
+{
+  "title": "Account settings",
+  "email": "Email",
+  "displayName": "Display name",
+  "sections": {
+    "profile": "Profile",
+    "security": "Login & security",
+    "account": "Account"
+  },
+  "actions": {
+    "saveProfile": "Save profile",
+    "requestEmailChange": "Request email change",
+    "changePassword": "Change password",
+    "editDisplayName": "Change display name",
+    "save": "Save",
+    "sendConfirmationLink": "Send confirmation link",
+    "savePassword": "Save password"
+  },
+  "security": {
+    "changeEmailTitle": "Change email address",
+    "newEmail": "New email address",
+    "changePasswordTitle": "Change password",
+    "newPassword": "New password",
+    "repeatNewPassword": "Repeat new password"
+  },
+  "dangerZone": "Danger zone",
+  "deleteDescription": "If you delete your account, it is deactivated immediately and permanently anonymized or deleted after 14 days.",
+  "restoreDescription": "You can undo the deletion within this period.",
+  "deleteButton": "Delete account",
+  "dialogTitle": "Schedule account for deletion",
+  "dialogWarning": "Please confirm with your current password and the text \"DELETE\". Your account will be deactivated and permanently anonymized after 14 days.",
+  "currentPassword": "Current password",
+  "deletePhraseLabel": "Confirmation text",
+  "deletePhraseHelper": "Please enter exactly \"DELETE\" to confirm.",
+  "cancel": "Cancel",
+  "confirmDelete": "Schedule account for deletion",
+  "deletionScheduled": "Your account has been scheduled for deletion. It will be permanently deleted on {{date}}.",
+  "noDisplayName": "—",
+  "errors": {
+    "generic": "The action could not be performed.",
+    "delete": "Failed to schedule the deletion."
+  },
+  "unsavedChangesWarning": "There are unsaved changes. They will be lost when you leave the page.",
+  "emailConfirm": {
+    "title": "Confirm email change",
+    "loading": "Checking confirmation…",
+    "invalid": "The confirmation link is invalid or has expired."
+  }
+}

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -1,0 +1,113 @@
+{
+  "login": {
+    "title": "Sign in",
+    "email": "Email",
+    "password": "Password",
+    "submit": "Sign in",
+    "submitting": "Signing in…",
+    "noAccount": "Don't have an account? Register",
+    "forgotPassword": "Forgot password?",
+    "failed": "Sign in failed.",
+    "pendingDeletion": "This account is scheduled for deletion. It will be permanently deleted on {{date}}.",
+    "restoreAccount": "Restore account",
+    "restoreFailed": "Restore failed.",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
+  },
+  "register": {
+    "title": "Register",
+    "email": "Email",
+    "displayName": "Display name (optional)",
+    "password": "Password",
+    "passwordConfirm": "Confirm password",
+    "submit": "Create account",
+    "submitting": "Creating account…",
+    "passwordMismatch": "Passwords do not match.",
+    "failed": "Registration failed.",
+    "termsNoticePrefix": "By creating an account, you agree to the ",
+    "termsNoticeTermsLinkLabel": "Terms of Service",
+    "termsNoticeMiddle": ". Information on the processing of your personal data can be found in the ",
+    "termsNoticePrivacyLinkLabel": "Privacy Policy",
+    "termsNoticeSuffix": ".",
+    "loggedInHint": "You are already signed in as {{user}}. Would you like to create a new account?",
+    "logoutAndCreate": "Sign out & create new account",
+    "backToApp": "Back to the app",
+    "logoutToCreateFailed": "Sign out failed. Please try again.",
+    "resendActivation": "Resend activation email",
+    "hasAccount": "Already have an account? Sign in",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
+  },
+  "activate": {
+    "title": "Activate account",
+    "loading": "Activating account…",
+    "success": "Account activated successfully. Redirecting…",
+    "incompleteLink": "The activation link is incomplete.",
+    "failed": "Activation failed.",
+    "toLogin": "Go to sign in"
+  },
+  "forgotPassword": {
+    "title": "Forgot password",
+    "email": "Email",
+    "submit": "Send reset email",
+    "backToLogin": "Back to sign in",
+    "failed": "Request failed."
+  },
+  "resetPassword": {
+    "title": "Reset password",
+    "password": "New password",
+    "passwordConfirm": "Confirm new password",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
+    "submit": "Reset password",
+    "backToLogin": "Back to sign in",
+    "failed": "Reset failed."
+  },
+  "invitation": {
+    "title": "Project invitation",
+    "loginRequired": "Please sign in to accept the invitation.",
+    "toLogin": "Go to sign in",
+    "processing": "Accepting invitation…",
+    "accepted": "The invitation was accepted successfully.",
+    "failed": "The invitation could not be accepted.",
+    "missingToken": "The invitation link is invalid (token missing).",
+    "openApp": "Open app"
+  },
+  "reconsent": {
+    "accepting": "Confirming…",
+    "logout": "Sign out",
+    "failed": "Unfortunately that didn't work. Please try again.",
+    "terms": {
+      "title": "We've updated our Terms of Service",
+      "body": "To keep using OpenFarmPlanner, please confirm the current version of the Terms of Service.",
+      "linkLabel": "View Terms of Service",
+      "acceptButton": "Accept Terms of Service"
+    }
+  },
+  "error": {
+    "requestFailed": "Request failed.",
+    "fields": {
+      "email": "Email",
+      "password": "Password",
+      "password_confirm": "Confirm password",
+      "uid": "User ID",
+      "token": "Token",
+      "display_name": "Display name",
+      "document": "Document",
+      "detail": "Error",
+      "non_field_errors": "Error"
+    },
+    "messages": {
+      "required": "This field is required.",
+      "invalidEmail": "Please enter a valid email address.",
+      "passwordTooCommon": "This password is too common.",
+      "passwordTooShort": "This password is too short.",
+      "passwordEntirelyNumeric": "This password can't be entirely numeric.",
+      "invalidCredentials": "Sign in with the entered credentials failed.",
+      "minLength": "Please enter at least {{count}} characters.",
+      "maxLength": "Please enter at most {{count}} characters.",
+      "emailSendFailed": "The email could not be sent. Please contact [info@openfarmplanner.org](mailto:info@openfarmplanner.org).",
+      "activationEmailSendFailed": "Your account was created, but the activation email could not be sent. Please contact [info@openfarmplanner.org](mailto:info@openfarmplanner.org) so we can activate your account or resend the link."
+    }
+  }
+}

--- a/frontend/src/i18n/locales/en/beds.json
+++ b/frontend/src/i18n/locales/en/beds.json
@@ -1,0 +1,22 @@
+{
+  "title": "Beds",
+  "columns": {
+    "name": "Name",
+    "field": "Field",
+    "area": "Area (m²)",
+    "notes": "Notes"
+  },
+  "errors": {
+    "load": "Failed to load beds",
+    "save": "Failed to save bed",
+    "delete": "Failed to delete bed",
+    "loadFields": "Failed to load fields"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "fieldRequired": "Field is required"
+  },
+  "confirmDelete": "Do you really want to delete this bed?",
+  "addButton": "Add bed",
+  "selectField": "Select field"
+}

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -1,0 +1,26 @@
+{
+  "title": "Overview",
+  "errors": {
+    "load": "Failed to load dashboard data"
+  },
+  "emptyState": {
+    "title": "Start your crop planning",
+    "description": "Open Fields & Beds and add a field there. Afterwards you can record cultures and planting plans.",
+    "shortDescription": "Add a field on the Fields & Beds page.",
+    "action": "Add field"
+  },
+  "tasks": {
+    "title": "Upcoming tasks",
+    "empty": "No upcoming tasks",
+    "emptyTitle": "No upcoming tasks",
+    "emptyDescription": "There are currently no upcoming tasks for this project."
+  },
+  "checklist": {
+    "title": "Project start",
+    "intro": "OpenFarmPlanner helps you structure the planning of areas, cultures, and growing cycles. Start with your first field.",
+    "field": "Add field",
+    "bed": "Add bed",
+    "culture": "Add culture",
+    "plan": "Add planting plan"
+  }
+}

--- a/frontend/src/i18n/locales/en/ganttChart.json
+++ b/frontend/src/i18n/locales/en/ganttChart.json
@@ -1,0 +1,189 @@
+{
+  "title": "Crop calendar",
+  "zoomIn": "Zoom in",
+  "zoomOut": "Zoom out",
+  "viewModes": {
+    "month": "Month view",
+    "week": "Week view"
+  },
+  "months": {
+    "jan": "January",
+    "feb": "February",
+    "mar": "March",
+    "apr": "April",
+    "may": "May",
+    "jun": "June",
+    "jul": "July",
+    "aug": "August",
+    "sep": "September",
+    "oct": "October",
+    "nov": "November",
+    "dec": "December"
+  },
+  "weekShort": "wk",
+  "field": "Field",
+  "bed": "Bed",
+  "area": "Area",
+  "year": "Year",
+  "today": "Today",
+  "previousYear": "Previous year",
+  "nextYear": "Next year",
+  "loading": "Loading...",
+  "errors": {
+    "load": "Failed to load data",
+    "updatePlan": "Failed to update planting plan",
+    "render": "The calendar view could not be loaded."
+  },
+  "tooltip": {
+    "culture": "Culture",
+    "plantingDate": "Planting date",
+    "harvestDate": "Harvest date",
+    "firstHarvest": "First harvest",
+    "lastHarvest": "Last harvest",
+    "areaUsage": "Area",
+    "propagationStart": "Propagation start",
+    "transplantDate": "Transplanting",
+    "propagationDuration": "Propagation duration",
+    "bed": "Bed",
+    "location": "Location",
+    "plantsCount": "Plant count",
+    "totalPlantsCount": "Total plants",
+    "plantingPlanCount": "Number of planting plans",
+    "involvedLocations": "Involved locations",
+    "seedRequirement": "Seed demand",
+    "notes": "Note"
+  },
+  "noData": "No planting plans available",
+  "modeLabel": "Mode",
+  "modeAriaLabel": "Select mode",
+  "modeViewOption": "View",
+  "moveModeOption": "Move period",
+  "moveModeActiveOption": "Move period active",
+  "moveModeCommandActivate": "Activate move period",
+  "moveModeCommandDeactivate": "Deactivate move period",
+  "modeViewTooltip": "View mode: view and navigate the calendar. No changes via drag & drop.",
+  "moveModeTooltipDescription": "Activate move mode to move planting periods via drag-and-drop.",
+  "moveModeActiveTooltipDescription": "Drag a period left or right to shift the entire planting plan in time.",
+  "viewMode": "View mode",
+  "viewSelectorAriaLabel": "Select calendar view",
+  "chartLocaleText": {
+    "titleOccupancy": "Field planning",
+    "titleSeedlings": "Propagation planning",
+    "resources": "Areas",
+    "resourcesSeedlings": "Cultures",
+    "today": "Today",
+    "viewModes": {
+      "minute": "Minute",
+      "hour": "Hour",
+      "day": "Day",
+      "week": "Week",
+      "month": "Month",
+      "quarter": "Quarter",
+      "year": "Year"
+    }
+  },
+  "days": "days",
+  "yieldDistributionTitle": "Yield distribution",
+  "noYieldData": "No expected yields available for this year.",
+  "modes": {
+    "occupancy": "Field occupancy",
+    "seedlings": "Propagation"
+  },
+  "modeTooltips": {
+    "occupancy": "Shows bed occupancy over the year. The displayed periods are calculated from the planting plans and culture-specific timing (e.g. sowing, planting, and harvest).",
+    "seedlings": "Shows the propagation phase of cultures before planting. The displayed periods are calculated from the planting plans and culture-specific propagation duration data."
+  },
+  "shortcuts": {
+    "today": "Jump to the current period",
+    "previousPeriod": "Previous calendar period",
+    "nextPeriod": "Next calendar period",
+    "previousLargePeriod": "Jump back a large period",
+    "nextLargePeriod": "Jump forward a large period",
+    "dayView": "Show day view",
+    "weekView": "Show week view",
+    "monthView": "Show month view",
+    "quarterView": "Show quarter view",
+    "yearView": "Show year view",
+    "showOccupancy": "Show field occupancy",
+    "showSeedlings": "Show propagation",
+    "focusSearch": "Focus search (/)"
+  },
+  "modeDescriptions": {
+    "occupancy": "Occupancy of fields and beds throughout the year. This view still supports moving existing planting plans.",
+    "seedlings": "Propagation periods by culture. This view is read-only and only shows relevant propagations in the current year."
+  },
+  "seedlings": {
+    "emptyState": "No propagation periods available for this year.",
+    "plantsUnit": "plants"
+  },
+  "requirements": {
+    "field": {
+      "label": "Field",
+      "missing": "Field missing",
+      "done": "Field available"
+    },
+    "culture": {
+      "label": "Culture",
+      "missing": "Culture missing",
+      "done": "Culture available"
+    },
+    "bed": {
+      "label": "Bed",
+      "missing": "Bed missing",
+      "done": "Bed available"
+    },
+    "plan": {
+      "label": "Planting plan",
+      "missing": "Planting plan missing",
+      "done": "Planting plan available"
+    }
+  },
+  "emptyStates": {
+    "requirementsTitle": "No crop planning possible yet",
+    "requirementsDescription": "Open Fields & Beds and add a field to the appropriate location there. Afterwards you can record beds, cultures, and planting plans.",
+    "states": {
+      "cultures": {
+        "title": "No cultures yet",
+        "description": "Create your first culture now or import one from the culture library. Afterwards you can create planting plans."
+      },
+      "plans": {
+        "title": "No planting plans yet",
+        "description": "No planting plans have been created for the existing growing areas yet. Create a planting plan to show cultures and dates in the crop calendar."
+      }
+    },
+    "actions": {
+      "createCulture": "Add culture",
+      "createField": "Add field",
+      "createAreas": "Go to Fields & Beds",
+      "createPlan": "Add planting plan"
+    }
+  },
+  "sidebar": {
+    "resizeHandle": "Widen or narrow the sidebar"
+  },
+  "treeFilters": {
+    "searchPlaceholder": "Search by culture, bed, field, or location…",
+    "searchPlaceholderSeedlings": "Search by culture…",
+    "allLocations": "All locations",
+    "allFields": "All fields",
+    "onlyOccupiedBeds": "Only occupied beds",
+    "filterButton": "Filter",
+    "filterButtonWithCount": "Filter ({{count}})",
+    "locationLabel": "Location",
+    "fieldLabel": "Field",
+    "resetFilters": "Reset filters",
+    "clearSearch": "Clear search"
+  },
+  "contextMenu": {
+    "openPlan": "Open planting plan",
+    "openCulture": "Open culture",
+    "openBed": "Open bed",
+    "openField": "Open field",
+    "openLocation": "Open location",
+    "editBed": "Edit bed",
+    "editField": "Edit field",
+    "editLocation": "Edit location",
+    "addPlan": "Add planting plan",
+    "confirmDeletePlan": "Really delete this planting plan?"
+  }
+}

--- a/frontend/src/i18n/locales/en/hierarchy.json
+++ b/frontend/src/i18n/locales/en/hierarchy.json
@@ -1,0 +1,118 @@
+{
+  "title": "Fields & Beds",
+  "addField": "Field",
+  "addBed": "Bed",
+  "addBedToField": "Add bed for this field",
+  "createPlantingPlan": "Add planting plan",
+  "columns": {
+    "name": "Name",
+    "location": "Location",
+    "field": "Field",
+    "bed": "Bed",
+    "area": "Area (m²)",
+    "notes": "Notes",
+    "length": "Length (m)",
+    "width": "Width (m)"
+  },
+  "errors": {
+    "load": "Failed to load data",
+    "save": "Failed to save",
+    "delete": "Failed to delete",
+    "createField": "Failed to create field",
+    "deleteField": "Failed to delete field",
+    "saveBed": "Failed to save bed",
+    "deleteBed": "Failed to delete bed"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "bedAreaExceedsField": "The sum of bed areas ({{sum}} m²) exceeds the field's area ({{max}} m²). Please adjust the areas.",
+    "areaMustBePositive": "The area must be greater than 0.",
+    "areaTooLarge": "The entered area is too large. Please enter a smaller value.",
+    "lengthNonNegative": "Length must be greater than or equal to 0.",
+    "widthNonNegative": "Width must be greater than or equal to 0.",
+    "lengthNotANumber": "Length must be a valid number.",
+    "widthNotANumber": "Width must be a valid number.",
+    "duplicateFieldName": "A field with this name already exists at this location.",
+    "duplicateBedName": "A bed with this name already exists in this field."
+  },
+  "confirmDelete": "Do you really want to delete this entry?",
+  "footer": {
+    "singleLocation": "Expand fields to add beds",
+    "multipleLocations": "Expand locations/fields to add new fields/beds"
+  },
+  "tooltips": {
+    "expand": "Expand entry",
+    "collapse": "Collapse entry",
+    "addField": "Add field",
+    "calculatedArea": "Calculated automatically from length × width. Not directly editable."
+  },
+  "messages": {
+    "createLocationFirst": "Please create a location first.",
+    "singleLocationHint": "Location: {{name}}",
+    "invalidLocationSelection": "Please select a valid location.",
+    "noBedsHintTitle": "There are no beds yet.",
+    "noBedsHintBeforeIcon": "Add beds using the",
+    "noBedsHintAfterIcon": "icon on the respective field. It appears on hover.",
+    "noBedsHintMobile": "Long-press the respective field and select \"Add bed\".",
+    "missingDimensionsHint": "Length and width are important for area calculations, seed demand, and crop planning.",
+    "missingDimensionsHintOptional": "You can add the values later.",
+    "missingDimensionsCellTooltip": "Required for area calculation.",
+    "createLocationError": "Failed to create location.",
+    "locationCreated": "Location was created.",
+    "unsavedMissingName": "Row was not saved because the name is missing.",
+    "unsavedInvalidRowsNavigationWarning": "There is an unsaved row without a name. It will be lost when you leave the page.",
+    "unsavedRowEditNavigationWarning": "A row is currently being edited. The changes will be lost when you leave the page.",
+    "locationDeleted": "Location deleted",
+    "fieldDeleted": "Field deleted",
+    "bedDeleted": "Bed deleted",
+    "locationAndBedsDeleted": "Location and {{count}} beds deleted",
+    "fieldAndBedsDeleted": "Field and {{count}} beds deleted",
+    "locationsNowVisible": "Locations are now shown because multiple locations exist."
+  },
+  "prompts": {
+    "newFieldName": "Name of the new field:",
+    "selectLocationForField": "Please enter the location ID for the new field:\n{{options}}"
+  },
+  "actions": {
+    "addField": "Add field",
+    "addBed": "Add bed",
+    "createLocation": "Add location",
+    "addAdditionalLocation": "Multiple places? Add another location",
+    "undo": "Undo",
+    "addFieldDropdown": "Add field"
+  },
+  "dialogs": {
+    "addField": {
+      "title": "Add field",
+      "nameLabel": "Field name",
+      "submit": "Add"
+    },
+    "addAdditionalLocation": {
+      "title": "Add another location",
+      "description": "Locations help you manage areas at different places separately. For a project with only one place, you don't need to set up anything else.",
+      "nameLabel": "Location name",
+      "submit": "Create location"
+    }
+  },
+  "emptyAreas": {
+    "title": "No growing areas yet",
+    "description": "The main location isn't available for this project yet. Afterwards you can record fields and beds there.",
+    "missingLocationTitle": "Location missing",
+    "missingLocationDescription": "The main location isn't available for this project yet.",
+    "missingFieldTitle": "Field missing",
+    "missingFieldSingleLocationDescription": "Create a field to get started.",
+    "additionalLocationHint": "If you manage areas in multiple places, you can also",
+    "additionalLocationLink": "create additional locations",
+    "missingFieldMultipleLocationsBeforeIcon": "Add a field at the desired location using the",
+    "missingFieldMultipleLocationsAfterIcon": "icon or the context menu.",
+    "actions": {
+      "createLocation": "Add location",
+      "createField": "Add field",
+      "createBed": "Add bed"
+    }
+  },
+  "confirm": {
+    "deleteFieldWithBeds": "Do you really want to delete this field? All associated beds will also be deleted.",
+    "deleteBed": "Do you really want to delete this bed?"
+  }
+}

--- a/frontend/src/i18n/locales/en/locations.json
+++ b/frontend/src/i18n/locales/en/locations.json
@@ -1,0 +1,55 @@
+{
+  "title": "Locations",
+  "errors": {
+    "load": "Failed to load locations",
+    "save": "Failed to save location",
+    "delete": "Failed to delete location"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "latitudeRange": "Latitude must be between -90 and 90.",
+    "longitudeRange": "Longitude must be between -180 and 180.",
+    "coordinateFormat": "Please enter coordinates in the format \"latitude, longitude\"."
+  },
+  "confirmDelete": "Do you really want to delete this location?",
+  "addButton": "Add location",
+  "editTitle": "Edit location",
+  "emptyState": "No locations yet.",
+  "openInGoogleMaps": "Open in Google Maps",
+  "upcomingTasks": "Upcoming tasks",
+  "noUpcomingTasks": "No upcoming tasks",
+  "taskTitles": {
+    "sowing": "Sowing",
+    "planting": "Planting",
+    "propagationStart": "Start propagation",
+    "harvestStart": "Harvest starts"
+  },
+  "columns": {
+    "coordinates": "Coordinates",
+    "latitude": "Latitude",
+    "longitude": "Longitude",
+    "address": "Address",
+    "description": "Description",
+    "soilType": "Soil type",
+    "exposure": "Exposure"
+  },
+  "helpers": {
+    "optionalField": "Optional",
+    "coordinatesExample": "Example: 46.6473, 13.8688"
+  },
+  "soilType": {
+    "sand": "Sand",
+    "loam": "Loam",
+    "clay": "Clay"
+  },
+  "exposure": {
+    "north": "North",
+    "south": "South",
+    "east": "East",
+    "west": "West",
+    "flat": "Flat"
+  },
+  "placeholders": {
+    "coordinates": "e.g. 46.6473, 13.8688"
+  }
+}

--- a/frontend/src/i18n/locales/en/plantingPlans.json
+++ b/frontend/src/i18n/locales/en/plantingPlans.json
@@ -1,0 +1,142 @@
+{
+  "title": "Planting plans",
+  "columns": {
+    "culture": "Culture",
+    "location": "Location",
+    "field": "Field",
+    "bed": "Bed",
+    "fieldBed": "Field{{separator}}Bed",
+    "plantingDate": "Planting date",
+    "harvestDate": "Harvest date",
+    "harvestStartDate": "Harvest start",
+    "harvestEndDate": "Harvest end",
+    "areaM2": "Area (m²)",
+    "plantsCount": "Plants (≈)",
+    "notes": "Notes",
+    "cultivationType": "Cultivation type"
+  },
+  "labels": {
+    "coupled": "coupled"
+  },
+  "actions": {
+    "useAvailableArea": "Use remaining area",
+    "useBedArea": "Use bed area",
+    "copyPlantingPlan": "Copy planting plan"
+  },
+  "feedback": {
+    "areaAutoFilled": "Available remaining area applied automatically: {{area}}"
+  },
+  "dateEditor": {
+    "openCalendar": "Open calendar"
+  },
+  "areaValidation": {
+    "maxAreaApplied": "Maximum available area applied: {{area}}",
+    "remainingLimitTitle": "The specified area exceeds this bed's available remaining area.",
+    "noRemainingTitle": "No free area is available for this bed in the selected period.",
+    "bedLimitTitle": "The specified area exceeds this bed's size.",
+    "availableArea": "Available remaining area: {{area}}",
+    "bedArea": "Bed area: {{area}}",
+    "occupiedArea": "Already occupied: {{area}}",
+    "requestedArea": "Requested: {{area}}",
+    "acceptedArea": "Applied: {{area}}",
+    "applyRemainingArea": "Use remaining area",
+    "applyBedArea": "Use bed area"
+  },
+  "placeholders": {
+    "selectCulture": "Select culture",
+    "selectCultivationType": "Select cultivation type",
+    "selectArea": "Select growing area",
+    "plantsCount": "Enter quantity",
+    "maxKeyword": "max"
+  },
+  "tooltips": {
+    "coupledFields": "Area used: coupled with plant count. Changes automatically update the other value.",
+    "areaAutoMax": "Empty or \"max\" automatically uses the maximum available remaining area.",
+    "areaInputTitle": "Area occupied by this planting plan",
+    "areaInputDescription": "The area of the bed occupied by this planting plan. Changes to the area or plant count automatically update the other value. Empty or \"max\" uses the maximum available remaining area.",
+    "plantsFromSpacing": "Plant count: coupled with area used. Changes automatically update the other value.",
+    "calculatedHarvestDate": "Calculated automatically from the planting date and the culture library data."
+  },
+  "errors": {
+    "load": "Failed to load planting plans",
+    "save": "Failed to save planting plan",
+    "delete": "Failed to delete planting plan"
+  },
+  "messages": {
+    "deleted": "Planting plan deleted",
+    "plantingPlanCopied": "Planting plan copied."
+  },
+  "validation": {
+    "plantingDateRequired": "Planting date is required",
+    "cultureRequired": "Culture is required",
+    "bedRequired": "Bed is required",
+    "cultivationTypeRequired": "Cultivation type is required",
+    "requiredFields": "The following required fields must be filled in: {{fields}}",
+    "areaExceedsRemaining": "The specified area exceeds this bed's available remaining area.",
+    "areaExceedsBedArea": "The specified area exceeds this bed's size.",
+    "bedArea": "Bed area",
+    "alreadyAllocated": "Occupied",
+    "requestedArea": "Requested",
+    "availableArea": "Available remaining area",
+    "noAvailableArea": "No free area is available for this bed in the selected period anymore."
+  },
+  "confirmDelete": "Do you really want to delete this planting plan?",
+  "addButton": "Add planting plan",
+  "cultivationTypes": {
+    "directSowing": "Direct sowing",
+    "preCultivation": "Transplanting"
+  },
+  "areaAssignment": {
+    "title": "Change growing area",
+    "editButton": "Edit growing area",
+    "hierarchyHint": "Location filters fields, field filters beds.",
+    "emptyStateTitle": "No growing areas available",
+    "emptyStateDescription": "Create fields and beds first before assigning an area to a planting plan.",
+    "emptyStateAction": "Go to Fields & Beds",
+    "apply": "Apply",
+    "cancel": "Cancel"
+  },
+  "mobile": {
+    "showDetails": "Show details",
+    "hideDetails": "Hide details",
+    "fabLabel": "Add planting plan",
+    "fabAria": "Add planting plan",
+    "emptyTitle": "No planting plans yet",
+    "emptyDescription": "Create your first planting plan to manage culture, cultivation type, and time periods clearly on mobile.",
+    "emptyCta": "Add planting plan",
+    "createTitle": "Add planting plan",
+    "editTitle": "Edit planting plan",
+    "editAria": "Edit planting plan",
+    "actionsAria": "Actions for planting plan {{plan}}",
+    "notesPhotos": "Photos",
+    "notesPhotosAria": "Open notes and photos"
+  },
+  "emptyStates": {
+    "createBlockedTooltip": "Beds are added inside fields on the Fields & Beds page.",
+    "states": {
+      "fields": {
+        "title": "You can't add a planting plan yet.",
+        "description": "Open Fields & Beds and add a field to the appropriate location there."
+      },
+      "beds": {
+        "title": "You haven't created any beds yet.",
+        "description": "Beds are the foundation for planting plans. Open Fields & Beds and add a bed via a field."
+      },
+      "cultures": {
+        "title": "You haven't created any cultures yet.",
+        "description": "Cultures are required to create planting plans."
+      },
+      "plans": {
+        "title": "You haven't created a planting plan yet.",
+        "description": "Create your first planting plan now."
+      }
+    },
+    "actions": {
+      "createField": "Add field",
+      "createAreas": "Go to Fields & Beds",
+      "openCultureLibrary": "Open culture library",
+      "addCulture": "Add culture",
+      "createPlan": "Add planting plan"
+    }
+  }
+}

--- a/frontend/src/i18n/locales/en/suppliers.json
+++ b/frontend/src/i18n/locales/en/suppliers.json
@@ -1,0 +1,47 @@
+{
+  "title": "Suppliers",
+  "create": "Add supplier",
+  "edit": "Edit supplier",
+  "name": "Name",
+  "homepage": "Website",
+  "allowedDomains": "Allowed domains",
+  "active": "Active",
+  "actions": "Actions",
+  "save": "Save",
+  "cancel": "Cancel",
+  "addDomain": "Add domain",
+  "add": "Add",
+  "saveError": "Failed to save supplier.",
+  "loadError": "Failed to load suppliers.",
+  "yes": "Yes",
+  "no": "No",
+  "editAction": "Edit",
+  "deleteAction": "Delete",
+  "deleteError": "Failed to delete supplier.",
+  "restoreDeleteError": "Failed to restore supplier.",
+  "messages": {
+    "deleted": "Supplier deleted.",
+    "deletedWithUnlinkedCultures_one": "Supplier deleted. The supplier link was removed from {{count}} culture.",
+    "deletedWithUnlinkedCultures_other": "Supplier deleted. The supplier link was removed from {{count}} cultures."
+  },
+  "deleteUsageDialog": {
+    "title": "Supplier is still in use",
+    "summary_one": "This supplier is still used by {{count}} culture.",
+    "summary_other": "This supplier is still used by {{count}} cultures.",
+    "cultureUsage_one": "{{count}} culture uses this supplier directly.",
+    "cultureUsage_other": "{{count}} cultures use this supplier directly.",
+    "supplierDataUsage": "{{cultureCount}} cultures have seed or supplier data with {{rowCount}} entries.",
+    "seedDemandUsage_one": "{{count}} culture uses this supplier in seed demand planning.",
+    "seedDemandUsage_other": "{{count}} cultures use this supplier in seed demand planning.",
+    "unlinkExplanation": "If you continue, all cultures are kept. Only the supplier link is removed.",
+    "openAffectedCultures": "Go to affected cultures",
+    "unlinkAndDelete": "Remove supplier from all cultures and delete"
+  },
+  "invalidDomain": "Invalid domain: {{domain}}. Domains must be valid hostnames without a scheme or path (e.g. example.com).",
+  "domainValidationError": "Some domains are invalid. Please correct the input.",
+  "invalidUrl": "Please enter a valid URL (e.g. https://example.com).",
+  "emptyState": {
+    "title": "No suppliers yet",
+    "description": "Suppliers help you with seed demand planning and package comparison. You can also start without any suppliers."
+  }
+}


### PR DESCRIPTION
## Summary

- 8 of 16 i18n namespaces (`dashboard`, `locations`, `plantingPlans`, `beds`, `hierarchy`, `ganttChart`, `suppliers`, `auth`, `account`) had no English translation file at all and weren't even registered in `i18n/config.ts`'s `resources.en` — any English-language use of the app would have silently fallen back to German for these areas (`fallbackLng: 'de'`).
- Added the missing `frontend/src/i18n/locales/en/*.json` files, translated key-for-key from the German source, and registered them in `config.ts` (imports + `resources.en`).
- Verified programmatically (not just by eye) that every new English file has **exactly the same key structure** as its German counterpart, and that every `{{interpolation}}` placeholder (including i18next `_one`/`_other` plural-suffixed keys) matches 1:1 between the two languages — a mismatch there would silently break interpolation or plural selection at runtime.
- Updated `docs/architecture-overview.md`, which described English as "partial (8 namespaces)," to reflect that all 16 namespaces now have translations.

**Note**: there is no language switcher UI yet (per explicit product direction — this only completes the translation data ahead of that UI being built). This PR has no visible effect on its own; the app still defaults to German (`lng: 'de'`) with nothing yet to switch away from it.

## Test plan

- [x] JSON validity check on all 9 new files.
- [x] Programmatic DE/EN key-structure parity check across all 9 namespaces — exact match.
- [x] Programmatic DE/EN interpolation-placeholder parity check — exact match.
- [x] `npx tsc --noEmit` — no errors.
- [x] Full frontend Vitest suite — 123 test files / 1111 tests passed, including `i18n.test.ts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_