### PR TITLE
refactor(frontend): extract GraphicalFieldDetailsDialog from GraphicalFields

### DIFF
--- a/frontend/src/pages/GraphicalFieldDetailsDialog.tsx
+++ b/frontend/src/pages/GraphicalFieldDetailsDialog.tsx
@@ -1,0 +1,73 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { TFunction } from "i18next";
+
+import type { SelectedElement } from "./graphicalFieldsGeometry";
+
+interface GraphicalFieldDetailsDialogProps {
+  /** The dialog is open while this is non-null. */
+  element: SelectedElement | null;
+  onClose: () => void;
+  t: TFunction<["fields", "common"]>;
+}
+
+/**
+ * Presentational details dialog for a clicked field/bed on the graphical
+ * map (name, location, parent field, area). Selection state lives in
+ * GraphicalFields.tsx; this component only renders.
+ */
+export function GraphicalFieldDetailsDialog({
+  element,
+  onClose,
+  t,
+}: GraphicalFieldDetailsDialogProps) {
+  return (
+    <Dialog
+      open={Boolean(element)}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+    >
+      <DialogTitle>
+        {element
+          ? t(`fields:graphical.details.${element.type}`)
+          : ""}
+      </DialogTitle>
+      <DialogContent>
+        {element ? (
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            <Typography>
+              {t("common:fields.name")}: {element.name}
+            </Typography>
+            <Typography>
+              {t("fields:graphical.location")}: {element.locationName}
+            </Typography>
+            {element.parentName ? (
+              <Typography>
+                {t("fields:graphical.parentField")}:{" "}
+                {element.parentName}
+              </Typography>
+            ) : null}
+            {element.area !== null ? (
+              <Typography>
+                {t("fields:graphical.area")}: {element.area} m²
+              </Typography>
+            ) : null}
+          </Stack>
+        ) : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>
+          {t("common:actions.close")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/GraphicalFields.tsx
+++ b/frontend/src/pages/GraphicalFields.tsx
@@ -5,12 +5,7 @@ import {
   AccordionSummary,
   Alert,
   Box,
-  Button,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   IconButton,
   Paper,
   Stack,
@@ -41,6 +36,7 @@ import {
 } from "../api/api";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { useTranslation } from "../i18n";
+import { GraphicalFieldDetailsDialog } from "./GraphicalFieldDetailsDialog";
 import ModeToggle from "../components/ModeToggle";
 import {
   clampInsideParent,
@@ -1760,46 +1756,11 @@ export default function GraphicalFields({
         },
       )}
 
-      <Dialog
-        open={Boolean(selectedElement)}
+      <GraphicalFieldDetailsDialog
+        element={selectedElement}
         onClose={() => setSelectedElement(null)}
-        fullWidth
-        maxWidth="xs"
-      >
-        <DialogTitle>
-          {selectedElement
-            ? t(`fields:graphical.details.${selectedElement.type}`)
-            : ""}
-        </DialogTitle>
-        <DialogContent>
-          {selectedElement ? (
-            <Stack spacing={1} sx={{ mt: 1 }}>
-              <Typography>
-                {t("common:fields.name")}: {selectedElement.name}
-              </Typography>
-              <Typography>
-                {t("fields:graphical.location")}: {selectedElement.locationName}
-              </Typography>
-              {selectedElement.parentName ? (
-                <Typography>
-                  {t("fields:graphical.parentField")}:{" "}
-                  {selectedElement.parentName}
-                </Typography>
-              ) : null}
-              {selectedElement.area !== null ? (
-                <Typography>
-                  {t("fields:graphical.area")}: {selectedElement.area} m²
-                </Typography>
-              ) : null}
-            </Stack>
-          ) : null}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setSelectedElement(null)}>
-            {t("common:actions.close")}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        t={t}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## Was

Nächster Schritt des iterativen Zyklus, jetzt in der größten verbliebenen Page `GraphicalFields.tsx` (1805 → 1766 Zeilen): der Element-Detail-Dialog (Name, Standort, übergeordnetes Feld, Fläche eines angeklickten Felds/Beets auf der grafischen Karte) wird in eine **rein präsentationale Komponente** `src/pages/GraphicalFieldDetailsDialog.tsx` verschoben.

- Selektions-State bleibt in `GraphicalFields`; die Komponente rendert nur den Dialog.
- Fünf nicht mehr benötigte MUI-Imports (`Button`, `Dialog`, `DialogTitle`, `DialogContent`, `DialogActions`) aus der Page entfernt.

**Kein Verhaltens-Change** — reine Code-Verschiebung mit Props-Verdrahtung.

## Verifikation

- `npm run test`: 1168 Tests grün
- `tsc -b`: sauber (Exit-Code geprüft)
- ESLint: regelgenaue Parität mit main für `GraphicalFields.tsx` (Stash-Vergleich); `GraphicalFieldDetailsDialog.tsx` ohne Findings
- `madge --circular`: keine Zyklen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5puJJAcTCcs91UcroBZhs)_