### PR TITLE
Grafik-bearbeiten-Button direkt neben den Standortnamen setzen

### DIFF
--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -1101,14 +1101,23 @@ export default function GraphicalFields({
                   sx={{
                     display: "flex",
                     alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: 1,
+                    justifyContent: "flex-start",
+                    flexWrap: "nowrap",
+                    gap: 1.5,
                     minWidth: 0,
                     width: "100%",
                     pr: 1,
                   }}
                 >
-                  <Typography variant="h6" sx={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+                  <Typography
+                    variant="h6"
+                    sx={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
                     {t("fields:graphical.locationTitle", { name: location.name })}
                   </Typography>
                   {!globalEditMode ? (


### PR DESCRIPTION
## Ziel

Der Button **„Grafik bearbeiten"** wird direkt neben den Standortnamen (z. B. „Standort: Hauptstandort") gesetzt, sodass eindeutig erkennbar ist, dass sich die Aktion auf diesen Standort bezieht.

## Änderungen

In `frontend/src/pages/GraphicalFields.tsx` (Kopfzeile der Standort-Accordion `AccordionSummary`):

- **Position:** Layout von `justifyContent: "space-between"` auf `flex-start` umgestellt. Der Button rutscht damit vom rechten Rand direkt neben den Standorttitel.
- **Abstand:** `gap` von `1` auf `1.5` (12 px) erhöht — angenehmer Abstand, ohne dass Titel und Button getrennt wirken.
- **Kein Umbruch:** `flexWrap: "nowrap"` am Container und `whiteSpace: "nowrap"` am Titel ergänzt. Lange Standortnamen werden per Ellipsis abgeschnitten (`minWidth: 0` + `overflow: hidden` + `textOverflow: ellipsis`), sodass der Button auf Desktop und Mobilgeräten sauber neben dem Titel bleibt und keine umbrechenden Layouts entstehen.
- **Visuelle Dominanz unverändert:** Am Button selbst (Größe, Farbe, Stil, Gewichtung) wurde nichts geändert — weder an der Desktop- noch an der mobilen Icon-Variante.

Die restliche Oberfläche und die Kartenansicht bleiben unverändert.

## Tests

- `GraphicalFields.test.tsx`: 18/18 bestanden
- `tsc --noEmit`: keine Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpfy3YyfdR6eaEAvWCxpSv)_