### PR TITLE
refactor(frontend): extract Cultures page dialogs into presentational components

### DIFF
--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Link as RouterLink, useLocation, useNavigate, useOutletContext } from 'react-router-dom';
+import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
 import { bedAPI, cultureAPI, fieldAPI, type Culture } from '../api/api';
@@ -21,20 +21,6 @@ import { CultureForm } from '../cultures/CultureForm';
 import { PublicCultureLibraryDialog } from '../crops/components/PublicCultureLibraryDialog';
 import {
   Box,
-  Button,
-  Chip,
-  Divider,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  List,
-  ListItem,
-  ListItemText,
-  Paper,
-  Typography,
-  Link,
-  Stack,
   type SxProps,
   type Theme,
   useMediaQuery,
@@ -46,15 +32,7 @@ import {
 } from './culturesPageUtils';
 import { createCulturesCommandSpecs } from './culturesCommandSpecs';
 import { buildCultureSavePayload } from './culturesSaveUtils';
-import {
-  formatHistoryChangeValue,
-  getHistoryChangeFieldLabel,
-  getHistoryEntryMeta,
-  getHistoryEntryTarget,
-  getHistoryEntryTitle,
-  isCurrentHistoryEntry,
-  type HistoryScope,
-} from './culturesHistoryUtils';
+import { type HistoryScope } from './culturesHistoryUtils';
 import { useSelectedCultureSync } from './useSelectedCultureSync';
 import { useAuth } from '../auth/useAuth';
 import { usePublicCultureLibrary } from './usePublicCultureLibrary';
@@ -63,6 +41,8 @@ import { useCultureImportExport } from './useCultureImportExport';
 import { CulturesImportDialog } from './CulturesImportDialog';
 import { CulturesImportStartDialog } from './CulturesImportStartDialog';
 import { CulturesExportDialog } from './CulturesExportDialog';
+import { CulturesPublishConfirmDialog } from './CulturesPublishConfirmDialog';
+import { CulturesHistoryDialog } from './CulturesHistoryDialog';
 import { AlertSnackbar } from '../components/feedback/AlertSnackbar';
 import { ConfirmationDialog } from '../components/feedback/ConfirmationDialog';
 import { useProjectRequirement } from '../hooks/useProjectRequirement';
@@ -629,48 +609,13 @@ function Cultures() {
         confirmButtonProps={{ color: 'error', variant: 'contained' }}
       />
 
-      <Dialog
+      <CulturesPublishConfirmDialog
         open={publishConfirmOpen}
+        cultureName={selectedCulture?.name ?? ''}
         onClose={() => setPublishConfirmOpen(false)}
-        fullWidth
-        maxWidth="xs"
-      >
-        <DialogTitle sx={{ pb: 1 }}>
-          {t('library.publishConfirm.title')}
-        </DialogTitle>
-        <DialogContent sx={{ pt: 1 }}>
-          <Stack spacing={1.5}>
-            <Typography color="text.secondary">
-              {t('library.publishConfirm.intro', { name: selectedCulture?.name ?? '' })}
-            </Typography>
-            <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
-              <li>{t('library.publishConfirm.published')}</li>
-              <li>{t('library.publishConfirm.neverPublished')}</li>
-              <li>{t('library.publishConfirm.attribution')}</li>
-              <li>{t('library.publishConfirm.persistence')}</li>
-            </Box>
-            <Typography variant="body2" color="text.secondary">
-              {t('library.publishConfirm.linkPrefix')}
-              <Link component={RouterLink} to="/datenschutz" target="_blank" rel="noopener">
-                {t('library.publishConfirm.privacyLinkLabel')}
-              </Link>
-              {t('library.publishConfirm.linkMiddle')}
-              <Link component={RouterLink} to="/nutzungsbedingungen" target="_blank" rel="noopener">
-                {t('library.publishConfirm.termsLinkLabel')}
-              </Link>
-              {t('library.publishConfirm.linkSuffix')}
-            </Typography>
-          </Stack>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
-          <Button variant="outlined" onClick={() => setPublishConfirmOpen(false)}>
-            {t('common:actions.cancel')}
-          </Button>
-          <Button variant="contained" onClick={handlePublishConfirm}>
-            {t('library.publishConfirm.confirmButton')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onConfirm={handlePublishConfirm}
+        t={t}
+      />
 
       {showForm ? (
         <CultureForm
@@ -709,199 +654,16 @@ function Cultures() {
 
       {/* Snackbar for notifications */}
 
-      <Dialog open={historyOpen} onClose={() => setHistoryOpen(false)} fullWidth maxWidth="sm"> 
-        <DialogTitle>
-          {historyScope === 'project'
-            ? t('history.titles.project')
-            : historyScope === 'global'
-              ? t('history.titles.global')
-              : t('history.titles.culture')}
-        </DialogTitle>
-        <DialogContent sx={{ pt: historyItems.length === 0 ? 1 : 2, pb: historyItems.length === 0 ? 1 : 2 }}>
-          {historyItems.length === 0 ? (
-            <Box sx={{ py: isMobile ? 0.5 : 1 }}>
-              <Typography variant="body2" color="text.secondary">
-                {t('history.emptyState.title')}
-              </Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                {t('history.emptyState.description')}
-              </Typography>
-            </Box>
-          ) : (
-            <>
-            <List>
-              {historyItems.map((item, index) => {
-                const isCurrentVersion = isCurrentHistoryEntry(item, index);
-                const isCultureHistory = historyScope === 'culture';
-                const historyTarget = getHistoryEntryTarget(item);
-                const mobileTitle = getHistoryEntryTitle(item, t);
-                const mobileMeta = getHistoryEntryMeta(item, t, fallbackHistoryActorLabel);
-                const changes = item.changes ?? [];
-                const changeList = changes.length > 0 ? (
-                  <Stack spacing={0.5} sx={{ mt: 0.5 }}>
-                    <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
-                      {t('history.changedFields')}
-                    </Typography>
-                    <Stack component="ul" spacing={0.25} sx={{ m: 0, pl: 2 }}>
-                      {changes.map((change) => (
-                        <Typography
-                          key={`${item.history_id}-${change.field}`}
-                          component="li"
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ lineHeight: 1.35 }}
-                        >
-                          <Typography component="span" variant="caption" sx={{ color: 'text.primary', fontWeight: 600 }}>
-                            {getHistoryChangeFieldLabel(change, t)}
-                          </Typography>
-                          {': '}
-                          {change.field === 'created'
-                            ? formatHistoryChangeValue(change.new_value, change.field, t)
-                            : `${formatHistoryChangeValue(change.old_value, change.field, t)} → ${formatHistoryChangeValue(change.new_value, change.field, t)}`}
-                        </Typography>
-                      ))}
-                    </Stack>
-                  </Stack>
-                ) : null;
-                return (
-                  <ListItem key={item.history_id} disableGutters sx={{ mb: isMobile ? 1 : 0 }}>
-                    {isMobile ? (
-                      <Paper variant="outlined" sx={{ width: '100%', p: 1.25, borderRadius: 1.5 }}>
-                        <Stack spacing={1}>
-                          {!isCultureHistory ? (
-                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
-                              <Chip
-                                size="small"
-                                label={item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
-                                variant="outlined"
-                              />
-                              {historyTarget ? (
-                                <Link
-                                  component={RouterLink}
-                                  to={historyTarget}
-                                  underline="hover"
-                                  onClick={() => setHistoryOpen(false)}
-                                  sx={{ fontSize: '0.78rem', color: 'text.secondary', flexShrink: 0 }}
-                                >
-                                  {t('history.objectTypes.openTarget')}
-                                </Link>
-                              ) : null}
-                            </Box>
-                          ) : null}
-                          {!isCultureHistory ? (
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                fontWeight: 600,
-                                lineHeight: 1.35,
-                                display: '-webkit-box',
-                                WebkitLineClamp: 2,
-                                WebkitBoxOrient: 'vertical',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                wordBreak: 'normal',
-                                overflowWrap: 'break-word',
-                              }}
-                            >
-                              {mobileTitle}
-                            </Typography>
-                          ) : null}
-                          <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            sx={{
-                              lineHeight: 1.3,
-                              display: '-webkit-box',
-                              WebkitLineClamp: 2,
-                              WebkitBoxOrient: 'vertical',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              wordBreak: 'normal',
-                              overflowWrap: 'break-word',
-                            }}
-                          >
-                            {mobileMeta}
-                          </Typography>
-                          {isCultureHistory ? changeList : null}
-                          <Divider />
-                          {isCurrentVersion ? (
-                            <Chip
-                              label={t('history.currentVersion')}
-                              size="small"
-                              color="success"
-                              variant="outlined"
-                              sx={{ alignSelf: 'flex-start' }}
-                            />
-                          ) : (
-                            <Button
-                              variant="outlined"
-                              size="small"
-                              onClick={() => handleRestoreVersion(item.history_id)}
-                              sx={{ alignSelf: 'flex-start', minHeight: 34 }}
-                            >
-                              {t('history.restoreButton')}
-                            </Button>
-                          )}
-                        </Stack>
-                      </Paper>
-                    ) : (
-                      <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
-                        <ListItemText
-                          sx={{ mr: 1 }}
-                          disableTypography
-                          primary={!isCultureHistory ? (
-                            <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.35 }}>
-                              {mobileTitle}
-                              {historyTarget ? (
-                                <>
-                                  {' · '}
-                                  <Link component={RouterLink} to={historyTarget} underline="hover" onClick={() => setHistoryOpen(false)}>
-                                    {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
-                                  </Link>
-                                </>
-                              ) : null}
-                            </Typography>
-                          ) : (
-                            <Typography variant="caption" color="text.secondary">
-                              {mobileMeta}
-                            </Typography>
-                          )}
-                          secondary={isCultureHistory ? changeList : (
-                            <Typography variant="caption" color="text.secondary">
-                              {mobileMeta}
-                            </Typography>
-                          )}
-                        />
-                        {isCurrentVersion ? (
-                          <Chip
-                            label={t('history.currentVersion')}
-                            size="small"
-                            color="success"
-                            variant="outlined"
-                          />
-                        ) : (
-                          <Button onClick={() => handleRestoreVersion(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
-                            {t('history.restoreButton')}
-                          </Button>
-                        )}
-                      </Stack>
-                    )}
-                  </ListItem>
-                );
-              })}
-            </List>
-            {historyItems.length === 1 && (
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, pt: 1, borderTop: 1, borderColor: 'divider' }}>
-                {t('history.emptyState.onlyCurrentVersion')}
-              </Typography>
-            )}
-            </>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setHistoryOpen(false)}>{t('history.closeButton')}</Button>
-        </DialogActions>
-      </Dialog>
+      <CulturesHistoryDialog
+        open={historyOpen}
+        scope={historyScope}
+        items={historyItems}
+        isMobile={isMobile}
+        fallbackActorLabel={fallbackHistoryActorLabel}
+        onClose={() => setHistoryOpen(false)}
+        onRestore={handleRestoreVersion}
+        t={t}
+      />
 
 
 

--- a/frontend/src/pages/CulturesHistoryDialog.tsx
+++ b/frontend/src/pages/CulturesHistoryDialog.tsx
@@ -1,0 +1,254 @@
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+import type { TFunction } from 'i18next';
+
+import type { CultureHistoryEntry } from '../api/types';
+import {
+  formatHistoryChangeValue,
+  getHistoryChangeFieldLabel,
+  getHistoryEntryMeta,
+  getHistoryEntryTarget,
+  getHistoryEntryTitle,
+  isCurrentHistoryEntry,
+  type HistoryScope,
+} from './culturesHistoryUtils';
+
+type CulturesHistoryDialogProps = {
+  open: boolean;
+  scope: HistoryScope;
+  items: CultureHistoryEntry[];
+  isMobile: boolean;
+  fallbackActorLabel: string | undefined;
+  onClose: () => void;
+  onRestore: (historyId: number) => void;
+  t: TFunction<'cultures'>;
+};
+
+/**
+ * Presentational history dialog for the cultures page (culture, project and
+ * global scopes; mobile card and desktop list layouts). State, data loading
+ * and the restore handler live in Cultures.tsx.
+ */
+export function CulturesHistoryDialog({
+  open,
+  scope,
+  items,
+  isMobile,
+  fallbackActorLabel,
+  onClose,
+  onRestore,
+  t,
+}: CulturesHistoryDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {scope === 'project'
+          ? t('history.titles.project')
+          : scope === 'global'
+            ? t('history.titles.global')
+            : t('history.titles.culture')}
+      </DialogTitle>
+      <DialogContent sx={{ pt: items.length === 0 ? 1 : 2, pb: items.length === 0 ? 1 : 2 }}>
+        {items.length === 0 ? (
+          <Box sx={{ py: isMobile ? 0.5 : 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              {t('history.emptyState.title')}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              {t('history.emptyState.description')}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+          <List>
+            {items.map((item, index) => {
+              const isCurrentVersion = isCurrentHistoryEntry(item, index);
+              const isCultureHistory = scope === 'culture';
+              const historyTarget = getHistoryEntryTarget(item);
+              const mobileTitle = getHistoryEntryTitle(item, t);
+              const mobileMeta = getHistoryEntryMeta(item, t, fallbackActorLabel);
+              const changes = item.changes ?? [];
+              const changeList = changes.length > 0 ? (
+                <Stack spacing={0.5} sx={{ mt: 0.5 }}>
+                  <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                    {t('history.changedFields')}
+                  </Typography>
+                  <Stack component="ul" spacing={0.25} sx={{ m: 0, pl: 2 }}>
+                    {changes.map((change) => (
+                      <Typography
+                        key={`${item.history_id}-${change.field}`}
+                        component="li"
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ lineHeight: 1.35 }}
+                      >
+                        <Typography component="span" variant="caption" sx={{ color: 'text.primary', fontWeight: 600 }}>
+                          {getHistoryChangeFieldLabel(change, t)}
+                        </Typography>
+                        {': '}
+                        {change.field === 'created'
+                          ? formatHistoryChangeValue(change.new_value, change.field, t)
+                          : `${formatHistoryChangeValue(change.old_value, change.field, t)} → ${formatHistoryChangeValue(change.new_value, change.field, t)}`}
+                      </Typography>
+                    ))}
+                  </Stack>
+                </Stack>
+              ) : null;
+              return (
+                <ListItem key={item.history_id} disableGutters sx={{ mb: isMobile ? 1 : 0 }}>
+                  {isMobile ? (
+                    <Paper variant="outlined" sx={{ width: '100%', p: 1.25, borderRadius: 1.5 }}>
+                      <Stack spacing={1}>
+                        {!isCultureHistory ? (
+                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+                            <Chip
+                              size="small"
+                              label={item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
+                              variant="outlined"
+                            />
+                            {historyTarget ? (
+                              <Link
+                                component={RouterLink}
+                                to={historyTarget}
+                                underline="hover"
+                                onClick={onClose}
+                                sx={{ fontSize: '0.78rem', color: 'text.secondary', flexShrink: 0 }}
+                              >
+                                {t('history.objectTypes.openTarget')}
+                              </Link>
+                            ) : null}
+                          </Box>
+                        ) : null}
+                        {!isCultureHistory ? (
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontWeight: 600,
+                              lineHeight: 1.35,
+                              display: '-webkit-box',
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              wordBreak: 'normal',
+                              overflowWrap: 'break-word',
+                            }}
+                          >
+                            {mobileTitle}
+                          </Typography>
+                        ) : null}
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            lineHeight: 1.3,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            wordBreak: 'normal',
+                            overflowWrap: 'break-word',
+                          }}
+                        >
+                          {mobileMeta}
+                        </Typography>
+                        {isCultureHistory ? changeList : null}
+                        <Divider />
+                        {isCurrentVersion ? (
+                          <Chip
+                            label={t('history.currentVersion')}
+                            size="small"
+                            color="success"
+                            variant="outlined"
+                            sx={{ alignSelf: 'flex-start' }}
+                          />
+                        ) : (
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            onClick={() => onRestore(item.history_id)}
+                            sx={{ alignSelf: 'flex-start', minHeight: 34 }}
+                          >
+                            {t('history.restoreButton')}
+                          </Button>
+                        )}
+                      </Stack>
+                    </Paper>
+                  ) : (
+                    <Stack direction="row" spacing={2} alignItems="flex-start" sx={{ width: '100%' }}>
+                      <ListItemText
+                        sx={{ mr: 1 }}
+                        disableTypography
+                        primary={!isCultureHistory ? (
+                          <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.35 }}>
+                            {mobileTitle}
+                            {historyTarget ? (
+                              <>
+                                {' · '}
+                                <Link component={RouterLink} to={historyTarget} underline="hover" onClick={onClose}>
+                                  {item.object_type === 'culture' ? t('history.objectTypes.culture') : t('history.objectTypes.plantingPlan')}
+                                </Link>
+                              </>
+                            ) : null}
+                          </Typography>
+                        ) : (
+                          <Typography variant="caption" color="text.secondary">
+                            {mobileMeta}
+                          </Typography>
+                        )}
+                        secondary={isCultureHistory ? changeList : (
+                          <Typography variant="caption" color="text.secondary">
+                            {mobileMeta}
+                          </Typography>
+                        )}
+                      />
+                      {isCurrentVersion ? (
+                        <Chip
+                          label={t('history.currentVersion')}
+                          size="small"
+                          color="success"
+                          variant="outlined"
+                        />
+                      ) : (
+                        <Button onClick={() => onRestore(item.history_id)} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>
+                          {t('history.restoreButton')}
+                        </Button>
+                      )}
+                    </Stack>
+                  )}
+                </ListItem>
+              );
+            })}
+          </List>
+          {items.length === 1 && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, pt: 1, borderTop: 1, borderColor: 'divider' }}>
+              {t('history.emptyState.onlyCurrentVersion')}
+            </Typography>
+          )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('history.closeButton')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/CulturesPublishConfirmDialog.tsx
+++ b/frontend/src/pages/CulturesPublishConfirmDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+type Translator = (key: string, options?: Record<string, unknown>) => string;
+
+type CulturesPublishConfirmDialogProps = {
+  open: boolean;
+  cultureName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  t: Translator;
+};
+
+/**
+ * Presentational confirmation dialog for publishing a culture to the public
+ * library. State and the publish handler live in Cultures.tsx.
+ */
+export function CulturesPublishConfirmDialog({
+  open,
+  cultureName,
+  onClose,
+  onConfirm,
+  t,
+}: CulturesPublishConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        {t('library.publishConfirm.title')}
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Stack spacing={1.5}>
+          <Typography color="text.secondary">
+            {t('library.publishConfirm.intro', { name: cultureName })}
+          </Typography>
+          <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
+            <li>{t('library.publishConfirm.published')}</li>
+            <li>{t('library.publishConfirm.neverPublished')}</li>
+            <li>{t('library.publishConfirm.attribution')}</li>
+            <li>{t('library.publishConfirm.persistence')}</li>
+          </Box>
+          <Typography variant="body2" color="text.secondary">
+            {t('library.publishConfirm.linkPrefix')}
+            <Link component={RouterLink} to="/datenschutz" target="_blank" rel="noopener">
+              {t('library.publishConfirm.privacyLinkLabel')}
+            </Link>
+            {t('library.publishConfirm.linkMiddle')}
+            <Link component={RouterLink} to="/nutzungsbedingungen" target="_blank" rel="noopener">
+              {t('library.publishConfirm.termsLinkLabel')}
+            </Link>
+            {t('library.publishConfirm.linkSuffix')}
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
+        <Button variant="outlined" onClick={onClose}>
+          {t('common:actions.cancel')}
+        </Button>
+        <Button variant="contained" onClick={onConfirm}>
+          {t('library.publishConfirm.confirmButton')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Was

Fortsetzung des iterativen Zyklus im Frontend: die zwei letzten Inline-Dialoge der Kulturen-Page wandern in präsentationale Komponenten — als Nachbarn der bereits bestehenden Dialog-Dateien in `src/pages/` und nach deren Konvention (Translator als Prop):

- **`CulturesPublishConfirmDialog`** — die Bestätigung „In öffentliche Bibliothek veröffentlichen" mit Datenschutz-/Nutzungsbedingungen-Links
- **`CulturesHistoryDialog`** — der Versions-Dialog für Kultur-/Projekt-/Global-Scope mit Mobile-Karten- und Desktop-Listen-Layout (~190 Zeilen JSX); als Prop-Typ bewusst `TFunction<'cultures'>`, weil die `culturesHistoryUtils`-Helfer diesen verlangen

State, Datenladen und die Publish-/Restore-Handler bleiben in `Cultures.tsx` — die Page schrumpft von 942 auf 704 Zeilen; 14 nicht mehr benötigte MUI-/Util-Imports entfernt.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1140 Tests / 126 Dateien grün
- `tsc -b`: sauber (Exit-Code geprüft)
- ESLint: regelgenaue Parität mit main für `Cultures.tsx` (Stash-Vergleich); beide neuen Komponenten ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_