### PR TITLE
refactor(frontend): extract CalendarFiltersPopover presentational component

### DIFF
--- a/frontend/src/components/gantt/CalendarFiltersPopover.tsx
+++ b/frontend/src/components/gantt/CalendarFiltersPopover.tsx
@@ -1,0 +1,121 @@
+import {
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Popover,
+  Select,
+  Stack,
+} from '@mui/material';
+
+import { useTranslation } from '../../i18n';
+import type { Location } from '../../api/api';
+import type { OccupancyHierarchyNode } from '../../pages/ganttChartUtils';
+
+interface CalendarFiltersPopoverProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  locations: Location[];
+  /** Field nodes of the currently selected location (empty for 'all'). */
+  fieldOptions: OccupancyHierarchyNode[];
+  locationFilter: number | 'all';
+  /** Selecting a location also resets the field filter — handled by the page. */
+  onLocationFilterChange: (value: number | 'all') => void;
+  fieldFilter: number | 'all';
+  onFieldFilterChange: (value: number | 'all') => void;
+  onlyOccupiedBeds: boolean;
+  onOnlyOccupiedBedsChange: (checked: boolean) => void;
+  /** Resets all hierarchy filters and closes the popover — handled by the page. */
+  onReset: () => void;
+}
+
+/**
+ * Presentational popover with the mobile calendar hierarchy filters
+ * (location, field, only-occupied-beds). All filter state lives in
+ * GanttChart.tsx; this component only renders and parses select values.
+ */
+export function CalendarFiltersPopover({
+  anchorEl,
+  onClose,
+  locations,
+  fieldOptions,
+  locationFilter,
+  onLocationFilterChange,
+  fieldFilter,
+  onFieldFilterChange,
+  onlyOccupiedBeds,
+  onOnlyOccupiedBedsChange,
+  onReset,
+}: CalendarFiltersPopoverProps) {
+  const { t } = useTranslation(['ganttChart', 'common']);
+
+  return (
+    <Popover
+      id="calendar-filters-popover"
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      PaperProps={{ sx: { width: 'min(92vw, 360px)', p: 1.5 } }}
+    >
+      <Stack spacing={1.25}>
+        <FormControl size="small" sx={{ minWidth: '100%' }}>
+          <InputLabel id="calendar-location-filter-label">{t('ganttChart:treeFilters.locationLabel')}</InputLabel>
+          <Select
+            labelId="calendar-location-filter-label"
+            value={locationFilter === 'all' ? 'all' : String(locationFilter)}
+            label={t('ganttChart:treeFilters.locationLabel')}
+            onChange={(event) => {
+              const { value } = event.target;
+              onLocationFilterChange(value === 'all' ? 'all' : Number(value));
+            }}
+          >
+            <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
+            {locations.filter((location) => location.id).map((location) => (
+              <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: '100%' }}>
+          <InputLabel id="calendar-field-filter-label">{t('ganttChart:treeFilters.fieldLabel')}</InputLabel>
+          <Select
+            labelId="calendar-field-filter-label"
+            value={fieldFilter === 'all' ? 'all' : String(fieldFilter)}
+            label={t('ganttChart:treeFilters.fieldLabel')}
+            onChange={(event) => {
+              const { value } = event.target;
+              onFieldFilterChange(value === 'all' ? 'all' : Number(value));
+            }}
+            disabled={locationFilter === 'all'}
+          >
+            <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
+            {fieldOptions.map((field) => (
+              <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControlLabel
+          control={(
+            <Checkbox
+              size="small"
+              checked={onlyOccupiedBeds}
+              onChange={(event) => onOnlyOccupiedBedsChange(event.target.checked)}
+            />
+          )}
+          label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
+        />
+        <Button
+          variant="text"
+          size="small"
+          onClick={onReset}
+          sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
+        >
+          {t('ganttChart:treeFilters.resetFilters')}
+        </Button>
+      </Stack>
+    </Popover>
+  );
+}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -22,13 +22,10 @@ import {
   ButtonGroup,
   Checkbox,
   Divider,
-  FormControl,
   FormControlLabel,
   IconButton,
   InputAdornment,
-  InputLabel,
   MenuItem,
-  Popover,
   Select,
   Stack,
   TextField,
@@ -140,6 +137,7 @@ import { useExpandedState } from '../components/hierarchy/hooks/useExpandedState
 import { collectVisibleIdsWithAncestors, flattenTreeRows } from '../components/hierarchy/utils/treeRows';
 import { useHierarchyLevelToggle } from '../components/hierarchy/hooks/useHierarchyLevelToggle';
 import { HierarchyLevelButtons } from '../components/hierarchy/HierarchyLevelToggle';
+import { CalendarFiltersPopover } from '../components/gantt/CalendarFiltersPopover';
 
 const GanttChartWithFocusMode = GanttChart as React.ComponentType<
   React.ComponentProps<typeof GanttChart> & { focusMode?: boolean }
@@ -2162,75 +2160,25 @@ function GanttChartPage() {
                       </Button>
                     </Stack>
                   )}
-                  <Popover
-                    id="calendar-filters-popover"
-                    open={isCalendarFilterPopoverOpen}
+                  <CalendarFiltersPopover
                     anchorEl={calendarFilterAnchorEl}
                     onClose={() => setCalendarFilterAnchorEl(null)}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                    PaperProps={{ sx: { width: 'min(92vw, 360px)', p: 1.5 } }}
-                  >
-                    <Stack spacing={1.25}>
-                      <FormControl size="small" sx={{ minWidth: '100%' }}>
-                        <InputLabel id="calendar-location-filter-label">{t('ganttChart:treeFilters.locationLabel')}</InputLabel>
-                        <Select
-                          labelId="calendar-location-filter-label"
-                          value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
-                          label={t('ganttChart:treeFilters.locationLabel')}
-                          onChange={(event) => {
-                            const { value } = event.target;
-                            setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
-                            setOccupancyFieldFilter('all');
-                          }}
-                        >
-                          <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
-                          {locations.filter((location) => location.id).map((location) => (
-                            <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                      <FormControl size="small" sx={{ minWidth: '100%' }}>
-                        <InputLabel id="calendar-field-filter-label">{t('ganttChart:treeFilters.fieldLabel')}</InputLabel>
-                        <Select
-                          labelId="calendar-field-filter-label"
-                          value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
-                          label={t('ganttChart:treeFilters.fieldLabel')}
-                          onChange={(event) => {
-                            const { value } = event.target;
-                            setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
-                          }}
-                          disabled={occupancyLocationFilter === 'all'}
-                        >
-                          <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
-                          {occupancyFieldOptions.map((field) => (
-                            <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                      <FormControlLabel
-                        control={(
-                          <Checkbox
-                            size="small"
-                            checked={onlyOccupiedBeds}
-                            onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
-                          />
-                        )}
-                        label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
-                      />
-                      <Button
-                        variant="text"
-                        size="small"
-                        onClick={() => {
-                          resetOccupancyHierarchyFilters();
-                          setCalendarFilterAnchorEl(null);
-                        }}
-                        sx={{ alignSelf: 'flex-end', whiteSpace: 'nowrap' }}
-                      >
-                        {t('ganttChart:treeFilters.resetFilters')}
-                      </Button>
-                    </Stack>
-                  </Popover>
+                    locations={locations}
+                    fieldOptions={occupancyFieldOptions}
+                    locationFilter={occupancyLocationFilter}
+                    onLocationFilterChange={(value) => {
+                      setOccupancyLocationFilter(value);
+                      setOccupancyFieldFilter('all');
+                    }}
+                    fieldFilter={occupancyFieldFilter}
+                    onFieldFilterChange={setOccupancyFieldFilter}
+                    onlyOccupiedBeds={onlyOccupiedBeds}
+                    onOnlyOccupiedBedsChange={setOnlyOccupiedBeds}
+                    onReset={() => {
+                      resetOccupancyHierarchyFilters();
+                      setCalendarFilterAnchorEl(null);
+                    }}
+                  />
                 </Stack>
               ) : (
                 <Box


### PR DESCRIPTION
## Was

Die Dekompositions-Strategie (#313–#315) erreicht jetzt `GanttChart.tsx` (2566 Zeilen): der mobile Kalender-Filter-Popover (Standort, Feld, „nur belegte Beete", Zurücksetzen) wird in eine **rein präsentationale Komponente** `components/gantt/CalendarFiltersPopover.tsx` verschoben.

- Sämtlicher Filter-State bleibt in der Page; die Komponente rendert nur den `Popover` und parst die Select-Werte (`'all'` vs. Zahl).
- Die State-Kopplungen bleiben als Inline-Callbacks in der Page: Standortwechsel setzt weiterhin den Feld-Filter zurück; „Zurücksetzen" ruft weiterhin `resetOccupancyHierarchyFilters` auf und schließt den Popover.
- Nicht mehr benötigte MUI-Imports in der Page entfernt (`Popover`, `FormControl`, `InputLabel`).

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `GanttChart.tsx` (Stash-Vergleich); `CalendarFiltersPopover.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_