### PR TITLE
refactor(frontend): extract MobilePlanFormDialog presentational component

### DIFF
--- a/frontend/src/components/planting-plans/MobilePlanFormDialog.tsx
+++ b/frontend/src/components/planting-plans/MobilePlanFormDialog.tsx
@@ -1,0 +1,208 @@
+import type { Dispatch, SetStateAction } from "react";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@mui/material";
+
+import type { CultivationType } from "../../api/types";
+import { useTranslation } from "../../i18n";
+import {
+  formatLocalizedNumber,
+  parseLocalizedNumber,
+} from "../../utils/numberLocalization";
+import type { SearchableSelectOption } from "../data-grid";
+import type { MobileCreateFormState } from "../../pages/plantingPlansUtils";
+import type { CultivationTypeSelectOption } from "../../pages/usePlantingPlanHierarchy";
+
+interface MobilePlanFormDialogProps {
+  open: boolean;
+  /** Edit mode changes only the title and submit label; the form is shared. */
+  isEdit: boolean;
+  form: MobileCreateFormState;
+  setForm: Dispatch<SetStateAction<MobileCreateFormState>>;
+  error: string;
+  cultureOptions: SearchableSelectOption[];
+  bedOptions: SearchableSelectOption[];
+  cultivationTypeOptions: CultivationTypeSelectOption[];
+  numberLocale: string;
+  getPlantsPerSqm: (cultureId: string) => number | null;
+  /** Called when the user edits one of the two linked area/plants inputs. */
+  onLinkedFieldEdited: (field: "area_m2" | "plants_count") => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+/**
+ * Presentational mobile create/edit/duplicate form for a planting plan.
+ * All state (form draft, edit id, error) and the submit handlers live in
+ * PlantingPlans.tsx; this component only renders the dialog and keeps the
+ * area ↔ plants-count inputs in sync while typing.
+ */
+export function MobilePlanFormDialog({
+  open,
+  isEdit,
+  form,
+  setForm,
+  error,
+  cultureOptions,
+  bedOptions,
+  cultivationTypeOptions,
+  numberLocale,
+  getPlantsPerSqm,
+  onLinkedFieldEdited,
+  onClose,
+  onSubmit,
+}: MobilePlanFormDialogProps) {
+  const { t } = useTranslation(["plantingPlans", "common"]);
+
+  const formatNumberForInput = (
+    value: number,
+    options?: Intl.NumberFormatOptions,
+  ): string =>
+    formatLocalizedNumber(value, numberLocale, {
+      useGrouping: false,
+      maximumFractionDigits: 6,
+      ...options,
+    });
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {isEdit ? t("plantingPlans:mobile.editTitle") : t("plantingPlans:mobile.createTitle")}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error ? <Alert severity="error">{error}</Alert> : null}
+          <FormControl fullWidth>
+            <InputLabel>{t("plantingPlans:columns.culture")}</InputLabel>
+            <Select
+              value={form.culture}
+              label={t("plantingPlans:columns.culture")}
+              onChange={(event) =>
+                setForm((previous) => ({ ...previous, culture: String(event.target.value) }))
+              }
+            >
+              {cultureOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel>{t("plantingPlans:columns.bed")}</InputLabel>
+            <Select
+              value={form.bed}
+              label={t("plantingPlans:columns.bed")}
+              onChange={(event) =>
+                setForm((previous) => ({ ...previous, bed: String(event.target.value) }))
+              }
+            >
+              {bedOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel>{t("plantingPlans:columns.cultivationType")}</InputLabel>
+            <Select
+              value={form.cultivation_type}
+              label={t("plantingPlans:columns.cultivationType")}
+              onChange={(event) =>
+                setForm((previous) => ({ ...previous, cultivation_type: event.target.value as CultivationType }))
+              }
+            >
+              {cultivationTypeOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            type="text"
+            label={t("plantingPlans:columns.plantingDate")}
+            placeholder="TT.MM.JJJJ"
+            InputLabelProps={{ shrink: true }}
+            value={form.planting_date}
+            onChange={(event) =>
+              setForm((previous) => ({ ...previous, planting_date: event.target.value }))
+            }
+          />
+          <TextField
+            type="text"
+            inputMode="decimal"
+            label={t("plantingPlans:columns.areaM2")}
+            value={form.area_m2}
+            onChange={(event) => {
+              const nextArea = event.target.value;
+              const plantsPerSqm = getPlantsPerSqm(form.culture);
+              const normalizedArea = nextArea.trim().toLowerCase();
+              const maxKeyword = t("plantingPlans:placeholders.maxKeyword").toLowerCase();
+              const parsedArea = normalizedArea === maxKeyword ? null : parseLocalizedNumber(nextArea, numberLocale);
+              setForm((previous) => ({
+                ...previous,
+                area_m2: nextArea,
+                plants_count:
+                  plantsPerSqm && parsedArea !== null
+                    ? formatNumberForInput(
+                        Math.round(parsedArea * plantsPerSqm),
+                        { maximumFractionDigits: 0 },
+                      )
+                    : previous.plants_count,
+              }));
+              onLinkedFieldEdited("area_m2");
+            }}
+            placeholder={t("plantingPlans:placeholders.maxKeyword")}
+            helperText={t("plantingPlans:tooltips.areaAutoMax")}
+            slotProps={{ htmlInput: { inputMode: "decimal" } }}
+          />
+          <TextField
+            type="text"
+            inputMode="numeric"
+            label={t("plantingPlans:columns.plantsCount")}
+            value={form.plants_count}
+            onChange={(event) => {
+              const nextPlants = event.target.value;
+              const plantsPerSqm = getPlantsPerSqm(form.culture);
+              const parsedPlants = parseLocalizedNumber(nextPlants, numberLocale);
+              setForm((previous) => ({
+                ...previous,
+                plants_count: nextPlants,
+                area_m2:
+                  plantsPerSqm && parsedPlants !== null
+                    ? formatNumberForInput(parsedPlants / plantsPerSqm, {
+                        maximumFractionDigits: 2,
+                      })
+                    : previous.area_m2,
+              }));
+              onLinkedFieldEdited("plants_count");
+            }}
+            slotProps={{ htmlInput: { inputMode: "numeric" } }}
+          />
+          <TextField
+            label={t("common:fields.notes")}
+            multiline
+            minRows={3}
+            value={form.notes}
+            onChange={(event) =>
+              setForm((previous) => ({ ...previous, notes: event.target.value }))
+            }
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t("common:actions.cancel")}</Button>
+        <Button onClick={onSubmit} variant="contained">
+          {isEdit ? t("common:actions.save") : t("common:actions.add")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -17,21 +17,13 @@ import type {
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
-  Alert,
   Box,
   Button,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   Divider,
-  FormControl,
   IconButton,
-  InputLabel,
   Menu,
   MenuItem,
-  Select,
   Stack,
   TextField,
   Tooltip,
@@ -111,6 +103,7 @@ export {
 
 import { useAreaValidationDialog, type AreaValidationDialogState } from "./useAreaValidationDialog";
 import { AreaValidationDialog } from "../components/planting-plans/AreaValidationDialog";
+import { MobilePlanFormDialog } from "../components/planting-plans/MobilePlanFormDialog";
 export { buildAreaColumnHeaderLabel } from "./plantingPlansUtils";
 export {
   buildMobileCreateForm,
@@ -1002,6 +995,11 @@ function PlantingPlans() {
     setMobileCreateError("");
     setMobileEditId(null);
     setMobileLastEditedField(null);
+  };
+
+  const handleMobileLinkedFieldEdited = (field: "area_m2" | "plants_count"): void => {
+    setMobileLastEditedField(field);
+    setAreaNotice(null);
   };
 
   useEffect(() => {
@@ -1951,136 +1949,21 @@ function PlantingPlans() {
 
       </Box>
 
-      <Dialog open={isMobileCreateOpen} onClose={closeMobileCreateDialog} fullWidth maxWidth="sm">
-        <DialogTitle>
-          {mobileEditId ? t("plantingPlans:mobile.editTitle") : t("plantingPlans:mobile.createTitle")}
-        </DialogTitle>
-        <DialogContent>
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            {mobileCreateError ? <Alert severity="error">{mobileCreateError}</Alert> : null}
-            <FormControl fullWidth>
-              <InputLabel>{t("plantingPlans:columns.culture")}</InputLabel>
-              <Select
-                value={mobileCreateForm.culture}
-                label={t("plantingPlans:columns.culture")}
-                onChange={(event) =>
-                  setMobileCreateForm((previous) => ({ ...previous, culture: String(event.target.value) }))
-                }
-              >
-                {cultureOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl fullWidth>
-              <InputLabel>{t("plantingPlans:columns.bed")}</InputLabel>
-              <Select
-                value={mobileCreateForm.bed}
-                label={t("plantingPlans:columns.bed")}
-                onChange={(event) =>
-                  setMobileCreateForm((previous) => ({ ...previous, bed: String(event.target.value) }))
-                }
-              >
-                {bedOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl fullWidth>
-              <InputLabel>{t("plantingPlans:columns.cultivationType")}</InputLabel>
-              <Select
-                value={mobileCreateForm.cultivation_type}
-                label={t("plantingPlans:columns.cultivationType")}
-                onChange={(event) =>
-                  setMobileCreateForm((previous) => ({ ...previous, cultivation_type: event.target.value as CultivationType }))
-                }
-              >
-                {cultivationTypeOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <TextField
-              type="text"
-              label={t("plantingPlans:columns.plantingDate")}
-              placeholder="TT.MM.JJJJ"
-              InputLabelProps={{ shrink: true }}
-              value={mobileCreateForm.planting_date}
-              onChange={(event) =>
-                setMobileCreateForm((previous) => ({ ...previous, planting_date: event.target.value }))
-              }
-            />
-            <TextField
-              type="text"
-              inputMode="decimal"
-              label={t("plantingPlans:columns.areaM2")}
-              value={mobileCreateForm.area_m2}
-              onChange={(event) => {
-                const nextArea = event.target.value;
-                const plantsPerSqm = getPlantsPerSqmForCulture(mobileCreateForm.culture);
-                const normalizedArea = nextArea.trim().toLowerCase();
-                const maxKeyword = t("plantingPlans:placeholders.maxKeyword").toLowerCase();
-                const parsedArea = normalizedArea === maxKeyword ? null : parseLocalizedNumber(nextArea, numberLocale);
-                setMobileCreateForm((previous) => ({
-                  ...previous,
-                  area_m2: nextArea,
-                  plants_count:
-                    plantsPerSqm && parsedArea !== null
-                      ? formatNumberForInput(
-                          Math.round(parsedArea * plantsPerSqm),
-                          { maximumFractionDigits: 0 },
-                        )
-                      : previous.plants_count,
-                }));
-                setMobileLastEditedField("area_m2");
-                setAreaNotice(null);
-              }}
-              placeholder={t("plantingPlans:placeholders.maxKeyword")}
-              helperText={t("plantingPlans:tooltips.areaAutoMax")}
-              slotProps={{ htmlInput: { inputMode: "decimal" } }}
-            />
-            <TextField
-              type="text"
-              inputMode="numeric"
-              label={t("plantingPlans:columns.plantsCount")}
-              value={mobileCreateForm.plants_count}
-              onChange={(event) => {
-                const nextPlants = event.target.value;
-                const plantsPerSqm = getPlantsPerSqmForCulture(mobileCreateForm.culture);
-                const parsedPlants = parseLocalizedNumber(nextPlants, numberLocale);
-                setMobileCreateForm((previous) => ({
-                  ...previous,
-                  plants_count: nextPlants,
-                  area_m2:
-                    plantsPerSqm && parsedPlants !== null
-                      ? formatNumberForInput(parsedPlants / plantsPerSqm, {
-                          maximumFractionDigits: 2,
-                        })
-                      : previous.area_m2,
-                }));
-                setMobileLastEditedField("plants_count");
-                setAreaNotice(null);
-              }}
-              slotProps={{ htmlInput: { inputMode: "numeric" } }}
-            />
-            <TextField
-              label={t("common:fields.notes")}
-              multiline
-              minRows={3}
-              value={mobileCreateForm.notes}
-              onChange={(event) =>
-                setMobileCreateForm((previous) => ({ ...previous, notes: event.target.value }))
-              }
-            />
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeMobileCreateDialog}>{t("common:actions.cancel")}</Button>
-          <Button onClick={() => void (mobileEditId ? handleMobileUpdate() : handleMobileCreate())} variant="contained">
-            {mobileEditId ? t("common:actions.save") : t("common:actions.add")}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <MobilePlanFormDialog
+        open={isMobileCreateOpen}
+        isEdit={mobileEditId !== null}
+        form={mobileCreateForm}
+        setForm={setMobileCreateForm}
+        error={mobileCreateError}
+        cultureOptions={cultureOptions}
+        bedOptions={bedOptions}
+        cultivationTypeOptions={cultivationTypeOptions}
+        numberLocale={numberLocale}
+        getPlantsPerSqm={getPlantsPerSqmForCulture}
+        onLinkedFieldEdited={handleMobileLinkedFieldEdited}
+        onClose={closeMobileCreateDialog}
+        onSubmit={() => void (mobileEditId ? handleMobileUpdate() : handleMobileCreate())}
+      />
       {areaValidationDialog && (
         <AreaValidationDialog
           dialog={areaValidationDialog}


### PR DESCRIPTION
## Was

Nächster Schritt der PlantingPlans-Dekomposition (Fortsetzung von #313, gleiche Strategie): das ~130-zeilige Mobile-Create/Edit/Duplicate-Dialog-JSX wird aus `PlantingPlans.tsx` in eine **rein präsentationale Komponente** `components/planting-plans/MobilePlanFormDialog.tsx` verschoben.

- Sämtlicher State (Formular-Entwurf, Edit-ID, Fehlermeldung) und die Submit-Handler bleiben in der Page; die Komponente rendert nur und hält die gekoppelten Felder Fläche ↔ Pflanzenanzahl beim Tippen synchron — Logik unverändert übernommen.
- Neue Props kapseln die bisherigen Inline-Zugriffe: `setForm` (der bestehende State-Setter), `getPlantsPerSqm`, `onLinkedFieldEdited` (ersetzt die beiden Inline-Aufrufe `setMobileLastEditedField` + `setAreaNotice(null)`).
- `PlantingPlans.tsx`: 2110 → 2001 Zeilen; nicht mehr benötigte MUI-Imports (`Alert`, `Dialog*`, `FormControl`, `InputLabel`, `Select`) entfernt.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `PlantingPlans.tsx` (Stash-Vergleich); `MobilePlanFormDialog.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_