### PR TITLE
refactor(frontend): extract pure helpers from the next three largest components

### DIFF
--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -83,89 +83,15 @@ interface CultureDetailProps {
   searchInputRef?: Ref<HTMLInputElement>;
 }
 
-const CULTURE_FILTERS_STORAGE_KEY = 'culturesDetailFiltersV1';
-
-interface PersistedCultureFilters {
-  searchQuery: string;
-  selectedFamilyFilter: string;
-  selectedCultivationFilter: string;
-  selectedNutrientFilter: string;
-  selectedSupplierFilter: string;
-  growthDaysMin: string;
-  growthDaysMax: string;
-  yieldMin: string;
-  yieldMax: string;
-  selectedSowingMonths: number[];
-}
-
-/**
- * Formats a number with fallback for null/undefined values
- * Handles floating point precision issues by rounding to 2 decimal places
- */
-function formatNumber(value: number | null | undefined, t: (key: string) => string): string {
-  if (value === null || value === undefined) {
-    return t('cultures:noData');
-  }
-  
-  // Round to 2 decimal places to avoid floating point precision issues
-  const rounded = Math.round(value * 100) / 100;
-  return new Intl.NumberFormat('de-DE', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(rounded);
-}
-
-function formatSeedRateNumber(value: number | null | undefined, t: (key: string) => string): string {
-  if (value === null || value === undefined) {
-    return t('cultures:noData');
-  }
-
-  return new Intl.NumberFormat('de-DE', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 3,
-  }).format(value);
-}
-
-/**
- * Formats a distance value (rounds to whole numbers since no one measures more precisely than 1cm)
- */
-function formatDistance(value: number | null | undefined, t: (key: string) => string, decimals = 0): string {
-  if (value === null || value === undefined) {
-    return t('cultures:noData');
-  }
-
-  const factor = 10 ** decimals;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded.toFixed(decimals);
-}
-
-function formatSeedUnitLabel(unit: string | null | undefined): string {
-  if (unit === 'g_per_m2') return 'g / m²';
-  if (unit === 'g_per_lfm') return 'g / lfm';
-  if (unit === 'seeds_per_m2') return 'Korn / m²';
-  if (unit === 'seeds_per_lfm') return 'Korn / lfm';
-  if (unit === 'seeds_per_plant') return 'Korn / Pflanze';
-  return unit ?? '';
-}
-
-function formatPackageSizes(
-  packageSizes: Array<{ size_value?: number | null; size_unit?: string | null }> | null | undefined,
-  t: (key: string) => string,
-): string {
-  if (!Array.isArray(packageSizes) || packageSizes.length === 0) {
-    return t('noData');
-  }
-
-  const normalized = packageSizes
-    .filter((entry) => entry && typeof entry.size_value === 'number' && Number.isFinite(entry.size_value) && entry.size_value > 0)
-    .map((entry) => `${formatNumber(entry.size_value ?? null, t)} ${entry.size_unit === 'seeds' ? 'Korn' : 'g'}`);
-
-  if (normalized.length === 0) {
-    return t('noData');
-  }
-
-  return normalized.join(', ');
-}
+import {
+  CULTURE_FILTERS_STORAGE_KEY,
+  formatDistance,
+  formatNumber,
+  formatPackageSizes,
+  formatSeedRateNumber,
+  formatSeedUnitLabel,
+  type PersistedCultureFilters,
+} from './cultureDetailFormatters';
 
 
 export function CultureDetail({

--- a/frontend/src/cultures/cultureDetailFormatters.ts
+++ b/frontend/src/cultures/cultureDetailFormatters.ts
@@ -1,0 +1,88 @@
+/**
+ * Storage key, persisted-filter shape, and pure value formatters for the
+ * culture detail view. Extracted verbatim from cultures/CultureDetail.tsx.
+ */
+
+export const CULTURE_FILTERS_STORAGE_KEY = 'culturesDetailFiltersV1';
+
+export interface PersistedCultureFilters {
+  searchQuery: string;
+  selectedFamilyFilter: string;
+  selectedCultivationFilter: string;
+  selectedNutrientFilter: string;
+  selectedSupplierFilter: string;
+  growthDaysMin: string;
+  growthDaysMax: string;
+  yieldMin: string;
+  yieldMax: string;
+  selectedSowingMonths: number[];
+}
+
+/**
+ * Formats a number with fallback for null/undefined values
+ * Handles floating point precision issues by rounding to 2 decimal places
+ */
+export function formatNumber(value: number | null | undefined, t: (key: string) => string): string {
+  if (value === null || value === undefined) {
+    return t('cultures:noData');
+  }
+  
+  // Round to 2 decimal places to avoid floating point precision issues
+  const rounded = Math.round(value * 100) / 100;
+  return new Intl.NumberFormat('de-DE', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(rounded);
+}
+
+export function formatSeedRateNumber(value: number | null | undefined, t: (key: string) => string): string {
+  if (value === null || value === undefined) {
+    return t('cultures:noData');
+  }
+
+  return new Intl.NumberFormat('de-DE', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 3,
+  }).format(value);
+}
+
+/**
+ * Formats a distance value (rounds to whole numbers since no one measures more precisely than 1cm)
+ */
+export function formatDistance(value: number | null | undefined, t: (key: string) => string, decimals = 0): string {
+  if (value === null || value === undefined) {
+    return t('cultures:noData');
+  }
+
+  const factor = 10 ** decimals;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded.toFixed(decimals);
+}
+
+export function formatSeedUnitLabel(unit: string | null | undefined): string {
+  if (unit === 'g_per_m2') return 'g / m²';
+  if (unit === 'g_per_lfm') return 'g / lfm';
+  if (unit === 'seeds_per_m2') return 'Korn / m²';
+  if (unit === 'seeds_per_lfm') return 'Korn / lfm';
+  if (unit === 'seeds_per_plant') return 'Korn / Pflanze';
+  return unit ?? '';
+}
+
+export function formatPackageSizes(
+  packageSizes: Array<{ size_value?: number | null; size_unit?: string | null }> | null | undefined,
+  t: (key: string) => string,
+): string {
+  if (!Array.isArray(packageSizes) || packageSizes.length === 0) {
+    return t('noData');
+  }
+
+  const normalized = packageSizes
+    .filter((entry) => entry && typeof entry.size_value === 'number' && Number.isFinite(entry.size_value) && entry.size_value > 0)
+    .map((entry) => `${formatNumber(entry.size_value ?? null, t)} ${entry.size_unit === 'seeds' ? 'Korn' : 'g'}`);
+
+  if (normalized.length === 0) {
+    return t('noData');
+  }
+
+  return normalized.join(', ');
+}

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -40,8 +40,14 @@ import { ContextMenuActionItem } from "../components/contextMenu/ContextMenuActi
 import { CustomContextMenu } from "../components/contextMenu/CustomContextMenu";
 import { HierarchyAddIcon } from "../components/hierarchy/HierarchyAddIcon";
 import EmptyStateCard from '../components/project/EmptyStateCard';
-import { CALCULATED_COLUMN_CELL_CLASS } from "../components/data-grid/calculatedColumns";
-import { dataGridSx } from "../components/data-grid/styles";
+import {
+  HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD,
+  HIERARCHY_DATA_GRID_SX,
+  HIERARCHY_GRID_PAGE_SIZE,
+  HIERARCHY_VIRTUAL_SCROLLER_SELECTOR,
+  TABLE_BOTTOM_MARGIN_PX,
+  TABLE_MIN_HEIGHT_PX,
+} from "./fieldsBedsHierarchyStyles";
 import {
   DeleteUndoSnackbar,
   ContextMenuHint,
@@ -124,133 +130,6 @@ interface HierarchyRowAction {
   shortcutHint?: string;
 }
 
-const HIERARCHY_SELECTED_VIEW_ROW_SELECTOR =
-  "& .MuiDataGrid-row.Mui-selected:not(.MuiDataGrid-row--editing)";
-
-// Above this many combined locations/fields/beds, fully expanding the tree on
-// first load produces an unwieldy wall of rows before the user has done
-// anything. Below it, full expansion (the long-standing default) is more
-// useful than hiding everything behind a chevron — mirrors the same
-// size-based fallback used for the occupancy tree in GanttChart.tsx.
-const HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD = 200;
-
-// Bottom breathing room left below the table when it's sized to the
-// available viewport height (see the tableWrapper measurement effect below),
-// and a floor so it never collapses to something unusably short.
-const TABLE_BOTTOM_MARGIN_PX = 24;
-const TABLE_MIN_HEIGHT_PX = 240;
-
-// The free/MIT @mui/x-data-grid we depend on hard-codes pagination on and
-// throws if paginationModel.pageSize exceeds 100 (DataGridPro lifts this;
-// not part of this project's dependencies). Above this many rows, the table
-// pages internally via useHierarchyRowWindow, which auto-advances/retreats
-// the page as the user scrolls near the grid's top/bottom edge — no pager UI
-// is shown, so it still reads as one continuous scroll.
-const HIERARCHY_GRID_PAGE_SIZE = 100;
-const HIERARCHY_VIRTUAL_SCROLLER_SELECTOR = ".MuiDataGrid-virtualScroller";
-
-const HIERARCHY_DATA_GRID_SX = {
-  ...dataGridSx,
-  // Intentionally no width: "fit-content" here (see git history/#50296dd7 for
-  // why it existed) — the name/dimension/area columns still keep their
-  // compact, content-based widths, but forcing the whole grid to shrink-wrap
-  // them fought the notes column's own flex: 1 (HierarchyColumns.tsx), which
-  // is designed to absorb whatever width is left over. Letting the grid fill
-  // its container lets notes do that job, so a horizontal scrollbar only
-  // shows up when the fixed columns genuinely don't fit (narrow viewports).
-  "& .MuiDataGrid-filler": {
-    display: "none",
-  },
-  "& .MuiDataGrid-scrollbarFiller": {
-    display: "none",
-  },
-  "& .MuiDataGrid-columnHeader": {
-    py: 0.25,
-  },
-  "& .MuiDataGrid-cell": {
-    py: 0,
-  },
-  "& .ofp-hierarchy-row-location .MuiDataGrid-cell": {
-    py: 0.5,
-  },
-  "& .ofp-hierarchy-row-field .MuiDataGrid-cell": {
-    py: 0.25,
-  },
-  "& .ofp-hierarchy-row-bed .MuiDataGrid-cell": {
-    py: 0,
-  },
-  "& .MuiDataGrid-row--editing .MuiDataGrid-cell": {
-    py: 0,
-  },
-  "& .MuiDataGrid-row--editing .MuiInputBase-root": {
-    minHeight: "30px",
-    height: "30px",
-    fontSize: "0.875rem",
-  },
-  "& .MuiDataGrid-row--editing .MuiInputBase-input": {
-    py: 0.5,
-  },
-  "& .MuiDataGrid-row--editing .MuiSelect-select": {
-    minHeight: "unset !important",
-    py: 0.5,
-  },
-  "& .MuiDataGrid-row--editing .MuiIconButton-root": {
-    width: 28,
-    height: 28,
-  },
-  "& .MuiDataGrid-row--editing .MuiDataGrid-cell[data-field='name'] .MuiInputBase-root":
-    {
-      minHeight: "32px",
-      height: "32px",
-    },
-  [HIERARCHY_SELECTED_VIEW_ROW_SELECTOR]: {
-    backgroundColor: "transparent",
-  },
-  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell`]: {
-    backgroundColor: "transparent",
-  },
-  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.MuiDataGrid-cell--editable`]:
-    {
-      backgroundColor: "surface.surfaceBackground",
-    },
-  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.${CALCULATED_COLUMN_CELL_CLASS}`]:
-    {
-      backgroundColor: "#F5F5F5",
-    },
-  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.ofp-hierarchy-cell-missing-dimension`]:
-    {
-      backgroundColor: "#fbf2d5",
-    },
-  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell:focus, ${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell:focus-within`]:
-    {
-      backgroundColor: "transparent",
-    },
-  "& .ofp-hierarchy-cell-missing-dimension": {
-    backgroundColor: "#fbf2d5",
-    color: "text.primary",
-  },
-  "& .MuiDataGrid-row:hover .ofp-hierarchy-cell-missing-dimension": {
-    backgroundColor: "surface.surfaceHoverBackground",
-    boxShadow: "inset 0 0 0 9999px rgba(237, 108, 2, 0.14)",
-  },
-  "& .ofp-hierarchy-row-highlighted .MuiDataGrid-cell": {
-    animation: "ofp-hierarchy-row-highlight-flash 2.5s ease-out",
-  },
-  // Matches the app's established green "selected" look (e.g. CultureDetail's
-  // selected list item) instead of an unrelated yellow flash.
-  "@keyframes ofp-hierarchy-row-highlight-flash": {
-    "0%": { backgroundColor: "rgba(37, 111, 42, 0.22)" },
-    "70%": { backgroundColor: "rgba(37, 111, 42, 0.14)" },
-    "100%": { backgroundColor: "transparent" },
-  },
-  // Replaced by the custom track/thumb rendered alongside the grid (see
-  // useHierarchyStableScrollbar) — MUI's own floating scrollbar sizes itself
-  // from only the currently-loaded ~100-row page, which visibly jumps on
-  // every internal page transition (see useHierarchyRowWindow).
-  "& .MuiDataGrid-scrollbar--vertical": {
-    display: "none",
-  },
-};
 
 function FieldsBedsHierarchy({
   showTitle = true,

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -32,7 +32,7 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import { Group, Layer, Rect, Stage, Text } from "react-konva";
 import type Konva from "konva";
 import type { KonvaEventObject } from "konva/lib/Node";
-import { useHierarchyData, type HierarchyDataState } from "../components/hierarchy/hooks/useHierarchyData";
+import { useHierarchyData } from "../components/hierarchy/hooks/useHierarchyData";
 import { useExpandedState } from "../components/hierarchy/hooks/useExpandedState";
 import {
   layoutAPI,
@@ -61,198 +61,41 @@ import {
   toContentBounds,
   type ContentBounds,
   type PanSession,
-  type ViewportPadding,
   type ViewportState,
   zoomAroundPoint,
 } from "./graphicalViewport";
+import {
+  DEFAULT_STAGE_HEIGHT,
+  FIELD_INNER_BOTTOM_PADDING,
+  FIELD_INNER_OFFSET_X,
+  FIELD_INNER_OFFSET_Y,
+  FIELD_SNAP_THRESHOLD,
+  FIELD_WORLD_BASE_WIDTH,
+  FIELD_WORLD_MAX_WIDTH,
+  FIELD_WORLD_MIN_HEIGHT,
+  FIELD_WORLD_MIN_WIDTH,
+  FIELD_WORLD_PX_PER_METER,
+  FIELD_WORLD_SCALE_FACTOR,
+  LOCATION_FIELD_GAP,
+  LOCATION_LAYOUT_PADDING,
+  MAX_STAGE_HEIGHT,
+  MIN_STAGE_HEIGHT,
+  PAN_FAST_STEP,
+  PAN_STEP,
+  WORKSPACE_MIN_HEIGHT,
+  WORKSPACE_MIN_WIDTH,
+  ZOOM_STEP,
+  getFitViewportPadding,
+  snapToNeighbors,
+  type BedViewModel,
+  type GraphicalFieldsProps,
+  type GuideLine,
+  type InteractionMode,
+  type Point,
+  type RectViewModel,
+  type SelectedElement,
+} from "./graphicalFieldsGeometry";
 
-interface Point {
-  x: number;
-  y: number;
-}
-
-interface SnapSize {
-  width: number;
-  height: number;
-}
-
-interface RectViewModel {
-  id: number;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-interface BedViewModel extends RectViewModel {
-  id: number;
-  name: string;
-  area: number;
-}
-
-interface GuideLine {
-  orientation: "vertical" | "horizontal";
-  value: number;
-  start: number;
-  end: number;
-}
-
-interface SnapResult {
-  x: number;
-  y: number;
-  guides: GuideLine[];
-}
-
-interface SelectedElement {
-  type: "field" | "bed";
-  name: string;
-  area: number | null;
-  locationName: string;
-  parentName?: string;
-}
-
-interface GraphicalFieldsProps {
-  showTitle?: boolean;
-  interactionMode?: InteractionMode;
-  onInteractionModeChange?: (mode: InteractionMode) => void;
-  showModeToggle?: boolean;
-  hierarchyData?: HierarchyDataState;
-}
-
-type InteractionMode = "view" | "edit";
-
-const VIEWPORT_PADDING = 24;
-const VIEWPORT_CONTROL_SAFE_AREA_RIGHT = 120;
-const MOBILE_VIEWPORT_PADDING = 12;
-const MOBILE_VIEWPORT_CONTROL_SAFE_AREA_RIGHT = 8;
-const FIELD_INNER_OFFSET_X = 10;
-const FIELD_LABEL_HEIGHT = 24;
-const FIELD_INNER_OFFSET_Y = FIELD_INNER_OFFSET_X + FIELD_LABEL_HEIGHT;
-const FIELD_INNER_BOTTOM_PADDING = FIELD_INNER_OFFSET_X;
-const SNAP_THRESHOLD = 8;
-const FIELD_SNAP_THRESHOLD = 14;
-const DEFAULT_STAGE_HEIGHT = 420;
-const MIN_STAGE_HEIGHT = 320;
-const MAX_STAGE_HEIGHT = 560;
-const ZOOM_STEP = 1.2;
-const PAN_STEP = 80;
-const PAN_FAST_STEP = 180;
-const WORKSPACE_MIN_WIDTH = 20000;
-const WORKSPACE_MIN_HEIGHT = 20000;
-const LOCATION_LAYOUT_PADDING = 20;
-const LOCATION_FIELD_GAP = 24;
-const FIELD_WORLD_PX_PER_METER = 18;
-const FIELD_WORLD_BASE_WIDTH = 560;
-const FIELD_WORLD_MIN_WIDTH = 560;
-const FIELD_WORLD_MAX_WIDTH = 920;
-const FIELD_WORLD_MIN_HEIGHT = 220;
-const FIELD_WORLD_SCALE_FACTOR = 12;
-
-const getFitViewportPadding = (stageWidth: number): ViewportPadding => ({
-  top: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
-  right:
-    (stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING) +
-    (stageWidth < 600
-      ? MOBILE_VIEWPORT_CONTROL_SAFE_AREA_RIGHT
-      : VIEWPORT_CONTROL_SAFE_AREA_RIGHT),
-  bottom: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
-  left: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
-});
-const snapToNeighbors = (
-  currentId: number,
-  position: Point,
-  size: SnapSize,
-  neighbors: RectViewModel[],
-  threshold: number = SNAP_THRESHOLD,
-): SnapResult => {
-  let snappedX = position.x;
-  let snappedY = position.y;
-  let bestXDelta = threshold + 1;
-  let bestYDelta = threshold + 1;
-  const guides: GuideLine[] = [];
-
-  const currentXPoints = [
-    { value: position.x },
-    { value: position.x + size.width / 2 },
-    { value: position.x + size.width },
-  ];
-  const currentYPoints = [
-    { value: position.y },
-    { value: position.y + size.height / 2 },
-    { value: position.y + size.height },
-  ];
-
-  neighbors
-    .filter((neighbor) => neighbor.id !== currentId)
-    .forEach((neighbor) => {
-      const neighborXPoints = [
-        { value: neighbor.x },
-        { value: neighbor.x + neighbor.width / 2 },
-        { value: neighbor.x + neighbor.width },
-      ];
-      const neighborYPoints = [
-        { value: neighbor.y },
-        { value: neighbor.y + neighbor.height / 2 },
-        { value: neighbor.y + neighbor.height },
-      ];
-
-      currentXPoints.forEach((currentPoint) => {
-        neighborXPoints.forEach((neighborPoint) => {
-          const delta = neighborPoint.value - currentPoint.value;
-          const absDelta = Math.abs(delta);
-          if (absDelta <= threshold && absDelta < bestXDelta) {
-            bestXDelta = absDelta;
-            snappedX = position.x + delta;
-            guides.push({
-              orientation: "vertical",
-              value: neighborPoint.value,
-              start: Math.min(position.y, neighbor.y),
-              end: Math.max(
-                position.y + size.height,
-                neighbor.y + neighbor.height,
-              ),
-            });
-          }
-        });
-      });
-
-      currentYPoints.forEach((currentPoint) => {
-        neighborYPoints.forEach((neighborPoint) => {
-          const delta = neighborPoint.value - currentPoint.value;
-          const absDelta = Math.abs(delta);
-          if (absDelta <= threshold && absDelta < bestYDelta) {
-            bestYDelta = absDelta;
-            snappedY = position.y + delta;
-            guides.push({
-              orientation: "horizontal",
-              value: neighborPoint.value,
-              start: Math.min(position.x, neighbor.x),
-              end: Math.max(
-                position.x + size.width,
-                neighbor.x + neighbor.width,
-              ),
-            });
-          }
-        });
-      });
-    });
-
-  const latestVerticalGuide = [...guides]
-    .reverse()
-    .find((guide) => guide.orientation === "vertical");
-  const latestHorizontalGuide = [...guides]
-    .reverse()
-    .find((guide) => guide.orientation === "horizontal");
-
-  return {
-    x: snappedX,
-    y: snappedY,
-    guides: [
-      ...(latestVerticalGuide ? [latestVerticalGuide] : []),
-      ...(latestHorizontalGuide ? [latestHorizontalGuide] : []),
-    ],
-  };
-};
 
 export default function GraphicalFields({
   showTitle = true,

--- a/frontend/src/pages/fieldsBedsHierarchyStyles.ts
+++ b/frontend/src/pages/fieldsBedsHierarchyStyles.ts
@@ -1,0 +1,135 @@
+/**
+ * Layout constants and the DataGrid style object for the fields/beds hierarchy
+ * table. Extracted verbatim from pages/FieldsBedsHierarchy.tsx.
+ */
+
+import { CALCULATED_COLUMN_CELL_CLASS } from "../components/data-grid/calculatedColumns";
+import { dataGridSx } from "../components/data-grid/styles";
+
+export const HIERARCHY_SELECTED_VIEW_ROW_SELECTOR =
+  "& .MuiDataGrid-row.Mui-selected:not(.MuiDataGrid-row--editing)";
+
+// Above this many combined locations/fields/beds, fully expanding the tree on
+// first load produces an unwieldy wall of rows before the user has done
+// anything. Below it, full expansion (the long-standing default) is more
+// useful than hiding everything behind a chevron — mirrors the same
+// size-based fallback used for the occupancy tree in GanttChart.tsx.
+export const HIERARCHY_AUTO_EXPAND_ALL_THRESHOLD = 200;
+
+// Bottom breathing room left below the table when it's sized to the
+// available viewport height (see the tableWrapper measurement effect below),
+// and a floor so it never collapses to something unusably short.
+export const TABLE_BOTTOM_MARGIN_PX = 24;
+export const TABLE_MIN_HEIGHT_PX = 240;
+
+// The free/MIT @mui/x-data-grid we depend on hard-codes pagination on and
+// throws if paginationModel.pageSize exceeds 100 (DataGridPro lifts this;
+// not part of this project's dependencies). Above this many rows, the table
+// pages internally via useHierarchyRowWindow, which auto-advances/retreats
+// the page as the user scrolls near the grid's top/bottom edge — no pager UI
+// is shown, so it still reads as one continuous scroll.
+export const HIERARCHY_GRID_PAGE_SIZE = 100;
+export const HIERARCHY_VIRTUAL_SCROLLER_SELECTOR = ".MuiDataGrid-virtualScroller";
+
+export const HIERARCHY_DATA_GRID_SX = {
+  ...dataGridSx,
+  // Intentionally no width: "fit-content" here (see git history/#50296dd7 for
+  // why it existed) — the name/dimension/area columns still keep their
+  // compact, content-based widths, but forcing the whole grid to shrink-wrap
+  // them fought the notes column's own flex: 1 (HierarchyColumns.tsx), which
+  // is designed to absorb whatever width is left over. Letting the grid fill
+  // its container lets notes do that job, so a horizontal scrollbar only
+  // shows up when the fixed columns genuinely don't fit (narrow viewports).
+  "& .MuiDataGrid-filler": {
+    display: "none",
+  },
+  "& .MuiDataGrid-scrollbarFiller": {
+    display: "none",
+  },
+  "& .MuiDataGrid-columnHeader": {
+    py: 0.25,
+  },
+  "& .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .ofp-hierarchy-row-location .MuiDataGrid-cell": {
+    py: 0.5,
+  },
+  "& .ofp-hierarchy-row-field .MuiDataGrid-cell": {
+    py: 0.25,
+  },
+  "& .ofp-hierarchy-row-bed .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .MuiDataGrid-row--editing .MuiDataGrid-cell": {
+    py: 0,
+  },
+  "& .MuiDataGrid-row--editing .MuiInputBase-root": {
+    minHeight: "30px",
+    height: "30px",
+    fontSize: "0.875rem",
+  },
+  "& .MuiDataGrid-row--editing .MuiInputBase-input": {
+    py: 0.5,
+  },
+  "& .MuiDataGrid-row--editing .MuiSelect-select": {
+    minHeight: "unset !important",
+    py: 0.5,
+  },
+  "& .MuiDataGrid-row--editing .MuiIconButton-root": {
+    width: 28,
+    height: 28,
+  },
+  "& .MuiDataGrid-row--editing .MuiDataGrid-cell[data-field='name'] .MuiInputBase-root":
+    {
+      minHeight: "32px",
+      height: "32px",
+    },
+  [HIERARCHY_SELECTED_VIEW_ROW_SELECTOR]: {
+    backgroundColor: "transparent",
+  },
+  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell`]: {
+    backgroundColor: "transparent",
+  },
+  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.MuiDataGrid-cell--editable`]:
+    {
+      backgroundColor: "surface.surfaceBackground",
+    },
+  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.${CALCULATED_COLUMN_CELL_CLASS}`]:
+    {
+      backgroundColor: "#F5F5F5",
+    },
+  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell.ofp-hierarchy-cell-missing-dimension`]:
+    {
+      backgroundColor: "#fbf2d5",
+    },
+  [`${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell:focus, ${HIERARCHY_SELECTED_VIEW_ROW_SELECTOR} .MuiDataGrid-cell:focus-within`]:
+    {
+      backgroundColor: "transparent",
+    },
+  "& .ofp-hierarchy-cell-missing-dimension": {
+    backgroundColor: "#fbf2d5",
+    color: "text.primary",
+  },
+  "& .MuiDataGrid-row:hover .ofp-hierarchy-cell-missing-dimension": {
+    backgroundColor: "surface.surfaceHoverBackground",
+    boxShadow: "inset 0 0 0 9999px rgba(237, 108, 2, 0.14)",
+  },
+  "& .ofp-hierarchy-row-highlighted .MuiDataGrid-cell": {
+    animation: "ofp-hierarchy-row-highlight-flash 2.5s ease-out",
+  },
+  // Matches the app's established green "selected" look (e.g. CultureDetail's
+  // selected list item) instead of an unrelated yellow flash.
+  "@keyframes ofp-hierarchy-row-highlight-flash": {
+    "0%": { backgroundColor: "rgba(37, 111, 42, 0.22)" },
+    "70%": { backgroundColor: "rgba(37, 111, 42, 0.14)" },
+    "100%": { backgroundColor: "transparent" },
+  },
+  // Replaced by the custom track/thumb rendered alongside the grid (see
+  // useHierarchyStableScrollbar) — MUI's own floating scrollbar sizes itself
+  // from only the currently-loaded ~100-row page, which visibly jumps on
+  // every internal page transition (see useHierarchyRowWindow).
+  "& .MuiDataGrid-scrollbar--vertical": {
+    display: "none",
+  },
+};

--- a/frontend/src/pages/graphicalFieldsGeometry.ts
+++ b/frontend/src/pages/graphicalFieldsGeometry.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure geometry, layout constants and snapping helpers for the graphical
+ * fields canvas. Extracted verbatim from pages/GraphicalFields.tsx.
+ */
+
+import type { HierarchyDataState } from "../components/hierarchy/hooks/useHierarchyData";
+import type { ViewportPadding } from "./graphicalViewport";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface SnapSize {
+  width: number;
+  height: number;
+}
+
+export interface RectViewModel {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BedViewModel extends RectViewModel {
+  id: number;
+  name: string;
+  area: number;
+}
+
+export interface GuideLine {
+  orientation: "vertical" | "horizontal";
+  value: number;
+  start: number;
+  end: number;
+}
+
+export interface SnapResult {
+  x: number;
+  y: number;
+  guides: GuideLine[];
+}
+
+export interface SelectedElement {
+  type: "field" | "bed";
+  name: string;
+  area: number | null;
+  locationName: string;
+  parentName?: string;
+}
+
+export interface GraphicalFieldsProps {
+  showTitle?: boolean;
+  interactionMode?: InteractionMode;
+  onInteractionModeChange?: (mode: InteractionMode) => void;
+  showModeToggle?: boolean;
+  hierarchyData?: HierarchyDataState;
+}
+
+export type InteractionMode = "view" | "edit";
+
+export const VIEWPORT_PADDING = 24;
+export const VIEWPORT_CONTROL_SAFE_AREA_RIGHT = 120;
+export const MOBILE_VIEWPORT_PADDING = 12;
+export const MOBILE_VIEWPORT_CONTROL_SAFE_AREA_RIGHT = 8;
+export const FIELD_INNER_OFFSET_X = 10;
+export const FIELD_LABEL_HEIGHT = 24;
+export const FIELD_INNER_OFFSET_Y = FIELD_INNER_OFFSET_X + FIELD_LABEL_HEIGHT;
+export const FIELD_INNER_BOTTOM_PADDING = FIELD_INNER_OFFSET_X;
+export const SNAP_THRESHOLD = 8;
+export const FIELD_SNAP_THRESHOLD = 14;
+export const DEFAULT_STAGE_HEIGHT = 420;
+export const MIN_STAGE_HEIGHT = 320;
+export const MAX_STAGE_HEIGHT = 560;
+export const ZOOM_STEP = 1.2;
+export const PAN_STEP = 80;
+export const PAN_FAST_STEP = 180;
+export const WORKSPACE_MIN_WIDTH = 20000;
+export const WORKSPACE_MIN_HEIGHT = 20000;
+export const LOCATION_LAYOUT_PADDING = 20;
+export const LOCATION_FIELD_GAP = 24;
+export const FIELD_WORLD_PX_PER_METER = 18;
+export const FIELD_WORLD_BASE_WIDTH = 560;
+export const FIELD_WORLD_MIN_WIDTH = 560;
+export const FIELD_WORLD_MAX_WIDTH = 920;
+export const FIELD_WORLD_MIN_HEIGHT = 220;
+export const FIELD_WORLD_SCALE_FACTOR = 12;
+
+export const getFitViewportPadding = (stageWidth: number): ViewportPadding => ({
+  top: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
+  right:
+    (stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING) +
+    (stageWidth < 600
+      ? MOBILE_VIEWPORT_CONTROL_SAFE_AREA_RIGHT
+      : VIEWPORT_CONTROL_SAFE_AREA_RIGHT),
+  bottom: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
+  left: stageWidth < 600 ? MOBILE_VIEWPORT_PADDING : VIEWPORT_PADDING,
+});
+export const snapToNeighbors = (
+  currentId: number,
+  position: Point,
+  size: SnapSize,
+  neighbors: RectViewModel[],
+  threshold: number = SNAP_THRESHOLD,
+): SnapResult => {
+  let snappedX = position.x;
+  let snappedY = position.y;
+  let bestXDelta = threshold + 1;
+  let bestYDelta = threshold + 1;
+  const guides: GuideLine[] = [];
+
+  const currentXPoints = [
+    { value: position.x },
+    { value: position.x + size.width / 2 },
+    { value: position.x + size.width },
+  ];
+  const currentYPoints = [
+    { value: position.y },
+    { value: position.y + size.height / 2 },
+    { value: position.y + size.height },
+  ];
+
+  neighbors
+    .filter((neighbor) => neighbor.id !== currentId)
+    .forEach((neighbor) => {
+      const neighborXPoints = [
+        { value: neighbor.x },
+        { value: neighbor.x + neighbor.width / 2 },
+        { value: neighbor.x + neighbor.width },
+      ];
+      const neighborYPoints = [
+        { value: neighbor.y },
+        { value: neighbor.y + neighbor.height / 2 },
+        { value: neighbor.y + neighbor.height },
+      ];
+
+      currentXPoints.forEach((currentPoint) => {
+        neighborXPoints.forEach((neighborPoint) => {
+          const delta = neighborPoint.value - currentPoint.value;
+          const absDelta = Math.abs(delta);
+          if (absDelta <= threshold && absDelta < bestXDelta) {
+            bestXDelta = absDelta;
+            snappedX = position.x + delta;
+            guides.push({
+              orientation: "vertical",
+              value: neighborPoint.value,
+              start: Math.min(position.y, neighbor.y),
+              end: Math.max(
+                position.y + size.height,
+                neighbor.y + neighbor.height,
+              ),
+            });
+          }
+        });
+      });
+
+      currentYPoints.forEach((currentPoint) => {
+        neighborYPoints.forEach((neighborPoint) => {
+          const delta = neighborPoint.value - currentPoint.value;
+          const absDelta = Math.abs(delta);
+          if (absDelta <= threshold && absDelta < bestYDelta) {
+            bestYDelta = absDelta;
+            snappedY = position.y + delta;
+            guides.push({
+              orientation: "horizontal",
+              value: neighborPoint.value,
+              start: Math.min(position.x, neighbor.x),
+              end: Math.max(
+                position.x + size.width,
+                neighbor.x + neighbor.width,
+              ),
+            });
+          }
+        });
+      });
+    });
+
+  const latestVerticalGuide = [...guides]
+    .reverse()
+    .find((guide) => guide.orientation === "vertical");
+  const latestHorizontalGuide = [...guides]
+    .reverse()
+    .find((guide) => guide.orientation === "horizontal");
+
+  return {
+    x: snappedX,
+    y: snappedY,
+    guides: [
+      ...(latestVerticalGuide ? [latestVerticalGuide] : []),
+      ...(latestHorizontalGuide ? [latestHorizontalGuide] : []),
+    ],
+  };
+};


### PR DESCRIPTION
## Summary

Second round of the frontend decomposition (after #304), same verbatim, behavior-preserving pattern applied to the next three largest components. No routes, UI behavior, or public contracts change.

- **`GraphicalFields.tsx` 1926 → 1769 lines**: layout constants, shared geometry types, `getFitViewportPadding`, and the 95-line `snapToNeighbors` helper moved to `pages/graphicalFieldsGeometry.ts`.
- **`FieldsBedsHierarchy.tsx` 1731 → 1610 lines**: the hierarchy layout constants and the ~100-line `HIERARCHY_DATA_GRID_SX` style object moved to `pages/fieldsBedsHierarchyStyles.ts`.
- **`CultureDetail.tsx` 1573 → 1499 lines**: the pure number/distance/seed-rate/package-size formatters, the persisted-filter shape and the filters storage key moved to `cultures/cultureDetailFormatters.ts`.

All moves are verbatim; only import blocks changed.

## Verification (after every commit)

- `npm run test` — all **1140 tests in 126 files pass** (unchanged from baseline)
- `tsc -b` clean
- `npm run lint` — no new findings vs. baseline (per-file error counts identical to `main`; the pre-existing react-compiler/setState-in-effect warnings are unchanged)
- `npm run lint:circular` (madge) — no circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_