### PR TITLE
feat: update legal consent flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ Deploy scripts, cron/scheduling config, and infra are **not** in this repo — t
 ## Agent Collaboration Preferences
 - When discussing how to approach a non-trivial task (architecture redesign, risky refactor, planning work), proactively recommend a reasoning-effort/model level (e.g. low/medium/high/xhigh, or a specific model) with a short rationale, before being asked.
 - User-workflow/collaboration preferences like this one should be recorded here in AGENTS.md, not only in a tool-specific private memory, since AGENTS.md is the shared, centrally-linked ruleset read by all coding agents (Claude, Codex, Copilot, etc.).
+- When changing the privacy policy or related legal texts, decide case by case whether the change only requires informing users or whether it requires renewed active consent from existing users. If renewed consent is necessary, implement the corresponding consent/version bump flow in the same change; if it is not necessary, state that explicitly in the summary.
 
 ## QA / Exploratory Testing
 When asked to search for bugs, run exploratory tests, or do a QA sweep:

--- a/backend/accounts/consent.py
+++ b/backend/accounts/consent.py
@@ -12,12 +12,17 @@ User = get_user_model()
 # on the document's page (e.g. frontend/src/i18n/locales/de/home.json,
 # legal.terms.version for DOCUMENT_TERMS).
 CURRENT_VERSIONS: dict[str, str] = {
-    DocumentConsent.DOCUMENT_TERMS: '2026-07-13',
+    DocumentConsent.DOCUMENT_TERMS: '2026-07-14',
+    DocumentConsent.DOCUMENT_PRIVACY: '2026-07-14',
 }
 
 # Documents a user currently must have accepted the current version of to
 # use the application. Add a document here once its consent flow (version
 # entry above, UI copy, etc.) is actually implemented.
+# Privacy policy consent is intentionally supported but not currently required:
+# the July 2026 privacy edits clarify existing processing rather than adding a
+# new consent-based processing purpose. Add DocumentConsent.DOCUMENT_PRIVACY
+# here when a future privacy-policy change genuinely requires active consent.
 REQUIRED_DOCUMENTS: list[str] = [
     DocumentConsent.DOCUMENT_TERMS,
 ]

--- a/backend/accounts/locale/de/LC_MESSAGES/django.po
+++ b/backend/accounts/locale/de/LC_MESSAGES/django.po
@@ -67,7 +67,7 @@ msgstr "Falls das Konto existiert, wurde eine E-Mail gesendet."
 
 #: accounts/views.py:46
 msgid "Registration successful. Please check your email to activate your account."
-msgstr "Registrierung erfolgreich. Bitte pruefe deine E-Mails, um dein Konto zu aktivieren."
+msgstr "Registrierung erfolgreich. Bitte prüfe deine E-Mails, um dein Konto zu aktivieren."
 
 #: accounts/views.py:49
 msgid ""

--- a/backend/accounts/migrations/0008_documentconsent_privacy_choice.py
+++ b/backend/accounts/migrations/0008_documentconsent_privacy_choice.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0007_publicprofile_unique_public_display_name_ci'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='documentconsent',
+            name='document',
+            field=models.CharField(
+                choices=[
+                    ('terms', 'Terms of Service'),
+                    ('privacy', 'Privacy Policy'),
+                ],
+                default='terms',
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -112,8 +112,10 @@ class DocumentConsent(models.Model):
     """
 
     DOCUMENT_TERMS = 'terms'
+    DOCUMENT_PRIVACY = 'privacy'
     DOCUMENT_CHOICES = [
         (DOCUMENT_TERMS, 'Terms of Service'),
+        (DOCUMENT_PRIVACY, 'Privacy Policy'),
     ]
 
     user = models.ForeignKey(

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -155,17 +155,11 @@ class ConsentAcceptSerializer(serializers.Serializer):
 
 
 class RegisterSerializer(serializers.Serializer):
-    """Registration has no separate terms-acceptance field: creating an account
-
-    itself constitutes acceptance of the current Terms of Service (see
-    `create()`), matching the implicit-consent pattern used by platforms like
-    GitHub or Wikipedia rather than a dedicated checkbox.
-    """
-
     email = serializers.EmailField()
     display_name = serializers.CharField(max_length=255, required=False, allow_blank=True)
     password = serializers.CharField(**_password_field_kwargs)
     password_confirm = serializers.CharField(**_password_field_kwargs)
+    accept_terms = serializers.BooleanField(required=True)
 
     def validate_email(self, value: str) -> str:
         normalized = normalize_email_lower(value)
@@ -173,18 +167,20 @@ class RegisterSerializer(serializers.Serializer):
             raise serializers.ValidationError(_de(_('An account with this email already exists.')))
         return normalized
 
-    def validate(self, attrs: dict[str, str]) -> dict[str, str]:
+    def validate(self, attrs: dict[str, object]) -> dict[str, object]:
         if attrs['password'] != attrs['password_confirm']:
             raise serializers.ValidationError({'password_confirm': _de(_('Passwords do not match.'))})
-        validate_password(attrs['password'])
+        if attrs.get('accept_terms') is not True:
+            raise serializers.ValidationError({'accept_terms': _de(_('You must accept the Terms of Service.'))})
+        validate_password(str(attrs['password']))
         return attrs
 
-    def create(self, validated_data: dict[str, str]) -> User:
-        display_name = validated_data.get('display_name', '').strip()
+    def create(self, validated_data: dict[str, object]) -> User:
+        display_name = str(validated_data.get('display_name', '')).strip()
         user = User.objects.create_user(
-            username=build_username_from_email(validated_data['email']),
-            email=validated_data['email'],
-            password=validated_data['password'],
+            username=build_username_from_email(str(validated_data['email'])),
+            email=str(validated_data['email']),
+            password=str(validated_data['password']),
             first_name=display_name,
             is_active=False,
         )

--- a/backend/accounts/tests/test_auth_api.py
+++ b/backend/accounts/tests/test_auth_api.py
@@ -40,12 +40,13 @@ class AuthApiTest(APITestCase):
                 'display_name': 'New User',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['detail'], 'Registrierung erfolgreich. Bitte pruefe deine E-Mails, um dein Konto zu aktivieren.')
+        self.assertEqual(response.data['detail'], 'Registrierung erfolgreich. Bitte prüfe deine E-Mails, um dein Konto zu aktivieren.')
         created = User.objects.get(email='new@example.com')
         self.assertFalse(created.is_active)
         self.assertEqual(created.first_name, 'New User')
@@ -67,6 +68,7 @@ class AuthApiTest(APITestCase):
                 'email': 'new@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -80,6 +82,7 @@ class AuthApiTest(APITestCase):
                 'email': 'mail-fail@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -99,6 +102,7 @@ class AuthApiTest(APITestCase):
                 'email': 'mail-link@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -115,6 +119,7 @@ class AuthApiTest(APITestCase):
                 'email': 'invalid-email',
                 'password': '123',
                 'password_confirm': '123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -136,14 +141,31 @@ class AuthApiTest(APITestCase):
         self.assertIn('email', response.data)
         self.assertIn('password', response.data)
         self.assertIn('password_confirm', response.data)
+        self.assertIn('accept_terms', response.data)
 
-    def test_registration_records_acceptance_of_the_current_terms_version_without_a_dedicated_field(self) -> None:
+    def test_registration_requires_explicit_terms_acceptance(self) -> None:
+        response = self.client.post(
+            '/openfarmplanner/api/auth/register/',
+            {
+                'email': 'no-terms@example.com',
+                'password': 'new-safe-password-123',
+                'password_confirm': 'new-safe-password-123',
+                'accept_terms': False,
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('accept_terms', response.data)
+        self.assertFalse(User.objects.filter(email='no-terms@example.com').exists())
+
+    def test_registration_records_acceptance_of_the_current_terms_version(self) -> None:
         response = self.client.post(
             '/openfarmplanner/api/auth/register/',
             {
                 'email': 'implicit-consent@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -159,6 +181,7 @@ class AuthApiTest(APITestCase):
                 'email': 'mismatch@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'different-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -183,6 +206,7 @@ class AuthApiTest(APITestCase):
                 'display_name': 'Pending User',
                 'password': self.password,
                 'password_confirm': self.password,
+                'accept_terms': True,
             },
             format='json',
         )
@@ -220,6 +244,7 @@ class AuthApiTest(APITestCase):
                 'email': 'expired-activation@example.com',
                 'password': self.password,
                 'password_confirm': self.password,
+                'accept_terms': True,
             },
             format='json',
         )
@@ -242,6 +267,7 @@ class AuthApiTest(APITestCase):
                 'email': 'one-time-token@example.com',
                 'password': self.password,
                 'password_confirm': self.password,
+                'accept_terms': True,
             },
             format='json',
         )
@@ -513,6 +539,7 @@ class AuthApiTest(APITestCase):
                 'email': 'console-message@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )
@@ -820,6 +847,15 @@ class ConsentApiTest(APITestCase):
         me_response = self.client.get('/openfarmplanner/api/auth/me/')
         self.assertEqual(me_response.data['pending_consents'], [])
 
+    def test_accept_endpoint_records_current_privacy_policy_version(self) -> None:
+        self.client.post('/openfarmplanner/api/auth/login/', {'email': self.user.email, 'password': self.password}, format='json')
+
+        response = self.client.post('/openfarmplanner/api/auth/consent/accept/', {'document': 'privacy'}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        record = DocumentConsent.objects.get(user=self.user, document=DocumentConsent.DOCUMENT_PRIVACY)
+        self.assertEqual(record.version, CURRENT_VERSIONS[DocumentConsent.DOCUMENT_PRIVACY])
+
     def test_accept_endpoint_requires_authentication(self) -> None:
         response = self.client.post('/openfarmplanner/api/auth/consent/accept/', {'document': 'terms'}, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -838,6 +874,7 @@ class ConsentApiTest(APITestCase):
                 'email': 'brand-new@example.com',
                 'password': 'new-safe-password-123',
                 'password_confirm': 'new-safe-password-123',
+                'accept_terms': True,
             },
             format='json',
         )

--- a/frontend/src/__tests__/ConsentGate.test.tsx
+++ b/frontend/src/__tests__/ConsentGate.test.tsx
@@ -22,15 +22,23 @@ vi.mock('../auth/useAuth', () => ({
 
 vi.mock('../i18n', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, params?: { version?: string }) => {
       const map: Record<string, string> = {
         'reconsent.accepting': 'Wird bestätigt…',
         'reconsent.logout': 'Abmelden',
         'reconsent.failed': 'Das hat leider nicht funktioniert. Bitte versuche es erneut.',
-        'reconsent.terms.title': 'Wir haben unsere Nutzungsbedingungen aktualisiert',
-        'reconsent.terms.body': 'Damit du OpenFarmPlanner weiter nutzen kannst, bestätige bitte die aktuelle Fassung der Nutzungsbedingungen.',
-        'reconsent.terms.linkLabel': 'Nutzungsbedingungen ansehen',
-        'reconsent.terms.acceptButton': 'Nutzungsbedingungen akzeptieren',
+        'reconsent.currentVersion': `Aktuelle Fassung: ${params?.version ?? ''}`,
+        'reconsent.additionalDocuments': 'Ebenfalls aktualisiert:',
+        'reconsent.terms.title': 'Die Nutzungsbedingungen wurden aktualisiert',
+        'reconsent.terms.body': 'Bitte lies und bestätige die aktuelle Fassung, bevor du OpenFarmPlanner weiter nutzt.',
+        'reconsent.terms.linkLabel': 'Nutzungsbedingungen lesen',
+        'reconsent.terms.acceptButton': 'Akzeptieren',
+        'reconsent.privacy.title': 'Die Datenschutzerklärung wurde aktualisiert',
+        'reconsent.privacy.body': 'Bitte lies und bestätige die aktuelle Fassung, bevor du OpenFarmPlanner weiter nutzt.',
+        'reconsent.privacy.linkLabel': 'Datenschutzerklärung lesen',
+        'reconsent.privacy.acceptButton': 'Akzeptieren',
+        'home:legal.terms.version': 'Stand: 14. Juli 2026',
+        'home:legal.privacy.version': 'Stand: 14. Juli 2026',
       };
       return map[key] ?? key;
     },
@@ -48,16 +56,18 @@ describe('ConsentGate', () => {
     };
   });
 
-  it('explains that the terms changed, links to the full text, and offers an accept button (no checkbox)', () => {
+  it('explains that the terms changed, links to the full text, shows the version, and offers a concise accept button', () => {
     render(
       <MemoryRouter>
         <ConsentGate />
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Wir haben unsere Nutzungsbedingungen aktualisiert' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Nutzungsbedingungen ansehen' })).toHaveAttribute('href', '/nutzungsbedingungen');
-    expect(screen.getByRole('button', { name: 'Nutzungsbedingungen akzeptieren' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Die Nutzungsbedingungen wurden aktualisiert' })).toBeInTheDocument();
+    expect(screen.getByText(/bevor du OpenFarmPlanner weiter nutzt/)).toBeInTheDocument();
+    expect(screen.getByText('Aktuelle Fassung: Stand: 14. Juli 2026')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Nutzungsbedingungen lesen' })).toHaveAttribute('href', '/nutzungsbedingungen');
+    expect(screen.getByRole('button', { name: 'Akzeptieren' })).toBeInTheDocument();
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
@@ -68,7 +78,7 @@ describe('ConsentGate', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Wir haben unsere Nutzungsbedingungen aktualisiert' })).toHaveFocus();
+    expect(screen.getByRole('heading', { name: 'Die Nutzungsbedingungen wurden aktualisiert' })).toHaveFocus();
   });
 
   it('accepts the current terms version with a single click, no checkbox required', async () => {
@@ -79,9 +89,50 @@ describe('ConsentGate', () => {
       </MemoryRouter>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Nutzungsbedingungen akzeptieren' }));
+    await user.click(screen.getByRole('button', { name: 'Akzeptieren' }));
 
     expect(acceptConsentMock).toHaveBeenCalledWith('terms');
+  });
+
+  it('can render and accept a required privacy policy consent', async () => {
+    authUser = {
+      id: 1,
+      email: 'test@example.com',
+      pending_consents: ['privacy'],
+    };
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ConsentGate />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Die Datenschutzerklärung wurde aktualisiert' })).toBeInTheDocument();
+    expect(screen.getByText('Aktuelle Fassung: Stand: 14. Juli 2026')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Datenschutzerklärung lesen' })).toHaveAttribute('href', '/datenschutz');
+
+    await user.click(screen.getByRole('button', { name: 'Akzeptieren' }));
+
+    expect(acceptConsentMock).toHaveBeenCalledWith('privacy');
+  });
+
+  it('links to the privacy policy when it is also pending after the terms update', () => {
+    authUser = {
+      id: 1,
+      email: 'test@example.com',
+      pending_consents: ['terms', 'privacy'],
+    };
+
+    render(
+      <MemoryRouter>
+        <ConsentGate />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Nutzungsbedingungen lesen' })).toHaveAttribute('href', '/nutzungsbedingungen');
+    expect(screen.getByText('Ebenfalls aktualisiert:')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Datenschutzerklärung lesen' })).toHaveAttribute('href', '/datenschutz');
   });
 
   it('is fully keyboard-operable: tab reaches the accept and logout buttons', async () => {
@@ -93,9 +144,9 @@ describe('ConsentGate', () => {
     );
 
     await user.tab();
-    expect(screen.getByRole('link', { name: 'Nutzungsbedingungen ansehen' })).toHaveFocus();
+    expect(screen.getByRole('link', { name: 'Nutzungsbedingungen lesen' })).toHaveFocus();
     await user.tab();
-    expect(screen.getByRole('button', { name: 'Nutzungsbedingungen akzeptieren' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Akzeptieren' })).toHaveFocus();
     await user.keyboard('{Enter}');
     expect(acceptConsentMock).toHaveBeenCalledWith('terms');
 
@@ -125,7 +176,7 @@ describe('ConsentGate', () => {
       </MemoryRouter>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Nutzungsbedingungen akzeptieren' }));
+    await user.click(screen.getByRole('button', { name: 'Akzeptieren' }));
 
     expect(await screen.findByText('Netzwerkfehler')).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/PrivacyPolicyPage.test.tsx
+++ b/frontend/src/__tests__/PrivacyPolicyPage.test.tsx
@@ -75,6 +75,8 @@ describe('PrivacyPolicyPage', () => {
     expect(screen.getByRole('heading', { name: /^\d+\. Cookies$/ })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /Lokaler Speicher/ })).toBeInTheDocument();
     expect(screen.getByText(/keine Analyse-, Tracking- oder Marketing-Cookies/)).toBeInTheDocument();
+    expect(screen.getByText(/zuletzt geöffnete Projekt/)).toBeInTheDocument();
+    expect(screen.getByText(/Session-Storage-Daten werden in der Regel beim Schließen des Browser-Tabs gelöscht/)).toBeInTheDocument();
   });
 
   it('does not claim data is never shared with third parties', () => {
@@ -90,6 +92,30 @@ describe('PrivacyPolicyPage', () => {
     expect(screen.getByText(/Widerruf einer erteilten Einwilligung/)).toBeInTheDocument();
     expect(screen.getByText(/Art\. 15 DSGVO/)).toBeInTheDocument();
     expect(screen.getByText(/Art\. 7 Abs\. 3 DSGVO/)).toBeInTheDocument();
+  });
+
+  it('covers WKO checklist details for officer, provision duty, third-country transfer, and profiling', () => {
+    renderPrivacyPolicyPage();
+
+    expect(screen.getByRole('heading', { name: /Datenschutzbeauftragter/ })).toBeInTheDocument();
+    expect(screen.getByText(/kein Datenschutzbeauftragter bestellt/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Bereitstellung personenbezogener Daten/ })).toBeInTheDocument();
+    expect(screen.getByText(/ohne diese Daten können wir kein Benutzerkonto bereitstellen/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Drittlandübermittlung/ })).toBeInTheDocument();
+    expect(screen.getByText(/außerhalb der Europäischen Union oder des Europäischen Wirtschaftsraums findet/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Automatisierte Entscheidungsfindung/ })).toBeInTheDocument();
+    expect(screen.getByText(/einschließlich Profiling im Sinne des Art\. 22 DSGVO/)).toBeInTheDocument();
+  });
+
+  it('states concrete retention windows visible from account and invitation flows', () => {
+    renderPrivacyPolicyPage();
+
+    expect(screen.getByText(/Aktivierungslinks sind derzeit 7 Tage gültig/)).toBeInTheDocument();
+    expect(screen.getByText(/E-Mail-Änderungslinks sind derzeit 24 Stunden gültig/)).toBeInTheDocument();
+    expect(screen.getByText(/Projekt-Einladungen sind derzeit 14 Tage gültig/)).toBeInTheDocument();
+    expect(screen.getByText(/für 14 Tage als „zur Löschung vorgemerkt“/)).toBeInTheDocument();
+    expect(screen.getByText(/Server-Logfiles des Hosting-Anbieters werden täglich rotiert und nach 7 Tagen gelöscht/)).toBeInTheDocument();
+    expect(screen.getByText(/Eigene technische Cron- und Anwendungslogs speichern wir höchstens 14 Tage/)).toBeInTheDocument();
   });
 
   it('uses a concrete revision date instead of a generic month/year stamp', () => {

--- a/frontend/src/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/__tests__/RegisterPage.test.tsx
@@ -60,6 +60,7 @@ vi.mock('../i18n', () => ({
         'auth:register.termsNoticeMiddle': ' zu. Informationen zur Verarbeitung Ihrer personenbezogenen Daten finden Sie in der ',
         'auth:register.termsNoticePrivacyLinkLabel': 'Datenschutzerklärung',
         'auth:register.termsNoticeSuffix': '.',
+        'auth:register.termsRequired': 'Bitte akzeptiere die Nutzungsbedingungen, um ein Konto zu erstellen.',
       };
       return map[key] ?? key;
     },
@@ -169,7 +170,7 @@ describe('RegisterPage', () => {
     expect(logoutMock).toHaveBeenCalledTimes(1);
   });
 
-  it('has no terms-acceptance checkbox and submits registration without one', async () => {
+  it('requires an explicit terms-acceptance checkbox before registration', async () => {
     authUser = null;
     const user = userEvent.setup();
 
@@ -179,19 +180,22 @@ describe('RegisterPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    const submitButton = screen.getByRole('button', { name: 'Konto erstellen' });
+    expect(submitButton).toBeDisabled();
 
     await user.type(screen.getByLabelText(/E-Mail/i), 'new@example.com');
     const passwordInputs = screen.getAllByLabelText(/^Passwort/i).filter((el) => el.tagName === 'INPUT');
     await user.type(passwordInputs[0], 'new-safe-password-123');
     await user.type(passwordInputs[1], 'new-safe-password-123');
+    await user.click(screen.getByRole('checkbox', { name: /Nutzungsbedingungen/ }));
 
-    await user.click(screen.getByRole('button', { name: 'Konto erstellen' }));
+    expect(submitButton).toBeEnabled();
+    await user.click(submitButton);
 
-    expect(registerMock).toHaveBeenCalledWith('new@example.com', 'new-safe-password-123', 'new-safe-password-123', '');
+    expect(registerMock).toHaveBeenCalledWith('new@example.com', 'new-safe-password-123', 'new-safe-password-123', '', true);
   });
 
-  it('shows an implicit-consent notice linking to the terms and the privacy policy', () => {
+  it('shows an explicit consent checkbox linking to the terms and the privacy policy', () => {
     authUser = null;
 
     render(
@@ -200,6 +204,7 @@ describe('RegisterPage', () => {
       </MemoryRouter>,
     );
 
+    expect(screen.getByRole('checkbox', { name: /Nutzungsbedingungen/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Nutzungsbedingungen' })).toHaveAttribute('href', '/nutzungsbedingungen');
     expect(screen.getByRole('link', { name: 'Datenschutzerklärung' })).toHaveAttribute('href', '/datenschutz');
   });
@@ -220,6 +225,7 @@ describe('RegisterPage', () => {
     const passwordInputs = screen.getAllByLabelText(/^Passwort/i).filter((el) => el.tagName === 'INPUT');
     await user.type(passwordInputs[0], 'new-safe-password-123');
     await user.type(passwordInputs[1], 'new-safe-password-123');
+    await user.click(screen.getByRole('checkbox', { name: /Nutzungsbedingungen/ }));
     await user.click(screen.getByRole('button', { name: 'Konto erstellen' }));
 
     expect(await screen.findByRole('button', { name: 'Aktivierungs-E-Mail erneut senden' })).toBeInTheDocument();

--- a/frontend/src/__tests__/TermsOfServicePage.test.tsx
+++ b/frontend/src/__tests__/TermsOfServicePage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
 import TermsOfServicePage from '../pages/public/TermsOfServicePage';
 
 function renderTermsOfServicePage(): ReturnType<typeof render> {
@@ -17,7 +18,7 @@ describe('TermsOfServicePage', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Nutzungsbedingungen' })).toBeInTheDocument();
 
     const sectionHeadings = screen.getAllByRole('heading', { level: 6 });
-    expect(sectionHeadings.length).toBeGreaterThanOrEqual(13);
+    expect(sectionHeadings.length).toBeGreaterThanOrEqual(16);
     for (const heading of sectionHeadings) {
       expect(heading.textContent).not.toMatch(/legal\.terms\.sections/);
     }
@@ -29,6 +30,29 @@ describe('TermsOfServicePage', () => {
     expect(screen.queryByText(/bewusst schlank gehalten/)).not.toBeInTheDocument();
     const sectionHeadings = screen.getAllByRole('heading', { level: 6 });
     expect(sectionHeadings[0].textContent).toMatch(/^1\./);
+  });
+
+  it('identifies the provider, contract language, and current no-payment scope', () => {
+    renderTermsOfServicePage();
+
+    expect(screen.getByRole('heading', { name: /Anbieter und Kontakt/ })).toBeInTheDocument();
+    expect(screen.getByText(/Martin Stipsitz/)).toBeInTheDocument();
+    expect(screen.getByText(/Eine Umsatzsteuer-Identifikationsnummer besteht derzeit nicht/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Leistungsumfang, Kosten und Lieferung/ })).toBeInTheDocument();
+    expect(screen.getByText(/keine Zahlungsabwicklung/)).toBeInTheDocument();
+    expect(screen.getByText(/keine Waren geliefert/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Vertragssprache/ })).toBeInTheDocument();
+    expect(screen.getByText(/Maßgeblich ist die deutsche Fassung/)).toBeInTheDocument();
+  });
+
+  it('offers a print action so the terms can be saved or printed from the browser', () => {
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => undefined);
+    renderTermsOfServicePage();
+
+    screen.getByRole('button', { name: 'Drucken / als PDF speichern' }).click();
+
+    expect(printSpy).toHaveBeenCalledTimes(1);
+    printSpy.mockRestore();
   });
 
   it('mentions the privacy policy from within the scope section instead of a standalone link', () => {
@@ -66,6 +90,6 @@ describe('TermsOfServicePage', () => {
   it('uses a concrete revision date instead of a generic month/year stamp', () => {
     renderTermsOfServicePage();
 
-    expect(screen.getByText(/Stand: 13\. Juli 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/Stand: 14\. Juli 2026/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -120,12 +120,13 @@ export function AuthProvider({
         await logoutRequest();
         clearAuthenticatedUser();
       },
-      register: async (email, password, passwordConfirm, displayName = "") => {
+      register: async (email, password, passwordConfirm, displayName = "", acceptTerms = false) => {
         const response = await registerRequest(
           email,
           password,
           passwordConfirm,
           displayName,
+          acceptTerms,
         );
         return response.detail;
       },

--- a/frontend/src/auth/ConsentGate.tsx
+++ b/frontend/src/auth/ConsentGate.tsx
@@ -10,19 +10,24 @@ import { useTranslation } from '../i18n';
  * document starts requiring versioned consent — no other gating logic
  * needs to change.
  */
-const CONSENT_DOCUMENT_CONFIG: Record<string, { path: string; translationKey: string }> = {
-  terms: { path: '/nutzungsbedingungen', translationKey: 'terms' },
+const CONSENT_DOCUMENT_CONFIG: Record<string, { path: string; translationKey: string; versionKey: string }> = {
+  terms: { path: '/nutzungsbedingungen', translationKey: 'terms', versionKey: 'legal.terms.version' },
+  privacy: { path: '/datenschutz', translationKey: 'privacy', versionKey: 'legal.privacy.version' },
 };
 
 export default function ConsentGate() {
   const { user, acceptConsent, logout } = useAuth();
-  const { t } = useTranslation('auth');
+  const { t } = useTranslation(['auth', 'home']);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
 
   const documentKey = user?.pending_consents[0];
   const config = documentKey ? CONSENT_DOCUMENT_CONFIG[documentKey] : undefined;
+  const additionalPendingDocuments = user?.pending_consents
+    .filter((pendingDocument) => pendingDocument !== documentKey)
+    .map((pendingDocument) => CONSENT_DOCUMENT_CONFIG[pendingDocument])
+    .filter((pendingConfig): pendingConfig is NonNullable<typeof pendingConfig> => pendingConfig !== undefined) ?? [];
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -67,10 +72,27 @@ export default function ConsentGate() {
         <Typography color="text.secondary">
           {t(`reconsent.${config.translationKey}.body`)}
         </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t('reconsent.currentVersion', { version: t(`home:${config.versionKey}`) })}
+        </Typography>
         {error ? <Alert severity="error">{error}</Alert> : null}
-        <Link component={RouterLink} to={config.path} target="_blank" rel="noopener">
-          {t(`reconsent.${config.translationKey}.linkLabel`)}
-        </Link>
+        <Stack spacing={0.75}>
+          <Link component={RouterLink} to={config.path} target="_blank" rel="noopener">
+            {t(`reconsent.${config.translationKey}.linkLabel`)}
+          </Link>
+          {additionalPendingDocuments.length > 0 ? (
+            <Stack spacing={0.5}>
+              <Typography variant="body2" color="text.secondary">
+                {t('reconsent.additionalDocuments')}
+              </Typography>
+              {additionalPendingDocuments.map((pendingConfig) => (
+                <Link key={pendingConfig.translationKey} component={RouterLink} to={pendingConfig.path} target="_blank" rel="noopener">
+                  {t(`reconsent.${pendingConfig.translationKey}.linkLabel`)}
+                </Link>
+              ))}
+            </Stack>
+          ) : null}
+        </Stack>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
           <Button variant="contained" onClick={() => void handleAccept()} disabled={submitting}>
             {submitting ? t('reconsent.accepting') : t(`reconsent.${config.translationKey}.acceptButton`)}

--- a/frontend/src/auth/authApi.test.ts
+++ b/frontend/src/auth/authApi.test.ts
@@ -36,7 +36,7 @@ describe('authApi error mapping', () => {
   });
 
   it('sends explicit terms acceptance during registration', async () => {
-    const fetchMock = vi.fn(async () => ({
+    const fetchMock = vi.fn<typeof fetch>(async () => ({
       ok: true,
       status: 201,
       text: async () => JSON.stringify({ detail: 'ok' }),
@@ -47,8 +47,11 @@ describe('authApi error mapping', () => {
     await register('new@example.com', 'new-safe-password-123', 'new-safe-password-123', '', true);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const registerCall = fetchMock.mock.calls[1];
-    const body = JSON.parse((registerCall[1] as RequestInit).body as string) as Record<string, unknown>;
+    const registerInit = fetchMock.mock.calls[1]?.[1];
+    if (!registerInit?.body) {
+      throw new Error('Expected registration request body');
+    }
+    const body = JSON.parse(String(registerInit.body)) as Record<string, unknown>;
     expect(body).toMatchObject({ accept_terms: true });
   });
 

--- a/frontend/src/auth/authApi.test.ts
+++ b/frontend/src/auth/authApi.test.ts
@@ -35,6 +35,23 @@ describe('authApi error mapping', () => {
     });
   });
 
+  it('sends explicit terms acceptance during registration', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ detail: 'ok' }),
+      json: async () => ({ detail: 'ok' }),
+    } as Response));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await register('new@example.com', 'new-safe-password-123', 'new-safe-password-123', '', true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const registerCall = fetchMock.mock.calls[1];
+    const body = JSON.parse((registerCall[1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({ accept_terms: true });
+  });
+
   it('does not expose non_field_errors and translates typical login messages', async () => {
     installFetchMock([
       { ok: true, status: 200, body: { detail: 'ok' } },

--- a/frontend/src/auth/authApi.ts
+++ b/frontend/src/auth/authApi.ts
@@ -36,6 +36,7 @@ const authFieldLabelFallbacks: Record<string, string> = {
   email: 'E-Mail',
   password: 'Passwort',
   password_confirm: 'Passwort bestätigen',
+  accept_terms: 'Nutzungsbedingungen',
   uid: 'Benutzerkennung',
   token: 'Token',
   display_name: 'Anzeigename',
@@ -51,6 +52,7 @@ const knownValidationMessageKeys: Record<string, string> = {
   'This password is too common.': 'passwordTooCommon',
   'This password is too short.': 'passwordTooShort',
   'This password is entirely numeric.': 'passwordEntirelyNumeric',
+  'You must accept the Terms of Service.': 'termsRequired',
   'Unable to log in with provided credentials.': 'invalidCredentials',
   'Die E-Mail konnte nicht gesendet werden. Bitte kontaktiere [info@openfarmplanner.org](mailto:info@openfarmplanner.org).': 'emailSendFailed',
   'Dein Konto wurde erstellt, aber die Aktivierungs-E-Mail konnte nicht gesendet werden. Bitte kontaktiere [info@openfarmplanner.org](mailto:info@openfarmplanner.org), damit wir dein Konto aktivieren oder dir den Link erneut senden können.': 'activationEmailSendFailed',
@@ -189,6 +191,7 @@ export async function register(
   password: string,
   passwordConfirm: string,
   displayName = '',
+  acceptTerms = false,
 ): Promise<{ detail: string }> {
   await ensureCsrfCookie();
   return request<{ detail: string }>('/auth/register/', {
@@ -199,6 +202,7 @@ export async function register(
       password,
       password_confirm: passwordConfirm,
       display_name: displayName,
+      accept_terms: acceptTerms,
     }),
   });
 }

--- a/frontend/src/auth/authContextShared.ts
+++ b/frontend/src/auth/authContextShared.ts
@@ -12,6 +12,7 @@ export interface AuthContextValue {
     password: string,
     passwordConfirm: string,
     displayName?: string,
+    acceptTerms?: boolean,
   ) => Promise<string>;
   acceptConsent: (document: string) => Promise<AuthUser>;
   activate: (uid: string, token: string) => Promise<void>;

--- a/frontend/src/i18n/locales/de/auth.json
+++ b/frontend/src/i18n/locales/de/auth.json
@@ -29,6 +29,7 @@
     "termsNoticeMiddle": " zu. Informationen zur Verarbeitung Ihrer personenbezogenen Daten finden Sie in der ",
     "termsNoticePrivacyLinkLabel": "Datenschutzerklärung",
     "termsNoticeSuffix": ".",
+    "termsRequired": "Bitte akzeptiere die Nutzungsbedingungen, um ein Konto zu erstellen.",
     "loggedInHint": "Du bist bereits angemeldet als {{user}}. Möchtest du einen neuen Account erstellen?",
     "logoutAndCreate": "Abmelden & neuen Account erstellen",
     "backToApp": "Zur App zurückkehren",
@@ -77,11 +78,19 @@
     "accepting": "Wird bestätigt…",
     "logout": "Abmelden",
     "failed": "Das hat leider nicht funktioniert. Bitte versuche es erneut.",
+    "currentVersion": "Aktuelle Fassung: {{version}}",
+    "additionalDocuments": "Ebenfalls aktualisiert:",
     "terms": {
-      "title": "Wir haben unsere Nutzungsbedingungen aktualisiert",
-      "body": "Damit du OpenFarmPlanner weiter nutzen kannst, bestätige bitte die aktuelle Fassung der Nutzungsbedingungen.",
-      "linkLabel": "Nutzungsbedingungen ansehen",
-      "acceptButton": "Nutzungsbedingungen akzeptieren"
+      "title": "Die Nutzungsbedingungen wurden aktualisiert",
+      "body": "Bitte lies und bestätige die aktuelle Fassung, bevor du OpenFarmPlanner weiter nutzt.",
+      "linkLabel": "Nutzungsbedingungen lesen",
+      "acceptButton": "Akzeptieren"
+    },
+    "privacy": {
+      "title": "Die Datenschutzerklärung wurde aktualisiert",
+      "body": "Bitte lies und bestätige die aktuelle Fassung, bevor du OpenFarmPlanner weiter nutzt.",
+      "linkLabel": "Datenschutzerklärung lesen",
+      "acceptButton": "Akzeptieren"
     }
   },
   "error": {
@@ -90,6 +99,7 @@
       "email": "E-Mail",
       "password": "Passwort",
       "password_confirm": "Passwort bestätigen",
+      "accept_terms": "Nutzungsbedingungen",
       "uid": "Benutzerkennung",
       "token": "Token",
       "display_name": "Anzeigename",
@@ -109,6 +119,7 @@
       "maxLength": "Bitte gib höchstens {{count}} Zeichen ein.",
       "emailSendFailed": "Die E-Mail konnte nicht gesendet werden. Bitte kontaktiere [info@openfarmplanner.org](mailto:info@openfarmplanner.org).",
       "activationEmailSendFailed": "Dein Konto wurde erstellt, aber die Aktivierungs-E-Mail konnte nicht gesendet werden. Bitte kontaktiere [info@openfarmplanner.org](mailto:info@openfarmplanner.org), damit wir dein Konto aktivieren oder dir den Link erneut senden können.",
+      "termsRequired": "Bitte akzeptiere die Nutzungsbedingungen, um ein Konto zu erstellen.",
       "publicDisplayNameTaken": "Dieser Name wird bereits verwendet."
     }
   }

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -93,6 +93,10 @@
           "title": "Verantwortlicher",
           "content": "Verantwortlich für die Datenverarbeitung im Sinne der Datenschutz-Grundverordnung (DSGVO) ist:\n\nMartin Stipsitz\nBurgenlandstraße 44A / 9\n9500 Villach\nÖsterreich\n\nE-Mail: info@openfarmplanner.org"
         },
+        "dataProtectionOfficer": {
+          "title": "Datenschutzbeauftragter",
+          "content": "Es ist kein Datenschutzbeauftragter bestellt, weil dafür nach derzeitigem Stand keine gesetzliche Verpflichtung besteht. Für Datenschutzanfragen erreichen Sie den Verantwortlichen über die oben genannten Kontaktdaten."
+        },
         "generalNotice": {
           "title": "Allgemeine Hinweise",
           "content": "Wir verarbeiten Ihre personenbezogenen Daten vertraulich und entsprechend der gesetzlichen Datenschutzvorschriften sowie dieser Datenschutzerklärung. Diese Datenschutzerklärung ergänzt die Nutzungsbedingungen von OpenFarmPlanner. Für Fragen zur Verarbeitung personenbezogener Daten ist ausschließlich diese Datenschutzerklärung maßgeblich.\n\nDie Nutzung der Startseite von OpenFarmPlanner ist ohne Angabe personenbezogener Daten möglich. Sobald Sie ein Benutzerkonto anlegen und die Anwendung nutzen, verarbeiten wir die in den folgenden Abschnitten beschriebenen Daten. Für jede Verarbeitung ist die jeweils angegebene Rechtsgrundlage nach Art. 6 Abs. 1 DSGVO maßgeblich."
@@ -162,7 +166,7 @@
         },
         "cookies": {
           "title": "Cookies",
-          "content": "OpenFarmPlanner verwendet ausschließlich technisch notwendige Cookies. Es werden keine Analyse-, Tracking- oder Marketing-Cookies eingesetzt.",
+          "content": "OpenFarmPlanner verwendet ausschließlich technisch notwendige Cookies. Es werden keine Analyse-, Tracking- oder Marketing-Cookies eingesetzt. Die Cookies dienen ausschließlich dazu, die angemeldete Nutzung der Anwendung und die technische Absicherung der Anfragen zu ermöglichen. Die konkrete Speicherdauer richtet sich nach der Sitzungs- und Sicherheitskonfiguration des Servers; Session-Cookies werden spätestens gelöscht, wenn sie ablaufen oder Sie sie in Ihrem Browser löschen.",
           "bullets": {
             "sessionCookies": "Session-Cookie zur Aufrechterhaltung Ihrer Anmeldung (Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO – ohne dieses Cookie kann die angemeldete Nutzung der Anwendung nicht bereitgestellt werden)",
             "securityCookies": "Sicherheits-Cookie zum Schutz vor Cross-Site-Request-Forgery, kurz CSRF (Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO, berechtigtes Interesse an der Absicherung der Anwendung, vgl. Erwägungsgrund 49 DSGVO)"
@@ -170,15 +174,27 @@
         },
         "localStorage": {
           "title": "Lokaler Speicher (Local Storage/Session Storage)",
-          "content": "Zusätzlich zu den Cookies speichert die Anwendung einzelne rein technische Einstellungen – etwa gewählte Ansichtsoptionen, das zuletzt geöffnete Projekt oder die Sortierung von Tabellen – im lokalen Speicher Ihres Browsers (Local Storage/Session Storage). Diese Daten verlassen Ihr Gerät nicht, sind für uns nicht einsehbar und enthalten keine Zugangsdaten. Da wir dabei keine Daten verarbeiten, handelt es sich nicht um eine Verarbeitung personenbezogener Daten unsererseits im Sinne des Art. 4 Nr. 2 DSGVO; eine gesonderte Rechtsgrundlage ist daher nicht einschlägig."
+          "content": "Zusätzlich zu den Cookies speichert die Anwendung einzelne technische Einstellungen im lokalen Speicher Ihres Browsers (Local Storage/Session Storage). Dazu gehören insbesondere das zuletzt geöffnete Projekt, Ansichtsoptionen, Sidebar- und Tabellenzustände, Sortierungen und Filter, Hinweise, die bereits angezeigt wurden, sowie kurzzeitig zwischengespeicherte Weiterleitungen oder Tokens für Projekt-Einladungen. Diese Daten verlassen Ihr Gerät nicht, sind für uns nicht einsehbar und enthalten keine Zugangsdaten. Local-Storage-Daten bleiben in Ihrem Browser gespeichert, bis sie durch die Anwendung ersetzt, von Ihnen über die Anwendung zurückgesetzt oder über die Browserfunktionen gelöscht werden; Session-Storage-Daten werden in der Regel beim Schließen des Browser-Tabs gelöscht. Da wir dabei keine Daten auf unseren Systemen verarbeiten, handelt es sich nicht um eine Verarbeitung personenbezogener Daten unsererseits im Sinne des Art. 4 Nr. 2 DSGVO; eine gesonderte Rechtsgrundlage ist daher nicht einschlägig."
         },
         "dataSharing": {
           "title": "Weitergabe von Daten",
-          "content": "Über die in Auftragsverarbeitung erfolgende Zusammenarbeit mit unserem Hosting-Anbieter (siehe Abschnitt „Hosting“) hinaus geben wir Ihre personenbezogenen Daten nur weiter, wenn:\n\n– Sie durch das aktive Veröffentlichen einer Kultur in der öffentlichen Kulturbibliothek deren Sichtbarkeit für alle angemeldeten Nutzer wählen, gegebenenfalls einschließlich Ihres öffentlichen Anzeigenamens, sofern Sie einen solchen festgelegt haben (siehe Abschnitt „Öffentliche Kulturbibliothek“), oder\n– wir gesetzlich dazu verpflichtet sind, etwa gegenüber Behörden."
+          "content": "Über die in Auftragsverarbeitung erfolgende Zusammenarbeit mit unserem Hosting-Anbieter (siehe Abschnitt „Hosting“) hinaus geben wir Ihre personenbezogenen Daten nur weiter, wenn:\n\n– dies für den technischen E-Mail-Versand im Zusammenhang mit Ihrem Konto oder Projekt-Einladungen erforderlich ist; der Versand erfolgt über die bei Uberspace betriebene Mail-Infrastruktur,\n– Sie durch das aktive Veröffentlichen einer Kultur in der öffentlichen Kulturbibliothek deren Sichtbarkeit für alle angemeldeten Nutzer wählen, gegebenenfalls einschließlich Ihres öffentlichen Anzeigenamens, sofern Sie einen solchen festgelegt haben (siehe Abschnitt „Öffentliche Kulturbibliothek“), oder\n– wir gesetzlich dazu verpflichtet sind, etwa gegenüber Behörden."
+        },
+        "thirdCountryTransfers": {
+          "title": "Drittlandübermittlung",
+          "content": "Eine Übermittlung personenbezogener Daten an Empfänger außerhalb der Europäischen Union oder des Europäischen Wirtschaftsraums findet nach derzeitigem Stand nicht statt."
+        },
+        "mandatoryProvision": {
+          "title": "Bereitstellung personenbezogener Daten",
+          "content": "Die Bereitstellung personenbezogener Daten ist weder gesetzlich noch vertraglich vorgeschrieben, soweit Sie nur die öffentliche Startseite aufrufen. Für die Registrierung und Nutzung der Anwendung sind E-Mail-Adresse, Passwort und die technisch notwendigen Cookies erforderlich; ohne diese Daten können wir kein Benutzerkonto bereitstellen und keine Anmeldung ermöglichen. Projekt- und Anwendungsdaten stellen Sie freiwillig bereit, soweit Sie die jeweiligen Funktionen nutzen möchten; ohne diese Angaben können die entsprechenden Planungsfunktionen nicht oder nur eingeschränkt verwendet werden. Die Veröffentlichung in der öffentlichen Kulturbibliothek ist freiwillig und für die Nutzung der übrigen Anwendung nicht erforderlich."
         },
         "storageDuration": {
           "title": "Speicherdauer",
-          "content": "Ihre Kontodaten werden gespeichert, solange Ihr Benutzerkonto besteht. Wenn Sie Ihr Konto löschen lassen, wird es zunächst für 14 Tage als „zur Löschung vorgemerkt“ geführt; in diesem Zeitraum können Sie die Löschung rückgängig machen. Nach Ablauf dieser Frist anonymisieren wir Ihr Konto (E-Mail-Adresse und Anzeigename werden entfernt, das Konto wird deaktiviert), anstatt es vollständig zu löschen, damit die Projekt- und Bibliotheksdaten anderer Nutzer konsistent bleiben – soweit dem keine gesetzlichen Pflichten oder sonstige zwingende Gründe entgegenstehen.\n\nProjektdaten, Anbaupläne und der zugehörige Änderungsverlauf bleiben – sofern das jeweilige Projekt weiterbesteht und nicht separat gelöscht wird – auch nach der Anonymisierung Ihres Kontos bestehen, ebenso von Ihnen bereits veröffentlichte Einträge in der öffentlichen Kulturbibliothek (siehe Abschnitte „Projekt- und Anwendungsdaten“ und „Öffentliche Kulturbibliothek“). Darüber hinausgehende gesetzliche Aufbewahrungspflichten bestehen für die von uns verarbeiteten Daten derzeit nicht, da OpenFarmPlanner keine abrechnungs- oder steuerrelevanten Daten verarbeitet."
+          "content": "Ihre Kontodaten werden gespeichert, solange Ihr Benutzerkonto besteht. Nicht aktivierte Benutzerkonten werden nach Ablauf der Aktivierungsfrist gelöscht; Aktivierungslinks sind derzeit 7 Tage gültig. Passwort-Reset-Links sind zeitlich begrenzt; E-Mail-Änderungslinks sind derzeit 24 Stunden gültig. Projekt-Einladungen sind derzeit 14 Tage gültig.\n\nWenn Sie Ihr Konto löschen lassen, wird es zunächst für 14 Tage als „zur Löschung vorgemerkt“ geführt; in diesem Zeitraum können Sie die Löschung rückgängig machen. Nach Ablauf dieser Frist anonymisieren wir Ihr Konto (E-Mail-Adresse und Anzeigename werden entfernt, das Konto wird deaktiviert), anstatt es vollständig zu löschen, damit die Projekt- und Bibliotheksdaten anderer Nutzer konsistent bleiben – soweit dem keine gesetzlichen Pflichten oder sonstige zwingende Gründe entgegenstehen.\n\nProjektdaten, Anbaupläne und der zugehörige Änderungsverlauf bleiben – sofern das jeweilige Projekt weiterbesteht und nicht separat gelöscht wird – auch nach der Anonymisierung Ihres Kontos bestehen, ebenso von Ihnen bereits veröffentlichte Einträge in der öffentlichen Kulturbibliothek (siehe Abschnitte „Projekt- und Anwendungsdaten“ und „Öffentliche Kulturbibliothek“). Server-Logfiles des Hosting-Anbieters werden täglich rotiert und nach 7 Tagen gelöscht; IP-Adressen werden dabei von Uberspace gekürzt gespeichert. Eigene technische Cron- und Anwendungslogs speichern wir höchstens 14 Tage, soweit sie nicht bereits früher für Betrieb, Fehleranalyse und Sicherheit entbehrlich sind. Darüber hinausgehende gesetzliche Aufbewahrungspflichten bestehen für die von uns verarbeiteten Daten derzeit nicht, da OpenFarmPlanner keine abrechnungs- oder steuerrelevanten Daten verarbeitet."
+        },
+        "automatedDecisionMaking": {
+          "title": "Automatisierte Entscheidungsfindung",
+          "content": "Eine automatisierte Entscheidungsfindung einschließlich Profiling im Sinne des Art. 22 DSGVO findet nicht statt."
         },
         "rights": {
           "title": "Ihre Rechte",
@@ -206,11 +222,24 @@
     },
     "terms": {
       "title": "Nutzungsbedingungen",
-      "version": "Stand: 13. Juli 2026",
+      "print": "Drucken / als PDF speichern",
+      "version": "Stand: 14. Juli 2026",
       "sections": {
+        "provider": {
+          "title": "Anbieter und Kontakt",
+          "content": "Anbieter der unter openfarmplanner.org bereitgestellten Anwendung ist:\n\nMartin Stipsitz\nBurgenlandstraße 44A / 9\n9500 Villach\nÖsterreich\n\nE-Mail: info@openfarmplanner.org\n\nEine Umsatzsteuer-Identifikationsnummer besteht derzeit nicht."
+        },
         "scope": {
           "title": "Geltungsbereich und Nutzung der Plattform",
           "content": "Diese Nutzungsbedingungen gelten für die Nutzung von OpenFarmPlanner, einer Webanwendung zur Planung von landwirtschaftlichem und gärtnerischem Anbau. Mit der Registrierung eines Benutzerkontos oder der Nutzung der Anwendung erkennen Sie diese Nutzungsbedingungen an.\n\nOpenFarmPlanner richtet sich an Privatpersonen sowie landwirtschaftliche und gärtnerische Betriebe, die ihre Anbauplanung digital organisieren möchten. Informationen zur Verarbeitung personenbezogener Daten finden Sie in der Datenschutzerklärung."
+        },
+        "serviceAndCosts": {
+          "title": "Leistungsumfang, Kosten und Lieferung",
+          "content": "OpenFarmPlanner stellt digitale Planungsfunktionen als gehostete Webanwendung bereit. Es werden keine Waren geliefert und es findet keine Zahlungsabwicklung über OpenFarmPlanner statt.\n\nDie Nutzung der unter openfarmplanner.org bereitgestellten Anwendung ist derzeit unentgeltlich. Sollten künftig kostenpflichtige Funktionen eingeführt werden, informieren wir Sie vorab; solche Funktionen kommen nur auf Grundlage gesonderter Bedingungen oder einer ausdrücklichen Zustimmung zustande.\n\nDa aktuell keine kostenpflichtigen Leistungen, Warenlieferungen oder digitalen Käufe angeboten werden, enthalten diese Nutzungsbedingungen keine Regelungen zu Preisen, Versandkosten, Zahlungsmitteln, Liefergebieten, After-Sales-Service oder kaufrechtlichen Widerrufs- und Gewährleistungsinformationen."
+        },
+        "contractLanguage": {
+          "title": "Vertragssprache",
+          "content": "Die Vertragssprache für die Nutzung der unter openfarmplanner.org bereitgestellten Anwendung ist Deutsch. Maßgeblich ist die deutsche Fassung dieser Nutzungsbedingungen."
         },
         "accounts": {
           "title": "Benutzerkonten",

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -29,6 +29,7 @@
     "termsNoticeMiddle": ". Information on the processing of your personal data can be found in the ",
     "termsNoticePrivacyLinkLabel": "Privacy Policy",
     "termsNoticeSuffix": ".",
+    "termsRequired": "Please accept the Terms of Service to create an account.",
     "loggedInHint": "You are already signed in as {{user}}. Would you like to create a new account?",
     "logoutAndCreate": "Sign out & create new account",
     "backToApp": "Back to the app",
@@ -77,11 +78,19 @@
     "accepting": "Confirming…",
     "logout": "Sign out",
     "failed": "Unfortunately that didn't work. Please try again.",
+    "currentVersion": "Current version: {{version}}",
+    "additionalDocuments": "Also updated:",
     "terms": {
-      "title": "We've updated our Terms of Service",
-      "body": "To keep using OpenFarmPlanner, please confirm the current version of the Terms of Service.",
-      "linkLabel": "View Terms of Service",
-      "acceptButton": "Accept Terms of Service"
+      "title": "The Terms of Service have been updated",
+      "body": "Please read and confirm the current version before continuing to use OpenFarmPlanner.",
+      "linkLabel": "Read Terms of Service",
+      "acceptButton": "Accept"
+    },
+    "privacy": {
+      "title": "The Privacy Policy has been updated",
+      "body": "Please read and confirm the current version before continuing to use OpenFarmPlanner.",
+      "linkLabel": "Read Privacy Policy",
+      "acceptButton": "Accept"
     }
   },
   "error": {
@@ -90,6 +99,7 @@
       "email": "Email",
       "password": "Password",
       "password_confirm": "Confirm password",
+      "accept_terms": "Terms of Service",
       "uid": "User ID",
       "token": "Token",
       "display_name": "Display name",
@@ -109,6 +119,7 @@
       "maxLength": "Please enter at most {{count}} characters.",
       "emailSendFailed": "The email could not be sent. Please contact [info@openfarmplanner.org](mailto:info@openfarmplanner.org).",
       "activationEmailSendFailed": "Your account was created, but the activation email could not be sent. Please contact [info@openfarmplanner.org](mailto:info@openfarmplanner.org) so we can activate your account or resend the link.",
+      "termsRequired": "Please accept the Terms of Service to create an account.",
       "publicDisplayNameTaken": "This name is already taken."
     }
   }

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -93,6 +93,10 @@
           "title": "Controller",
           "content": "Responsible for data processing on this website:\n\nMartin Stipsitz\nBurgenlandstraße 44A / 9\n9500 Villach\nAustria\n\nEmail: info@openfarmplanner.org"
         },
+        "dataProtectionOfficer": {
+          "title": "Data protection officer",
+          "content": "No data protection officer has been appointed because, based on the current assessment, there is no legal obligation to do so. For privacy requests, you can contact the controller using the contact details above."
+        },
         "generalNotice": {
           "title": "General information on data processing",
           "content": "We take the protection of your personal data seriously. We process your data confidentially and in accordance with applicable data protection laws and this privacy policy.\n\nUsing OpenFarmPlanner is generally possible without providing personal data. If personal data is collected (for example during registration), this is done on a voluntary basis."
@@ -149,20 +153,35 @@
         },
         "cookies": {
           "title": "Cookies",
-          "content": "OpenFarmPlanner uses technically necessary cookies to ensure core functionality.",
+          "content": "OpenFarmPlanner uses only technically necessary cookies. No analytics, tracking, or marketing cookies are used. The cookies are used only to enable logged-in use of the application and to protect requests technically. The specific storage period depends on the server's session and security configuration; session cookies are deleted at the latest when they expire or when you delete them in your browser.",
           "bullets": {
-            "sessionCookies": "Session cookies for login",
-            "securityCookies": "Security cookies (CSRF protection)"
-          },
-          "legalBasis": "Legal basis: Art. 6(1)(f) GDPR"
+            "sessionCookies": "Session cookie to maintain your login (legal basis: Art. 6(1)(b) GDPR - without this cookie, logged-in use of the application cannot be provided)",
+            "securityCookies": "Security cookie for protection against cross-site request forgery, or CSRF (legal basis: Art. 6(1)(f) GDPR, legitimate interest in securing the application)"
+          }
+        },
+        "localStorage": {
+          "title": "Local storage (Local Storage/Session Storage)",
+          "content": "In addition to cookies, the application stores individual technical settings in your browser's local storage (Local Storage/Session Storage). This includes, in particular, the last opened project, view options, sidebar and table states, sorting and filters, hints that have already been shown, and temporarily stored redirects or tokens for project invitations. This data does not leave your device, is not visible to us, and does not contain login credentials. Local Storage data remains in your browser until it is replaced by the application, reset by you in the application, or deleted via browser functions; Session Storage data is usually deleted when the browser tab is closed. Because we do not process this data on our systems, this is not processing of personal data by us within the meaning of Art. 4 No. 2 GDPR; a separate legal basis is therefore not applicable."
         },
         "dataSharing": {
           "title": "Data sharing",
-          "content": "Your data is not shared with third parties, except where necessary for contractual performance or where legally required."
+          "content": "Apart from cooperation with our hosting provider as a processor (see the Hosting section), we share your personal data only if:\n\n- this is necessary for technical email delivery in connection with your account or project invitations; email delivery uses the mail infrastructure operated by Uberspace,\n- you actively publish a crop in the public crop library and thereby choose visibility for all logged-in users, including your public display name if you have set one (see the Public crop library section), or\n- we are legally required to do so, for example toward authorities."
+        },
+        "thirdCountryTransfers": {
+          "title": "Third-country transfers",
+          "content": "Based on the current assessment, personal data is not transferred to recipients outside the European Union or the European Economic Area."
+        },
+        "mandatoryProvision": {
+          "title": "Provision of personal data",
+          "content": "Providing personal data is neither legally nor contractually required if you only visit the public landing page. For registration and use of the application, your email address, password, and technically necessary cookies are required; without this data we cannot provide a user account or enable login. You provide project and application data voluntarily when you want to use the relevant features; without this information, the corresponding planning features cannot be used or can be used only in a limited way. Publishing to the public crop library is voluntary and is not required for using the rest of the application."
         },
         "storageDuration": {
           "title": "Storage duration",
-          "content": "Your data is stored as long as your user account exists. You can request account deletion at any time."
+          "content": "Your account data is stored as long as your user account exists. User accounts that are not activated are deleted after the activation period expires; activation links are currently valid for 7 days. Password reset links are time-limited; email change links are currently valid for 24 hours. Project invitations are currently valid for 14 days.\n\nIf you request account deletion, the account is first marked for deletion for 14 days; during this period, you can undo the deletion. After that period, we anonymize your account (email address and display name are removed and the account is deactivated) instead of deleting it completely, so that project and library data of other users remains consistent, unless legal obligations or other compelling reasons prevent this.\n\nProject data, cultivation plans, and related change history remain, if the respective project continues to exist and is not deleted separately, even after your account has been anonymized. The same applies to entries you have already published in the public crop library (see the Project and application data and Public crop library sections). Server log files of the hosting provider are rotated daily and deleted after 7 days; IP addresses are stored in shortened form by Uberspace. Our own technical cron and application logs are stored for no more than 14 days, unless they are no longer needed earlier for operation, troubleshooting, and security. There are currently no further statutory retention obligations for the data we process because OpenFarmPlanner does not process billing- or tax-relevant data."
+        },
+        "automatedDecisionMaking": {
+          "title": "Automated decision-making",
+          "content": "Automated decision-making, including profiling within the meaning of Art. 22 GDPR, does not take place."
         },
         "rights": {
           "title": "Your rights",
@@ -184,6 +203,83 @@
         "changes": {
           "title": "Changes to this privacy policy",
           "content": "We reserve the right to adjust this privacy policy to reflect new features or legal requirements."
+        }
+      }
+    },
+    "terms": {
+      "title": "Terms of Service",
+      "print": "Print / save as PDF",
+      "version": "Status: July 14, 2026",
+      "sections": {
+        "provider": {
+          "title": "Provider and contact",
+          "content": "The provider of the application available at openfarmplanner.org is:\n\nMartin Stipsitz\nBurgenlandstraße 44A / 9\n9500 Villach\nAustria\n\nEmail: info@openfarmplanner.org\n\nThere is currently no VAT identification number."
+        },
+        "scope": {
+          "title": "Scope and use of the platform",
+          "content": "These Terms of Service apply to the use of OpenFarmPlanner, a web application for planning agricultural and horticultural cultivation. By registering a user account or using the application, you accept these Terms of Service.\n\nOpenFarmPlanner is intended for private individuals as well as agricultural and horticultural businesses that want to organize their cultivation planning digitally. Information on the processing of personal data can be found in the Privacy Policy."
+        },
+        "serviceAndCosts": {
+          "title": "Service scope, costs, and delivery",
+          "content": "OpenFarmPlanner provides digital planning functions as a hosted web application. No goods are delivered and no payment processing takes place through OpenFarmPlanner.\n\nUse of the application available at openfarmplanner.org is currently free of charge. If paid features are introduced in the future, we will inform you in advance; such features will only be provided on the basis of separate terms or explicit consent.\n\nBecause no paid services, goods deliveries, or digital purchases are currently offered, these Terms of Service do not contain provisions on prices, shipping costs, payment methods, delivery territories, after-sales service, or statutory withdrawal and warranty information for purchases."
+        },
+        "contractLanguage": {
+          "title": "Contract language",
+          "content": "The contract language for using the application available at openfarmplanner.org is German. The German version of these Terms of Service is authoritative."
+        },
+        "accounts": {
+          "title": "User accounts",
+          "content": "A user account is required to use the application. You are obliged to provide truthful information during registration and to keep your password confidential.\n\nYou are responsible for all activities carried out through your user account. Please inform us immediately at info@openfarmplanner.org if you suspect that someone has gained unauthorized access to your account. A user account is personal and non-transferable."
+        },
+        "userContent": {
+          "title": "Your content in OpenFarmPlanner",
+          "content": "Within your projects, you can create your own data, such as location, field and crop data, cultivation plans, tasks, notes, and photos. You are responsible for the accuracy, completeness, and legality of this content.\n\nDo not upload content for which you do not have the necessary rights, such as copyrighted photos of third parties."
+        },
+        "publicLibrary": {
+          "title": "Public crop library",
+          "content": "You can voluntarily publish individual crop records from a private project to the public crop library. This library is visible to all logged-in users and entries can be imported into their own projects. Which data is published, that only your freely chosen public display name or, if not set, no name (anonymous) appears as author, and how you can undo a publication is explained in the Privacy Policy, section \"Public crop library\".\n\nBy publishing, you confirm that the published information is accurate to the best of your knowledge and that you are entitled to publish it."
+        },
+        "contributionLicense": {
+          "title": "Rights to published crop data",
+          "content": "When you publish a crop record to the public crop library, you grant OpenFarmPlanner a simple, unlimited right in time and territory to display this information to all logged-in users, enable its import into their own projects, and technically store and process the information for that purpose.\n\nYou remain the owner of your rights to the data. You can revoke this use at any time with effect for the future (see the \"Content removal\" section); copies that other users imported into their own project before revocation or removal of the entry are not affected, because they continue to exist independently in the respective project and can be edited there independently."
+        },
+        "prohibitedContent": {
+          "title": "Prohibited content and behavior",
+          "content": "When using OpenFarmPlanner, especially when publishing content in the public crop library, it is not permitted to",
+          "bullets": {
+            "illegalContent": "post unlawful, misleading, or third-party-rights-infringing content (for example copyright or personality rights),",
+            "malware": "distribute malware or bypass security measures of the application,",
+            "abuse": "misuse the application in an automated way, for example through mass registrations or spam,",
+            "misrepresentation": "impersonate another person or knowingly publish false information."
+          }
+        },
+        "copyright": {
+          "title": "Copyright",
+          "content": "The OpenFarmPlanner software is protected by copyright and is licensed under the license named in the \"Open-source software\" section. The content you enter, such as crop data or notes, remains your property.\n\nIf you believe that an entry published in the public crop library infringes your copyright or other rights, please contact info@openfarmplanner.org. We investigate justified notices (see the \"Content removal\" section)."
+        },
+        "contentRemoval": {
+          "title": "Content removal",
+          "content": "We reserve the right to remove or block published content in the public crop library in whole or in part if there are concrete indications of a violation of these Terms of Service or applicable law, for example following a notice within the meaning of Art. 16 of the EU Digital Services Act. Notices of allegedly unlawful content can be sent at any time to info@openfarmplanner.org. We are not obliged to carry out general, proactive monitoring of published content.\n\nYou can request removal of an entry you published at any time by contacting info@openfarmplanner.org."
+        },
+        "accountSuspension": {
+          "title": "Suspension of user accounts",
+          "content": "In the event of a serious or repeated violation of these Terms of Service, we may temporarily restrict access to your user account or suspend the account. We proceed proportionately and take into account the severity of the violation and whether it is an isolated or repeated incident.\n\nIn the event of suspension, we will inform you of the reason where possible. You can contact info@openfarmplanner.org at any time about this."
+        },
+        "liability": {
+          "title": "Liability",
+          "content": "OpenFarmPlanner is developed and operated with great care. Nevertheless, we cannot guarantee error-free or uninterrupted availability at all times, for example during maintenance, technical disruptions, or events outside our control.\n\nThe public crop library contains content created by users themselves. The respective publishing users are responsible for its accuracy, not OpenFarmPlanner (see the \"Your content in OpenFarmPlanner\" section).\n\nAgricultural and horticultural information in OpenFarmPlanner, such as growth and harvest periods, plant spacing, or seed quantities, is intended only to support your own cultivation planning and does not replace professional advice.\n\nFor damages resulting from slightly negligent breaches of duty, our liability is limited. Our liability for intent and gross negligence as well as for damages resulting from injury to life, body, or health remains unaffected, as do other mandatory statutory liability rules."
+        },
+        "openSource": {
+          "title": "Open-source software",
+          "content": "The OpenFarmPlanner source code is published as open-source software under the GNU Affero General Public License Version 3 (AGPLv3) and can be viewed, reused, and modified in the OpenFarmPlanner GitHub repository (https://github.com/stipsitzm/OpenFarmPlanner). The license regulates only the rights to the software itself and, as is common with open-source software, excludes any warranty for the software.\n\nThis is separate from use of the hosted application at openfarmplanner.org, which is governed by these Terms of Service."
+        },
+        "futureFeatures": {
+          "title": "Further development of the platform",
+          "content": "OpenFarmPlanner is continuously developed. These Terms of Service apply analogously to future features around user-provided content, such as comments, ratings, or version histories for entries in the public crop library. In the case of material new functions of this kind, we will update these Terms of Service if necessary (see the \"Changes to these Terms of Service\" section)."
+        },
+        "changes": {
+          "title": "Changes to these Terms of Service",
+          "content": "We update these Terms of Service if the offered functions or legal framework change. The version published within the application at the time of your use is authoritative; the date of the last change can be found at the top of this page. In the event of material changes, we will inform active users in an appropriate way, for example by email or through a notice in the application."
         }
       }
     }

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, Container, InputAdornment, Link, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Checkbox, Container, FormControlLabel, InputAdornment, Link, Stack, TextField, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
@@ -25,6 +25,7 @@ export default function RegisterPage() {
   const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
   const [registrationSucceeded, setRegistrationSucceeded] = useState(false);
   const [pendingInvitation, setPendingInvitation] = useState<InvitationPublicStatus | null>(null);
+  const [acceptTerms, setAcceptTerms] = useState(false);
   const nextPath = getNextFromSearch(location.search);
   const isLoggedIn = user !== null;
   const currentUserLabel = user?.display_label || user?.email || '–';
@@ -61,13 +62,17 @@ export default function RegisterPage() {
       setError(t('auth:register.passwordMismatch'));
       return;
     }
+    if (!acceptTerms) {
+      setError(t('auth:register.termsRequired'));
+      return;
+    }
 
     setSubmitting(true);
     try {
       if (nextPath) {
         storeInvitationRedirect(nextPath, getTokenFromNextPath(nextPath));
       }
-      const message = await register(email.trim().toLowerCase(), password, passwordConfirm, displayName.trim());
+      const message = await register(email.trim().toLowerCase(), password, passwordConfirm, displayName.trim(), acceptTerms);
       setSuccess(pendingInvitation ? t('projectInvitations:registerSuccessWithInvitation', { detail: message }) : message);
       setRegistrationSucceeded(true);
     } catch (err) {
@@ -179,18 +184,31 @@ export default function RegisterPage() {
               htmlInput: { autoComplete: 'new-password' },
             }}
           />
-          <Button type="submit" variant="contained" disabled={submitting || isLoggedIn}>{submitting ? t('auth:register.submitting') : t('auth:register.submit')}</Button>
-          <Typography variant="caption" color="text.secondary">
-            {t('auth:register.termsNoticePrefix')}
-            <Link component={RouterLink} to="/nutzungsbedingungen" target="_blank" rel="noopener">
-              {t('auth:register.termsNoticeTermsLinkLabel')}
-            </Link>
-            {t('auth:register.termsNoticeMiddle')}
-            <Link component={RouterLink} to="/datenschutz" target="_blank" rel="noopener">
-              {t('auth:register.termsNoticePrivacyLinkLabel')}
-            </Link>
-            {t('auth:register.termsNoticeSuffix')}
-          </Typography>
+          <FormControlLabel
+            control={(
+              <Checkbox
+                checked={acceptTerms}
+                onChange={(event) => setAcceptTerms(event.target.checked)}
+                disabled={isLoggedIn}
+              />
+            )}
+            label={(
+              <Typography variant="body2" color="text.secondary">
+                {t('auth:register.termsNoticePrefix')}
+                <Link component={RouterLink} to="/nutzungsbedingungen" target="_blank" rel="noopener">
+                  {t('auth:register.termsNoticeTermsLinkLabel')}
+                </Link>
+                {t('auth:register.termsNoticeMiddle')}
+                <Link component={RouterLink} to="/datenschutz" target="_blank" rel="noopener">
+                  {t('auth:register.termsNoticePrivacyLinkLabel')}
+                </Link>
+                {t('auth:register.termsNoticeSuffix')}
+              </Typography>
+            )}
+          />
+          <Button type="submit" variant="contained" disabled={submitting || isLoggedIn || !acceptTerms}>
+            {submitting ? t('auth:register.submitting') : t('auth:register.submit')}
+          </Button>
           {registrationSucceeded && !isLoggedIn ? (
             <Button type="button" onClick={() => void handleResend()}>{t('auth:register.resendActivation')}</Button>
           ) : null}

--- a/frontend/src/pages/public/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/public/PrivacyPolicyPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../../i18n';
 
 const privacySections = [
   'controller',
+  'dataProtectionOfficer',
   'generalNotice',
   'hosting',
   'registration',
@@ -14,7 +15,10 @@ const privacySections = [
   'cookies',
   'localStorage',
   'dataSharing',
+  'thirdCountryTransfers',
+  'mandatoryProvision',
   'storageDuration',
+  'automatedDecisionMaking',
   'rights',
   'complaint',
   'changes',

--- a/frontend/src/pages/public/TermsOfServicePage.tsx
+++ b/frontend/src/pages/public/TermsOfServicePage.tsx
@@ -1,8 +1,12 @@
-import { Box, Container, Stack, Typography } from '@mui/material';
+import PrintIcon from '@mui/icons-material/Print';
+import { Box, Button, Container, Stack, Typography } from '@mui/material';
 import { useTranslation } from '../../i18n';
 
 const termsSections = [
+  'provider',
   'scope',
+  'serviceAndCosts',
+  'contractLanguage',
   'accounts',
   'userContent',
   'publicLibrary',
@@ -27,9 +31,20 @@ export default function TermsOfServicePage() {
   return (
     <Container maxWidth="md" sx={{ py: { xs: 6, md: 9 } }}>
       <Stack spacing={3}>
-        <Typography variant="h3" component="h1">
-          {t('legal.terms.title')}
-        </Typography>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }} justifyContent="space-between">
+          <Typography variant="h3" component="h1">
+            {t('legal.terms.title')}
+          </Typography>
+          <Button
+            type="button"
+            variant="outlined"
+            startIcon={<PrintIcon />}
+            onClick={() => window.print()}
+            sx={{ '@media print': { display: 'none' } }}
+          >
+            {t('legal.terms.print')}
+          </Button>
+        </Stack>
 
         {termsSections.map((sectionKey, index) => {
           const bulletKeys = termsSectionBulletKeys[sectionKey];


### PR DESCRIPTION
## Summary
- update privacy policy and Terms of Service text to cover the reviewed checklist items
- require explicit Terms acceptance during registration and bump the current Terms version
- add versioned Privacy Policy consent support for future consent-requiring privacy changes
- improve the re-consent gate UX with concise copy, document links, and current version display

## Validation
- npm run test -- TermsOfServicePage.test.tsx RegisterPage.test.tsx authApi.test.ts
- npm run test -- TermsOfServicePage.test.tsx ConsentGate.test.tsx
- npm run test -- ConsentGate.test.tsx
- npm run test -- PrivacyPolicyPage.test.tsx
- pdm run python manage.py test accounts.tests.test_auth_api --settings=config.settings_test
- pdm run python manage.py makemigrations --check --dry-run --settings=config.settings_test
- scoped ESLint on changed frontend files