### PR TITLE
fix: resolve e2e login flake (SQLite snapshot conflicts + login throttling)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -203,8 +203,21 @@ if db_engine == 'sqlite':
             # writer is active, which is what actually removes the contention; the
             # timeout stays as a backstop for the now-rare case of two writers
             # overlapping.
+            #
+            # transaction_mode=IMMEDIATE is the second half of the fix: with the
+            # default DEFERRED transactions, an ATOMIC_REQUESTS request that reads
+            # first and writes later (e.g. login: read user -> write session +
+            # last_login) starts on a read snapshot and then cannot upgrade to a
+            # write lock if any other writer committed in between - SQLite reports
+            # "database is locked" for that upgrade IMMEDIATELY, without consulting
+            # the busy timeout, because retrying on a stale snapshot could never
+            # succeed. BEGIN IMMEDIATE takes the write lock up front, so concurrent
+            # writers queue on the busy timeout instead of failing mid-request.
+            # Reproduced locally with concurrent logins + parallel GETs; see the
+            # e2e "database is locked" flake history (git log around this block).
             'OPTIONS': {
                 'timeout': 20,
+                'transaction_mode': 'IMMEDIATE',
                 'init_command': (
                     'PRAGMA journal_mode=WAL;'
                     'PRAGMA synchronous=NORMAL;'

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -39,6 +39,15 @@ export default defineConfig({
         CORS_ALLOWED_ORIGINS: `http://127.0.0.1:${frontendPort}`,
         CSRF_TRUSTED_ORIGINS: `http://127.0.0.1:${frontendPort}`,
         E2E_TEST_TOKEN: e2eToken,
+        // The whole suite logs in from one IP (127.0.0.1) at roughly one login
+        // per test, which sits right at the production default of 10/minute -
+        // whenever tests run fast enough, the shared per-IP bucket overflows and
+        // a login gets a 429, leaving the page stuck on /login (a long-standing
+        // e2e flake). Raise the auth rates for the e2e server only; production
+        // defaults in config/settings.py are unchanged.
+        THROTTLE_AUTH_LOGIN: '1000/minute',
+        THROTTLE_AUTH_REGISTER: '1000/minute',
+        THROTTLE_INVITATION_ACCEPT: '1000/hour',
       },
     },
     {


### PR DESCRIPTION
## Summary

Root-caused the long-standing e2e flake where tests intermittently fail with the page stuck on `/login` after clicking "Anmelden". There are **two independent causes**, both producing the same visible symptom:

### 1. SQLite "database is locked" despite WAL + 20s busy timeout

With Django's default DEFERRED transactions, an `ATOMIC_REQUESTS` request that **reads first and writes later** — exactly what login does (read user → write session + `last_login`) — starts on a read snapshot and then cannot upgrade to a write lock if any other writer committed in between. SQLite reports that upgrade conflict **immediately, without consulting the busy timeout**, because retrying on a stale snapshot could never succeed. That's why the earlier busy-timeout bump (`e2a237f`) and WAL didn't fully fix the flake.

**Reproduced locally** (script: concurrent login POSTs + 6 parallel GET threads against `manage.py runserver`, mimicking the app's polling behavior):
- Before: **183 of 187 login attempts failed** (500 `OperationalError: database is locked` after ~1.2–1.8s — well under the 20s timeout, confirming the timeout never applied).
- After adding `'transaction_mode': 'IMMEDIATE'` (Django 5.1+ option; this repo is on 5.2): **0 errors** in the same stress run — writers queue on the busy timeout instead of failing mid-request.

Trade-off, stated explicitly: with `ATOMIC_REQUESTS`, IMMEDIATE means every request (including GETs) takes the SQLite write lock at BEGIN, i.e. requests serialize. For this app's request durations (ms-scale) that's the right trade — errors are gone, and the 20s timeout is the backstop. The PostgreSQL path is untouched.

**This also fixes real production 500s** for SQLite deployments (the default), not just the test flake — any two concurrent write requests could hit this.

### 2. Login throttling at exactly the suite's login rate

`auth_login` defaults to **10/minute per IP**. The e2e suite logs in roughly once per ~7s test, all from 127.0.0.1 — sitting exactly at that limit, so fast runs overflow the shared bucket and a login gets a 429 (same stuck-on-`/login` symptom). Fixed by raising `THROTTLE_AUTH_LOGIN` / `THROTTLE_AUTH_REGISTER` / `THROTTLE_INVITATION_ACCEPT` via env **for the e2e backend only** (`playwright.config.ts` webServer env); production defaults in `config/settings.py` are unchanged.

Corroborating evidence that this flake is pure infrastructure: docs-only PRs (#288, #296) failed the same e2e job.

## Test plan

- [x] Local stress repro before/after (see numbers above); server log contains zero `database is locked` after the change.
- [x] Full backend suite (`pdm run test`) with the IMMEDIATE change active — **362 passed** (`settings_test` uses its own DATABASES config and is additionally unaffected).
- [x] `npx tsc --noEmit` + `npx eslint playwright.config.ts` — clean.
- [x] Several consecutive green e2e CI runs on this PR — **3 of 3 green** (attempts 1–3 of run 29105599875, see PR comment for details).
