### PR TITLE
refactor(frontend): extract MobilePlanActionsMenu presentational component

### DIFF
--- a/frontend/src/components/planting-plans/MobilePlanActionsMenu.tsx
+++ b/frontend/src/components/planting-plans/MobilePlanActionsMenu.tsx
@@ -1,0 +1,88 @@
+import { Divider, Menu } from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DeleteIcon from "@mui/icons-material/Delete";
+
+import { useTranslation } from "../../i18n";
+import { ContextMenuActionItem } from "../contextMenu/ContextMenuActionItem";
+import type { PlantingPlanRow } from "../../pages/plantingPlansUtils";
+
+interface MobilePlanActionsMenuProps {
+  anchorEl: HTMLElement | null;
+  /** The row the menu was opened for; actions are no-ops while it is null. */
+  row: PlantingPlanRow | null;
+  onClose: () => void;
+  onEdit: (row: PlantingPlanRow) => void;
+  onDuplicate: (row: PlantingPlanRow) => void;
+  onCopy: (row: PlantingPlanRow) => void;
+  onDelete: (row: PlantingPlanRow) => void;
+}
+
+/**
+ * Presentational per-card actions menu for the mobile planting-plan list.
+ * Anchor/row state and the action handlers live in PlantingPlans.tsx; every
+ * item closes the menu after delegating, matching the original inline JSX.
+ */
+export function MobilePlanActionsMenu({
+  anchorEl,
+  row,
+  onClose,
+  onEdit,
+  onDuplicate,
+  onCopy,
+  onDelete,
+}: MobilePlanActionsMenuProps) {
+  const { t } = useTranslation(["plantingPlans", "common"]);
+
+  return (
+    <Menu
+      id="planting-plan-mobile-actions-menu"
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      onClose={onClose}
+    >
+      <ContextMenuActionItem
+        label={t("common:actions.edit")}
+        icon={<EditIcon fontSize="small" />}
+        onClick={() => {
+          if (row) {
+            onEdit(row);
+          }
+          onClose();
+        }}
+      />
+      <ContextMenuActionItem
+        label={t("common:actions.duplicate")}
+        icon={<ContentCopyIcon fontSize="small" />}
+        onClick={() => {
+          if (row) {
+            onDuplicate(row);
+          }
+          onClose();
+        }}
+      />
+      <ContextMenuActionItem
+        label={t("plantingPlans:actions.copyPlantingPlan")}
+        icon={<ContentCopyIcon fontSize="small" />}
+        onClick={() => {
+          if (row) {
+            onCopy(row);
+          }
+          onClose();
+        }}
+      />
+      <Divider role="separator" />
+      <ContextMenuActionItem
+        label={t("common:actions.delete")}
+        icon={<DeleteIcon fontSize="small" />}
+        color="error"
+        onClick={() => {
+          if (row) {
+            onDelete(row);
+          }
+          onClose();
+        }}
+      />
+    </Menu>
+  );
+}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -20,9 +20,7 @@ import {
   Box,
   Button,
   CircularProgress,
-  Divider,
   IconButton,
-  Menu,
   MenuItem,
   Stack,
   TextField,
@@ -31,8 +29,6 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import EditIcon from "@mui/icons-material/Edit";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteIcon from "@mui/icons-material/Delete";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
@@ -48,7 +44,6 @@ import {
 import { usePlantingPlanHierarchy, type CultivationTypeSelectOption } from "./usePlantingPlanHierarchy";
 import PageContainer from "../components/layout/PageContainer";
 import PageSurface from "../components/layout/PageSurface";
-import { ContextMenuActionItem } from "../components/contextMenu/ContextMenuActionItem";
 import { AlertSnackbar } from "../components/feedback/AlertSnackbar";
 import {
   plantingPlanAPI,
@@ -104,6 +99,7 @@ export {
 import { useAreaValidationDialog, type AreaValidationDialogState } from "./useAreaValidationDialog";
 import { AreaValidationDialog } from "../components/planting-plans/AreaValidationDialog";
 import { MobilePlanFormDialog } from "../components/planting-plans/MobilePlanFormDialog";
+import { MobilePlanActionsMenu } from "../components/planting-plans/MobilePlanActionsMenu";
 export { buildAreaColumnHeaderLabel } from "./plantingPlansUtils";
 export {
   buildMobileCreateForm,
@@ -1594,55 +1590,15 @@ function PlantingPlans() {
                 </Box>
               )}
             />
-            <Menu
-              id="planting-plan-mobile-actions-menu"
+            <MobilePlanActionsMenu
               anchorEl={mobileActionMenuAnchor}
-              open={Boolean(mobileActionMenuAnchor)}
+              row={mobileActionMenuRow}
               onClose={closeMobileActionMenu}
-            >
-              <ContextMenuActionItem
-                label={t("common:actions.edit")}
-                icon={<EditIcon fontSize="small" />}
-                onClick={() => {
-                  if (mobileActionMenuRow) {
-                    openMobileEditDialog(mobileActionMenuRow);
-                  }
-                  closeMobileActionMenu();
-                }}
-              />
-              <ContextMenuActionItem
-                label={t("common:actions.duplicate")}
-                icon={<ContentCopyIcon fontSize="small" />}
-                onClick={() => {
-                  if (mobileActionMenuRow) {
-                    openMobileDuplicateDialog(mobileActionMenuRow);
-                  }
-                  closeMobileActionMenu();
-                }}
-              />
-              <ContextMenuActionItem
-                label={t("plantingPlans:actions.copyPlantingPlan")}
-                icon={<ContentCopyIcon fontSize="small" />}
-                onClick={() => {
-                  if (mobileActionMenuRow) {
-                    handleCopyPlantingPlan(mobileActionMenuRow);
-                  }
-                  closeMobileActionMenu();
-                }}
-              />
-              <Divider role="separator" />
-              <ContextMenuActionItem
-                label={t("common:actions.delete")}
-                icon={<DeleteIcon fontSize="small" />}
-                color="error"
-                onClick={() => {
-                  if (mobileActionMenuRow) {
-                    gridCommandApiRef.current?.deleteRow(mobileActionMenuRow.id);
-                  }
-                  closeMobileActionMenu();
-                }}
-              />
-            </Menu>
+              onEdit={openMobileEditDialog}
+              onDuplicate={openMobileDuplicateDialog}
+              onCopy={handleCopyPlantingPlan}
+              onDelete={(row) => gridCommandApiRef.current?.deleteRow(row.id)}
+            />
           </Box>
         ) : null}
 


### PR DESCRIPTION
## Was

Fortsetzung der PlantingPlans-Dekomposition (nach #313/#314, gleiche Strategie): das Aktions-Menü der mobilen Kartenliste (Bearbeiten/Duplizieren/Kopieren/Löschen) wird aus `PlantingPlans.tsx` in eine **rein präsentationale Komponente** `components/planting-plans/MobilePlanActionsMenu.tsx` verschoben.

- Anchor-/Row-State und die Aktions-Handler bleiben in der Page; die Komponente rendert nur das `Menu` mit den vier `ContextMenuActionItem`s. Jedes Item delegiert weiterhin an den Handler und schließt danach das Menü — Logik unverändert übernommen.
- Props: `anchorEl`, `row`, `onClose`, `onEdit`, `onDuplicate`, `onCopy`, `onDelete`; das Löschen delegiert die Page wie bisher an `gridCommandApiRef.current?.deleteRow`.
- Nicht mehr benötigte Imports in der Page entfernt (`Menu`, `Divider`, `ContextMenuActionItem`, `EditIcon`, `ContentCopyIcon`).

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `PlantingPlans.tsx` (Stash-Vergleich); `MobilePlanActionsMenu.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_