### PR TITLE
refactor(frontend): extract DataGrid DOM-target helpers into a module

### DIFF
--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -31,6 +31,11 @@ import {
 } from '@mui/x-data-grid';
 import { dataGridSx, dataGridFooterSx, dataGridAddRowButtonSx, deleteIconButtonSx } from './styles';
 import { handleRowEditStop, handleEditableCellClick } from './handlers';
+import {
+  editModeEditorArrowKeys,
+  getRowIdFromElement,
+  isEnterSaveInputTarget,
+} from './domEventTargets';
 import type { GridColDef, GridRowsProp, GridRowModesModel, GridRowId, GridSortModel, GridFilterModel, GridCellParams, GridRenderCellParams, GridRowParams, GridPaginationModel } from '@mui/x-data-grid';
 import { Box, Alert, IconButton, Chip, Button, Tooltip, useMediaQuery } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
@@ -102,24 +107,9 @@ export type {
   NotesFieldConfig,
 } from './types';
 
-const editModeEditorArrowKeys = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
-
 type DataGridKeyboardEvent = KeyboardEvent & {
   defaultMuiPrevented?: boolean;
 };
-
-const isComboboxInteractionTarget = (target: EventTarget | null): boolean => {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  return Boolean(
-    target.closest('[role="combobox"], [aria-haspopup="listbox"], [aria-haspopup="menu"]'),
-  );
-};
-
-const isEnterSaveInputTarget = (target: EventTarget | null): boolean =>
-  target instanceof HTMLInputElement && !isComboboxInteractionTarget(target);
 
 export function EditableDataGrid<T extends EditableRow>({
   columns,
@@ -1160,14 +1150,6 @@ export function EditableDataGrid<T extends EditableRow>({
     onBeforeEdit: rememberRowSnapshotForCellEdit,
     onReplaceValue: (params) => markRowDirty(String(params.id)),
   });
-
-  const getRowIdFromElement = (target: EventTarget | null): GridRowId | null => {
-    if (!(target instanceof HTMLElement)) {
-      return null;
-    }
-    const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
-    return rowElement?.dataset.id ?? null;
-  };
 
   const hasContextualRowActions = true;
 

--- a/frontend/src/components/data-grid/domEventTargets.ts
+++ b/frontend/src/components/data-grid/domEventTargets.ts
@@ -1,0 +1,27 @@
+// Pure DOM-target helpers for EditableDataGrid's keyboard/pointer handling.
+// Extracted from DataGrid.tsx; all functions only inspect the event target,
+// they hold no grid state.
+import type { GridRowId } from '@mui/x-data-grid';
+
+export const editModeEditorArrowKeys = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']);
+
+export const isComboboxInteractionTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest('[role="combobox"], [aria-haspopup="listbox"], [aria-haspopup="menu"]'),
+  );
+};
+
+export const isEnterSaveInputTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLInputElement && !isComboboxInteractionTarget(target);
+
+export const getRowIdFromElement = (target: EventTarget | null): GridRowId | null => {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+  const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
+  return rowElement?.dataset.id ?? null;
+};


### PR DESCRIPTION
## Was

Letzter Schritt der Etappe: erste, bewusst kleine Runde an `DataGrid.tsx` (2185 Zeilen, Infrastruktur für fast alle Tabellen). Die puren DOM-Event-Target-Helfer wandern in ein eigenes Modul `components/data-grid/domEventTargets.ts`:

- `editModeEditorArrowKeys`, `isComboboxInteractionTarget`, `isEnterSaveInputTarget` (bisher Modul-Level in DataGrid.tsx)
- `getRowIdFromElement` (bisher **pro Render neu erzeugt** im Komponenten-Rumpf und an `useDataGridRowActionMenu` übergeben — bekommt jetzt eine stabile Identität)

Alle Funktionen inspizieren nur das Event-Target und halten keinerlei Grid-State. Der `DataGridKeyboardEvent`-Typ bleibt bewusst lokal, weil `keyboardEditing.ts` einen gleichnamigen, abweichenden Typ definiert.

**Warum so klein:** Der restliche Komponenten-Rumpf besteht aus ~50 Closure-gebundenen `useCallback`/`useMemo`-Blöcken — dort wäre jede Extraktion eine Stateful-Hook-Extraktion, die nach der React-Compiler-Erfahrung aus #312 tabu ist. Dies ist der sichere Teil.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün (inkl. der DataGrid-spezifischen Tests)
- `tsc -b`: sauber (inkl. noUnusedLocals)
- ESLint: regelgenaue Parität mit main für `DataGrid.tsx` (Stash-Vergleich); `domEventTargets.ts` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_