### PR TITLE
refactor(backend): eliminate the last four mccabe complexity hotspots

### DIFF
--- a/backend/farm/cultures/serializers.py
+++ b/backend/farm/cultures/serializers.py
@@ -625,44 +625,58 @@ class CultureSerializer(serializers.ModelSerializer):
         seed_packages = validated_data.pop('seed_packages', None)
         culture = super().update(instance, validated_data)
         if supplier_data_input is not None:
-            existing_by_id = {row.id: row for row in culture.supplier_data.all()}
-            seen_ids: set[int] = set()
-            if isinstance(supplier_data_input, list):
-                for row in supplier_data_input:
-                    if not isinstance(row, dict):
-                        continue
-                    row_data = dict(row)
-                    if _is_empty_supplier_data_payload(row_data):
-                        continue
-                    raw_row_id = row_data.get('id')
-                    try:
-                        row_id = int(raw_row_id)
-                    except (TypeError, ValueError):
-                        row_id = None
-                    instance_row = existing_by_id.get(row_id) if row_id is not None else None
-                    serializer = CultureSupplierDataSerializer(
-                        instance=instance_row,
-                        data=row_data,
-                        context={**self.context, 'parent_culture': culture},
-                        partial=instance_row is not None,
-                    )
-                    serializer.is_valid(raise_exception=True)
-                    saved_row = serializer.save(culture=culture, project=culture.project)
-                    seen_ids.add(saved_row.id)
-
-            ids_to_delete = [row_id for row_id in existing_by_id if row_id not in seen_ids]
-            if ids_to_delete:
-                CultureSupplierData.objects.filter(id__in=ids_to_delete).delete()
+            self._sync_supplier_data_rows(culture, supplier_data_input)
         if seed_packages is not None:
-            culture.seed_packages.all().delete()
-            if isinstance(seed_packages, list):
-                for package_data in seed_packages:
-                    if isinstance(package_data, dict):
-                        package_data = dict(package_data)
-                        package_data.pop('culture', None)
-                        package_data.setdefault('project', culture.project)
-                        SeedPackage.objects.create(culture=culture, **package_data)
+            self._replace_seed_packages(culture, seed_packages)
         return culture
+
+    def _sync_supplier_data_rows(self, culture, supplier_data_input):
+        """Upsert the supplied supplier-data rows and delete rows no longer present."""
+        existing_by_id = {row.id: row for row in culture.supplier_data.all()}
+        seen_ids: set[int] = set()
+        if isinstance(supplier_data_input, list):
+            for row in supplier_data_input:
+                saved_id = self._save_supplier_data_row(culture, row, existing_by_id)
+                if saved_id is not None:
+                    seen_ids.add(saved_id)
+
+        ids_to_delete = [row_id for row_id in existing_by_id if row_id not in seen_ids]
+        if ids_to_delete:
+            CultureSupplierData.objects.filter(id__in=ids_to_delete).delete()
+
+    def _save_supplier_data_row(self, culture, row, existing_by_id) -> int | None:
+        """Upsert one supplier-data row; returns its id, or None if skipped."""
+        if not isinstance(row, dict):
+            return None
+        row_data = dict(row)
+        if _is_empty_supplier_data_payload(row_data):
+            return None
+        raw_row_id = row_data.get('id')
+        try:
+            row_id = int(raw_row_id)
+        except (TypeError, ValueError):
+            row_id = None
+        instance_row = existing_by_id.get(row_id) if row_id is not None else None
+        serializer = CultureSupplierDataSerializer(
+            instance=instance_row,
+            data=row_data,
+            context={**self.context, 'parent_culture': culture},
+            partial=instance_row is not None,
+        )
+        serializer.is_valid(raise_exception=True)
+        saved_row = serializer.save(culture=culture, project=culture.project)
+        return saved_row.id
+
+    def _replace_seed_packages(self, culture, seed_packages):
+        """Delete all existing seed packages and recreate them from the payload."""
+        culture.seed_packages.all().delete()
+        if isinstance(seed_packages, list):
+            for package_data in seed_packages:
+                if isinstance(package_data, dict):
+                    package_data = dict(package_data)
+                    package_data.pop('culture', None)
+                    package_data.setdefault('project', culture.project)
+                    SeedPackage.objects.create(culture=culture, **package_data)
 
     def validate_origin_type(self, value):
         if value in {None, ''}:

--- a/backend/farm/models.py
+++ b/backend/farm/models.py
@@ -1009,6 +1009,20 @@ class Culture(TimestampedModel):
         if self.display_color and not re.match(r'^#[0-9A-Fa-f]{6}$', self.display_color):
             errors['display_color'] = 'Display color must be in hex format (#RRGGBB).'
 
+    # Fields whose change marks an imported culture as diverged from its source.
+    _SOURCE_DIVERGENCE_TRACKED_FIELDS = {
+        'name', 'variety', 'notes', 'seed_supplier', 'crop_family', 'nutrient_demand', 'cultivation_types',
+        'cultivation_type', 'growth_duration_days', 'harvest_duration_days', 'propagation_duration_days',
+        'harvest_method', 'expected_yield', 'allow_deviation_delivery_weeks', 'distance_within_row_m',
+        'row_spacing_m', 'sowing_depth_m', 'seed_rate_value', 'seed_rate_unit', 'seed_rate_by_cultivation',
+        'sowing_calculation_safety_percent', 'seed_rate_direct_value', 'seed_rate_direct_unit',
+        'sowing_calculation_safety_percent_direct', 'seed_rate_pre_cultivation_value',
+        'seed_rate_pre_cultivation_unit', 'sowing_calculation_safety_percent_pre_cultivation',
+        'thousand_kernel_weight_g', 'seeding_requirement',
+        'seeding_requirement_type', 'display_color', 'supplier_id', 'supplier_product_url', 'image_file_id',
+        'selected_seed_demand_supplier_id',
+    }
+
     def save(self, *args: Any, **kwargs: Any) -> None:
         """Save the culture and auto-generate display color and normalized fields."""
         from .utils import normalize_text
@@ -1017,21 +1031,7 @@ class Culture(TimestampedModel):
         if self.pk:
             previous = Culture.all_objects.filter(pk=self.pk).values().first()
 
-        if previous and previous.get('source_public_culture_id') and not previous.get('is_modified_from_source'):
-            tracked_fields = {
-                'name', 'variety', 'notes', 'seed_supplier', 'crop_family', 'nutrient_demand', 'cultivation_types',
-                'cultivation_type', 'growth_duration_days', 'harvest_duration_days', 'propagation_duration_days',
-                'harvest_method', 'expected_yield', 'allow_deviation_delivery_weeks', 'distance_within_row_m',
-                'row_spacing_m', 'sowing_depth_m', 'seed_rate_value', 'seed_rate_unit', 'seed_rate_by_cultivation',
-                'sowing_calculation_safety_percent', 'seed_rate_direct_value', 'seed_rate_direct_unit',
-                'sowing_calculation_safety_percent_direct', 'seed_rate_pre_cultivation_value',
-                'seed_rate_pre_cultivation_unit', 'sowing_calculation_safety_percent_pre_cultivation',
-                'thousand_kernel_weight_g', 'seeding_requirement',
-                'seeding_requirement_type', 'display_color', 'supplier_id', 'supplier_product_url', 'image_file_id',
-                'selected_seed_demand_supplier_id',
-            }
-            if any(previous.get(field) != getattr(self, field) for field in tracked_fields):
-                self.is_modified_from_source = True
+        self._flag_source_divergence(previous)
 
         # Generate display color on creation if not set.
         if not self.pk and not self.display_color:
@@ -1044,20 +1044,37 @@ class Culture(TimestampedModel):
         super().save(*args, **kwargs)
 
         current = Culture.all_objects.filter(pk=self.pk).values().first() or {}
+        changed_fields = self._compute_changed_fields(previous, current)
+        self._record_save_revision(current, previous, changed_fields)
+
+        if any(field in changed_fields for field in ('growth_duration_days', 'harvest_duration_days')):
+            self._recalculate_related_planting_plan_dates()
+
+    def _flag_source_divergence(self, previous: dict[str, Any] | None) -> None:
+        """Mark an imported, still-pristine culture as modified if a tracked field changed."""
+        if not (previous and previous.get('source_public_culture_id') and not previous.get('is_modified_from_source')):
+            return
+        if any(previous.get(field) != getattr(self, field) for field in self._SOURCE_DIVERGENCE_TRACKED_FIELDS):
+            self.is_modified_from_source = True
+
+    @staticmethod
+    def _compute_changed_fields(previous: dict[str, Any] | None, current: dict[str, Any]) -> list[str]:
+        if not previous:
+            return ['created']
+        return [
+            key for key, value in current.items()
+            if key not in {'created_at', 'updated_at'} and previous.get(key) != value
+        ]
+
+    def _record_save_revision(
+        self,
+        current: dict[str, Any],
+        previous: dict[str, Any] | None,
+        changed_fields: list[str],
+    ) -> None:
         serializable_snapshot: dict[str, Any] = json.loads(
             json.dumps(current, cls=DjangoJSONEncoder)
         )
-
-        changed_fields: list[str] = []
-        if previous:
-            for key, value in current.items():
-                if key in {'created_at', 'updated_at'}:
-                    continue
-                if previous.get(key) != value:
-                    changed_fields.append(key)
-        else:
-            changed_fields.append('created')
-
         history_action = getattr(self, '_history_action', None)
         if hasattr(self, '_history_action'):
             del self._history_action
@@ -1073,9 +1090,6 @@ class Culture(TimestampedModel):
             snapshot=serializable_snapshot,
             changed_fields=changed_fields,
         )
-
-        if any(field in changed_fields for field in ('growth_duration_days', 'harvest_duration_days')):
-            self._recalculate_related_planting_plan_dates()
 
     def _recalculate_related_planting_plan_dates(self) -> None:
         """Update stored planting-plan harvest dates after culture timing changes."""

--- a/backend/farm/planning/serializers.py
+++ b/backend/farm/planning/serializers.py
@@ -61,6 +61,13 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
         return round(obj.area_usage_sqm * plants_per_m2)
 
     def validate(self, attrs):
+        self._validate_project_scope(attrs)
+        self._apply_area_input_conversion(attrs)
+        self._run_model_clean(attrs)
+        return attrs
+
+    def _validate_project_scope(self, attrs):
+        """Culture and bed must belong to the active project."""
         project = _resolve_active_project_from_serializer(self)
         culture = attrs.get('culture') or (self.instance.culture if self.instance else None)
         bed = attrs.get('bed') or (self.instance.bed if self.instance else None)
@@ -68,57 +75,65 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({'culture': 'Culture does not belong to the active project.'})
         if project is not None and bed is not None and bed.project_id != project.id:
             raise serializers.ValidationError({'bed': 'Bed does not belong to the active project.'})
-        
-        # Handle area input conversion
+
+    def _apply_area_input_conversion(self, attrs):
+        """Convert the M2/PLANTS area input into area_usage_sqm on attrs."""
         area_input_value = attrs.pop('area_input_value', None)
         area_input_unit = attrs.pop('area_input_unit', None)
-        
-        # Validate area input fields
-        if area_input_value is not None:
-            # Value must be positive
-            if area_input_value <= 0:
-                raise serializers.ValidationError({
-                    'area_input_value': 'Area input value must be greater than 0.'
-                })
-            
-            # Unit is required when value is provided
-            if not area_input_unit:
-                raise serializers.ValidationError({
-                    'area_input_unit': (
-                        'Area input unit is required when '
-                        'area_input_value is provided.'
-                    )
-                })
-            
-            # Get culture (could be from attrs for create, or from instance for update)
-            culture = attrs.get('culture')
-            if not culture and self.instance:
-                culture = self.instance.culture
-            
-            # Convert based on unit
-            if area_input_unit == 'M2':
-                # Direct assignment
-                attrs['area_usage_sqm'] = area_input_value
-            elif area_input_unit == 'PLANTS':
-                # Validate culture is present
-                if not culture:
-                    raise serializers.ValidationError({
-                        'area_input_unit': 'Culture must be selected to input area as plant count.'
-                    })
-                
-                # Validate culture has valid spacing
-                plants_per_m2 = culture.plants_per_m2
-                if plants_per_m2 is None or plants_per_m2 <= 0:
-                    raise serializers.ValidationError({
-                        'area_input_unit': (
-                            'Culture spacing data is missing or invalid. '
-                            'Cannot calculate area from plant count.'
-                        )
-                    })
-                
-                # Calculate area in m²: plants / (plants_per_m2)
-                attrs['area_usage_sqm'] = area_input_value / plants_per_m2
-        
+
+        if area_input_value is None:
+            return
+
+        # Value must be positive
+        if area_input_value <= 0:
+            raise serializers.ValidationError({
+                'area_input_value': 'Area input value must be greater than 0.'
+            })
+
+        # Unit is required when value is provided
+        if not area_input_unit:
+            raise serializers.ValidationError({
+                'area_input_unit': (
+                    'Area input unit is required when '
+                    'area_input_value is provided.'
+                )
+            })
+
+        # Get culture (could be from attrs for create, or from instance for update)
+        culture = attrs.get('culture')
+        if not culture and self.instance:
+            culture = self.instance.culture
+
+        # Convert based on unit
+        if area_input_unit == 'M2':
+            # Direct assignment
+            attrs['area_usage_sqm'] = area_input_value
+        elif area_input_unit == 'PLANTS':
+            attrs['area_usage_sqm'] = self._plants_to_area(area_input_value, culture)
+
+    def _plants_to_area(self, plant_count, culture):
+        """Convert a plant count into an area in m² using the culture's spacing."""
+        # Validate culture is present
+        if not culture:
+            raise serializers.ValidationError({
+                'area_input_unit': 'Culture must be selected to input area as plant count.'
+            })
+
+        # Validate culture has valid spacing
+        plants_per_m2 = culture.plants_per_m2
+        if plants_per_m2 is None or plants_per_m2 <= 0:
+            raise serializers.ValidationError({
+                'area_input_unit': (
+                    'Culture spacing data is missing or invalid. '
+                    'Cannot calculate area from plant count.'
+                )
+            })
+
+        # Calculate area in m²: plants / (plants_per_m2)
+        return plant_count / plants_per_m2
+
+    def _run_model_clean(self, attrs):
+        """Run PlantingPlan.clean on a throwaway instance without mutating the real one."""
         model_field_names = {field.name for field in PlantingPlan._meta.fields}
         if self.instance:
             validation_attrs = {}
@@ -138,8 +153,6 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
             instance.clean()
         except ValidationError as e:
             raise serializers.ValidationError(e.message_dict) from e
-        
-        return attrs
 
 
 class TaskSerializer(serializers.ModelSerializer):

--- a/backend/farm/services/seed_packages.py
+++ b/backend/farm/services/seed_packages.py
@@ -90,21 +90,65 @@ def _build_metrics(
     )
 
 
-def compute_seed_package_suggestion(required_amount: Decimal, packages: Iterable[PackageOption], unit: str) -> SeedPackageSuggestion:
-    if required_amount <= 0:
-        return SeedPackageSuggestion(selection=[], total_amount=Decimal('0'), overage=Decimal('0'), pack_count=0)
+def _empty_suggestion() -> SeedPackageSuggestion:
+    return SeedPackageSuggestion(selection=[], total_amount=Decimal('0'), overage=Decimal('0'), pack_count=0)
 
+
+def _normalize_packages(packages: Iterable[PackageOption], unit: str) -> list[PackageOption]:
+    """Deduplicate valid packages for the requested unit, sorted ascending by size."""
     unique_packages: dict[tuple[Decimal, str], PackageOption] = {}
     for package in packages:
         if package.size_unit != unit or package.size_value <= 0:
             continue
         unique_packages[(package.size_value, package.size_unit)] = package
-
     normalized = list(unique_packages.values())
-    if not normalized:
-        return SeedPackageSuggestion(selection=[], total_amount=Decimal('0'), overage=Decimal('0'), pack_count=0)
-
     normalized.sort(key=lambda p: p.size_value)
+    return normalized
+
+
+def _count_vectors(total_count: int, dimension_count: int) -> Iterable[list[int]]:
+    """Yield every non-negative integer vector of the given length summing to total_count."""
+    current = [0] * dimension_count
+
+    def build(index: int, remaining: int) -> Iterable[list[int]]:
+        if index == dimension_count - 1:
+            current[index] = remaining
+            yield current.copy()
+            return
+        for count in range(remaining + 1):
+            current[index] = count
+            yield from build(index + 1, remaining - count)
+
+    yield from build(0, total_count)
+
+
+def _candidates_for_pack_count(
+    pack_count: int,
+    normalized: list[PackageOption],
+    required_amount: Decimal,
+) -> Iterable[tuple[SeedPackageSuggestion, Decimal]]:
+    """Yield (suggestion, overage) for every selection of exactly pack_count packs
+    that meets the required amount."""
+    for counts in _count_vectors(pack_count, len(normalized)):
+        total = sum((normalized[i].size_value * Decimal(counts[i]) for i in range(len(normalized))), Decimal('0'))
+        if total < required_amount:
+            continue
+        overage = total - required_amount
+        selection = [
+            PackageSelection(size_value=normalized[i].size_value, size_unit=normalized[i].size_unit, count=counts[i])
+            for i in range(len(normalized)) if counts[i] > 0
+        ]
+        yield SeedPackageSuggestion(selection=selection, total_amount=total, overage=overage, pack_count=pack_count), overage
+
+
+def compute_seed_package_suggestion(required_amount: Decimal, packages: Iterable[PackageOption], unit: str) -> SeedPackageSuggestion:
+    if required_amount <= 0:
+        return _empty_suggestion()
+
+    normalized = _normalize_packages(packages, unit)
+    if not normalized:
+        return _empty_suggestion()
+
     min_pack_count = int((required_amount / normalized[-1].size_value).to_integral_value(rounding=ROUND_CEILING))
     max_pack_count = int((required_amount / normalized[0].size_value).to_integral_value(rounding=ROUND_CEILING)) + 2
 
@@ -112,41 +156,10 @@ def compute_seed_package_suggestion(required_amount: Decimal, packages: Iterable
     best: SeedPackageSuggestion | None = None
     best_metrics: _SuggestionMetrics | None = None
 
-    def count_vectors(total_count: int, dimension_count: int) -> Iterable[list[int]]:
-        current = [0] * dimension_count
-
-        def build(index: int, remaining: int) -> Iterable[list[int]]:
-            if index == dimension_count - 1:
-                current[index] = remaining
-                yield current.copy()
-                return
-            for count in range(remaining + 1):
-                current[index] = count
-                yield from build(index + 1, remaining - count)
-
-        yield from build(0, total_count)
-
     for pack_count in range(max(1, min_pack_count), max_pack_count + 1):
-        for counts in count_vectors(pack_count, len(normalized)):
-            total = sum((normalized[i].size_value * Decimal(counts[i]) for i in range(len(normalized))), Decimal('0'))
-            if total < required_amount:
-                continue
-            overage = total - required_amount
-            selection = [
-                PackageSelection(size_value=normalized[i].size_value, size_unit=normalized[i].size_unit, count=counts[i])
-                for i in range(len(normalized)) if counts[i] > 0
-            ]
-            candidate = SeedPackageSuggestion(selection=selection, total_amount=total, overage=overage, pack_count=pack_count)
-            metrics = _build_metrics(selection=selection, overage=overage, smallest_size=smallest_size)
-            if best is None:
-                best = candidate
-                best_metrics = metrics
-                continue
-
-            cand_key = _metrics_sort_key(metrics)
-            assert best_metrics is not None  # for type checkers; best and best_metrics are paired.
-            best_key = _metrics_sort_key(best_metrics)
-            if cand_key < best_key:
+        for candidate, overage in _candidates_for_pack_count(pack_count, normalized, required_amount):
+            metrics = _build_metrics(selection=candidate.selection, overage=overage, smallest_size=smallest_size)
+            if best_metrics is None or _metrics_sort_key(metrics) < _metrics_sort_key(best_metrics):
                 best = candidate
                 best_metrics = metrics
 
@@ -155,4 +168,4 @@ def compute_seed_package_suggestion(required_amount: Decimal, packages: Iterable
             if lower_bound_next_pack_count > best_metrics.weighted_score:
                 break
 
-    return best or SeedPackageSuggestion(selection=[], total_amount=Decimal('0'), overage=Decimal('0'), pack_count=0)
+    return best or _empty_suggestion()


### PR DESCRIPTION
## Summary

Final backend complexity pass, following the domain split (#302), Culture-validation decomposition (#305), thin views (#306) and test split (#307). Decompose the four remaining `C901` (mccabe > 10) offenders into focused helpers. Behavior-preserving — no logic, ordering, or error messages change.

- **`PlantingPlanSerializer.validate`** (16) → `_validate_project_scope`, `_apply_area_input_conversion`, a `_plants_to_area` converter, and `_run_model_clean`.
- **`compute_seed_package_suggestion`** (16) → `_normalize_packages`, the `_count_vectors` generator, and `_candidates_for_pack_count` lifted to module functions; the search loop keeps the same pruning and tie-break ordering.
- **`CultureSerializer.update`** (12) → `_sync_supplier_data_rows` / `_save_supplier_data_row` and `_replace_seed_packages`.
- **`Culture.save`** (12) → `_flag_source_divergence`, `_compute_changed_fields`, and `_record_save_revision`; the tracked-field set is now the `_SOURCE_DIVERGENCE_TRACKED_FIELDS` class constant.

**Net effect: `farm/` now has zero mccabe violations, down from 10** at the start of this refactoring series.

## Verification

- pytest: all **382 backend tests pass**
- `ruff check farm/` — **0 `C901` findings** (only the two pre-existing unused-import warnings in `models.py` remain, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_