### PR TITLE
fix: improve tooltip readability

### DIFF
--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -43,9 +43,9 @@
   --rmg-task-text-color: var(--rmg-white);
 
   /* UI-Elemente */
-  --rmg-tooltip-bg: var(--rmg-white);
-  --rmg-tooltip-text: var(--rmg-gray-800);
-  --rmg-tooltip-border: var(--rmg-gray-200);
+  --rmg-tooltip-bg: #1f2a24;
+  --rmg-tooltip-text: var(--rmg-white);
+  --rmg-tooltip-border: #314138;
   --rmg-resize-handle-bg: rgba(255, 255, 255, 0.3);
   --rmg-progress-bg: rgba(0, 0, 0, 0.2);
   --rmg-progress-fill: var(--rmg-white);
@@ -751,9 +751,10 @@
   background-color: var(--rmg-tooltip-bg);
   color: var(--rmg-tooltip-text);
   border: 1px solid var(--rmg-tooltip-border);
-  padding: 4px 8px;
+  padding: 6px 10px;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
   font-weight: 600;
   white-space: nowrap;
   box-shadow: 0 2px 8px var(--rmg-shadow-color);
@@ -835,8 +836,9 @@
   color: var(--rmg-tooltip-text);
   border: 1px solid var(--rmg-tooltip-border);
   border-radius: 4px;
-  padding: 8px;
-  font-size: 0.75rem;
+  padding: 10px 12px;
+  font-size: 0.8125rem;
+  line-height: 1.45;
   box-shadow: 0 2px 8px var(--rmg-shadow-color);
   opacity: 0;
   transform: translateY(5px);
@@ -845,6 +847,7 @@
     transform 0.2s ease;
   pointer-events: none;
   min-width: 12rem;
+  max-width: 320px;
 }
 
 .rmg-tooltip-visible {
@@ -881,11 +884,11 @@
 
 .rmg-tooltip-label {
   font-weight: 600;
-  color: var(--rmg-gray-500);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .rmg-dark .rmg-tooltip-label {
-  color: var(--rmg-gray-400);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 /* ======================================================

--- a/frontend/src/gantt-chart/src/themes.ts
+++ b/frontend/src/gantt-chart/src/themes.ts
@@ -48,9 +48,9 @@ export const defaultTheme: GanttTheme = {
   taskColor: "#3b82f6",
   taskTextColor: "#ffffff",
 
-  tooltipBgColor: "#ffffff",
-  tooltipTextColor: "#1f2937",
-  tooltipBorderColor: "#e5e7eb",
+  tooltipBgColor: "#1f2a24",
+  tooltipTextColor: "#ffffff",
+  tooltipBorderColor: "#314138",
 
   progressBgColor: "rgba(0, 0, 0, 0.2)",
   progressFillColor: "#ffffff",
@@ -106,9 +106,9 @@ export const materialTheme: GanttTheme = {
   taskColor: "#2196f3",
   taskTextColor: "#ffffff",
 
-  tooltipBgColor: "#ffffff",
-  tooltipTextColor: "#212121",
-  tooltipBorderColor: "#e0e0e0",
+  tooltipBgColor: "#1f2a24",
+  tooltipTextColor: "#ffffff",
+  tooltipBorderColor: "#314138",
 
   progressBgColor: "rgba(0, 0, 0, 0.12)",
   progressFillColor: "#ffffff",

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -289,7 +289,7 @@
     "noSupplierConfiguredTooltip": "Für diese Kultur sind noch keine Lieferantendaten hinterlegt.",
     "supplierNotSelectedTooltip": "Für diese Kultur ist noch kein Lieferant ausgewählt. Wähle einen Lieferanten in der Spalte „Lieferant“, damit die passende Packungsgröße berechnet werden kann.",
     "noPackagesAvailable": "Noch nicht hinterlegt",
-    "noPackagesAvailableTooltip": "Für diese Kultur wurden noch keine Packungsgrößen hinterlegt. Sobald diese gepflegt sind, wird die optimale Bestellmenge automatisch berechnet.",
+    "noPackagesAvailableTooltip": "Für diese Kultur sind noch keine Packungsgrößen hinterlegt. Sobald sie eingetragen wurden, wird die optimale Bestellmenge automatisch berechnet.",
     "noPackageCalculationPossible": "Nicht berechenbar",
     "noPackageCalculationPossibleTooltip": "Die Berechnung ist trotz vorhandener Lieferanten- und Packungsdaten aktuell nicht möglich. Bitte prüfe die Kultur- und Lieferantendaten auf Vollständigkeit.",
     "requiredAmountMissingTkg": "Nicht berechenbar (TKG fehlt)",

--- a/frontend/src/navigation/navigationStyles.ts
+++ b/frontend/src/navigation/navigationStyles.ts
@@ -66,9 +66,6 @@ export const getNavigationToggleButtonSx = (cursor: 'e-resize' | 'w-resize'): Sx
 
 export const navigationTooltipSx: SxProps<Theme> = (theme) => ({
   bgcolor: theme.palette.navigation.tooltipBackground,
-  fontSize: '0.72rem',
-  px: 1,
-  py: 0.5,
 });
 
 export const getNavigationItemSx = (

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -352,15 +352,17 @@ const YieldChartSegment = memo(function YieldChartSegment({
       slotProps={{
         tooltip: {
           sx: {
-            bgcolor: "background.paper",
-            color: "text.primary",
-            border: "1px solid",
-            borderColor: "divider",
-            borderRadius: 1,
-            boxShadow: 3,
-            p: 1,
             minWidth: "12rem",
-            maxWidth: 320,
+            "& .MuiTypography-root": {
+              color: "inherit",
+            },
+            "& .MuiTypography-caption": {
+              fontSize: "inherit",
+              lineHeight: "inherit",
+            },
+            "& [data-yield-tooltip-label='true']": {
+              color: "rgba(255, 255, 255, 0.72)",
+            },
           },
         },
       }}
@@ -370,11 +372,11 @@ const YieldChartSegment = memo(function YieldChartSegment({
             {cultureName}
           </Typography>
           <Box sx={{ display: "grid", gridTemplateColumns: "auto 1fr", columnGap: 1, rowGap: 0.25 }}>
-            <Typography variant="caption" sx={{ fontWeight: 600, color: "text.secondary" }}>
+            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
               {tooltipPeriodLabel}:
             </Typography>
             <Typography variant="caption">{periodLabel}</Typography>
-            <Typography variant="caption" sx={{ fontWeight: 600, color: "text.secondary" }}>
+            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
               {tooltipYieldLabel}:
             </Typography>
             <Typography variant="caption">{yieldValue.toFixed(2)} kg</Typography>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -327,6 +327,26 @@ const theme = createTheme({
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: ({ theme }) => ({
+          backgroundColor: theme.palette.navigation.tooltipBackground,
+          color: theme.palette.primary.contrastText,
+          fontSize: '0.8125rem',
+          lineHeight: 1.45,
+          padding: '10px 12px',
+          maxWidth: 320,
+          borderRadius: 4,
+          '& .MuiTypography-caption': {
+            fontSize: 'inherit',
+            lineHeight: 'inherit',
+          },
+        }),
+        arrow: ({ theme }) => ({
+          color: theme.palette.navigation.tooltipBackground,
+        }),
+      },
+    },
     MuiPaper: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Summary

- centralize the default MUI tooltip presentation with a slightly larger font, more padding, improved line height, and a readable max width while keeping the dark tooltip design
- update the seed-demand package-size tooltip wording to use clearer German copy with „eingetragen“ instead of „gepflegt“
- align custom Gantt and yield-overview tooltips with the same dark/readable treatment

## Validation

- `git diff --check`
- `cd frontend && npx eslint src/theme.ts src/navigation/navigationStyles.ts src/pages/YieldOverview.tsx src/gantt-chart/src/themes.ts`
- `cd frontend && npx tsc -b --pretty false`
- `cd frontend && npm run test -- src/__tests__/SeedDemand.test.tsx src/__tests__/cultureSections.test.tsx src/__tests__/DropdownAwareTooltip.test.tsx src/__tests__/CompactAreaCell.test.tsx src/__tests__/gantt-chart/Tooltip.portal.test.tsx`

## Notes

- Full `cd frontend && npm run test` was also run: 1158 tests passed and 5 unrelated tests failed/time-boxed (`App.test.tsx`, `DateEditCell.test.tsx`, `FieldsBedsHierarchy.editCancel.test.tsx`, `PrivacyPolicyPage.test.tsx`, `ProjectSelectionPage.test.tsx`).
- Full `cd frontend && npm run lint` currently fails on pre-existing lint issues, including generated `.vite/deps` files and unrelated React Compiler/ref rules.