### PR TITLE
refactor(backend): thin views — move supplier, layout and yield-calendar logic into services

### DIFF
--- a/backend/farm/cultures/views.py
+++ b/backend/farm/cultures/views.py
@@ -2,7 +2,6 @@
 
 import logging
 from datetime import timedelta
-from decimal import Decimal
 
 from django.db import IntegrityError, transaction
 from django.db.models import Prefetch, Q
@@ -39,6 +38,18 @@ from farm.services.public_cultures import (
     publish_culture_to_public_library,
 )
 from farm.services.seed_demand import build_seed_demand_rows, parse_selected_suppliers
+from farm.services.suppliers import (
+    DuplicateSupplierNameError,
+    SupplierPayloadError,
+    SupplierRestoreConflictError,
+    SupplierRestoreFailedError,
+    build_delete_undo_payload,
+    build_delete_usage,
+    create_supplier,
+    normalize_new_supplier_payload,
+    restore_unlinked_supplier,
+    unlink_supplier_references,
+)
 
 from .serializers import (
     CultureSerializer,
@@ -66,89 +77,6 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
     queryset = Supplier.objects.all()
     serializer_class = SupplierSerializer
 
-    def _build_delete_usage(self, supplier: Supplier) -> dict[str, int | bool | list[int]]:
-        supplier_culture_ids = set(
-            Culture.objects.filter(
-                project=supplier.project,
-                deleted_at__isnull=True,
-                supplier=supplier,
-            ).values_list('id', flat=True)
-        )
-        seed_demand_culture_ids = set(
-            Culture.objects.filter(
-                project=supplier.project,
-                deleted_at__isnull=True,
-                selected_seed_demand_supplier=supplier,
-            ).values_list('id', flat=True)
-        )
-        supplier_data_culture_ids = set(
-            CultureSupplierData.objects.filter(
-                project=supplier.project,
-                supplier=supplier,
-                culture__deleted_at__isnull=True,
-            ).values_list('culture_id', flat=True)
-        )
-        supplier_data_rows = CultureSupplierData.objects.filter(
-            project=supplier.project,
-            supplier=supplier,
-            culture__deleted_at__isnull=True,
-        ).count()
-        total_culture_ids = supplier_culture_ids | seed_demand_culture_ids | supplier_data_culture_ids
-
-        return {
-            'can_delete': len(total_culture_ids) == 0 and supplier_data_rows == 0,
-            'culture_count': len(supplier_culture_ids),
-            'seed_demand_culture_count': len(seed_demand_culture_ids),
-            'supplier_data_culture_count': len(supplier_data_culture_ids),
-            'supplier_data_count': supplier_data_rows,
-            'total_culture_count': len(total_culture_ids),
-            'culture_ids': sorted(total_culture_ids),
-        }
-
-    def _build_supplier_delete_undo_payload(self, supplier: Supplier) -> dict[str, object]:
-        supplier_cultures = list(
-            Culture.all_objects.filter(project=supplier.project, supplier=supplier).values_list('id', flat=True)
-        )
-        seed_demand_cultures = list(
-            Culture.all_objects.filter(
-                project=supplier.project,
-                selected_seed_demand_supplier=supplier,
-            ).values_list('id', flat=True)
-        )
-        supplier_data_rows = []
-        for row in CultureSupplierData.objects.filter(project=supplier.project, supplier=supplier):
-            supplier_data_rows.append({
-                'id': row.id,
-                'culture_id': row.culture_id,
-                'supplier_name': row.supplier_name,
-                'supplier_url': row.supplier_url,
-                'supplier_product_name': row.supplier_product_name,
-                'supplier_product_url': row.supplier_product_url,
-                'packaging_sizes': row.packaging_sizes,
-                'thousand_kernel_weight_g': (
-                    str(row.thousand_kernel_weight_g)
-                    if row.thousand_kernel_weight_g is not None
-                    else None
-                ),
-                'germination_rate': row.germination_rate,
-                'price': str(row.price) if row.price is not None else None,
-                'notes': row.notes,
-                'source_url': row.source_url,
-            })
-
-        return {
-            'supplier': {
-                'id': supplier.id,
-                'name': supplier.name,
-                'homepage_url': supplier.homepage_url,
-                'slug': supplier.slug,
-                'allowed_domains': supplier.allowed_domains,
-            },
-            'culture_ids': supplier_cultures,
-            'seed_demand_culture_ids': seed_demand_cultures,
-            'supplier_data': supplier_data_rows,
-        }
-
     def perform_update(self, serializer):
         previous_snapshot = _serialize_instance(serializer.instance)
         try:
@@ -160,11 +88,11 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
     @action(detail=True, methods=['get'], url_path='delete-usage')
     def delete_usage(self, request: Request, pk: int | None = None) -> Response:
         supplier = self.get_object()
-        return Response(self._build_delete_usage(supplier))
+        return Response(build_delete_usage(supplier))
 
     def destroy(self, request: Request, *args: object, **kwargs: object) -> Response:
         instance = self.get_object()
-        usage = self._build_delete_usage(instance)
+        usage = build_delete_usage(instance)
         if not usage['can_delete']:
             return Response(
                 {
@@ -179,16 +107,11 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
     @action(detail=True, methods=['post'], url_path='unlink-and-delete')
     def unlink_and_delete(self, request: Request, pk: int | None = None) -> Response:
         supplier = self.get_object()
-        usage = self._build_delete_usage(supplier)
-        undo_payload = self._build_supplier_delete_undo_payload(supplier)
+        usage = build_delete_usage(supplier)
+        undo_payload = build_delete_undo_payload(supplier)
 
         with transaction.atomic():
-            Culture.all_objects.filter(project=supplier.project, supplier=supplier).update(supplier=None)
-            Culture.all_objects.filter(
-                project=supplier.project,
-                selected_seed_demand_supplier=supplier,
-            ).update(selected_seed_demand_supplier=None)
-            CultureSupplierData.objects.filter(project=supplier.project, supplier=supplier).delete()
+            unlink_supplier_references(supplier)
             supplier_id = supplier.pk
             supplier_snapshot = _serialize_instance(supplier)
             supplier_name = supplier.name
@@ -205,89 +128,28 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
 
     @action(detail=False, methods=['post'], url_path='restore-unlinked-delete')
     def restore_unlinked_delete(self, request: Request) -> Response:
-        active_project = request.active_project
         payload = request.data if isinstance(request.data, dict) else {}
-        supplier_payload = payload.get('supplier')
-        if not isinstance(supplier_payload, dict):
-            raise DRFValidationError({'supplier': ['Supplier restore data is required.']})
-
-        supplier_id = supplier_payload.get('id')
-        if not isinstance(supplier_id, int):
-            raise DRFValidationError({'supplier': ['Supplier id is required.']})
-        if Supplier.objects.filter(project=active_project, pk=supplier_id).exists():
+        try:
+            result = restore_unlinked_supplier(
+                project=request.active_project,
+                payload=payload,
+                record_restore=lambda supplier: self.record_revision(supplier, EntityRevision.ACTION_RESTORED),
+            )
+        except SupplierPayloadError as exc:
+            raise DRFValidationError(exc.errors) from exc
+        except SupplierRestoreConflictError:
             return Response(
                 {'detail': 'Supplier cannot be restored because the id is already in use.'},
                 status=status.HTTP_409_CONFLICT,
             )
-
-        culture_ids = [item for item in payload.get('culture_ids', []) if isinstance(item, int)]
-        seed_demand_culture_ids = [
-            item for item in payload.get('seed_demand_culture_ids', []) if isinstance(item, int)
-        ]
-        supplier_data_rows = payload.get('supplier_data', [])
-        if not isinstance(supplier_data_rows, list):
-            supplier_data_rows = []
-
-        try:
-            with transaction.atomic():
-                supplier = Supplier.objects.create(
-                    id=supplier_id,
-                    project=active_project,
-                    name=str(supplier_payload.get('name') or ''),
-                    homepage_url=str(supplier_payload.get('homepage_url') or ''),
-                    slug=str(supplier_payload.get('slug') or ''),
-                    allowed_domains=supplier_payload.get('allowed_domains') or [],
-                )
-                Culture.all_objects.filter(project=active_project, id__in=culture_ids).update(supplier=supplier)
-                Culture.all_objects.filter(
-                    project=active_project,
-                    id__in=seed_demand_culture_ids,
-                ).update(selected_seed_demand_supplier=supplier)
-
-                restored_supplier_data_count = 0
-                for row_payload in supplier_data_rows:
-                    if not isinstance(row_payload, dict):
-                        continue
-                    culture_id = row_payload.get('culture_id')
-                    if not isinstance(culture_id, int):
-                        continue
-                    if not Culture.all_objects.filter(project=active_project, pk=culture_id).exists():
-                        continue
-                    CultureSupplierData.objects.create(
-                        id=row_payload.get('id') if isinstance(row_payload.get('id'), int) else None,
-                        culture_id=culture_id,
-                        supplier=supplier,
-                        project=active_project,
-                        supplier_name=str(row_payload.get('supplier_name') or ''),
-                        supplier_url=str(row_payload.get('supplier_url') or ''),
-                        supplier_product_name=str(row_payload.get('supplier_product_name') or ''),
-                        supplier_product_url=str(row_payload.get('supplier_product_url') or ''),
-                        packaging_sizes=row_payload.get('packaging_sizes') or [],
-                        thousand_kernel_weight_g=(
-                            Decimal(str(row_payload['thousand_kernel_weight_g']))
-                            if row_payload.get('thousand_kernel_weight_g') is not None
-                            else None
-                        ),
-                        germination_rate=row_payload.get('germination_rate'),
-                        price=(
-                            Decimal(str(row_payload['price']))
-                            if row_payload.get('price') is not None
-                            else None
-                        ),
-                        notes=str(row_payload.get('notes') or ''),
-                        source_url=str(row_payload.get('source_url') or ''),
-                    )
-                    restored_supplier_data_count += 1
-
-                self.record_revision(supplier, EntityRevision.ACTION_RESTORED)
-        except (IntegrityError, ValueError) as exc:
+        except SupplierRestoreFailedError as exc:
             raise DRFValidationError({'detail': ['Supplier could not be restored.']}) from exc
 
-        serializer = self.get_serializer(supplier)
+        serializer = self.get_serializer(result.supplier)
         return Response({
             'supplier': serializer.data,
-            'restored_culture_count': len(set(culture_ids) | set(seed_demand_culture_ids)),
-            'restored_supplier_data_count': restored_supplier_data_count,
+            'restored_culture_count': result.restored_culture_count,
+            'restored_supplier_data_count': result.restored_supplier_data_count,
         })
 
     def perform_destroy(self, instance: Supplier) -> None:
@@ -324,78 +186,26 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
     
     def create(self, request, *args, **kwargs):
         """Create a supplier with project-scoped duplicate-name validation.
-        
+
         :param request: HTTP request containing supplier data
         :return: Response with supplier data and created flag
         """
-        name = (request.data.get('name') or '').strip()
-        homepage_url = (request.data.get('homepage_url') or '').strip()
-        allowed_domains = request.data.get('allowed_domains', [])
-
-        if not name:
-            return Response(
-                {'name': ['Dieses Feld ist erforderlich.']},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        
-        # Normalize homepage_url (prepend https:// if no protocol)
-        if homepage_url and not homepage_url.startswith(('http://', 'https://')):
-            homepage_url = f'https://{homepage_url}'
-        
-        # Validate homepage_url format
-        from django.core.validators import URLValidator
-        from django.core.exceptions import ValidationError as DjangoValidationError
-        url_validator = URLValidator()
         try:
-            if homepage_url:
-                url_validator(homepage_url)
-        except DjangoValidationError:
-            return Response(
-                {'homepage_url': ['Bitte geben Sie eine gültige URL ein.']},
-                status=status.HTTP_400_BAD_REQUEST
+            fields = normalize_new_supplier_payload(
+                name=request.data.get('name'),
+                homepage_url=request.data.get('homepage_url'),
+                allowed_domains=request.data.get('allowed_domains', []),
             )
-        
-        # Validate allowed_domains
-        if allowed_domains and not isinstance(allowed_domains, list):
-            return Response(
-                {'allowed_domains': ['Bitte geben Sie eine Liste von Domains an.']},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        if allowed_domains:
-            normalized_domains = Supplier.normalize_allowed_domains(allowed_domains)
-            invalid = [domain for domain in normalized_domains if not Supplier._is_valid_domain(Supplier._normalize_domain(domain))]
-            if invalid:
-                return Response(
-                    {'allowed_domains': [f'Ungültige Domain(s): {", ".join(invalid)}. Domains müssen gültige Hostnamen ohne Schema oder Pfad sein.']},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+            supplier = create_supplier(project=request.active_project, **fields)
+        except SupplierPayloadError as exc:
+            return Response(exc.errors, status=status.HTTP_400_BAD_REQUEST)
+        except DuplicateSupplierNameError as exc:
+            raise DRFValidationError({'name': ['Ein Lieferant mit diesem Namen existiert bereits.']}) from exc
 
-        # Check normalized duplicates before relying on the database constraint.
-        from farm.utils import normalize_supplier_name
-        normalized = normalize_supplier_name(name) or ''
-
-        duplicate_error = {'name': ['Ein Lieferant mit diesem Namen existiert bereits.']}
-        if Supplier.objects.filter(project=request.active_project, name_normalized=normalized).exists():
-            raise DRFValidationError(duplicate_error)
-
-        supplier_defaults = {
-            'name': name,
-            'homepage_url': homepage_url,
-            'allowed_domains': Supplier.normalize_allowed_domains(allowed_domains) if isinstance(allowed_domains, list) else [],
-            'project': request.active_project,
-        }
-        try:
-            with transaction.atomic():
-                supplier = Supplier.objects.create(**supplier_defaults)
-        except IntegrityError as exc:
-            if Supplier.objects.filter(project=request.active_project, name_normalized=normalized).exists():
-                raise DRFValidationError(duplicate_error) from exc
-            raise
-        
         serializer = self.get_serializer(supplier)
         data = serializer.data
         data['created'] = True
-        
+
         self.record_revision(supplier, EntityRevision.ACTION_CREATED)
         return Response(
             data,

--- a/backend/farm/planning/views.py
+++ b/backend/farm/planning/views.py
@@ -1,9 +1,7 @@
 """API endpoints for the planning domain (planting plans, tasks, yield calendar)."""
 
 import logging
-from collections import defaultdict
-from datetime import date, timedelta
-from decimal import ROUND_HALF_UP, Decimal
+from datetime import date
 
 from django.db.models import Count
 from django.utils.dateparse import parse_date
@@ -15,6 +13,7 @@ from farm.common.mixins import ProjectRevisionMixin, ProjectScopedMixin
 from farm.history import _entity_display_name, _serialize_instance
 from farm.models import Bed, EntityRevision, PlantingPlan, Task
 from farm.project_context import get_active_project_or_400
+from farm.services.yield_calendar import build_yield_calendar
 from farm.services_area import calculate_remaining_bed_area
 
 from .serializers import PlantingPlanSerializer, TaskSerializer
@@ -22,15 +21,42 @@ from .serializers import PlantingPlanSerializer, TaskSerializer
 logger = logging.getLogger(__name__)
 
 
-def _week_start_for_iso_year(iso_year: int) -> date:
-    """Return Monday of ISO week 1 for an ISO year."""
-    return date.fromisocalendar(iso_year, 1, 1)
+def _parse_remaining_area_params(query_params) -> tuple[dict | None, str | None]:
+    """Parse/validate the remaining-area query parameters.
 
+    Returns (params, None) on success or (None, error_detail) on failure.
+    """
+    bed_id_param = query_params.get('bed_id')
+    start_date_param = query_params.get('start_date')
+    end_date_param = query_params.get('end_date')
+    exclude_plan_id_param = query_params.get('exclude_plan_id')
 
-def _iso_week_key(day: date) -> str:
-    """Return ISO week key in the format YYYY-Www using ISO year and week."""
-    iso_year, iso_week, _ = day.isocalendar()
-    return f"{iso_year}-W{iso_week:02d}"
+    if not bed_id_param or not start_date_param or not end_date_param:
+        return None, 'bed_id, start_date and end_date are required.'
+
+    try:
+        bed_id = int(bed_id_param)
+    except ValueError:
+        return None, 'bed_id must be an integer.'
+
+    start_date = parse_date(start_date_param)
+    end_date = parse_date(end_date_param)
+    if start_date is None or end_date is None:
+        return None, 'start_date and end_date must use YYYY-MM-DD format.'
+
+    exclude_plan_id: int | None = None
+    if exclude_plan_id_param:
+        try:
+            exclude_plan_id = int(exclude_plan_id_param)
+        except ValueError:
+            return None, 'exclude_plan_id must be an integer.'
+
+    return {
+        'bed_id': bed_id,
+        'start_date': start_date,
+        'end_date': end_date,
+        'exclude_plan_id': exclude_plan_id,
+    }, None
 
 
 class YieldCalendarListView(generics.GenericAPIView):
@@ -47,97 +73,7 @@ class YieldCalendarListView(generics.GenericAPIView):
         if iso_year < 1 or iso_year > 9999:
             return Response({'detail': 'Year out of supported range.'}, status=status.HTTP_400_BAD_REQUEST)
 
-        year_start = _week_start_for_iso_year(iso_year)
-        year_end = _week_start_for_iso_year(iso_year + 1) if iso_year < 9999 else date.max
-
-        plans = (
-            PlantingPlan.objects
-            .select_related('culture')
-            .filter(
-                project=active_project,
-                harvest_date__isnull=False,
-                harvest_end_date__isnull=False,
-                culture__expected_yield__gt=0,
-                harvest_date__lt=year_end,
-                harvest_end_date__gt=year_start,
-            )
-        )
-
-        weekly_data: dict[str, dict[str, object]] = {}
-
-        for plan in plans:
-            harvest_start = plan.harvest_date
-            harvest_end = plan.harvest_end_date
-            if harvest_end <= harvest_start:
-                continue
-
-            total_days = (harvest_end - harvest_start).days
-            if total_days <= 0:
-                continue
-
-            expected_yield = Decimal(plan.culture.expected_yield)
-            first_week_start = harvest_start - timedelta(days=harvest_start.weekday())
-            week_start = first_week_start
-
-            while week_start < harvest_end:
-                week_end = week_start + timedelta(days=7)
-                overlap_start = max(harvest_start, week_start)
-                overlap_end = min(harvest_end, week_end)
-                overlap_days = (overlap_end - overlap_start).days
-
-                if overlap_days > 0:
-                    iso_year_of_week, _, _ = week_start.isocalendar()
-                    if iso_year_of_week == iso_year:
-                        iso_week = _iso_week_key(week_start)
-                        week_entry = weekly_data.setdefault(
-                            iso_week,
-                            {
-                                'iso_week': iso_week,
-                                'week_start': week_start,
-                                'week_end': week_end,
-                                'cultures': defaultdict(Decimal),
-                            },
-                        )
-                        culture_key = (
-                            plan.culture_id,
-                            plan.culture.name,
-                            plan.culture.display_color or '#3b82f6',
-                        )
-                        contribution = expected_yield * Decimal(overlap_days) / Decimal(total_days)
-                        week_entry['cultures'][culture_key] += contribution
-
-                week_start += timedelta(days=7)
-
-        response_data = []
-        for iso_week in sorted(weekly_data.keys()):
-            week_entry = weekly_data[iso_week]
-            cultures_payload = []
-            for (culture_id, culture_name, color), value in sorted(week_entry['cultures'].items(), key=lambda c: c[0][1]):
-                rounded_yield = value.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                if rounded_yield <= 0:
-                    continue
-                cultures_payload.append(
-                    {
-                        'culture_id': culture_id,
-                        'culture_name': culture_name,
-                        'color': color,
-                        'yield': float(rounded_yield),
-                    }
-                )
-
-            if not cultures_payload:
-                continue
-
-            response_data.append(
-                {
-                    'iso_week': week_entry['iso_week'],
-                    'week_start': week_entry['week_start'].isoformat(),
-                    'week_end': week_entry['week_end'].isoformat(),
-                    'cultures': cultures_payload,
-                }
-            )
-
-        return Response(response_data)
+        return Response(build_yield_calendar(active_project, iso_year))
 
 
 class PlantingPlanViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelViewSet):
@@ -189,55 +125,25 @@ class PlantingPlanViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.Mod
         :return: Remaining area payload for the requested bed and interval.
         """
         active_project = request.active_project
-        bed_id_param = request.query_params.get('bed_id')
-        start_date_param = request.query_params.get('start_date')
-        end_date_param = request.query_params.get('end_date')
-        exclude_plan_id_param = request.query_params.get('exclude_plan_id')
+        params, error_detail = _parse_remaining_area_params(request.query_params)
+        if error_detail:
+            return Response({'detail': error_detail}, status=status.HTTP_400_BAD_REQUEST)
 
-        if not bed_id_param or not start_date_param or not end_date_param:
-            return Response(
-                {'detail': 'bed_id, start_date and end_date are required.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        try:
-            bed_id = int(bed_id_param)
-        except ValueError:
-            return Response({'detail': 'bed_id must be an integer.'}, status=status.HTTP_400_BAD_REQUEST)
-
-        start_date = parse_date(start_date_param)
-        end_date = parse_date(end_date_param)
-        if start_date is None or end_date is None:
-            return Response(
-                {'detail': 'start_date and end_date must use YYYY-MM-DD format.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        exclude_plan_id: int | None = None
-        if exclude_plan_id_param:
-            try:
-                exclude_plan_id = int(exclude_plan_id_param)
-            except ValueError:
-                return Response(
-                    {'detail': 'exclude_plan_id must be an integer.'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-        bed = Bed.objects.filter(id=bed_id, project=active_project).only('id').first()
+        bed = Bed.objects.filter(id=params['bed_id'], project=active_project).only('id').first()
         if bed is None:
             return Response({'detail': 'Bed not found.'}, status=status.HTTP_404_NOT_FOUND)
 
-        if exclude_plan_id is not None:
-            plan_exists = PlantingPlan.objects.filter(id=exclude_plan_id, project=active_project).exists()
+        if params['exclude_plan_id'] is not None:
+            plan_exists = PlantingPlan.objects.filter(id=params['exclude_plan_id'], project=active_project).exists()
             if not plan_exists:
                 return Response({'detail': 'exclude_plan_id not found in active project.'}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             payload = calculate_remaining_bed_area(
-                bed_id=bed_id,
-                start_date=start_date,
-                end_date=end_date,
-                exclude_plan_id=exclude_plan_id,
+                bed_id=params['bed_id'],
+                start_date=params['start_date'],
+                end_date=params['end_date'],
+                exclude_plan_id=params['exclude_plan_id'],
             )
         except ValueError as error:
             return Response({'detail': str(error)}, status=status.HTTP_400_BAD_REQUEST)
@@ -249,8 +155,8 @@ class PlantingPlanViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.Mod
             'bed_area_sqm': float(payload['bed_area_sqm']),
             'overlapping_used_area_sqm': float(payload['overlapping_used_area_sqm']),
             'remaining_area_sqm': float(payload['remaining_area_sqm']),
-            'start_date': start_date.isoformat(),
-            'end_date': end_date.isoformat(),
+            'start_date': params['start_date'].isoformat(),
+            'end_date': params['end_date'].isoformat(),
         })
 
 

--- a/backend/farm/services/bed_layouts.py
+++ b/backend/farm/services/bed_layouts.py
@@ -1,0 +1,110 @@
+"""Persistence of graphical bed/field layout positions for a location.
+
+Business logic behind the `locations/<id>/layouts/` PUT endpoint; the view
+only parses the request and maps the outcome to a response.
+
+Note on failure semantics (kept from the original inline implementation): a
+validation error mid-list returns normally from inside `transaction.atomic()`,
+so entries upserted before the invalid one stay committed.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+from farm.models import Bed, BedLayout, Field, FieldLayout, Location
+
+
+def extract_layout_payloads(data) -> tuple[object, object]:
+    """Pull bed/field layout lists from the request body.
+
+    Falls back to the Phase-1 payload format (a bare list or `layouts` key)
+    when neither modern key is present.
+    """
+    bed_payload = data.get('bed_layouts')
+    field_payload = data.get('field_layouts')
+    if bed_payload is None and field_payload is None:
+        bed_payload = data.get('layouts', data)
+        field_payload = []
+    return bed_payload, field_payload
+
+
+@dataclass
+class LayoutSaveOutcome:
+    """Saved layouts, or `error_detail` when a payload entry was invalid."""
+
+    bed_layouts: list[BedLayout] = field(default_factory=list)
+    field_layouts: list[FieldLayout] = field(default_factory=list)
+    error_detail: str | None = None
+
+
+def save_location_layouts(location: Location, bed_payload: list, field_payload: list) -> LayoutSaveOutcome:
+    """Upsert the graphical layout entries for all beds/fields of a location."""
+    bed_ids = [item.get('bed') for item in bed_payload if isinstance(item, dict) and item.get('bed') is not None]
+    beds = {bed.id: bed for bed in Bed.objects.select_related('field__location').filter(id__in=bed_ids)}
+
+    field_ids = [item.get('field') for item in field_payload if isinstance(item, dict) and item.get('field') is not None]
+    fields = {f.id: f for f in Field.objects.select_related('location').filter(id__in=field_ids)}
+
+    saved_bed_layouts: list[BedLayout] = []
+    saved_field_layouts: list[FieldLayout] = []
+
+    with transaction.atomic():
+        for item in bed_payload:
+            error_detail = _bed_entry_error(location, beds, item)
+            if error_detail:
+                return LayoutSaveOutcome(error_detail=error_detail)
+            bed = beds[item['bed']]
+            layout, _ = BedLayout.objects.update_or_create(
+                bed=bed,
+                defaults=_layout_defaults(location, item),
+            )
+            saved_bed_layouts.append(layout)
+
+        for item in field_payload:
+            error_detail = _field_entry_error(location, fields, item)
+            if error_detail:
+                return LayoutSaveOutcome(error_detail=error_detail)
+            field_obj = fields[item['field']]
+            layout, _ = FieldLayout.objects.update_or_create(
+                field=field_obj,
+                defaults=_layout_defaults(location, item),
+            )
+            saved_field_layouts.append(layout)
+
+    return LayoutSaveOutcome(bed_layouts=saved_bed_layouts, field_layouts=saved_field_layouts)
+
+
+def _layout_defaults(location: Location, item: dict) -> dict:
+    return {
+        'location': location,
+        'project': location.project,
+        'x': float(item.get('x', 0.0)),
+        'y': float(item.get('y', 0.0)),
+        'scale': item.get('scale'),
+        'version': int(item.get('version', 1)),
+    }
+
+
+def _bed_entry_error(location: Location, beds: dict[int, Bed], item: object) -> str | None:
+    if not isinstance(item, dict):
+        return 'Each bed layout entry must be an object.'
+    bed_id = item.get('bed')
+    bed = beds.get(bed_id)
+    if bed is None:
+        return f'Bed {bed_id} does not exist.'
+    if bed.field.location_id != location.id:
+        return f'Bed {bed_id} does not belong to location {location.id}.'
+    return None
+
+
+def _field_entry_error(location: Location, fields: dict[int, Field], item: object) -> str | None:
+    if not isinstance(item, dict):
+        return 'Each field layout entry must be an object.'
+    field_id = item.get('field')
+    field_obj = fields.get(field_id)
+    if field_obj is None:
+        return f'Field {field_id} does not exist.'
+    if field_obj.location_id != location.id:
+        return f'Field {field_id} does not belong to location {location.id}.'
+    return None

--- a/backend/farm/services/suppliers.py
+++ b/backend/farm/services/suppliers.py
@@ -1,0 +1,307 @@
+"""Supplier workflows: creation validation, delete-usage analysis, unlink/restore.
+
+Business logic for the supplier endpoints; the viewset only parses requests,
+wraps transactions/revision recording, and maps domain errors to responses.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import URLValidator
+from django.db import IntegrityError, transaction
+
+from farm.models import Culture, CultureSupplierData, Supplier
+from farm.utils import normalize_supplier_name
+
+
+class SupplierPayloadError(Exception):
+    """A supplier payload failed field validation; `errors` maps field -> messages."""
+
+    def __init__(self, errors: dict[str, list[str]]):
+        super().__init__(str(errors))
+        self.errors = errors
+
+
+class DuplicateSupplierNameError(Exception):
+    """A supplier with the same normalized name already exists in the project."""
+
+
+class SupplierRestoreConflictError(Exception):
+    """The supplier id from the undo payload is already in use."""
+
+
+class SupplierRestoreFailedError(Exception):
+    """The restore transaction failed (integrity or value error)."""
+
+
+def build_delete_usage(supplier: Supplier) -> dict[str, int | bool | list[int]]:
+    """Summarize which cultures/rows still reference the supplier."""
+    supplier_culture_ids = set(
+        Culture.objects.filter(
+            project=supplier.project,
+            deleted_at__isnull=True,
+            supplier=supplier,
+        ).values_list('id', flat=True)
+    )
+    seed_demand_culture_ids = set(
+        Culture.objects.filter(
+            project=supplier.project,
+            deleted_at__isnull=True,
+            selected_seed_demand_supplier=supplier,
+        ).values_list('id', flat=True)
+    )
+    supplier_data_culture_ids = set(
+        CultureSupplierData.objects.filter(
+            project=supplier.project,
+            supplier=supplier,
+            culture__deleted_at__isnull=True,
+        ).values_list('culture_id', flat=True)
+    )
+    supplier_data_rows = CultureSupplierData.objects.filter(
+        project=supplier.project,
+        supplier=supplier,
+        culture__deleted_at__isnull=True,
+    ).count()
+    total_culture_ids = supplier_culture_ids | seed_demand_culture_ids | supplier_data_culture_ids
+
+    return {
+        'can_delete': len(total_culture_ids) == 0 and supplier_data_rows == 0,
+        'culture_count': len(supplier_culture_ids),
+        'seed_demand_culture_count': len(seed_demand_culture_ids),
+        'supplier_data_culture_count': len(supplier_data_culture_ids),
+        'supplier_data_count': supplier_data_rows,
+        'total_culture_count': len(total_culture_ids),
+        'culture_ids': sorted(total_culture_ids),
+    }
+
+
+def build_delete_undo_payload(supplier: Supplier) -> dict[str, object]:
+    """Capture everything needed to undo an unlink-and-delete of the supplier."""
+    supplier_cultures = list(
+        Culture.all_objects.filter(project=supplier.project, supplier=supplier).values_list('id', flat=True)
+    )
+    seed_demand_cultures = list(
+        Culture.all_objects.filter(
+            project=supplier.project,
+            selected_seed_demand_supplier=supplier,
+        ).values_list('id', flat=True)
+    )
+    supplier_data_rows = []
+    for row in CultureSupplierData.objects.filter(project=supplier.project, supplier=supplier):
+        supplier_data_rows.append({
+            'id': row.id,
+            'culture_id': row.culture_id,
+            'supplier_name': row.supplier_name,
+            'supplier_url': row.supplier_url,
+            'supplier_product_name': row.supplier_product_name,
+            'supplier_product_url': row.supplier_product_url,
+            'packaging_sizes': row.packaging_sizes,
+            'thousand_kernel_weight_g': (
+                str(row.thousand_kernel_weight_g)
+                if row.thousand_kernel_weight_g is not None
+                else None
+            ),
+            'germination_rate': row.germination_rate,
+            'price': str(row.price) if row.price is not None else None,
+            'notes': row.notes,
+            'source_url': row.source_url,
+        })
+
+    return {
+        'supplier': {
+            'id': supplier.id,
+            'name': supplier.name,
+            'homepage_url': supplier.homepage_url,
+            'slug': supplier.slug,
+            'allowed_domains': supplier.allowed_domains,
+        },
+        'culture_ids': supplier_cultures,
+        'seed_demand_culture_ids': seed_demand_cultures,
+        'supplier_data': supplier_data_rows,
+    }
+
+
+def unlink_supplier_references(supplier: Supplier) -> None:
+    """Detach all culture references to the supplier and drop its data rows."""
+    Culture.all_objects.filter(project=supplier.project, supplier=supplier).update(supplier=None)
+    Culture.all_objects.filter(
+        project=supplier.project,
+        selected_seed_demand_supplier=supplier,
+    ).update(selected_seed_demand_supplier=None)
+    CultureSupplierData.objects.filter(project=supplier.project, supplier=supplier).delete()
+
+
+@dataclass
+class SupplierRestoreResult:
+    supplier: Supplier
+    restored_culture_count: int
+    restored_supplier_data_count: int
+
+
+def restore_unlinked_supplier(
+    *,
+    project,
+    payload: dict,
+    record_restore: Callable[[Supplier], None],
+) -> SupplierRestoreResult:
+    """Recreate a supplier (with its original id) from an unlink-and-delete undo payload.
+
+    `record_restore` is invoked inside the restore transaction so a failing
+    revision write rolls the whole restore back, matching the previous inline
+    behavior.
+    """
+    supplier_payload = payload.get('supplier')
+    if not isinstance(supplier_payload, dict):
+        raise SupplierPayloadError({'supplier': ['Supplier restore data is required.']})
+
+    supplier_id = supplier_payload.get('id')
+    if not isinstance(supplier_id, int):
+        raise SupplierPayloadError({'supplier': ['Supplier id is required.']})
+    if Supplier.objects.filter(project=project, pk=supplier_id).exists():
+        raise SupplierRestoreConflictError()
+
+    culture_ids = [item for item in payload.get('culture_ids', []) if isinstance(item, int)]
+    seed_demand_culture_ids = [
+        item for item in payload.get('seed_demand_culture_ids', []) if isinstance(item, int)
+    ]
+    supplier_data_rows = payload.get('supplier_data', [])
+    if not isinstance(supplier_data_rows, list):
+        supplier_data_rows = []
+
+    try:
+        with transaction.atomic():
+            supplier = Supplier.objects.create(
+                id=supplier_id,
+                project=project,
+                name=str(supplier_payload.get('name') or ''),
+                homepage_url=str(supplier_payload.get('homepage_url') or ''),
+                slug=str(supplier_payload.get('slug') or ''),
+                allowed_domains=supplier_payload.get('allowed_domains') or [],
+            )
+            Culture.all_objects.filter(project=project, id__in=culture_ids).update(supplier=supplier)
+            Culture.all_objects.filter(
+                project=project,
+                id__in=seed_demand_culture_ids,
+            ).update(selected_seed_demand_supplier=supplier)
+
+            restored_supplier_data_count = 0
+            for row_payload in supplier_data_rows:
+                if _restore_supplier_data_row(project, supplier, row_payload):
+                    restored_supplier_data_count += 1
+
+            record_restore(supplier)
+    except (IntegrityError, ValueError) as exc:
+        raise SupplierRestoreFailedError() from exc
+
+    return SupplierRestoreResult(
+        supplier=supplier,
+        restored_culture_count=len(set(culture_ids) | set(seed_demand_culture_ids)),
+        restored_supplier_data_count=restored_supplier_data_count,
+    )
+
+
+def _restore_supplier_data_row(project, supplier: Supplier, row_payload: object) -> bool:
+    """Recreate one CultureSupplierData row from the undo payload; skip invalid rows."""
+    if not isinstance(row_payload, dict):
+        return False
+    culture_id = row_payload.get('culture_id')
+    if not isinstance(culture_id, int):
+        return False
+    if not Culture.all_objects.filter(project=project, pk=culture_id).exists():
+        return False
+    CultureSupplierData.objects.create(
+        id=row_payload.get('id') if isinstance(row_payload.get('id'), int) else None,
+        culture_id=culture_id,
+        supplier=supplier,
+        project=project,
+        supplier_name=str(row_payload.get('supplier_name') or ''),
+        supplier_url=str(row_payload.get('supplier_url') or ''),
+        supplier_product_name=str(row_payload.get('supplier_product_name') or ''),
+        supplier_product_url=str(row_payload.get('supplier_product_url') or ''),
+        packaging_sizes=row_payload.get('packaging_sizes') or [],
+        thousand_kernel_weight_g=(
+            Decimal(str(row_payload['thousand_kernel_weight_g']))
+            if row_payload.get('thousand_kernel_weight_g') is not None
+            else None
+        ),
+        germination_rate=row_payload.get('germination_rate'),
+        price=(
+            Decimal(str(row_payload['price']))
+            if row_payload.get('price') is not None
+            else None
+        ),
+        notes=str(row_payload.get('notes') or ''),
+        source_url=str(row_payload.get('source_url') or ''),
+    )
+    return True
+
+
+def normalize_new_supplier_payload(
+    *,
+    name: object,
+    homepage_url: object,
+    allowed_domains: object,
+) -> dict[str, object]:
+    """Validate and normalize the create-supplier fields.
+
+    Returns the normalized field dict; raises SupplierPayloadError with the
+    exact field -> message mapping the endpoint has always returned.
+    """
+    name = (name or '').strip()
+    homepage_url = (homepage_url or '').strip()
+
+    if not name:
+        raise SupplierPayloadError({'name': ['Dieses Feld ist erforderlich.']})
+
+    # Normalize homepage_url (prepend https:// if no protocol)
+    if homepage_url and not homepage_url.startswith(('http://', 'https://')):
+        homepage_url = f'https://{homepage_url}'
+
+    url_validator = URLValidator()
+    try:
+        if homepage_url:
+            url_validator(homepage_url)
+    except DjangoValidationError:
+        raise SupplierPayloadError({'homepage_url': ['Bitte geben Sie eine gültige URL ein.']}) from None
+
+    if allowed_domains and not isinstance(allowed_domains, list):
+        raise SupplierPayloadError({'allowed_domains': ['Bitte geben Sie eine Liste von Domains an.']})
+    if allowed_domains:
+        normalized_domains = Supplier.normalize_allowed_domains(allowed_domains)
+        invalid = [domain for domain in normalized_domains if not Supplier._is_valid_domain(Supplier._normalize_domain(domain))]
+        if invalid:
+            raise SupplierPayloadError({
+                'allowed_domains': [
+                    f'Ungültige Domain(s): {", ".join(invalid)}. Domains müssen gültige Hostnamen ohne Schema oder Pfad sein.'
+                ],
+            })
+
+    return {
+        'name': name,
+        'homepage_url': homepage_url,
+        'allowed_domains': Supplier.normalize_allowed_domains(allowed_domains) if isinstance(allowed_domains, list) else [],
+    }
+
+
+def create_supplier(*, project, name: str, homepage_url: str, allowed_domains: list) -> Supplier:
+    """Create a supplier, rejecting normalized duplicate names within the project."""
+    normalized = normalize_supplier_name(name) or ''
+
+    # Check normalized duplicates before relying on the database constraint.
+    if Supplier.objects.filter(project=project, name_normalized=normalized).exists():
+        raise DuplicateSupplierNameError()
+
+    try:
+        with transaction.atomic():
+            return Supplier.objects.create(
+                name=name,
+                homepage_url=homepage_url,
+                allowed_domains=allowed_domains,
+                project=project,
+            )
+    except IntegrityError as exc:
+        if Supplier.objects.filter(project=project, name_normalized=normalized).exists():
+            raise DuplicateSupplierNameError() from exc
+        raise

--- a/backend/farm/services/yield_calendar.py
+++ b/backend/farm/services/yield_calendar.py
@@ -1,0 +1,126 @@
+"""Weekly yield-distribution calculation for the yield calendar endpoint.
+
+Aggregates each planting plan's expected yield across the ISO weeks its
+harvest window overlaps, proportional to the overlapping days.
+"""
+
+from collections import defaultdict
+from datetime import date, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
+from farm.models import PlantingPlan, Project
+
+
+def week_start_for_iso_year(iso_year: int) -> date:
+    """Return Monday of ISO week 1 for an ISO year."""
+    return date.fromisocalendar(iso_year, 1, 1)
+
+
+def iso_week_key(day: date) -> str:
+    """Return ISO week key in the format YYYY-Www using ISO year and week."""
+    iso_year, iso_week, _ = day.isocalendar()
+    return f"{iso_year}-W{iso_week:02d}"
+
+
+def build_yield_calendar(project: Project, iso_year: int) -> list[dict[str, object]]:
+    """Return the per-week, per-culture expected yield rows for one ISO year."""
+    year_start = week_start_for_iso_year(iso_year)
+    year_end = week_start_for_iso_year(iso_year + 1) if iso_year < 9999 else date.max
+
+    plans = (
+        PlantingPlan.objects
+        .select_related('culture')
+        .filter(
+            project=project,
+            harvest_date__isnull=False,
+            harvest_end_date__isnull=False,
+            culture__expected_yield__gt=0,
+            harvest_date__lt=year_end,
+            harvest_end_date__gt=year_start,
+        )
+    )
+
+    weekly_data: dict[str, dict[str, object]] = {}
+    for plan in plans:
+        _accumulate_plan_yield(weekly_data, plan, iso_year)
+
+    return _build_response_rows(weekly_data)
+
+
+def _accumulate_plan_yield(weekly_data: dict[str, dict[str, object]], plan: PlantingPlan, iso_year: int) -> None:
+    """Distribute one plan's expected yield over the ISO weeks it overlaps."""
+    harvest_start = plan.harvest_date
+    harvest_end = plan.harvest_end_date
+    if harvest_end <= harvest_start:
+        return
+
+    total_days = (harvest_end - harvest_start).days
+    if total_days <= 0:
+        return
+
+    expected_yield = Decimal(plan.culture.expected_yield)
+    first_week_start = harvest_start - timedelta(days=harvest_start.weekday())
+    week_start = first_week_start
+
+    while week_start < harvest_end:
+        week_end = week_start + timedelta(days=7)
+        overlap_start = max(harvest_start, week_start)
+        overlap_end = min(harvest_end, week_end)
+        overlap_days = (overlap_end - overlap_start).days
+
+        if overlap_days > 0:
+            iso_year_of_week, _, _ = week_start.isocalendar()
+            if iso_year_of_week == iso_year:
+                iso_week = iso_week_key(week_start)
+                week_entry = weekly_data.setdefault(
+                    iso_week,
+                    {
+                        'iso_week': iso_week,
+                        'week_start': week_start,
+                        'week_end': week_end,
+                        'cultures': defaultdict(Decimal),
+                    },
+                )
+                culture_key = (
+                    plan.culture_id,
+                    plan.culture.name,
+                    plan.culture.display_color or '#3b82f6',
+                )
+                contribution = expected_yield * Decimal(overlap_days) / Decimal(total_days)
+                week_entry['cultures'][culture_key] += contribution
+
+        week_start += timedelta(days=7)
+
+
+def _build_response_rows(weekly_data: dict[str, dict[str, object]]) -> list[dict[str, object]]:
+    """Round and serialize the accumulated weekly data, dropping empty weeks."""
+    response_data = []
+    for iso_week in sorted(weekly_data.keys()):
+        week_entry = weekly_data[iso_week]
+        cultures_payload = []
+        for (culture_id, culture_name, color), value in sorted(week_entry['cultures'].items(), key=lambda c: c[0][1]):
+            rounded_yield = value.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            if rounded_yield <= 0:
+                continue
+            cultures_payload.append(
+                {
+                    'culture_id': culture_id,
+                    'culture_name': culture_name,
+                    'color': color,
+                    'yield': float(rounded_yield),
+                }
+            )
+
+        if not cultures_payload:
+            continue
+
+        response_data.append(
+            {
+                'iso_week': week_entry['iso_week'],
+                'week_start': week_entry['week_start'].isoformat(),
+                'week_end': week_entry['week_end'].isoformat(),
+                'cultures': cultures_payload,
+            }
+        )
+
+    return response_data

--- a/backend/farm/structure/views.py
+++ b/backend/farm/structure/views.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -13,6 +13,7 @@ from farm.common.mixins import ProjectRevisionMixin, ProjectScopedMixin
 from farm.history import _entity_display_name, _serialize_instance
 from farm.models import Bed, BedLayout, EntityRevision, Field, FieldLayout, Location
 from farm.project_context import get_active_project_or_400
+from farm.services.bed_layouts import extract_layout_payloads, save_location_layouts
 
 from .serializers import (
     BED_NAME_DUPLICATE_MESSAGE,
@@ -44,13 +45,7 @@ class BedLayoutByLocationView(APIView):
     def put(self, request, location_id: int):
         active_project = get_active_project_or_400(request)
         location = get_object_or_404(Location, pk=location_id, project=active_project)
-        bed_payload = request.data.get('bed_layouts')
-        field_payload = request.data.get('field_layouts')
-
-        # Backward compatibility with Phase-1 payload format.
-        if bed_payload is None and field_payload is None:
-            bed_payload = request.data.get('layouts', request.data)
-            field_payload = []
+        bed_payload, field_payload = extract_layout_payloads(request.data)
 
         if not isinstance(bed_payload, list) or not isinstance(field_payload, list):
             return Response(
@@ -58,68 +53,14 @@ class BedLayoutByLocationView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        bed_ids = [item.get('bed') for item in bed_payload if isinstance(item, dict) and item.get('bed') is not None]
-        beds = {bed.id: bed for bed in Bed.objects.select_related('field__location').filter(id__in=bed_ids)}
-
-        field_ids = [item.get('field') for item in field_payload if isinstance(item, dict) and item.get('field') is not None]
-        fields = {field.id: field for field in Field.objects.select_related('location').filter(id__in=field_ids)}
-
-        saved_bed_layouts: list[BedLayout] = []
-        saved_field_layouts: list[FieldLayout] = []
-
-        with transaction.atomic():
-            for item in bed_payload:
-                if not isinstance(item, dict):
-                    return Response({'detail': 'Each bed layout entry must be an object.'}, status=status.HTTP_400_BAD_REQUEST)
-
-                bed_id = item.get('bed')
-                bed = beds.get(bed_id)
-                if bed is None:
-                    return Response({'detail': f'Bed {bed_id} does not exist.'}, status=status.HTTP_400_BAD_REQUEST)
-                if bed.field.location_id != location.id:
-                    return Response({'detail': f'Bed {bed_id} does not belong to location {location.id}.'}, status=status.HTTP_400_BAD_REQUEST)
-
-                layout, _ = BedLayout.objects.update_or_create(
-                    bed=bed,
-                    defaults={
-                        'location': location,
-                        'project': location.project,
-                        'x': float(item.get('x', 0.0)),
-                        'y': float(item.get('y', 0.0)),
-                        'scale': item.get('scale'),
-                        'version': int(item.get('version', 1)),
-                    },
-                )
-                saved_bed_layouts.append(layout)
-
-            for item in field_payload:
-                if not isinstance(item, dict):
-                    return Response({'detail': 'Each field layout entry must be an object.'}, status=status.HTTP_400_BAD_REQUEST)
-
-                field_id = item.get('field')
-                field = fields.get(field_id)
-                if field is None:
-                    return Response({'detail': f'Field {field_id} does not exist.'}, status=status.HTTP_400_BAD_REQUEST)
-                if field.location_id != location.id:
-                    return Response({'detail': f'Field {field_id} does not belong to location {location.id}.'}, status=status.HTTP_400_BAD_REQUEST)
-
-                layout, _ = FieldLayout.objects.update_or_create(
-                    field=field,
-                    defaults={
-                        'location': location,
-                        'project': location.project,
-                        'x': float(item.get('x', 0.0)),
-                        'y': float(item.get('y', 0.0)),
-                        'scale': item.get('scale'),
-                        'version': int(item.get('version', 1)),
-                    },
-                )
-                saved_field_layouts.append(layout)
+        outcome = save_location_layouts(location, bed_payload, field_payload)
+        if outcome.error_detail:
+            return Response({'detail': outcome.error_detail}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(
             {
-                'bed_layouts': BedLayoutSerializer(saved_bed_layouts, many=True).data,
-                'field_layouts': FieldLayoutSerializer(saved_field_layouts, many=True).data,
+                'bed_layouts': BedLayoutSerializer(outcome.bed_layouts, many=True).data,
+                'field_layouts': FieldLayoutSerializer(outcome.field_layouts, many=True).data,
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## Summary

Follow-up to #302/#305, completing the AGENTS.md "thin views" goal: the remaining fat view methods delegate their business logic to `farm/services/` modules. Behavior-preserving — routes, payloads, status codes and error messages are unchanged.

- **`farm/services/suppliers.py`** (new): supplier delete-usage analysis, unlink-and-delete undo payload, reference unlinking, the undo-restore transaction (was `SupplierViewSet.restore_unlinked_delete`, complexity **D/29**) and create-payload validation/creation (was `SupplierViewSet.create`, **C/19**), with domain errors (`SupplierPayloadError`, `DuplicateSupplierNameError`, `SupplierRestoreConflictError`, `SupplierRestoreFailedError`) that the viewset maps to the exact same responses. The revision write stays inside the restore transaction via a callback.
- **`farm/services/bed_layouts.py`** (new): payload extraction (incl. the Phase-1 fallback format) and the transactional bed/field layout upsert (was `BedLayoutByLocationView.put`, **D/21**). The original commit-on-early-return semantics inside the transaction are deliberately preserved.
- **`farm/services/yield_calendar.py`** (new): the ISO-week yield distribution (was `YieldCalendarListView.get`, **C/17**) split into query, per-plan week accumulation, and response-row building. The remaining-area query-parameter parsing also moved into a view-module helper, taking `PlantingPlanViewSet.remaining_area` below the mccabe threshold.

Net effect on the quality gate: `farm/` now has **4 mccabe (`C901`) violations, down from 10** at the start of this refactoring series — none of them in views anymore.

## Verification (after every commit)

- pytest: all **382 backend tests pass**
- `ruff check` — no new findings; three view-layer `C901` violations removed
- URL-contract snapshot diff — route table byte-identical
- `manage.py makemigrations --check --dry-run` — no changes detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_