### PR TITLE
refactor(frontend): extract area-validation dialog state into useAreaValidationDialog hook

### DIFF
--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -109,6 +109,7 @@ export {
   filterFieldOptionsByLocation,
 } from "../components/planting-plans/areaHierarchySelection";
 
+import { useAreaValidationDialog, type AreaValidationDialogState } from "./useAreaValidationDialog";
 export { buildAreaColumnHeaderLabel } from "./plantingPlansUtils";
 export {
   buildMobileCreateForm,
@@ -140,18 +141,6 @@ const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
  * Row data type for Data Grid
  */
 
-interface AreaValidationDialogState {
-  rowId: number;
-  requestedArea: number;
-  availableArea: number;
-  bedArea: number;
-  occupiedArea: number;
-  cultureId?: number;
-  plantsCount?: number | null;
-  mode: "bedLimit" | "remainingLimit" | "noRemainingArea";
-}
-
-const AREA_VALIDATION_CLOSE_SUPPRESSION_MS = 250;
 const CULTURE_COLUMN_MAX_WIDTH = 280;
 const BED_COLUMN_MAX_WIDTH = 220;
 
@@ -274,7 +263,6 @@ function PlantingPlans() {
     message: string;
     severity: "info" | "warning";
   } | null>(null);
-  const [areaValidationDialog, setAreaValidationDialog] = useState<AreaValidationDialogState | null>(null);
   const urlParamProcessedRef = useRef<boolean>(false);
   const gridCommandApiRef = useRef<EditableDataGridCommandApi | null>(null);
   const plantingPlanGridAPI = useMemo<DataGridAPI<PlantingPlanRow>>(() => ({
@@ -362,43 +350,15 @@ function PlantingPlans() {
 
   // Track which field was last edited (for determining API payload)
   const lastEditedFieldRef = useRef<"area_m2" | "plants_count" | null>(null);
-  const areaValidationDialogRef = useRef<AreaValidationDialogState | null>(null);
-  const suppressAreaValidationSaveRef = useRef(false);
-  const areaValidationCloseTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
-
-  const clearAreaValidationCloseTimer = useCallback((): void => {
-    if (areaValidationCloseTimerRef.current === null) {
-      return;
-    }
-    window.clearTimeout(areaValidationCloseTimerRef.current);
-    areaValidationCloseTimerRef.current = null;
-  }, []);
-
-  const suppressAreaValidationSaveCycle = useCallback((): void => {
-    suppressAreaValidationSaveRef.current = true;
-    clearAreaValidationCloseTimer();
-    areaValidationCloseTimerRef.current = window.setTimeout(() => {
-      suppressAreaValidationSaveRef.current = false;
-      areaValidationCloseTimerRef.current = null;
-    }, AREA_VALIDATION_CLOSE_SUPPRESSION_MS);
-  }, [clearAreaValidationCloseTimer]);
-
-  const openAreaValidationDialog = useCallback((dialog: AreaValidationDialogState): void => {
-    clearAreaValidationCloseTimer();
-    suppressAreaValidationSaveRef.current = false;
-    areaValidationDialogRef.current = dialog;
-    setAreaValidationDialog(dialog);
-  }, [clearAreaValidationCloseTimer]);
-
-  const closeAreaValidationDialog = useCallback((): void => {
-    areaValidationDialogRef.current = null;
-    suppressAreaValidationSaveCycle();
-    setAreaValidationDialog(null);
-  }, [suppressAreaValidationSaveCycle]);
-
-  useEffect(() => () => {
-    clearAreaValidationCloseTimer();
-  }, [clearAreaValidationCloseTimer]);
+  const {
+    areaValidationDialog,
+    setAreaValidationDialog,
+    areaValidationDialogRef,
+    suppressAreaValidationSaveRef,
+    clearAreaValidationCloseTimer,
+    openAreaValidationDialog,
+    closeAreaValidationDialog,
+  } = useAreaValidationDialog();
 
   const getBedLabelForRow = useCallback(
     (row: PlantingPlanRow | null | undefined): string => {

--- a/frontend/src/pages/useAreaValidationDialog.ts
+++ b/frontend/src/pages/useAreaValidationDialog.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * State and timer lifecycle for the planting-plan area-validation dialog.
+ *
+ * Extracted from PlantingPlans.tsx. Owns the dialog's visible state, the
+ * "suppress the next save cycle" flag used to avoid re-triggering validation
+ * right after the dialog closes, and the close-suppression timer. The two
+ * refs are returned so the page's save-guard and commit handler can read/reset
+ * them, matching the original inline behavior.
+ */
+
+// After the dialog closes we briefly suppress the follow-up save so closing it
+// does not immediately re-open validation for the same edit cycle.
+const AREA_VALIDATION_CLOSE_SUPPRESSION_MS = 250;
+
+export interface AreaValidationDialogState {
+  rowId: number;
+  requestedArea: number;
+  availableArea: number;
+  bedArea: number;
+  occupiedArea: number;
+  cultureId?: number;
+  plantsCount?: number | null;
+  mode: "bedLimit" | "remainingLimit" | "noRemainingArea";
+}
+
+export interface UseAreaValidationDialogResult {
+  areaValidationDialog: AreaValidationDialogState | null;
+  setAreaValidationDialog: React.Dispatch<React.SetStateAction<AreaValidationDialogState | null>>;
+  areaValidationDialogRef: React.MutableRefObject<AreaValidationDialogState | null>;
+  suppressAreaValidationSaveRef: React.MutableRefObject<boolean>;
+  clearAreaValidationCloseTimer: () => void;
+  openAreaValidationDialog: (dialog: AreaValidationDialogState) => void;
+  closeAreaValidationDialog: () => void;
+}
+
+export function useAreaValidationDialog(): UseAreaValidationDialogResult {
+  const [areaValidationDialog, setAreaValidationDialog] = useState<AreaValidationDialogState | null>(null);
+  const areaValidationDialogRef = useRef<AreaValidationDialogState | null>(null);
+  const suppressAreaValidationSaveRef = useRef(false);
+  const areaValidationCloseTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const clearAreaValidationCloseTimer = useCallback((): void => {
+    if (areaValidationCloseTimerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(areaValidationCloseTimerRef.current);
+    areaValidationCloseTimerRef.current = null;
+  }, []);
+
+  const suppressAreaValidationSaveCycle = useCallback((): void => {
+    suppressAreaValidationSaveRef.current = true;
+    clearAreaValidationCloseTimer();
+    areaValidationCloseTimerRef.current = window.setTimeout(() => {
+      suppressAreaValidationSaveRef.current = false;
+      areaValidationCloseTimerRef.current = null;
+    }, AREA_VALIDATION_CLOSE_SUPPRESSION_MS);
+  }, [clearAreaValidationCloseTimer]);
+
+  const openAreaValidationDialog = useCallback((dialog: AreaValidationDialogState): void => {
+    clearAreaValidationCloseTimer();
+    suppressAreaValidationSaveRef.current = false;
+    areaValidationDialogRef.current = dialog;
+    setAreaValidationDialog(dialog);
+  }, [clearAreaValidationCloseTimer]);
+
+  const closeAreaValidationDialog = useCallback((): void => {
+    areaValidationDialogRef.current = null;
+    suppressAreaValidationSaveCycle();
+    setAreaValidationDialog(null);
+  }, [suppressAreaValidationSaveCycle]);
+
+  useEffect(() => () => {
+    clearAreaValidationCloseTimer();
+  }, [clearAreaValidationCloseTimer]);
+
+  return {
+    areaValidationDialog,
+    setAreaValidationDialog,
+    areaValidationDialogRef,
+    suppressAreaValidationSaveRef,
+    clearAreaValidationCloseTimer,
+    openAreaValidationDialog,
+    closeAreaValidationDialog,
+  };
+}


### PR DESCRIPTION
## Summary

First step of the (more invasive) frontend component decomposition: extract a cohesive custom hook out of `PlantingPlans.tsx` rather than just pure helpers. Behavior-preserving.

`useAreaValidationDialog` now owns the planting-plan area-validation dialog's lifecycle — its visible state, the "suppress the next save cycle" flag, and the close-suppression timer — together with the `AreaValidationDialogState` type and the suppression-window constant. `PlantingPlans.tsx` consumes the returned `{ areaValidationDialog, setAreaValidationDialog, openAreaValidationDialog, closeAreaValidationDialog, clearAreaValidationCloseTimer }` plus the two refs (`areaValidationDialogRef`, `suppressAreaValidationSaveRef`) that its save-guard and commit handler read — exactly as the inline version did.

`PlantingPlans.tsx`: 2194 → 2154 lines; new focused hook: 87 lines.

## Verification

- `npm run test` — all **1140 tests in 126 files pass** (unchanged), including the planting-plan area-validation suites
- `tsc -b` clean
- `npm run lint` — identical error count to `main` (12 = 12; only pre-existing warnings)
- `npm run lint:circular` (madge) — no circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_