### PR TITLE
refactor(frontend): extract CultureHeaderActionsMenu from CultureDetail

### DIFF
--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -19,14 +19,12 @@ import remarkGfm from 'remark-gfm';
 import { useTranslation } from '../i18n';
 import { CultureFiltersPopover } from './CultureFiltersPopover';
 import { CultureMobileSelectorDialog } from './CultureMobileSelectorDialog';
+import { CultureHeaderActionsMenu } from './CultureHeaderActionsMenu';
 import TuneIcon from '@mui/icons-material/Tune';
 import EditIcon from '@mui/icons-material/Edit';
 import AgricultureIcon from '@mui/icons-material/Agriculture';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import PublicIcon from '@mui/icons-material/Public';
-import HistoryIcon from '@mui/icons-material/History';
-import DeleteIcon from '@mui/icons-material/Delete';
 import {
   Badge,
   Box,
@@ -45,11 +43,9 @@ import {
   List,
   ListItemButton,
   ListItemText,
-  MenuItem,
   Stack,
   Button,
   IconButton,
-  Menu,
   Tooltip,
 } from '@mui/material';
 import type { Culture } from '../api/api';
@@ -169,7 +165,6 @@ export function CultureDetail({
   const [headerMenuAnchorEl, setHeaderMenuAnchorEl] = useState<HTMLElement | null>(null);
   const [mobileSelectorOpen, setMobileSelectorOpen] = useState(false);
   const isFilterPopoverOpen = Boolean(filterAnchorEl);
-  const isHeaderMenuOpen = Boolean(headerMenuAnchorEl);
   const headerActionButtonSx = {
     width: useUnifiedMobileLayout ? 30 : 34,
     height: useUnifiedMobileLayout ? 30 : 34,
@@ -873,28 +868,16 @@ export function CultureDetail({
                   </IconButton>
                 </Box>
               </Box>
-              <Menu
+              <CultureHeaderActionsMenu
                 anchorEl={headerMenuAnchorEl}
-                open={isHeaderMenuOpen}
                 onClose={() => setHeaderMenuAnchorEl(null)}
-              >
-                <MenuItem onClick={() => { setHeaderMenuAnchorEl(null); onOpenHistory?.(); }}>
-                  <HistoryIcon sx={{ fontSize: 18, mr: 1, color: 'text.secondary' }} />
-                  Versionen
-                </MenuItem>
-                <MenuItem
-                  onClick={() => { setHeaderMenuAnchorEl(null); onPublishCulture?.(); }}
-                  disabled={isPublishingCulture}
-                  sx={{ color: 'text.primary' }}
-                >
-                  <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'rgba(37, 111, 42, 0.78)' }} />
-                  {publishActionLabel ?? t('library.publishButton')}
-                </MenuItem>
-                <MenuItem onClick={() => { setHeaderMenuAnchorEl(null); onDeleteCulture?.(selectedCulture); }} sx={{ color: 'error.main' }}>
-                  <DeleteIcon sx={{ fontSize: 18, mr: 1, color: 'error.main' }} />
-                  {t('buttons.delete')}
-                </MenuItem>
-              </Menu>
+                onOpenHistory={() => onOpenHistory?.()}
+                onPublish={() => onPublishCulture?.()}
+                isPublishing={isPublishingCulture}
+                publishLabel={publishActionLabel ?? t('library.publishButton')}
+                onDelete={() => onDeleteCulture?.(selectedCulture)}
+                t={t}
+              />
             </Box>
 
             <Divider sx={{ mb: 2.5 }} />

--- a/frontend/src/cultures/CultureHeaderActionsMenu.tsx
+++ b/frontend/src/cultures/CultureHeaderActionsMenu.tsx
@@ -1,0 +1,58 @@
+import { Menu, MenuItem } from '@mui/material';
+import HistoryIcon from '@mui/icons-material/History';
+import PublicIcon from '@mui/icons-material/Public';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { TFunction } from 'i18next';
+
+interface CultureHeaderActionsMenuProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  onOpenHistory: () => void;
+  onPublish: () => void;
+  isPublishing: boolean;
+  publishLabel: string;
+  onDelete: () => void;
+  t: TFunction<'cultures'>;
+}
+
+/**
+ * Presentational overflow menu for the culture detail header (versions,
+ * publish to public library, delete). Anchor state lives in
+ * CultureDetail.tsx; each item closes the menu before running its action,
+ * matching the original inline behavior.
+ */
+export function CultureHeaderActionsMenu({
+  anchorEl,
+  onClose,
+  onOpenHistory,
+  onPublish,
+  isPublishing,
+  publishLabel,
+  onDelete,
+  t,
+}: CultureHeaderActionsMenuProps) {
+  return (
+    <Menu
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      onClose={onClose}
+    >
+      <MenuItem onClick={() => { onClose(); onOpenHistory(); }}>
+        <HistoryIcon sx={{ fontSize: 18, mr: 1, color: 'text.secondary' }} />
+        Versionen
+      </MenuItem>
+      <MenuItem
+        onClick={() => { onClose(); onPublish(); }}
+        disabled={isPublishing}
+        sx={{ color: 'text.primary' }}
+      >
+        <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'rgba(37, 111, 42, 0.78)' }} />
+        {publishLabel}
+      </MenuItem>
+      <MenuItem onClick={() => { onClose(); onDelete(); }} sx={{ color: 'error.main' }}>
+        <DeleteIcon sx={{ fontSize: 18, mr: 1, color: 'error.main' }} />
+        {t('buttons.delete')}
+      </MenuItem>
+    </Menu>
+  );
+}


### PR DESCRIPTION
## Was

Nächster Schritt des iterativen Zyklus: das Overflow-Menü im Header der Kultur-Detailansicht (Versionen, In öffentliche Bibliothek veröffentlichen, Löschen) wird aus `CultureDetail.tsx` (1355 → 1338 Zeilen) in eine **rein präsentationale Komponente** `src/cultures/CultureHeaderActionsMenu.tsx` verschoben.

- Anchor-State bleibt in `CultureDetail`; jedes Item schließt das Menü vor der Aktion — identisch zum Original.
- Fünf nicht mehr benötigte Imports (`Menu`, `MenuItem`, `HistoryIcon`, `PublicIcon`, `DeleteIcon`) und die ungenutzt gewordene `isHeaderMenuOpen`-Konstante aus der Page entfernt.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1146 Tests grün
- `tsc -b`: sauber (Exit-Code geprüft)
- ESLint: regelgenaue Parität mit main für `CultureDetail.tsx` (Stash-Vergleich); `CultureHeaderActionsMenu.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_