### PR TITLE
refactor(frontend): extract CultureMobileSelectorDialog from CultureDetail

### DIFF
--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -18,6 +18,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
 import { CultureFiltersPopover } from './CultureFiltersPopover';
+import { CultureMobileSelectorDialog } from './CultureMobileSelectorDialog';
 import TuneIcon from '@mui/icons-material/Tune';
 import EditIcon from '@mui/icons-material/Edit';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
@@ -50,9 +51,6 @@ import {
   IconButton,
   Menu,
   Tooltip,
-  Dialog,
-  DialogTitle,
-  DialogContent,
 } from '@mui/material';
 import type { Culture } from '../api/api';
 import { SearchableSelect } from '../components/inputs/SearchableSelect';
@@ -1280,35 +1278,18 @@ export function CultureDetail({
 
 
       {useUnifiedMobileLayout ? (
-        <Dialog fullScreen open={mobileSelectorOpen} onClose={() => setMobileSelectorOpen(false)}>
-          <DialogTitle>{t('selectCulture')}</DialogTitle>
-          <DialogContent sx={{ px: 1.5, pb: 2 }}>
-            {selectorControl}
-            <List dense sx={{ py: 0.5, px: 0.25, overflowY: 'auto' }}>
-              {filteredCultures.map((culture) => {
-                const secondary = [culture.variety].filter(Boolean).join(' • ');
-                return (
-                  <ListItemButton
-                    key={`mobile-${culture.id}`}
-                    selected={selectedCulture?.id === culture.id}
-                    onClick={() => {
-                      onCultureSelect(culture);
-                      setMobileSelectorOpen(false);
-                    }}
-                    sx={{ borderRadius: 1.25, mb: 0.375 }}
-                  >
-                    <ListItemText
-                      primary={culture.name}
-                      secondary={secondary || culture.crop_family || undefined}
-                      primaryTypographyProps={{ fontSize: '0.95rem', fontWeight: 600 }}
-                      secondaryTypographyProps={{ fontSize: '0.8rem', color: 'text.secondary' }}
-                    />
-                  </ListItemButton>
-                );
-              })}
-            </List>
-          </DialogContent>
-        </Dialog>
+        <CultureMobileSelectorDialog
+          open={mobileSelectorOpen}
+          onClose={() => setMobileSelectorOpen(false)}
+          selectorControl={selectorControl}
+          cultures={filteredCultures}
+          selectedCultureId={selectedCulture?.id}
+          onSelect={(culture) => {
+            onCultureSelect(culture);
+            setMobileSelectorOpen(false);
+          }}
+          t={t}
+        />
       ) : null}
 
       {/* Empty State */}

--- a/frontend/src/cultures/CultureMobileSelectorDialog.tsx
+++ b/frontend/src/cultures/CultureMobileSelectorDialog.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import type { TFunction } from 'i18next';
+
+import type { Culture } from '../api/api';
+
+interface CultureMobileSelectorDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The shared search/filter control rendered above the list. */
+  selectorControl: ReactNode;
+  cultures: Culture[];
+  selectedCultureId: number | undefined;
+  onSelect: (culture: Culture) => void;
+  t: TFunction<'cultures'>;
+}
+
+/**
+ * Presentational full-screen culture picker for the unified mobile layout.
+ * State (open flag, filtered cultures, selected culture) and the select
+ * handler live in CultureDetail.tsx; this component only renders.
+ */
+export function CultureMobileSelectorDialog({
+  open,
+  onClose,
+  selectorControl,
+  cultures,
+  selectedCultureId,
+  onSelect,
+  t,
+}: CultureMobileSelectorDialogProps) {
+  return (
+    <Dialog fullScreen open={open} onClose={onClose}>
+      <DialogTitle>{t('selectCulture')}</DialogTitle>
+      <DialogContent sx={{ px: 1.5, pb: 2 }}>
+        {selectorControl}
+        <List dense sx={{ py: 0.5, px: 0.25, overflowY: 'auto' }}>
+          {cultures.map((culture) => {
+            const secondary = [culture.variety].filter(Boolean).join(' • ');
+            return (
+              <ListItemButton
+                key={`mobile-${culture.id}`}
+                selected={selectedCultureId === culture.id}
+                onClick={() => onSelect(culture)}
+                sx={{ borderRadius: 1.25, mb: 0.375 }}
+              >
+                <ListItemText
+                  primary={culture.name}
+                  secondary={secondary || culture.crop_family || undefined}
+                  primaryTypographyProps={{ fontSize: '0.95rem', fontWeight: 600 }}
+                  secondaryTypographyProps={{ fontSize: '0.8rem', color: 'text.secondary' }}
+                />
+              </ListItemButton>
+            );
+          })}
+        </List>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Was

Nächster Schritt des iterativen Zyklus: der Vollbild-Kultur-Picker der mobilen Ansicht (Such-/Filter-Control + auswählbare Kulturliste) wird aus `CultureDetail.tsx` (1374 → 1355 Zeilen) in eine **rein präsentationale Komponente** `src/cultures/CultureMobileSelectorDialog.tsx` verschoben.

- Das geteilte Selector-Control wird als `ReactNode`-Prop durchgereicht; Open-State, gefilterte Kulturen und der Select-Handler bleiben in `CultureDetail`.
- Drei nicht mehr benötigte MUI-Imports (`Dialog`, `DialogTitle`, `DialogContent`) aus der Page entfernt.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1146 Tests grün
- `tsc -b`: sauber (Exit-Code geprüft)
- ESLint: regelgenaue Parität mit main für `CultureDetail.tsx` (Stash-Vergleich); `CultureMobileSelectorDialog.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_