### PR TITLE
refactor(frontend): extract SeedlingFilters presentational component

### DIFF
--- a/frontend/src/components/gantt/SeedlingFilters.tsx
+++ b/frontend/src/components/gantt/SeedlingFilters.tsx
@@ -1,0 +1,125 @@
+import type { Ref } from 'react';
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Tooltip,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+
+import { useTranslation } from '../../i18n';
+
+interface SeedlingFiltersProps {
+  /** Mobile layout renders a collapsible search icon; desktop a plain field. */
+  useMobileLayout: boolean;
+  /** Mobile only: show the expanded search field instead of the icon. */
+  searchExpanded: boolean;
+  searchText: string;
+  onSearchTextChange: (value: string) => void;
+  searchInputRef: Ref<HTMLInputElement>;
+  onClearSearch: () => void;
+  onOpenSearch: () => void;
+}
+
+/**
+ * Presentational filter bar for the seedling calendar (search only).
+ * Search state and the expand/clear handlers live in GanttChart.tsx;
+ * this component only renders.
+ */
+export function SeedlingFilters({
+  useMobileLayout,
+  searchExpanded,
+  searchText,
+  onSearchTextChange,
+  searchInputRef,
+  onClearSearch,
+  onOpenSearch,
+}: SeedlingFiltersProps) {
+  const { t } = useTranslation(['ganttChart', 'common']);
+
+  return (
+    <Box
+      data-testid="seedling-filters"
+      sx={{
+        mb: { xs: 0, md: 1.5 },
+      }}
+    >
+      {useMobileLayout ? (
+        <Stack spacing={0}>
+          {searchExpanded ? (
+            <Stack direction="row" spacing={0.75} alignItems="center">
+              <TextField
+                size="small"
+                placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
+                value={searchText}
+                onChange={(event) => onSearchTextChange(event.target.value)}
+                inputRef={searchInputRef}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon fontSize="small" />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={{ flex: '1 1 auto', minWidth: 0 }}
+              />
+              <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
+                <IconButton
+                  size="small"
+                  aria-label={t('ganttChart:treeFilters.clearSearch')}
+                  onClick={onClearSearch}
+                  sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          ) : (
+            <Tooltip title={t('common:actions.search')}>
+              <IconButton
+                size="small"
+                aria-label={t('common:actions.search')}
+                onClick={onOpenSearch}
+                sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+              >
+                <SearchIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+      ) : (
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1.5,
+            alignItems: 'center',
+          }}
+        >
+          <TextField
+            size="small"
+            placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
+            value={searchText}
+            onChange={(event) => onSearchTextChange(event.target.value)}
+            inputRef={searchInputRef}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{ minWidth: 240, flex: '1 1 240px' }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -137,6 +137,7 @@ import { useHierarchyLevelToggle } from '../components/hierarchy/hooks/useHierar
 import { HierarchyLevelButtons } from '../components/hierarchy/HierarchyLevelToggle';
 import { CalendarFiltersPopover } from '../components/gantt/CalendarFiltersPopover';
 import { OccupancyFilterRow } from '../components/gantt/OccupancyFilterRow';
+import { SeedlingFilters } from '../components/gantt/SeedlingFilters';
 
 const GanttChartWithFocusMode = GanttChart as React.ComponentType<
   React.ComponentProps<typeof GanttChart> & { focusMode?: boolean }
@@ -2200,86 +2201,15 @@ function GanttChartPage() {
             </Box>
           )}
           {calendarMode === 'seedlings' && (
-            <Box
-              data-testid="seedling-filters"
-              sx={{
-                mb: { xs: 0, md: 1.5 },
-              }}
-            >
-              {useMobileFilterLayout ? (
-                <Stack spacing={0}>
-                  {mobileSearchOpen || activeSearchText ? (
-                    <Stack direction="row" spacing={0.75} alignItems="center">
-                      <TextField
-                        size="small"
-                        placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
-                        value={seedlingSearchText}
-                        onChange={(event) => setSeedlingSearchText(event.target.value)}
-                        inputRef={searchInputRef}
-                        slotProps={{
-                          input: {
-                            startAdornment: (
-                              <InputAdornment position="start">
-                                <SearchIcon fontSize="small" />
-                              </InputAdornment>
-                            ),
-                          },
-                        }}
-                        sx={{ flex: '1 1 auto', minWidth: 0 }}
-                      />
-                      <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('ganttChart:treeFilters.clearSearch')}
-                          onClick={clearActiveSearch}
-                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
-                        >
-                          <CloseIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    </Stack>
-                  ) : (
-                    <Tooltip title={t('common:actions.search')}>
-                      <IconButton
-                        size="small"
-                        aria-label={t('common:actions.search')}
-                        onClick={() => setMobileSearchOpen(true)}
-                        sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
-                      >
-                        <SearchIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </Stack>
-              ) : (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 1.5,
-                    alignItems: 'center',
-                  }}
-                >
-                  <TextField
-                    size="small"
-                    placeholder={t('ganttChart:treeFilters.searchPlaceholderSeedlings')}
-                    value={seedlingSearchText}
-                    onChange={(event) => setSeedlingSearchText(event.target.value)}
-                    inputRef={searchInputRef}
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                          <InputAdornment position="start">
-                            <SearchIcon fontSize="small" />
-                          </InputAdornment>
-                        ),
-                      },
-                    }}
-                    sx={{ minWidth: 240, flex: '1 1 240px' }}
-                  />
-                </Box>
-              )}
-            </Box>
+            <SeedlingFilters
+              useMobileLayout={useMobileFilterLayout}
+              searchExpanded={Boolean(mobileSearchOpen || activeSearchText)}
+              searchText={seedlingSearchText}
+              onSearchTextChange={setSeedlingSearchText}
+              searchInputRef={searchInputRef}
+              onClearSearch={clearActiveSearch}
+              onOpenSearch={() => setMobileSearchOpen(true)}
+            />
           )}
           <Box
             className={`gantt-container-wrapper gantt-container-wrapper--${calendarMode}`}


### PR DESCRIPTION
## Was

Fortsetzung der GanttChart-Dekomposition (nach #316/#317, gleiche Strategie): die Filterleiste des Anzuchtkalenders — mobile einklappbare Suche (Icon ↔ Suchfeld mit Clear-Button) und Desktop-Suchfeld — wird aus `GanttChart.tsx` in eine **rein präsentationale Komponente** `components/gantt/SeedlingFilters.tsx` verschoben (inkl. `data-testid="seedling-filters"`-Wrapper).

- Such-State und die Expand-/Clear-Handler bleiben in der Page; die Komponente rendert nur beide Layout-Varianten unverändert.
- Bewusst **nicht** gemacht: die fast identische Mobile-Suchleiste des Belegungskalenders mitzuvereinheitlichen — die Blöcke unterscheiden sich strukturell (Filter-Button, Stack-Wrapper im eingeklappten Zustand), eine Zusammenführung wäre kein verbatim-Move mehr.
- `GanttChart.tsx`: 2445 → 2374 Zeilen.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `GanttChart.tsx` (Stash-Vergleich); `SeedlingFilters.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_