### PR TITLE
refactor(frontend): extract OccupancyFilterRow presentational component

### DIFF
--- a/frontend/src/components/gantt/OccupancyFilterRow.tsx
+++ b/frontend/src/components/gantt/OccupancyFilterRow.tsx
@@ -1,0 +1,120 @@
+import type { Ref } from 'react';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  InputAdornment,
+  MenuItem,
+  Select,
+  TextField,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+
+import { useTranslation } from '../../i18n';
+import type { Location } from '../../api/api';
+import type { OccupancyHierarchyNode } from '../../pages/ganttChartUtils';
+
+interface OccupancyFilterRowProps {
+  searchText: string;
+  onSearchTextChange: (value: string) => void;
+  searchInputRef: Ref<HTMLInputElement>;
+  locations: Location[];
+  /** Field nodes of the currently selected location (empty for 'all'). */
+  fieldOptions: OccupancyHierarchyNode[];
+  locationFilter: number | 'all';
+  /** Selecting a location also resets the field filter — handled by the page. */
+  onLocationFilterChange: (value: number | 'all') => void;
+  fieldFilter: number | 'all';
+  onFieldFilterChange: (value: number | 'all') => void;
+  onlyOccupiedBeds: boolean;
+  onOnlyOccupiedBedsChange: (checked: boolean) => void;
+}
+
+/**
+ * Presentational desktop filter row for the bed-occupancy calendar
+ * (search, location, field, only-occupied-beds). All filter state lives in
+ * GanttChart.tsx; this component only renders and parses select values.
+ */
+export function OccupancyFilterRow({
+  searchText,
+  onSearchTextChange,
+  searchInputRef,
+  locations,
+  fieldOptions,
+  locationFilter,
+  onLocationFilterChange,
+  fieldFilter,
+  onFieldFilterChange,
+  onlyOccupiedBeds,
+  onOnlyOccupiedBedsChange,
+}: OccupancyFilterRowProps) {
+  const { t } = useTranslation(['ganttChart', 'common']);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1.5,
+        alignItems: 'center',
+      }}
+    >
+      <TextField
+        size="small"
+        placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
+        value={searchText}
+        onChange={(event) => onSearchTextChange(event.target.value)}
+        inputRef={searchInputRef}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          },
+        }}
+        sx={{ minWidth: 240, flex: '1 1 240px' }}
+      />
+      <Select
+        size="small"
+        value={locationFilter === 'all' ? 'all' : String(locationFilter)}
+        onChange={(event) => {
+          const { value } = event.target;
+          onLocationFilterChange(value === 'all' ? 'all' : Number(value));
+        }}
+        sx={{ minWidth: 160 }}
+      >
+        <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
+        {locations.filter((location) => location.id).map((location) => (
+          <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
+        ))}
+      </Select>
+      <Select
+        size="small"
+        value={fieldFilter === 'all' ? 'all' : String(fieldFilter)}
+        onChange={(event) => {
+          const { value } = event.target;
+          onFieldFilterChange(value === 'all' ? 'all' : Number(value));
+        }}
+        disabled={locationFilter === 'all'}
+        sx={{ minWidth: 160 }}
+      >
+        <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
+        {fieldOptions.map((field) => (
+          <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
+        ))}
+      </Select>
+      <FormControlLabel
+        control={(
+          <Checkbox
+            size="small"
+            checked={onlyOccupiedBeds}
+            onChange={(event) => onOnlyOccupiedBedsChange(event.target.checked)}
+          />
+        )}
+        label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -20,9 +20,7 @@ import {
   Box,
   Button,
   ButtonGroup,
-  Checkbox,
   Divider,
-  FormControlLabel,
   IconButton,
   InputAdornment,
   MenuItem,
@@ -138,6 +136,7 @@ import { collectVisibleIdsWithAncestors, flattenTreeRows } from '../components/h
 import { useHierarchyLevelToggle } from '../components/hierarchy/hooks/useHierarchyLevelToggle';
 import { HierarchyLevelButtons } from '../components/hierarchy/HierarchyLevelToggle';
 import { CalendarFiltersPopover } from '../components/gantt/CalendarFiltersPopover';
+import { OccupancyFilterRow } from '../components/gantt/OccupancyFilterRow';
 
 const GanttChartWithFocusMode = GanttChart as React.ComponentType<
   React.ComponentProps<typeof GanttChart> & { focusMode?: boolean }
@@ -2181,72 +2180,22 @@ function GanttChartPage() {
                   />
                 </Stack>
               ) : (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 1.5,
-                    alignItems: 'center',
+                <OccupancyFilterRow
+                  searchText={occupancySearchText}
+                  onSearchTextChange={setOccupancySearchText}
+                  searchInputRef={searchInputRef}
+                  locations={locations}
+                  fieldOptions={occupancyFieldOptions}
+                  locationFilter={occupancyLocationFilter}
+                  onLocationFilterChange={(value) => {
+                    setOccupancyLocationFilter(value);
+                    setOccupancyFieldFilter('all');
                   }}
-                >
-                  <TextField
-                    size="small"
-                    placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
-                    value={occupancySearchText}
-                    onChange={(event) => setOccupancySearchText(event.target.value)}
-                    inputRef={searchInputRef}
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <SearchIcon fontSize="small" />
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                    sx={{ minWidth: 240, flex: '1 1 240px' }}
-                  />
-                  <Select
-                    size="small"
-                    value={occupancyLocationFilter === 'all' ? 'all' : String(occupancyLocationFilter)}
-                    onChange={(event) => {
-                      const { value } = event.target;
-                      setOccupancyLocationFilter(value === 'all' ? 'all' : Number(value));
-                      setOccupancyFieldFilter('all');
-                    }}
-                    sx={{ minWidth: 160 }}
-                  >
-                    <MenuItem value="all">{t('ganttChart:treeFilters.allLocations')}</MenuItem>
-                    {locations.filter((location) => location.id).map((location) => (
-                      <MenuItem key={location.id} value={String(location.id)}>{location.name}</MenuItem>
-                    ))}
-                  </Select>
-                  <Select
-                    size="small"
-                    value={occupancyFieldFilter === 'all' ? 'all' : String(occupancyFieldFilter)}
-                    onChange={(event) => {
-                      const { value } = event.target;
-                      setOccupancyFieldFilter(value === 'all' ? 'all' : Number(value));
-                    }}
-                    disabled={occupancyLocationFilter === 'all'}
-                    sx={{ minWidth: 160 }}
-                  >
-                    <MenuItem value="all">{t('ganttChart:treeFilters.allFields')}</MenuItem>
-                    {occupancyFieldOptions.map((field) => (
-                      <MenuItem key={field.id} value={String(field.fieldId)}>{field.name}</MenuItem>
-                    ))}
-                  </Select>
-                  <FormControlLabel
-                    control={(
-                      <Checkbox
-                        size="small"
-                        checked={onlyOccupiedBeds}
-                        onChange={(event) => setOnlyOccupiedBeds(event.target.checked)}
-                      />
-                    )}
-                    label={t('ganttChart:treeFilters.onlyOccupiedBeds')}
-                  />
-                </Box>
+                  fieldFilter={occupancyFieldFilter}
+                  onFieldFilterChange={setOccupancyFieldFilter}
+                  onlyOccupiedBeds={onlyOccupiedBeds}
+                  onOnlyOccupiedBedsChange={setOnlyOccupiedBeds}
+                />
               )}
             </Box>
           )}


### PR DESCRIPTION
## Was

Fortsetzung der GanttChart-Dekomposition (nach #316, gleiche Strategie): die Desktop-Filterzeile des Belegungskalenders (Suchfeld, Standort-/Feld-Selects, „nur belegte Beete"-Checkbox) wird aus `GanttChart.tsx` in eine **rein präsentationale Komponente** `components/gantt/OccupancyFilterRow.tsx` verschoben.

- Sämtlicher Filter-State bleibt in der Page; die Komponente rendert nur und parst die Select-Werte (`'all'` vs. Zahl). Das geteilte `searchInputRef` wird als Prop durchgereicht.
- Die State-Kopplung (Standortwechsel setzt den Feld-Filter zurück) bleibt als Inline-Callback in der Page — identisch zu #316, sodass Popover (mobil) und Filterzeile (Desktop) dieselbe Handler-Logik der Page teilen.
- Nicht mehr benötigte MUI-Imports in der Page entfernt (`Checkbox`, `FormControlLabel`).

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `GanttChart.tsx` (Stash-Vergleich); `OccupancyFilterRow.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_