### PR TITLE
test(e2e): retry login submit once to deflake login-dependent specs

### DIFF
--- a/frontend/e2e/fields-beds-keyboard-focus.spec.ts
+++ b/frontend/e2e/fields-beds-keyboard-focus.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { submitLoginFormAndAwaitApp } from './utils';
 
 const backendPort = process.env.BACKEND_PORT ?? '8000';
 const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
@@ -52,8 +53,7 @@ async function loginWithFreshProject(
   await page.goto('/login');
   await page.getByLabel('E-Mail').fill(setup.admin.email);
   await page.locator('input[type="password"]').fill(setup.admin.password);
-  await page.getByRole('button', { name: 'Anmelden' }).click();
-  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await submitLoginFormAndAwaitApp(page);
   await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
 }
 

--- a/frontend/e2e/focus-region-outline.spec.ts
+++ b/frontend/e2e/focus-region-outline.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
-import { MAIN_ROUTES, waitForPageStable } from './utils';
+import { MAIN_ROUTES, submitLoginFormAndAwaitApp, waitForPageStable } from './utils';
 
 const backendPort = process.env.BACKEND_PORT ?? '8000';
 const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
@@ -50,8 +50,7 @@ async function loginWithFreshProject(
   await page.goto('/login');
   await page.getByLabel('E-Mail').fill(setup.admin.email);
   await page.locator('input[type="password"]').fill(setup.admin.password);
-  await page.getByRole('button', { name: 'Anmelden' }).click();
-  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await submitLoginFormAndAwaitApp(page);
   await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
 }
 

--- a/frontend/e2e/gantt-layout.spec.ts
+++ b/frontend/e2e/gantt-layout.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { submitLoginFormAndAwaitApp } from './utils';
 
 const backendPort = process.env.BACKEND_PORT ?? '8000';
 const e2eToken = process.env.E2E_TEST_TOKEN || 'openfarmplanner-e2e-token';
@@ -50,8 +51,7 @@ async function loginWithFreshProject(page: Page, request: APIRequestContext, sce
   await page.goto('/login');
   await page.getByLabel('E-Mail').fill(setup.admin.email);
   await page.locator('input[type="password"]').fill(setup.admin.password);
-  await page.getByRole('button', { name: 'Anmelden' }).click();
-  await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  await submitLoginFormAndAwaitApp(page);
   await expect.poll(() => page.evaluate(() => window.localStorage.getItem('activeProjectId'))).toBeTruthy();
 }
 

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -46,6 +46,25 @@ export async function setupUserWithoutProjects(
   return fixture.user;
 }
 
+// Submits the already-filled login form and waits for the app shell. A
+// transiently failed login request (backend/network hiccup under CI load)
+// keeps the login form on screen with an error alert instead of navigating,
+// so one resubmit is attempted before failing the test. Anything else — e.g.
+// a slow but ongoing navigation where the form is already gone — rethrows.
+export async function submitLoginFormAndAwaitApp(page: Page): Promise<void> {
+  const submit = page.getByRole('button', { name: 'Anmelden' });
+  await submit.click();
+  try {
+    await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  } catch (error) {
+    if (!(await submit.isVisible().catch(() => false))) {
+      throw error;
+    }
+    await submit.click();
+    await expect(page).toHaveURL(/\/app\//, { timeout: 10_000 });
+  }
+}
+
 export async function loginWithDeterministicProject(
   page: Page,
   request: APIRequestContext,
@@ -66,8 +85,7 @@ export async function loginWithDeterministicProject(
   await page.goto(options.loginAsAdmin ? '/login' : fixture.inviteUrl);
   await page.getByLabel('E-Mail').fill(loginUser.email);
   await page.locator('input[type="password"]').fill(loginUser.password);
-  await page.getByRole('button', { name: 'Anmelden' }).click();
-  await expect.poll(() => page.evaluate(() => window.location.pathname)).toMatch(/^\/app\//);
+  await submitLoginFormAndAwaitApp(page);
 }
 
 // Saves a fields-beds hierarchy row by tabbing through the editable cells, then


### PR DESCRIPTION
## Problem

Die Login-Helper der e2e-Specs klicken einmal auf „Anmelden" und erwarten dann `/app/` innerhalb von 10 s. Schlägt der Login-Request transient fehl (Backend-/Netzwerk-Hickser unter CI-Last), bleibt die Login-Seite mit Error-Alert stehen und der Test stirbt an der URL-Assertion — zuletzt zweimal in `focus-region-outline.spec.ts` (u. a. beim CI-Lauf zu #317, wo erst ein Rerun grün wurde). Throttling ist als Ursache bereits ausgeschlossen: `playwright.config.ts` setzt `THROTTLE_AUTH_LOGIN=1000/minute` genau wegen eines früheren Login-Flakes.

## Fix

Neuer gemeinsamer Helper `submitLoginFormAndAwaitApp` in `e2e/utils.ts`: klickt „Anmelden", wartet auf `/app/`, und wiederholt den Submit **genau einmal** — aber nur, wenn das Login-Formular danach noch sichtbar ist (d. h. der Login tatsächlich fehlgeschlagen ist). Ist das Formular weg (z. B. langsame, aber laufende Navigation), wird der ursprüngliche Fehler unverändert geworfen.

Verwendet in `loginWithDeterministicProject` (utils) und den drei Specs mit identischen lokalen Login-Helpern: `focus-region-outline`, `fields-beds-keyboard-focus`, `gantt-layout`. Inline-Logins mit abweichenden Flows (invitation-flow, onboarding etc.) sind bewusst unangetastet.

## Verifikation

Lokal gegen echten Backend+Preview-Stack (Playwright webServer):
- `focus-region-outline.spec.ts`: 2 passed
- `fields-beds-keyboard-focus.spec.ts` + `fields-beds-click-outside.spec.ts` (nutzt den utils-Helper): 5 passed
- `gantt-layout.spec.ts`: 5 passed
- `tsc -b` und ESLint auf den geänderten Dateien sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_