### PR TITLE
refactor(frontend): extract SupplierDeleteUsageDialog presentational component

### DIFF
--- a/frontend/src/components/suppliers/SupplierDeleteUsageDialog.tsx
+++ b/frontend/src/components/suppliers/SupplierDeleteUsageDialog.tsx
@@ -1,0 +1,115 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+
+import { useTranslation } from '../../i18n';
+import type { Supplier, SupplierDeleteUsage } from '../../api/types';
+
+export interface SupplierDeleteUsageDialogState {
+  supplier: Supplier;
+  usage: SupplierDeleteUsage;
+}
+
+interface SupplierDeleteUsageDialogProps {
+  /** The dialog is open while this is non-null. */
+  dialog: SupplierDeleteUsageDialogState | null;
+  /** The supplier id currently being unlink-deleted (disables the button). */
+  unlinkDeletingSupplierId: number | null;
+  onClose: () => void;
+  onOpenAffectedCultures: () => void;
+  onUnlinkAndDelete: () => void;
+}
+
+/**
+ * Presentational dialog shown before deleting a supplier that is still
+ * referenced by cultures: lists the usages and offers unlink-and-delete.
+ * State and the delete/navigation handlers live in Suppliers.tsx; this
+ * component only renders.
+ */
+export function SupplierDeleteUsageDialog({
+  dialog,
+  unlinkDeletingSupplierId,
+  onClose,
+  onOpenAffectedCultures,
+  onUnlinkAndDelete,
+}: SupplierDeleteUsageDialogProps) {
+  const { t } = useTranslation(['suppliers', 'common']);
+
+  return (
+    <Dialog
+      open={dialog !== null}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle sx={{ pb: 1 }}>{t('deleteUsageDialog.title')}</DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          {dialog
+            ? t('deleteUsageDialog.summary', { count: dialog.usage.total_culture_count })
+            : ''}
+        </Typography>
+        {dialog ? (
+          <Box
+            sx={{
+              p: 2,
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'surface.surfaceSoftBorder',
+              bgcolor: 'surface.surfaceSubtleBackground',
+            }}
+          >
+            <Typography sx={{ fontWeight: 700, mb: 1 }}>
+              {dialog.supplier.name}
+            </Typography>
+            <Box component="ul" sx={{ m: 0, pl: 2.5, color: 'text.secondary' }}>
+              {dialog.usage.culture_count > 0 ? (
+                <Typography component="li" variant="body2">
+                  {t('deleteUsageDialog.cultureUsage', { count: dialog.usage.culture_count })}
+                </Typography>
+              ) : null}
+              {dialog.usage.supplier_data_culture_count > 0 ? (
+                <Typography component="li" variant="body2">
+                  {t('deleteUsageDialog.supplierDataUsage', {
+                    cultureCount: dialog.usage.supplier_data_culture_count,
+                    rowCount: dialog.usage.supplier_data_count,
+                  })}
+                </Typography>
+              ) : null}
+              {dialog.usage.seed_demand_culture_count > 0 ? (
+                <Typography component="li" variant="body2">
+                  {t('deleteUsageDialog.seedDemandUsage', { count: dialog.usage.seed_demand_culture_count })}
+                </Typography>
+              ) : null}
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              {t('deleteUsageDialog.unlinkExplanation')}
+            </Typography>
+          </Box>
+        ) : null}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1, gap: 1, flexWrap: 'wrap' }}>
+        <Button onClick={onOpenAffectedCultures} variant="outlined">
+          {t('deleteUsageDialog.openAffectedCultures')}
+        </Button>
+        <Button
+          onClick={onUnlinkAndDelete}
+          color="error"
+          variant="contained"
+          disabled={unlinkDeletingSupplierId === dialog?.supplier.id}
+        >
+          {t('deleteUsageDialog.unlinkAndDelete')}
+        </Button>
+        <Button onClick={onClose}>
+          {t('common:actions.cancel')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -31,7 +31,11 @@ import { ContextMenuIndicator } from '../components/contextMenu/ContextMenuIndic
 import { contextMenuActionsOverlaySx } from '../components/contextMenu/contextMenuIndicatorStyles';
 import { CustomContextMenu } from '../components/contextMenu/CustomContextMenu';
 import TableSurface from '../components/layout/TableSurface';
-import type { Supplier, SupplierDeleteUndoPayload, SupplierDeleteUsage } from '../api/types';
+import type { Supplier, SupplierDeleteUndoPayload } from '../api/types';
+import {
+  SupplierDeleteUsageDialog,
+  type SupplierDeleteUsageDialogState,
+} from '../components/suppliers/SupplierDeleteUsageDialog';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
@@ -66,11 +70,6 @@ interface PendingSupplierDeletion {
   visible: boolean;
   message: string;
   undoPayload?: SupplierDeleteUndoPayload;
-}
-
-interface SupplierDeleteUsageDialogState {
-  supplier: Supplier;
-  usage: SupplierDeleteUsage;
 }
 
 const normalizeUrl = (input: string): string => {
@@ -752,75 +751,13 @@ export default function Suppliers() {
         </Box>
       </Dialog>
 
-      <Dialog
-        open={deleteUsageDialog !== null}
+      <SupplierDeleteUsageDialog
+        dialog={deleteUsageDialog}
+        unlinkDeletingSupplierId={unlinkDeletingSupplierId}
         onClose={() => setDeleteUsageDialog(null)}
-        fullWidth
-        maxWidth="sm"
-      >
-        <DialogTitle sx={{ pb: 1 }}>{t('deleteUsageDialog.title')}</DialogTitle>
-        <DialogContent sx={{ pt: 1 }}>
-          <Typography color="text.secondary" sx={{ mb: 2 }}>
-            {deleteUsageDialog
-              ? t('deleteUsageDialog.summary', { count: deleteUsageDialog.usage.total_culture_count })
-              : ''}
-          </Typography>
-          {deleteUsageDialog ? (
-            <Box
-              sx={{
-                p: 2,
-                borderRadius: 1,
-                border: '1px solid',
-                borderColor: 'surface.surfaceSoftBorder',
-                bgcolor: 'surface.surfaceSubtleBackground',
-              }}
-            >
-              <Typography sx={{ fontWeight: 700, mb: 1 }}>
-                {deleteUsageDialog.supplier.name}
-              </Typography>
-              <Box component="ul" sx={{ m: 0, pl: 2.5, color: 'text.secondary' }}>
-                {deleteUsageDialog.usage.culture_count > 0 ? (
-                  <Typography component="li" variant="body2">
-                    {t('deleteUsageDialog.cultureUsage', { count: deleteUsageDialog.usage.culture_count })}
-                  </Typography>
-                ) : null}
-                {deleteUsageDialog.usage.supplier_data_culture_count > 0 ? (
-                  <Typography component="li" variant="body2">
-                    {t('deleteUsageDialog.supplierDataUsage', {
-                      cultureCount: deleteUsageDialog.usage.supplier_data_culture_count,
-                      rowCount: deleteUsageDialog.usage.supplier_data_count,
-                    })}
-                  </Typography>
-                ) : null}
-                {deleteUsageDialog.usage.seed_demand_culture_count > 0 ? (
-                  <Typography component="li" variant="body2">
-                    {t('deleteUsageDialog.seedDemandUsage', { count: deleteUsageDialog.usage.seed_demand_culture_count })}
-                  </Typography>
-                ) : null}
-              </Box>
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
-                {t('deleteUsageDialog.unlinkExplanation')}
-              </Typography>
-            </Box>
-          ) : null}
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2.5, pt: 1, gap: 1, flexWrap: 'wrap' }}>
-          <Button onClick={openAffectedCultures} variant="outlined">
-            {t('deleteUsageDialog.openAffectedCultures')}
-          </Button>
-          <Button
-            onClick={() => void unlinkAndDeleteSupplier()}
-            color="error"
-            variant="contained"
-            disabled={unlinkDeletingSupplierId === deleteUsageDialog?.supplier.id}
-          >
-            {t('deleteUsageDialog.unlinkAndDelete')}
-          </Button>
-          <Button onClick={() => setDeleteUsageDialog(null)}>
-            {t('common:actions.cancel')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onOpenAffectedCultures={openAffectedCultures}
+        onUnlinkAndDelete={() => void unlinkAndDeleteSupplier()}
+      />
 
       {pendingSupplierDeletions.map((deletion, index) => (
         <DeleteUndoSnackbar


### PR DESCRIPTION
## Was

Das Dekompositions-Muster (#313–#319) erreicht `Suppliers.tsx`: der Lösch-Nutzungs-Dialog (Zusammenfassung der Verwendungen einer Lieferanten-Referenz, „Betroffene Kulturen öffnen", „Verknüpfungen lösen & löschen") wird in eine **rein präsentationale Komponente** `components/suppliers/SupplierDeleteUsageDialog.tsx` verschoben.

- Der State-Typ `SupplierDeleteUsageDialogState` zieht mit in die Komponentendatei und wird von der Page re-importiert; sämtlicher State und die Lösch-/Navigations-Handler bleiben in der Page.
- Das Disable-Kriterium des Lösch-Buttons (`unlinkDeletingSupplierId === dialog?.supplier.id`) ist unverändert übernommen.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `Suppliers.tsx` (Stash-Vergleich); `SupplierDeleteUsageDialog.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_