### PR TITLE
refactor(frontend): extract RootLayout dialogs into presentational components

### DIFF
--- a/frontend/src/navigation/CreateProjectDialog.tsx
+++ b/frontend/src/navigation/CreateProjectDialog.tsx
@@ -1,0 +1,62 @@
+import type { FormEvent } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+} from '@mui/material';
+
+import { useTranslation } from '../i18n';
+
+interface CreateProjectDialogProps {
+  open: boolean;
+  name: string;
+  onNameChange: (value: string) => void;
+  isCreating: boolean;
+  onClose: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+/**
+ * Presentational create-project dialog. The draft name, submit handler and
+ * open state live in RootLayout.tsx; this component only renders the form.
+ */
+export function CreateProjectDialog({
+  open,
+  name,
+  onNameChange,
+  isCreating,
+  onClose,
+  onSubmit,
+}: CreateProjectDialogProps) {
+  const { t } = useTranslation('navigation');
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <Box component="form" onSubmit={onSubmit}>
+        <DialogTitle>{t('projectSwitcher.createDialogTitle')}</DialogTitle>
+        <DialogContent sx={{ pt: 1, pb: 1 }}>
+          <Stack spacing={1.5} sx={{ mt: 0.5 }}>
+            <TextField
+              label={t('projectSwitcher.createNameLabel')}
+              value={name}
+              onChange={(event) => onNameChange(event.target.value)}
+              autoFocus
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button type="button" onClick={onClose}>{t('projectSwitcher.createCancel')}</Button>
+          <Button type="submit" variant="contained" disabled={!name.trim() || isCreating}>
+            {t('projectSwitcher.createSubmit')}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/frontend/src/navigation/MobileProjectSwitcherDialog.tsx
+++ b/frontend/src/navigation/MobileProjectSwitcherDialog.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import CheckIcon from '@mui/icons-material/Check';
+
+import { useTranslation } from '../i18n';
+import type { ProjectMembershipInfo } from '../auth/types';
+
+interface MobileProjectSwitcherDialogProps {
+  open: boolean;
+  onClose: () => void;
+  activeProjectLabel: string;
+  memberships: ProjectMembershipInfo[];
+  activeProjectId: number | null;
+  isSwitchingProject: boolean;
+  onSwitchProject: (projectId: number) => void;
+  onOpenCreateProject: () => void;
+}
+
+/**
+ * Presentational mobile project-switcher dialog: shows the active project,
+ * the membership list and a create-project shortcut. All state and the
+ * switch/create handlers live in RootLayout.tsx; this component only renders.
+ */
+export function MobileProjectSwitcherDialog({
+  open,
+  onClose,
+  activeProjectLabel,
+  memberships,
+  activeProjectId,
+  isSwitchingProject,
+  onSwitchProject,
+  onOpenCreateProject,
+}: MobileProjectSwitcherDialogProps) {
+  const { t } = useTranslation('navigation');
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{t('projectSwitcher.ariaLabel')}</DialogTitle>
+      <DialogContent>
+        <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
+          {t('projectSwitcher.activeProject')}
+        </Typography>
+        <Paper variant="outlined" sx={{ p: 1.25, mb: 2 }}>
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <CheckIcon fontSize="small" color="success" />
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>{activeProjectLabel}</Typography>
+          </Stack>
+        </Paper>
+        <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
+          {t('projectSwitcher.projects')}
+        </Typography>
+        <List dense sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, py: 0 }}>
+          {memberships.length === 0 ? (
+            <ListItem><ListItemText primary={t('projectSwitcher.zeroProjects')} /></ListItem>
+          ) : memberships.map((membership) => (
+            <ListItemButton
+              key={`switcher-${membership.project_id}`}
+              onClick={() => onSwitchProject(membership.project_id)}
+              selected={membership.project_id === activeProjectId}
+              disabled={isSwitchingProject}
+            >
+              <ListItemIcon sx={{ minWidth: 28 }}>
+                {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" color="success" /> : null}
+              </ListItemIcon>
+              <ListItemText primary={membership.project_name} />
+            </ListItemButton>
+          ))}
+        </List>
+        <Button
+          startIcon={<AddIcon fontSize="small" />}
+          variant="outlined"
+          onClick={onOpenCreateProject}
+          sx={{ mt: 2, textTransform: 'none' }}
+        >
+          {t('project.create')}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/navigation/RestoreVersionDialog.tsx
+++ b/frontend/src/navigation/RestoreVersionDialog.tsx
@@ -1,0 +1,86 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+
+import type { CultureHistoryEntry } from '../api/types';
+
+interface RestoreVersionDialogProps {
+  /** The dialog is open while this is non-null. */
+  entry: CultureHistoryEntry | null;
+  /** Fallback title when the entry has no display name (page supplies i18n). */
+  getEntryTitle: (entry: CultureHistoryEntry) => string;
+  formatTimestamp: (value: string) => string;
+  onClose: () => void;
+  onConfirm: (historyId: number) => void;
+}
+
+/**
+ * Presentational confirmation dialog for restoring a project version from
+ * the history panel. State and the restore handler live in RootLayout.tsx;
+ * this component only renders. The copy is intentionally German-only,
+ * matching the original inline dialog.
+ */
+export function RestoreVersionDialog({
+  entry,
+  getEntryTitle,
+  formatTimestamp,
+  onClose,
+  onConfirm,
+}: RestoreVersionDialogProps) {
+  return (
+    <Dialog open={Boolean(entry)} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Version wiederherstellen?</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ mb: 1.5 }}>
+          Du stellst eine frühere Version wieder her.
+        </Typography>
+        {entry ? (
+          <Box sx={{ mb: 1.5 }}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {entry.object_display_name?.trim() || getEntryTitle(entry)}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Bearbeitet am {formatTimestamp(entry.history_date)}
+            </Typography>
+          </Box>
+        ) : null}
+        <Box
+          sx={{
+            borderRadius: 1.5,
+            border: '1px solid',
+            borderColor: 'success.light',
+            bgcolor: 'rgba(76, 175, 80, 0.08)',
+            px: 1.25,
+            py: 1,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Die aktuelle Version bleibt erhalten. Vor der Wiederherstellung wird automatisch eine neue Version erstellt, sodass du jederzeit wieder zurückwechseln kannst.
+          </Typography>
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+          Es gehen keine Daten verloren.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button autoFocus variant="outlined" onClick={onClose}>Abbrechen</Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            if (entry) {
+              onConfirm(entry.history_id);
+            }
+          }}
+        >
+          Version wiederherstellen
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/navigation/RootLayout.tsx
+++ b/frontend/src/navigation/RootLayout.tsx
@@ -28,7 +28,6 @@ import {
   Stack,
   SvgIcon,
   type SvgIconProps,
-  TextField,
   Drawer,
   ListItemButton,
   ListItemIcon,
@@ -72,6 +71,9 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { cultureAPI, projectAPI } from '../api/api';
 import type { CultureHistoryEntry } from '../api/types';
+import { MobileProjectSwitcherDialog } from './MobileProjectSwitcherDialog';
+import { RestoreVersionDialog } from './RestoreVersionDialog';
+import { CreateProjectDialog } from './CreateProjectDialog';
 import { useAuth } from '../auth/useAuth';
 import type { RootLayoutOutletContext, TopbarContextAction } from '../navigation/topbarTypes';
 import AppLogo from '../components/layout/AppLogo';
@@ -1910,120 +1912,32 @@ function RootLayout() {
       </Dialog>
 
       <HelpDialog open={globalHelpOpen} onClose={closeGlobalHelp} />
-      <Dialog open={mobileProjectSwitcherOpen} onClose={handleCloseMobileProjectSwitcher} fullWidth maxWidth="sm">
-        <DialogTitle>{t('projectSwitcher.ariaLabel')}</DialogTitle>
-        <DialogContent>
-          <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
-            {t('projectSwitcher.activeProject')}
-          </Typography>
-          <Paper variant="outlined" sx={{ p: 1.25, mb: 2 }}>
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <CheckIcon fontSize="small" color="success" />
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>{activeProjectLabel}</Typography>
-            </Stack>
-          </Paper>
-          <Typography variant="caption" sx={{ display: 'block', mb: 1.25, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.4 }}>
-            {t('projectSwitcher.projects')}
-          </Typography>
-          <List dense sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, py: 0 }}>
-            {memberships.length === 0 ? (
-              <ListItem><ListItemText primary={t('projectSwitcher.zeroProjects')} /></ListItem>
-            ) : memberships.map((membership) => (
-              <ListItemButton
-                key={`switcher-${membership.project_id}`}
-                onClick={() => void handleSwitchProject(membership.project_id)}
-                selected={membership.project_id === activeProjectId}
-                disabled={isSwitchingProject}
-              >
-                <ListItemIcon sx={{ minWidth: 28 }}>
-                  {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" color="success" /> : null}
-                </ListItemIcon>
-                <ListItemText primary={membership.project_name} />
-              </ListItemButton>
-            ))}
-          </List>
-          <Button
-            startIcon={<AddIcon fontSize="small" />}
-            variant="outlined"
-            onClick={handleOpenCreateProject}
-            sx={{ mt: 2, textTransform: 'none' }}
-          >
-            {t('project.create')}
-          </Button>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={Boolean(pendingRestoreEntry)} onClose={() => setPendingRestoreEntry(null)} fullWidth maxWidth="xs">
-        <DialogTitle>Version wiederherstellen?</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" sx={{ mb: 1.5 }}>
-            Du stellst eine frühere Version wieder her.
-          </Typography>
-          {pendingRestoreEntry ? (
-            <Box sx={{ mb: 1.5 }}>
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {pendingRestoreEntry.object_display_name?.trim() || getHistoryEntryTitle(pendingRestoreEntry, tCultures)}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                Bearbeitet am {formatHistoryTimestamp(pendingRestoreEntry.history_date)}
-              </Typography>
-            </Box>
-          ) : null}
-          <Box
-            sx={{
-              borderRadius: 1.5,
-              border: '1px solid',
-              borderColor: 'success.light',
-              bgcolor: 'rgba(76, 175, 80, 0.08)',
-              px: 1.25,
-              py: 1,
-            }}
-          >
-            <Typography variant="body2" sx={{ fontWeight: 500 }}>
-              Die aktuelle Version bleibt erhalten. Vor der Wiederherstellung wird automatisch eine neue Version erstellt, sodass du jederzeit wieder zurückwechseln kannst.
-            </Typography>
-          </Box>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
-            Es gehen keine Daten verloren.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button autoFocus variant="outlined" onClick={() => setPendingRestoreEntry(null)}>Abbrechen</Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              if (pendingRestoreEntry) {
-                void handleRestoreProjectVersion(pendingRestoreEntry.history_id);
-              }
-            }}
-          >
-            Version wiederherstellen
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <MobileProjectSwitcherDialog
+        open={mobileProjectSwitcherOpen}
+        onClose={handleCloseMobileProjectSwitcher}
+        activeProjectLabel={activeProjectLabel}
+        memberships={memberships}
+        activeProjectId={activeProjectId}
+        isSwitchingProject={isSwitchingProject}
+        onSwitchProject={(projectId) => void handleSwitchProject(projectId)}
+        onOpenCreateProject={handleOpenCreateProject}
+      />
+      <RestoreVersionDialog
+        entry={pendingRestoreEntry}
+        getEntryTitle={(entry) => getHistoryEntryTitle(entry, tCultures)}
+        formatTimestamp={formatHistoryTimestamp}
+        onClose={() => setPendingRestoreEntry(null)}
+        onConfirm={(historyId) => void handleRestoreProjectVersion(historyId)}
+      />
 
-
-      <Dialog open={isCreateProjectOpen} onClose={closeCreateProjectDialog} fullWidth maxWidth="xs">
-        <Box component="form" onSubmit={handleCreateProjectSubmit}>
-          <DialogTitle>{t('projectSwitcher.createDialogTitle')}</DialogTitle>
-          <DialogContent sx={{ pt: 1, pb: 1 }}>
-            <Stack spacing={1.5} sx={{ mt: 0.5 }}>
-              <TextField
-                label={t('projectSwitcher.createNameLabel')}
-                value={newProjectName}
-                onChange={(event) => setNewProjectName(event.target.value)}
-                autoFocus
-                fullWidth
-              />
-            </Stack>
-          </DialogContent>
-          <DialogActions>
-            <Button type="button" onClick={closeCreateProjectDialog}>{t('projectSwitcher.createCancel')}</Button>
-            <Button type="submit" variant="contained" disabled={!newProjectName.trim() || isCreatingProject}>
-              {t('projectSwitcher.createSubmit')}
-            </Button>
-          </DialogActions>
-        </Box>
-      </Dialog>
+      <CreateProjectDialog
+        open={isCreateProjectOpen}
+        name={newProjectName}
+        onNameChange={setNewProjectName}
+        isCreating={isCreatingProject}
+        onClose={closeCreateProjectDialog}
+        onSubmit={handleCreateProjectSubmit}
+      />
 
       <AlertSnackbar
         open={snackbar.open}


### PR DESCRIPTION
## Was

Start des Frontend-Teils der Etappe: die drei Dialoge am Ende der Navigation-Shell wandern aus `RootLayout.tsx` (2053 → 1967 Zeilen) in **rein präsentationale Komponenten** daneben in `src/navigation/`:

- `MobileProjectSwitcherDialog` — aktives Projekt, Mitgliedschafts-Liste, „Projekt anlegen"-Shortcut
- `RestoreVersionDialog` — die Bestätigung „Version wiederherstellen?" (bewusst deutschsprachige Copy verbatim übernommen); Titel-Fallback und Zeitstempel-Formatierung liefert die Page als Props
- `CreateProjectDialog` — das Anlege-Formular

Sämtlicher State und die Switch-/Restore-/Create-Handler bleiben in `RootLayout`; die Komponenten rendern nur Props (etabliertes Muster aus #313–#320, keine Stateful-Hook-Extraktionen).

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (inkl. noUnusedLocals; ungenutzter `TextField`-Import entfernt)
- ESLint: regelgenaue Parität mit main für `RootLayout.tsx` (Stash-Vergleich); alle drei neuen Komponenten ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_