### PR TITLE
refactor(frontend): extract OccupancyMobileFilterBar presentational component

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -117,6 +117,13 @@ docs/                  # This documentation
   implementation superseded by `InvitationAcceptPage.tsx`, was confirmed
   dead — nothing in `App.tsx`'s router referenced it — and removed.)
 
+- **Page sub-components**: the largest pages are being decomposed by
+  extracting purely presentational blocks (dialogs, menus, filter bars)
+  into per-domain component folders — `components/planting-plans/` for
+  `PlantingPlans.tsx`, `components/gantt/` for `GanttChart.tsx`. The
+  pattern is deliberate: all state and handlers stay in the page; the
+  extracted components only render props. Stateful-hook extraction from
+  these pages is avoided because it breaks React Compiler analysis.
 - **API layer** (`frontend/src/api/`): `httpClient.ts` is the one shared
   axios instance; a single request interceptor attaches `X-Project-Id`
   (read fresh from `localStorage` per request) and `X-CSRFToken`.

--- a/frontend/src/components/gantt/OccupancyMobileFilterBar.tsx
+++ b/frontend/src/components/gantt/OccupancyMobileFilterBar.tsx
@@ -1,0 +1,136 @@
+import type { MouseEvent, Ref } from 'react';
+import {
+  Button,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Tooltip,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import TuneIcon from '@mui/icons-material/Tune';
+
+import { useTranslation } from '../../i18n';
+
+interface OccupancyMobileFilterBarProps {
+  /** Show the expanded search field instead of the search icon. */
+  searchExpanded: boolean;
+  searchText: string;
+  onSearchTextChange: (value: string) => void;
+  searchInputRef: Ref<HTMLInputElement>;
+  onClearSearch: () => void;
+  onOpenSearch: () => void;
+  /** Whether the calendar-filters popover is open (for ARIA wiring). */
+  filterPopoverOpen: boolean;
+  activeFilterCount: number;
+  onOpenFilterPopover: (event: MouseEvent<HTMLButtonElement>) => void;
+}
+
+/**
+ * Presentational mobile filter bar for the bed-occupancy calendar: the
+ * collapsible search row plus the filter button that anchors the
+ * calendar-filters popover. All state (search text, popover anchor,
+ * filter counts) lives in GanttChart.tsx; the popover itself is rendered
+ * by the page next to this bar.
+ */
+export function OccupancyMobileFilterBar({
+  searchExpanded,
+  searchText,
+  onSearchTextChange,
+  searchInputRef,
+  onClearSearch,
+  onOpenSearch,
+  filterPopoverOpen,
+  activeFilterCount,
+  onOpenFilterPopover,
+}: OccupancyMobileFilterBarProps) {
+  const { t } = useTranslation(['ganttChart', 'common']);
+
+  return searchExpanded ? (
+    <Stack direction="row" spacing={0.75} alignItems="center">
+      <TextField
+        size="small"
+        placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
+        value={searchText}
+        onChange={(event) => onSearchTextChange(event.target.value)}
+        inputRef={searchInputRef}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          },
+        }}
+        sx={{ flex: '1 1 auto', minWidth: 0 }}
+      />
+      <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
+        <IconButton
+          size="small"
+          aria-label={t('ganttChart:treeFilters.clearSearch')}
+          onClick={onClearSearch}
+          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Button
+        size="small"
+        variant="outlined"
+        color="inherit"
+        startIcon={<TuneIcon fontSize="small" />}
+        onClick={onOpenFilterPopover}
+        aria-expanded={filterPopoverOpen}
+        aria-haspopup="dialog"
+        aria-controls={filterPopoverOpen ? 'calendar-filters-popover' : undefined}
+        sx={{
+          minHeight: 40,
+          minWidth: 0,
+          px: 1,
+          whiteSpace: 'nowrap',
+          borderColor: activeFilterCount > 0 ? 'text.secondary' : 'divider',
+          bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent',
+        }}
+      >
+        {activeFilterCount > 0
+          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeFilterCount })
+          : t('ganttChart:treeFilters.filterButton')}
+      </Button>
+    </Stack>
+  ) : (
+    <Stack direction="row" spacing={0.75} alignItems="center">
+      <Tooltip title={t('common:actions.search')}>
+        <IconButton
+          size="small"
+          aria-label={t('common:actions.search')}
+          onClick={onOpenSearch}
+          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
+        >
+          <SearchIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Button
+        size="small"
+        variant="outlined"
+        color="inherit"
+        startIcon={<TuneIcon fontSize="small" />}
+        onClick={onOpenFilterPopover}
+        aria-expanded={filterPopoverOpen}
+        aria-haspopup="dialog"
+        aria-controls={filterPopoverOpen ? 'calendar-filters-popover' : undefined}
+        sx={{
+          minHeight: 40,
+          whiteSpace: 'nowrap',
+          borderColor: activeFilterCount > 0 ? 'text.secondary' : 'divider',
+          bgcolor: activeFilterCount > 0 ? 'action.selected' : 'transparent',
+        }}
+      >
+        {activeFilterCount > 0
+          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeFilterCount })
+          : t('ganttChart:treeFilters.filterButton')}
+      </Button>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -10,10 +10,8 @@
 import React, { useState, useEffect, useMemo, useCallback, useContext, useRef, useLayoutEffect } from 'react';
 import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
-import TuneIcon from '@mui/icons-material/Tune';
 import { useTranslation } from '../i18n';
 import {
   Alert,
@@ -21,18 +19,14 @@ import {
   Button,
   ButtonGroup,
   Divider,
-  IconButton,
-  InputAdornment,
   MenuItem,
   Select,
   Stack,
-  TextField,
   Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
 import {
   shouldOpenCustomContextMenu,
   suppressNativeContextMenu,
@@ -138,6 +132,7 @@ import { HierarchyLevelButtons } from '../components/hierarchy/HierarchyLevelTog
 import { CalendarFiltersPopover } from '../components/gantt/CalendarFiltersPopover';
 import { OccupancyFilterRow } from '../components/gantt/OccupancyFilterRow';
 import { SeedlingFilters } from '../components/gantt/SeedlingFilters';
+import { OccupancyMobileFilterBar } from '../components/gantt/OccupancyMobileFilterBar';
 
 const GanttChartWithFocusMode = GanttChart as React.ComponentType<
   React.ComponentProps<typeof GanttChart> & { focusMode?: boolean }
@@ -2074,92 +2069,17 @@ function GanttChartPage() {
             >
               {useMobileFilterLayout ? (
                 <Stack spacing={0}>
-                  {mobileSearchOpen || activeSearchText ? (
-                    <Stack direction="row" spacing={0.75} alignItems="center">
-                      <TextField
-                        size="small"
-                        placeholder={t('ganttChart:treeFilters.searchPlaceholder')}
-                        value={occupancySearchText}
-                        onChange={(event) => setOccupancySearchText(event.target.value)}
-                        inputRef={searchInputRef}
-                        slotProps={{
-                          input: {
-                            startAdornment: (
-                              <InputAdornment position="start">
-                                <SearchIcon fontSize="small" />
-                              </InputAdornment>
-                            ),
-                          },
-                        }}
-                        sx={{ flex: '1 1 auto', minWidth: 0 }}
-                      />
-                      <Tooltip title={t('ganttChart:treeFilters.clearSearch')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('ganttChart:treeFilters.clearSearch')}
-                          onClick={clearActiveSearch}
-                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
-                        >
-                          <CloseIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        color="inherit"
-                        startIcon={<TuneIcon fontSize="small" />}
-                        onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
-                        aria-expanded={isCalendarFilterPopoverOpen}
-                        aria-haspopup="dialog"
-                        aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
-                        sx={{
-                          minHeight: 40,
-                          minWidth: 0,
-                          px: 1,
-                          whiteSpace: 'nowrap',
-                          borderColor: activeHierarchyFilterCount > 0 ? 'text.secondary' : 'divider',
-                          bgcolor: activeHierarchyFilterCount > 0 ? 'action.selected' : 'transparent',
-                        }}
-                      >
-                        {activeHierarchyFilterCount > 0
-                          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
-                          : t('ganttChart:treeFilters.filterButton')}
-                      </Button>
-                    </Stack>
-                  ) : (
-                    <Stack direction="row" spacing={0.75} alignItems="center">
-                      <Tooltip title={t('common:actions.search')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('common:actions.search')}
-                          onClick={() => setMobileSearchOpen(true)}
-                          sx={{ width: 40, height: 40, border: '1px solid', borderColor: 'divider' }}
-                        >
-                          <SearchIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        color="inherit"
-                        startIcon={<TuneIcon fontSize="small" />}
-                        onClick={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
-                        aria-expanded={isCalendarFilterPopoverOpen}
-                        aria-haspopup="dialog"
-                        aria-controls={isCalendarFilterPopoverOpen ? 'calendar-filters-popover' : undefined}
-                        sx={{
-                          minHeight: 40,
-                          whiteSpace: 'nowrap',
-                          borderColor: activeHierarchyFilterCount > 0 ? 'text.secondary' : 'divider',
-                          bgcolor: activeHierarchyFilterCount > 0 ? 'action.selected' : 'transparent',
-                        }}
-                      >
-                        {activeHierarchyFilterCount > 0
-                          ? t('ganttChart:treeFilters.filterButtonWithCount', { count: activeHierarchyFilterCount })
-                          : t('ganttChart:treeFilters.filterButton')}
-                      </Button>
-                    </Stack>
-                  )}
+                  <OccupancyMobileFilterBar
+                    searchExpanded={Boolean(mobileSearchOpen || activeSearchText)}
+                    searchText={occupancySearchText}
+                    onSearchTextChange={setOccupancySearchText}
+                    searchInputRef={searchInputRef}
+                    onClearSearch={clearActiveSearch}
+                    onOpenSearch={() => setMobileSearchOpen(true)}
+                    filterPopoverOpen={isCalendarFilterPopoverOpen}
+                    activeFilterCount={activeHierarchyFilterCount}
+                    onOpenFilterPopover={(event) => setCalendarFilterAnchorEl(event.currentTarget)}
+                  />
                   <CalendarFiltersPopover
                     anchorEl={calendarFilterAnchorEl}
                     onClose={() => setCalendarFilterAnchorEl(null)}


### PR DESCRIPTION
## Was

Fortsetzung der GanttChart-Dekomposition (nach #316–#318): die mobile Filterleiste des Belegungskalenders — einklappbare Such-Zeile plus der Filter-Button, der den Kalender-Filter-Popover verankert (beide Varianten: eingeklappt/ausgeklappt) — wird aus `GanttChart.tsx` in eine **rein präsentationale Komponente** `components/gantt/OccupancyMobileFilterBar.tsx` verschoben.

- Sämtlicher State (Suchtext, Popover-Anchor, Filter-Zähler) bleibt in der Page; der `CalendarFiltersPopover` (#316) wird weiterhin von der Page direkt neben der Leiste gerendert. Die ARIA-Verdrahtung (`aria-controls="calendar-filters-popover"` etc.) ist unverändert übernommen.
- Sechs nicht mehr benötigte Imports in der Page entfernt (`CloseIcon`, `SearchIcon`, `TuneIcon`, `TextField`, `InputAdornment`, `IconButton`); `GanttChart.tsx`: 2374 → 2288 Zeilen.
- **Doku**: `docs/architecture-overview.md` beschreibt jetzt das Dekompositions-Muster (präsentationale Sub-Komponenten unter `components/planting-plans/` und `components/gantt/`, State bleibt in der Page).

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `GanttChart.tsx` (Stash-Vergleich); `OccupancyMobileFilterBar.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_