### PR TITLE
feat: auto-place new beds without overlapping existing beds

### DIFF
--- a/frontend/src/__tests__/graphicalLayoutUtils.test.ts
+++ b/frontend/src/__tests__/graphicalLayoutUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { areaToRectSize, clampInsideParent, getBedRectSize, getBedRectSizeWithinField, getBedScaleFromField, getFieldRectSize, initialAutoLayout } from '../pages/graphicalLayoutUtils';
+import { areaToRectSize, clampInsideParent, findFreePlacementPosition, getBedRectSize, getBedRectSizeWithinField, getBedScaleFromField, getFieldRectSize, initialAutoLayout, rectsOverlap, type Rect } from '../pages/graphicalLayoutUtils';
 
 describe('graphicalLayoutUtils', () => {
   it('returns deterministic area size', () => {
@@ -121,5 +121,79 @@ describe('graphicalLayoutUtils', () => {
     expect(output.get(1)?.x).toBe(10);
     expect(output.get(2)?.y).toBe(10);
     expect(output.get(3)?.y).toBe(70);
+  });
+
+  it('detects rectangle intersection with and without spacing', () => {
+    const a: Rect = { x: 0, y: 0, width: 50, height: 50 };
+    const b: Rect = { x: 60, y: 0, width: 50, height: 50 };
+
+    expect(rectsOverlap(a, b)).toBe(false);
+    // 10px gap between them: still clear at spacing 10, blocked at spacing 20.
+    expect(rectsOverlap(a, b, 10)).toBe(false);
+    expect(rectsOverlap(a, b, 20)).toBe(true);
+    expect(rectsOverlap(a, { ...a }, 0)).toBe(true);
+  });
+
+  it('keeps the preferred position when it is already free', () => {
+    const occupied: Rect[] = [{ x: 200, y: 200, width: 50, height: 50 }];
+    const result = findFreePlacementPosition(
+      { x: 10, y: 10 },
+      { width: 50, height: 50 },
+      occupied,
+      { spacing: 20 },
+    );
+    expect(result).toEqual({ x: 10, y: 10 });
+  });
+
+  it('searches outward for a collision-free position when the preferred one overlaps', () => {
+    const size = { width: 50, height: 50 };
+    const occupied: Rect[] = [{ x: 10, y: 10, width: 50, height: 50 }];
+    const result = findFreePlacementPosition({ x: 10, y: 10 }, size, occupied, {
+      spacing: 20,
+    });
+
+    expect(result).not.toBeNull();
+    const placed: Rect = { ...size, x: result!.x, y: result!.y };
+    expect(occupied.some((rect) => rectsOverlap(placed, rect, 20))).toBe(false);
+  });
+
+  it('clamps candidate positions to the provided bounds', () => {
+    const size = { width: 50, height: 50 };
+    const bounds = { width: 200, height: 200 };
+    const occupied: Rect[] = [{ x: 0, y: 0, width: 50, height: 50 }];
+    const result = findFreePlacementPosition({ x: 0, y: 0 }, size, occupied, {
+      spacing: 20,
+      bounds,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.x).toBeGreaterThanOrEqual(0);
+    expect(result!.y).toBeGreaterThanOrEqual(0);
+    expect(result!.x).toBeLessThanOrEqual(bounds.width - size.width);
+    expect(result!.y).toBeLessThanOrEqual(bounds.height - size.height);
+  });
+
+  it('returns null when no free position fits within the search radius', () => {
+    const size = { width: 50, height: 50 };
+    const bounds = { width: 50, height: 50 };
+    const occupied: Rect[] = [{ x: 0, y: 0, width: 50, height: 50 }];
+    const result = findFreePlacementPosition({ x: 0, y: 0 }, size, occupied, {
+      spacing: 20,
+      bounds,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('places new beds without overlapping existing occupied beds', () => {
+    const sizes = new Map<number, { width: number; height: number }>([
+      [1, { width: 100, height: 50 }],
+    ]);
+    const occupied: Rect[] = [{ x: 12, y: 12, width: 100, height: 50 }];
+
+    const output = initialAutoLayout([1], sizes, { width: 400, height: 400 }, 12, occupied, 20);
+    const placed: Rect = { x: output.get(1)!.x, y: output.get(1)!.y, width: 100, height: 50 };
+
+    expect(rectsOverlap(placed, occupied[0], 20)).toBe(false);
   });
 });

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -44,9 +44,11 @@ import { useTranslation } from "../i18n";
 import ModeToggle from "../components/ModeToggle";
 import {
   clampInsideParent,
+  DEFAULT_PLACEMENT_SPACING,
   getBedRectSizeWithinField,
   getFieldRectSize,
   initialAutoLayout,
+  type Rect,
   type RectSize,
 } from "./graphicalLayoutUtils";
 import {
@@ -96,6 +98,10 @@ import {
   type SelectedElement,
 } from "./graphicalFieldsGeometry";
 
+/** Gap used when auto-arranging beds that do not yet have a saved layout. */
+const BED_AUTO_LAYOUT_GAP = DEFAULT_PLACEMENT_SPACING;
+/** Minimum spacing kept between a newly placed bed and existing beds. */
+const BED_PLACEMENT_SPACING = DEFAULT_PLACEMENT_SPACING;
 
 export default function GraphicalFields({
   showTitle = true,
@@ -1527,10 +1533,31 @@ export default function GraphicalFields({
                         const missingBeds = fieldBeds
                           .map((bed) => bed.id!)
                           .filter((bedId) => !layoutsByBed[bedId]);
+                        const occupiedBedRects: Rect[] = fieldBeds
+                          .filter((bed) => layoutsByBed[bed.id!])
+                          .map((bed) => {
+                            const bedId = bed.id!;
+                            const size = bedSizeMap.get(bedId)!;
+                            const saved = layoutsByBed[bedId];
+                            const clamped = clampInsideParent(
+                              { x: saved.x, y: saved.y },
+                              size,
+                              fieldInnerSize,
+                            );
+                            return {
+                              x: clamped.x,
+                              y: clamped.y,
+                              width: size.width,
+                              height: size.height,
+                            };
+                          });
                         const autoLayout = initialAutoLayout(
                           missingBeds,
                           bedSizeMap,
                           fieldInnerSize,
+                          BED_AUTO_LAYOUT_GAP,
+                          occupiedBedRects,
+                          BED_PLACEMENT_SPACING,
                         );
                         const bedViewModels: BedViewModel[] = fieldBeds.map(
                           (bed) => {

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -48,7 +48,7 @@ import {
   getBedRectSizeWithinField,
   getFieldRectSize,
   initialAutoLayout,
-  type Rect,
+  type Rect as PlacementRect,
   type RectSize,
 } from "./graphicalLayoutUtils";
 import {
@@ -1533,7 +1533,7 @@ export default function GraphicalFields({
                         const missingBeds = fieldBeds
                           .map((bed) => bed.id!)
                           .filter((bedId) => !layoutsByBed[bedId]);
-                        const occupiedBedRects: Rect[] = fieldBeds
+                        const occupiedBedRects: PlacementRect[] = fieldBeds
                           .filter((bed) => layoutsByBed[bed.id!])
                           .map((bed) => {
                             const bedId = bed.id!;

--- a/frontend/src/pages/graphicalLayoutUtils.ts
+++ b/frontend/src/pages/graphicalLayoutUtils.ts
@@ -10,6 +10,14 @@ export interface Position {
   y: number;
 }
 
+export interface Rect extends Position, RectSize {}
+
+/**
+ * Default gap (in world pixels) to keep between graphical objects when
+ * searching for a collision-free placement position.
+ */
+export const DEFAULT_PLACEMENT_SPACING = 20;
+
 interface AreaToRectOptions {
   baseWidth?: number;
   minWidth?: number;
@@ -137,8 +145,101 @@ export function clampInsideParent(position: Position, childSize: RectSize, paren
   };
 }
 
-export function initialAutoLayout(ids: number[], childSizes: Map<number, RectSize>, parentSize: RectSize, gap = 12): Map<number, Position> {
+/**
+ * Returns true when two rectangles intersect, treating `spacing` as an extra
+ * margin that must stay clear around each rectangle. With `spacing === 0` this
+ * is a plain axis-aligned bounding box intersection test.
+ */
+export function rectsOverlap(a: Rect, b: Rect, spacing = 0): boolean {
+  return (
+    a.x < b.x + b.width + spacing &&
+    a.x + a.width + spacing > b.x &&
+    a.y < b.y + b.height + spacing &&
+    a.y + a.height + spacing > b.y
+  );
+}
+
+export interface FreePlacementOptions {
+  /** Minimum gap to keep between the placed rectangle and every occupied one. */
+  spacing?: number;
+  /** Distance between candidate positions in the expanding grid search. */
+  step?: number;
+  /** Maximum number of rings to probe before giving up. */
+  maxRadius?: number;
+  /** Optional parent bounds; candidates are clamped to stay inside. */
+  bounds?: RectSize;
+}
+
+/**
+ * Finds the nearest collision-free position for a rectangle of `size`, starting
+ * from `preferred` and probing outwards in an expanding square-ring (grid)
+ * pattern. This keeps the preferred position when it is already free and is
+ * generic enough to be reused for any graphical object, not just beds.
+ *
+ * Returns `null` when no free position is found within `maxRadius` rings, so
+ * callers can fall back to their previous behavior.
+ */
+export function findFreePlacementPosition(
+  preferred: Position,
+  size: RectSize,
+  occupied: Rect[],
+  options: FreePlacementOptions = {},
+): Position | null {
+  const spacing = options.spacing ?? DEFAULT_PLACEMENT_SPACING;
+  const step =
+    options.step ??
+    Math.max(1, Math.round(Math.min(size.width, size.height) / 2 + spacing));
+  const maxRadius = options.maxRadius ?? 32;
+  const { bounds } = options;
+
+  const place = (pos: Position): Position =>
+    bounds ? clampInsideParent(pos, size, bounds) : pos;
+
+  const collides = (pos: Position): boolean => {
+    const candidate: Rect = {
+      x: pos.x,
+      y: pos.y,
+      width: size.width,
+      height: size.height,
+    };
+    return occupied.some((rect) => rectsOverlap(candidate, rect, spacing));
+  };
+
+  const base = place(preferred);
+  if (!collides(base)) {
+    return base;
+  }
+
+  for (let radius = 1; radius <= maxRadius; radius += 1) {
+    for (let dy = -radius; dy <= radius; dy += 1) {
+      for (let dx = -radius; dx <= radius; dx += 1) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) {
+          continue;
+        }
+        const candidate = place({
+          x: preferred.x + dx * step,
+          y: preferred.y + dy * step,
+        });
+        if (!collides(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function initialAutoLayout(
+  ids: number[],
+  childSizes: Map<number, RectSize>,
+  parentSize: RectSize,
+  gap = 12,
+  occupiedRects: Rect[] = [],
+  spacing: number = gap,
+): Map<number, Position> {
   const output = new Map<number, Position>();
+  const placed: Rect[] = [...occupiedRects];
   let cursorX = gap;
   let cursorY = gap;
   let rowHeight = 0;
@@ -153,7 +254,21 @@ export function initialAutoLayout(ids: number[], childSizes: Map<number, RectSiz
       rowHeight = 0;
     }
 
-    output.set(id, clampInsideParent({ x: cursorX, y: cursorY }, size, parentSize));
+    const preferred = clampInsideParent({ x: cursorX, y: cursorY }, size, parentSize);
+    const free = findFreePlacementPosition(preferred, size, placed, {
+      spacing,
+      bounds: parentSize,
+    });
+    const position = free ?? preferred;
+
+    output.set(id, position);
+    placed.push({
+      x: position.x,
+      y: position.y,
+      width: size.width,
+      height: size.height,
+    });
+
     cursorX += size.width + gap;
     rowHeight = Math.max(rowHeight, size.height);
   }


### PR DESCRIPTION
## Problem

Newly created beds in the graphical fields view were often placed directly on top of existing beds, forcing users to immediately drag them apart. The auto-layout that positions beds without a saved layout (`initialAutoLayout`) ignored the positions of beds that already had a saved layout, so new beds could land on occupied space.

## Change

Added generic, reusable placement helpers to `graphicalLayoutUtils.ts`:

- **`rectsOverlap(a, b, spacing)`** — axis-aligned bounding-box intersection test with a configurable spacing margin. Centralizes collision detection so it isn't duplicated.
- **`findFreePlacementPosition(preferred, size, occupied, options)`** — keeps the preferred position when it is already free; otherwise probes outward in a deterministic expanding square-ring (grid) pattern for the nearest collision-free position. Candidates are clamped to optional bounds, and it returns `null` when no free spot is found within the search radius so callers can fall back to previous behavior. Written generically so it can be reused for other graphical objects, not just beds.

`initialAutoLayout` now accepts the existing occupied rectangles and a spacing value, routing each placement through `findFreePlacementPosition`. `GraphicalFields` passes each field's saved beds as the occupied set, so newly created beds are placed close to their intended slot without overlapping saved beds or one another.

Spacing between beds is configurable via `DEFAULT_PLACEMENT_SPACING` (20 px, within the requested 20–40 px range).

## Behavior

- The default placement remains the preferred starting point; it is only changed on collision.
- Existing, manually positioned (saved) beds are never moved.
- New beds appear near the intended insertion point rather than at arbitrary distant coordinates.
- If no free position is found within the search radius, the previous fallback position is used.

## Tests

- Added unit tests for `rectsOverlap`, `findFreePlacementPosition` (preferred-free, outward search, bounds clamping, no-fit fallback), and collision-aware `initialAutoLayout`.
- Full frontend suite passes (1152 tests). Lint and typecheck clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9hpAB8p2qQ4vBs2jToyen

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9hpAB8p2qQ4vBs2jToyen)_