### PR TITLE
refactor(frontend): extract shared row-context-menu state machine

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -145,13 +145,19 @@ Separately, `renderInlineActionCell` overlays icon buttons directly inside
 one cell on row hover — this is the "hover actions" surface distinct from
 the right-click menu.
 
-**`FieldsBedsHierarchy.tsx`'s `useHierarchyContextMenu.ts` is a second,
-hand-rolled implementation of the same right-click/long-press pattern**,
-built directly on the same lower-level shared primitives
-(`contextMenuFocus.ts`, `utils/contextMenu.ts`) but not on
-`useDataGridRowActionMenu.ts` itself, because that page uses a raw
-`<DataGrid>`, not `EditableDataGrid`. Treat a UX fix to one as *not*
-automatically fixing the other.
+**`FieldsBedsHierarchy.tsx`'s `useHierarchyContextMenu.ts` is a separate
+implementation of the same right-click/long-press pattern**, because that
+page uses a raw `<DataGrid>`, not `EditableDataGrid`, and needs different
+data shapes (three row types/APIs, whole-row-object state) that
+`EditableDataGrid` has no concept of. It shares its open/close/reposition
+state machine and long-press timer with `useDataGridRowActionMenu.ts` via
+two small, tree-agnostic hooks
+(`components/contextMenu/useRowContextMenuState.ts`,
+`useLongPressTimer.ts`), but the trigger conditions and row-data wiring
+around that shared core are deliberately separate — treat a UX fix to
+*when/how* the menu opens (or the row-type-specific actions inside it) as
+*not* automatically fixing the other; only a fix to the shared
+open/close/reposition/focus-restore mechanics itself applies to both.
 
 ## Notes / markdown cells
 
@@ -233,9 +239,12 @@ grid," that's new work, not exposing something that already half-exists.
 
 ## What to check before changing this layer
 
-- If you change row-action-menu or keyboard-navigation behavior, check
-  whether `FieldsBedsHierarchy.tsx`'s parallel implementation needs the
-  same change (see above) — it will not pick up the fix automatically.
+- If you change *when/how* the row-action menu opens or keyboard-navigation
+  behavior, check whether `FieldsBedsHierarchy.tsx`'s implementation needs
+  the same change (see above) — only the shared
+  `useRowContextMenuState`/`useLongPressTimer` mechanics are common; a fix
+  to trigger conditions or row-type wiring in one does not apply to the
+  other automatically.
 - Keep new edit cells consistent with the "preserve raw input text, defer
   normalization to save time" pattern used by the existing custom edit
   cells, rather than coercing on every keystroke.

--- a/frontend/src/components/contextMenu/useLongPressTimer.ts
+++ b/frontend/src/components/contextMenu/useLongPressTimer.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Minimal touch-long-press timer: start(fire) (re)arms a single timeout,
+ * clear() cancels it, and the timer is always cancelled on unmount. Callers
+ * own their own touch-target validation before calling start() - this hook
+ * only manages the timer lifecycle, not what counts as a valid long-press
+ * target.
+ */
+export function useLongPressTimer(durationMs: number) {
+  const timerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const clear = useCallback((): void => {
+    if (timerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  useEffect(() => () => clear(), [clear]);
+
+  const start = useCallback((fire: () => void): void => {
+    clear();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      fire();
+    }, durationMs);
+  }, [clear, durationMs]);
+
+  return { start, clear };
+}

--- a/frontend/src/components/contextMenu/useRowContextMenuState.ts
+++ b/frontend/src/components/contextMenu/useRowContextMenuState.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, useState } from 'react';
+import { focusContextMenuOrigin, useContextMenuFocus } from '../data-grid/contextMenuFocus';
+import { useCloseCustomContextMenuOnNativeContextMenu } from '../../utils/contextMenu';
+
+export interface RowContextMenuState<TKey> {
+  key: TKey;
+  mouseX: number;
+  mouseY: number;
+}
+
+export interface UseRowContextMenuStateParams {
+  /** Whether an event target belongs to a row this menu can open for. Gates
+   * the "close this menu if a native context menu opens elsewhere" listener. */
+  isContextMenuTarget: (target: EventTarget | null) => boolean;
+}
+
+/**
+ * Shared open/close/reposition state machine behind both EditableDataGrid's
+ * row-action menu (useDataGridRowActionMenu) and FieldsBedsHierarchy's
+ * context menu (useHierarchyContextMenu) — see
+ * docs/datagrid-architecture.md ("Hover actions / row actions / context
+ * menu"). `TKey` is whatever the caller wants to identify the target row by
+ * (a row id looked up later, or the row object itself); this hook doesn't
+ * care which, it only manages position, focus-restore-on-close, and
+ * dismissal when another context menu opens elsewhere.
+ */
+export function useRowContextMenuState<TKey>({
+  isContextMenuTarget,
+}: UseRowContextMenuStateParams) {
+  const [state, setState] = useState<RowContextMenuState<TKey> | null>(null);
+  const originRef = useRef<HTMLElement | null>(null);
+
+  const open = useCallback((
+    key: TKey,
+    mouseX: number,
+    mouseY: number,
+    origin?: HTMLElement | null,
+  ): void => {
+    originRef.current = origin ?? null;
+    setState({ key, mouseX, mouseY });
+  }, []);
+
+  const close = useCallback((): void => {
+    setState(null);
+    focusContextMenuOrigin(originRef.current);
+  }, []);
+
+  /** Clears the menu without restoring focus, only if it's currently showing
+   * a key matching `predicate` — for silently dropping the menu when its
+   * underlying row disappears (e.g. deleted), as opposed to a user-driven
+   * close which should return focus to whatever opened the menu. */
+  const clearIf = useCallback((predicate: (key: TKey) => boolean): void => {
+    setState((current) => (current && predicate(current.key) ? null : current));
+  }, []);
+
+  const reposition = useCallback((event: globalThis.MouseEvent): void => {
+    setState((current) => (
+      current ? { key: current.key, mouseX: event.clientX + 2, mouseY: event.clientY - 6 } : current
+    ));
+  }, []);
+
+  useCloseCustomContextMenuOnNativeContextMenu(
+    state !== null,
+    close,
+    isContextMenuTarget,
+    reposition,
+  );
+
+  const listRef = useContextMenuFocus(state !== null, close);
+
+  return { state, originRef, listRef, open, close, clearIf };
+}

--- a/frontend/src/components/data-grid/hooks/useDataGridRowActionMenu.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridRowActionMenu.ts
@@ -1,11 +1,8 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { GridRowId } from '@mui/x-data-grid';
-import { focusContextMenuOrigin, useContextMenuFocus } from '../contextMenuFocus';
-import {
-  shouldOpenCustomContextMenu,
-  suppressNativeContextMenu,
-  useCloseCustomContextMenuOnNativeContextMenu,
-} from '../../../utils/contextMenu';
+import { shouldOpenCustomContextMenu, suppressNativeContextMenu } from '../../../utils/contextMenu';
+import { useRowContextMenuState } from '../../contextMenu/useRowContextMenuState';
+import { useLongPressTimer } from '../../contextMenu/useLongPressTimer';
 
 const ROW_ACTION_LONG_PRESS_MS = 550;
 
@@ -31,22 +28,19 @@ export function useDataGridRowActionMenu({
   setSelectedRowIds,
   getRowIdFromElement,
 }: UseDataGridRowActionMenuParams) {
-  const [rowActionMenuState, setRowActionMenuState] = useState<RowActionMenuState | null>(null);
   const [longPressFeedbackRowId, setLongPressFeedbackRowId] = useState<GridRowId | null>(null);
-  const rowActionMenuOriginRef = useRef<HTMLElement | null>(null);
-  const rowActionLongPressTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
 
-  const clearRowActionLongPressTimer = useCallback((): void => {
-    if (rowActionLongPressTimerRef.current === null) {
-      return;
+  const isRowActionContextMenuTarget = useCallback((target: EventTarget | null): boolean => {
+    if (!hasContextualRowActions || !shouldOpenCustomContextMenu(target)) {
+      return false;
     }
-    window.clearTimeout(rowActionLongPressTimerRef.current);
-    rowActionLongPressTimerRef.current = null;
-  }, []);
+    const rowId = getRowIdFromElement(target);
+    return rowId !== null && rowsById.has(String(rowId));
+  }, [getRowIdFromElement, hasContextualRowActions, rowsById]);
 
-  useEffect(() => () => {
-    clearRowActionLongPressTimer();
-  }, [clearRowActionLongPressTimer]);
+  const { state: menuState, originRef: menuOriginRef, listRef: menuListRef, open: menuOpen, close: menuClose, clearIf: menuClearIf } =
+    useRowContextMenuState<GridRowId>({ isContextMenuTarget: isRowActionContextMenuTarget });
+  const longPressTimer = useLongPressTimer(ROW_ACTION_LONG_PRESS_MS);
 
   const openRowActionMenuAt = useCallback((
     rowId: GridRowId,
@@ -56,9 +50,8 @@ export function useDataGridRowActionMenu({
   ): void => {
     markContextMenuHintUsed();
     setSelectedRowIds([rowId]);
-    rowActionMenuOriginRef.current = originElement;
-    setRowActionMenuState({ rowId, mouseX, mouseY });
-  }, [markContextMenuHintUsed, setSelectedRowIds]);
+    menuOpen(rowId, mouseX, mouseY, originElement);
+  }, [markContextMenuHintUsed, setSelectedRowIds, menuOpen]);
 
   const openRowActionContextMenu = useCallback((rowId: GridRowId, event: React.MouseEvent): void => {
     suppressNativeContextMenu(event);
@@ -72,42 +65,16 @@ export function useDataGridRowActionMenu({
   }, [openRowActionMenuAt]);
 
   const closeRowActionMenu = useCallback((): void => {
-    setRowActionMenuState(null);
+    menuClose();
     setLongPressFeedbackRowId(null);
-    focusContextMenuOrigin(rowActionMenuOriginRef.current);
-  }, []);
-
-  const isRowActionContextMenuTarget = useCallback((target: EventTarget | null): boolean => {
-    if (!hasContextualRowActions || !shouldOpenCustomContextMenu(target)) {
-      return false;
-    }
-    const rowId = getRowIdFromElement(target);
-    return rowId !== null && rowsById.has(String(rowId));
-  }, [getRowIdFromElement, hasContextualRowActions, rowsById]);
-
-  const repositionOpenRowActionMenu = useCallback((event: globalThis.MouseEvent): void => {
-    setRowActionMenuState((currentState) => (
-      currentState
-        ? { rowId: currentState.rowId, mouseX: event.clientX + 2, mouseY: event.clientY - 6 }
-        : currentState
-    ));
-  }, []);
-
-  useCloseCustomContextMenuOnNativeContextMenu(
-    Boolean(rowActionMenuState),
-    closeRowActionMenu,
-    isRowActionContextMenuTarget,
-    repositionOpenRowActionMenu,
-  );
-
-  const rowActionMenuListRef = useContextMenuFocus(Boolean(rowActionMenuState), closeRowActionMenu);
+  }, [menuClose]);
 
   // Used by the parent's clearRowInteractionState when a row is removed.
   const clearRowActionMenuForId = useCallback((rowId: GridRowId): void => {
     const rowKey = String(rowId);
     setLongPressFeedbackRowId((current) => (String(current) === rowKey ? null : current));
-    setRowActionMenuState((current) => (current && String(current.rowId) === rowKey ? null : current));
-  }, []);
+    menuClearIf((key) => String(key) === rowKey);
+  }, [menuClearIf]);
 
   const handleGridTouchStart = useCallback((event: React.TouchEvent<HTMLDivElement>): void => {
     if (!hasContextualRowActions || event.touches.length !== 1) {
@@ -124,30 +91,31 @@ export function useDataGridRowActionMenu({
       ? event.target.closest<HTMLElement>('[role="row"][data-id]')
       : null;
     const touch = event.touches[0];
-    clearRowActionLongPressTimer();
-    rowActionLongPressTimerRef.current = window.setTimeout(() => {
+    longPressTimer.start(() => {
       markContextMenuHintUsed();
       setSelectedRowIds([rowId]);
       setLongPressFeedbackRowId(rowId);
-      rowActionMenuOriginRef.current = originElement;
-      setRowActionMenuState({ rowId, mouseX: touch.clientX + 2, mouseY: touch.clientY - 6 });
-      rowActionLongPressTimerRef.current = null;
-    }, ROW_ACTION_LONG_PRESS_MS);
-  }, [clearRowActionLongPressTimer, getRowIdFromElement, hasContextualRowActions, markContextMenuHintUsed, rowsById, setSelectedRowIds]);
+      menuOpen(rowId, touch.clientX + 2, touch.clientY - 6, originElement);
+    });
+  }, [longPressTimer, getRowIdFromElement, hasContextualRowActions, markContextMenuHintUsed, rowsById, setSelectedRowIds, menuOpen]);
 
   const handleGridTouchMove = useCallback((): void => {
-    clearRowActionLongPressTimer();
-  }, [clearRowActionLongPressTimer]);
+    longPressTimer.clear();
+  }, [longPressTimer]);
 
   const handleGridTouchEnd = useCallback((): void => {
-    clearRowActionLongPressTimer();
-  }, [clearRowActionLongPressTimer]);
+    longPressTimer.clear();
+  }, [longPressTimer]);
+
+  const rowActionMenuState = useMemo((): RowActionMenuState | null => (
+    menuState ? { rowId: menuState.key, mouseX: menuState.mouseX, mouseY: menuState.mouseY } : null
+  ), [menuState]);
 
   return {
     rowActionMenuState,
     longPressFeedbackRowId,
-    rowActionMenuOriginRef,
-    rowActionMenuListRef,
+    rowActionMenuOriginRef: menuOriginRef,
+    rowActionMenuListRef: menuListRef,
     openRowActionMenuAt,
     openRowActionContextMenu,
     openRowActionKeyboardContextMenu,

--- a/frontend/src/components/hierarchy/hooks/useHierarchyContextMenu.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyContextMenu.ts
@@ -1,20 +1,17 @@
 // Right-click/long-press row-action menu for FieldsBedsHierarchy's raw MUI
-// DataGrid. This is a parallel, hand-rolled implementation of the same UX as
-// EditableDataGrid's useDataGridRowActionMenu — they share the lower-level
-// contextMenuFocus/utils/contextMenu primitives but not this state machine.
-// See docs/datagrid-architecture.md ("Hover actions / row actions / context
-// menu"). A fix here does not automatically apply to useDataGridRowActionMenu.
-import { useCallback, useRef, useState } from "react";
+// DataGrid. Shares its open/close/reposition state machine with
+// EditableDataGrid's useDataGridRowActionMenu via useRowContextMenuState -
+// see docs/datagrid-architecture.md ("Hover actions / row actions / context
+// menu"). What's NOT shared is deliberate: this hook opens on a right-click
+// anywhere in the row (or the name cell specifically) and stores the whole
+// row object, while EditableDataGrid opens via an explicit inline action
+// icon and stores only a row id looked up separately. Those differences are
+// UX/data-shape choices, not something to unify further.
+import { useCallback, useMemo } from "react";
 import type { HierarchyRow } from "../utils/types";
-import {
-  focusContextMenuOrigin,
-  useContextMenuFocus,
-} from "../../data-grid/contextMenuFocus";
-import {
-  shouldOpenCustomContextMenu,
-  suppressNativeContextMenu,
-  useCloseCustomContextMenuOnNativeContextMenu,
-} from "../../../utils/contextMenu";
+import { shouldOpenCustomContextMenu, suppressNativeContextMenu } from "../../../utils/contextMenu";
+import { useRowContextMenuState } from "../../contextMenu/useRowContextMenuState";
+import { useLongPressTimer } from "../../contextMenu/useLongPressTimer";
 
 interface ContextMenuState {
   row: HierarchyRow;
@@ -35,10 +32,23 @@ export function useHierarchyContextMenu({
   setSelectedRowId,
   setTreeActive,
 }: UseHierarchyContextMenuParams) {
-  const [contextMenuState, setContextMenuState] =
-    useState<ContextMenuState | null>(null);
-  const contextMenuOriginRef = useRef<HTMLElement | null>(null);
-  const touchLongPressTimeoutRef = useRef<number | null>(null);
+  const isHierarchyContextMenuTarget = useCallback(
+    (target: EventTarget | null): boolean => {
+      if (!shouldOpenCustomContextMenu(target) || !(target instanceof HTMLElement)) {
+        return false;
+      }
+      const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
+      const rowId = rowElement?.dataset.id;
+      return Boolean(rowId && rows.some((row) => String(row.id) === rowId));
+    },
+    [rows],
+  );
+
+  const { state: menuState, listRef: menuListRef, open: menuOpen, close: menuClose } =
+    useRowContextMenuState<HierarchyRow>({ isContextMenuTarget: isHierarchyContextMenuTarget });
+  // Unlike EditableDataGrid's handleGridTouchMove, this page has no
+  // touch-move cancellation today - only handleGridTouchEnd clears the timer.
+  const longPressTimer = useLongPressTimer(550);
 
   const openContextMenuForRow = useCallback(
     (
@@ -53,10 +63,9 @@ export function useHierarchyContextMenu({
       }
       setSelectedRowId(row.id as string | number);
       setTreeActive(true);
-      contextMenuOriginRef.current = origin ?? null;
-      setContextMenuState({ row, mouseX, mouseY });
+      menuOpen(row, mouseX, mouseY, origin ?? null);
     },
-    [markContextMenuHintUsed, setSelectedRowId, setTreeActive],
+    [markContextMenuHintUsed, setSelectedRowId, setTreeActive, menuOpen],
   );
 
   const handleNameCellContextMenu = useCallback(
@@ -82,18 +91,6 @@ export function useHierarchyContextMenu({
       openContextMenuForRow(row, rect.right - 8, rect.top + 12, event.currentTarget);
     },
     [openContextMenuForRow],
-  );
-
-  const isHierarchyContextMenuTarget = useCallback(
-    (target: EventTarget | null): boolean => {
-      if (!shouldOpenCustomContextMenu(target) || !(target instanceof HTMLElement)) {
-        return false;
-      }
-      const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
-      const rowId = rowElement?.dataset.id;
-      return Boolean(rowId && rows.some((row) => String(row.id) === rowId));
-    },
-    [rows],
   );
 
   const handleGridContextMenu = useCallback(
@@ -125,49 +122,22 @@ export function useHierarchyContextMenu({
       const targetRow = rows.find((row) => String(row.id) === rowId);
       const touch = event.touches[0];
       if (!targetRow || !touch) return;
-      touchLongPressTimeoutRef.current = window.setTimeout(() => {
+      longPressTimer.start(() => {
         openContextMenuForRow(targetRow, touch.clientX, touch.clientY, rowElement, {
           markHintUsed: false,
         });
-      }, 550);
+      });
     },
-    [openContextMenuForRow, rows],
+    [longPressTimer, openContextMenuForRow, rows],
   );
 
   const handleGridTouchEnd = useCallback((): void => {
-    if (touchLongPressTimeoutRef.current !== null) {
-      window.clearTimeout(touchLongPressTimeoutRef.current);
-      touchLongPressTimeoutRef.current = null;
-    }
-  }, []);
+    longPressTimer.clear();
+  }, [longPressTimer]);
 
-  const closeContextMenu = useCallback((): void => {
-    setContextMenuState(null);
-    focusContextMenuOrigin(contextMenuOriginRef.current);
-  }, []);
-
-  const repositionOpenContextMenu = useCallback(
-    (event: globalThis.MouseEvent): void => {
-      setContextMenuState((currentState) =>
-        currentState
-          ? { row: currentState.row, mouseX: event.clientX + 2, mouseY: event.clientY - 6 }
-          : currentState,
-      );
-    },
-    [],
-  );
-
-  useCloseCustomContextMenuOnNativeContextMenu(
-    contextMenuState !== null,
-    closeContextMenu,
-    isHierarchyContextMenuTarget,
-    repositionOpenContextMenu,
-  );
-
-  const contextMenuListRef = useContextMenuFocus(
-    contextMenuState !== null,
-    closeContextMenu,
-  );
+  const contextMenuState = useMemo((): ContextMenuState | null => (
+    menuState ? { row: menuState.key, mouseX: menuState.mouseX, mouseY: menuState.mouseY } : null
+  ), [menuState]);
 
   return {
     contextMenuState,
@@ -177,7 +147,7 @@ export function useHierarchyContextMenu({
     handleGridContextMenu,
     handleGridTouchStart,
     handleGridTouchEnd,
-    closeContextMenu,
-    contextMenuListRef,
+    closeContextMenu: menuClose,
+    contextMenuListRef: menuListRef,
   };
 }


### PR DESCRIPTION
## Summary

- `useDataGridRowActionMenu.ts` (EditableDataGrid) and `useHierarchyContextMenu.ts` (FieldsBedsHierarchy) each hand-rolled the same context-menu state machine — open at position with origin tracking, close with focus restore, reposition while open, dismiss when a native context menu opens elsewhere, and a 550ms touch-long-press timer. The sections were near line-for-line duplicates sitting on top of the already-shared low-level primitives (`contextMenuFocus.ts`, `utils/contextMenu.ts`), so every fix had to be made twice.
- Extracted the common core into two small, tree-agnostic hooks under `frontend/src/components/contextMenu/`:
  - **`useRowContextMenuState<TKey>`** — menu state (`key` + position), `open`/`close`/`clearIf`/reposition, plus the `useCloseCustomContextMenuOnNativeContextMenu` and `useContextMenuFocus` wiring both callers previously duplicated. `TKey` is generic: EditableDataGrid stores a `GridRowId`, the hierarchy page stores the whole `HierarchyRow` — the hook doesn't care.
  - **`useLongPressTimer`** — arm/clear/auto-cleanup-on-unmount for the touch long-press.
- Both callers keep their **deliberately different** trigger conditions and row wiring (right-click anywhere in the row + whole-row state vs. inline action icon + row-id lookup): per the preceding analysis, those differences are UX/data-shape choices, not duplication, and unifying further (e.g. migrating FieldsBedsHierarchy onto EditableDataGrid) was assessed and rejected — EditableDataGrid has no tree/multi-entity-type concept and retrofitting one would burden its flat-grid consumers.
- No behavior change intended. Public hook APIs (`rowActionMenuState`, `contextMenuState`, all handler names) are unchanged, so `DataGrid.tsx` and `FieldsBedsHierarchy.tsx` needed no edits.
- `docs/datagrid-architecture.md` updated: the "second, hand-rolled implementation" note now describes the shared core and clarifies which layer of a fix propagates to both grids and which doesn't.

## Test plan

- [x] `npx tsc --noEmit` — no errors.
- [x] `npx eslint .` — zero findings in the four touched files (only pre-existing, unrelated repo findings remain; React Compiler memoization warnings introduced by an intermediate version were resolved by destructuring the hook results).
- [x] Targeted Vitest: `EditableDataGrid.test.tsx`, `hierarchyComponents.test.tsx`, `FieldsBedsHierarchy.navigation/editCancel/scalability`, `useHierarchyGridKeyboard/Focus` — 135/135 passed (covers right-click menu, long-press, keyboard menu navigation, undo flows).
- [x] Full frontend Vitest suite — 122 files / 1108 tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JG923mp79Fk2EcKB14yrtT)_