### PR TITLE
fix: resolve public assets under base path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenFarmPlanner</title>
     <meta name="description" content="OpenFarmPlanner ist ein Open-Source-Anbauplaner für den Gemüsebau. Plane Kulturen, Anbauflächen und Anbauzeiträume an einem Ort." />

--- a/frontend/src/__tests__/publicAssetUrl.test.ts
+++ b/frontend/src/__tests__/publicAssetUrl.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { publicAssetUrl } from '../utils/publicAssetUrl';
+
+describe('publicAssetUrl', () => {
+  it('keeps root-based builds unchanged', () => {
+    expect(publicAssetUrl('/landing/hero-field.webp', '/')).toBe('/landing/hero-field.webp');
+  });
+
+  it('prefixes assets with a configured deployment base path', () => {
+    expect(publicAssetUrl('/landing/screenshots/demo-areas.webp', '/openfarmplanner/')).toBe(
+      '/openfarmplanner/landing/screenshots/demo-areas.webp',
+    );
+  });
+
+  it('normalizes missing slashes in the base path and asset path', () => {
+    expect(publicAssetUrl('favicon.png', '/openfarmplanner')).toBe('/openfarmplanner/favicon.png');
+  });
+});

--- a/frontend/src/components/layout/AppLogo.tsx
+++ b/frontend/src/components/layout/AppLogo.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { NavLink, useLocation } from 'react-router-dom';
 import { normalizeMainRoutePath } from '../../navigation/mainNavigation';
 import { useTranslation } from '../../i18n';
+import { publicAssetUrl } from '../../utils/publicAssetUrl';
 
 interface AppLogoProps {
   to?: string;
@@ -47,7 +48,7 @@ export default function AppLogo({ to = '/app/dashboard', size = 28, showText = t
     >
       <Box
         component="img"
-        src="/favicon.png"
+        src={publicAssetUrl('/favicon.png')}
         alt="OpenFarmPlanner"
         sx={{ height: size, width: size, borderRadius: 0.5, flexShrink: 0 }}
       />

--- a/frontend/src/navigation/RootLayout.tsx
+++ b/frontend/src/navigation/RootLayout.tsx
@@ -94,6 +94,7 @@ import { OPEN_CREATE_PROJECT_EVENT } from '../projects/projectCreationFlow';
 import { useGlobalOverlayKeyboardScroll } from '../hooks/useDialogKeyboardScroll';
 import { useFocusRegion } from '../focus/useFocusManager';
 import { useTopbarActionsRouteReset } from '../hooks/useTopbarActionsRouteReset';
+import { publicAssetUrl } from '../utils/publicAssetUrl';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, getKeyboardNavigationRouteFromPathname, normalizeMainRoutePath } from '../navigation/mainNavigation';
 import {
   getMobileNavigationIconSx,
@@ -971,7 +972,7 @@ function RootLayout() {
                 >
                   <Box
                     component="img"
-                    src="/favicon.png"
+                    src={publicAssetUrl('/favicon.png')}
                     alt="OpenFarmPlanner"
                     sx={{ width: 24, height: 24, borderRadius: 0.5, flexShrink: 0 }}
                   />

--- a/frontend/src/pages/auth/AuthPageShell.tsx
+++ b/frontend/src/pages/auth/AuthPageShell.tsx
@@ -1,6 +1,7 @@
 import { Box, Container, Paper, Stack, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 import LegalLinks from '../../components/legal/LegalLinks';
+import { publicAssetUrl } from '../../utils/publicAssetUrl';
 import { authLegalLinkSx } from './authPageStyles';
 
 type AuthPageShellProps = {
@@ -18,7 +19,7 @@ export default function AuthPageShell({ title, subtitle, children, legalLinksDen
         display: 'flex',
         flexDirection: 'column',
         bgcolor: '#f5f7f1',
-        backgroundImage: 'linear-gradient(rgba(245, 247, 241, 0.88), rgba(245, 247, 241, 0.9)), url(/landing/hero-field.webp)',
+        backgroundImage: `linear-gradient(rgba(245, 247, 241, 0.88), rgba(245, 247, 241, 0.9)), url(${publicAssetUrl('/landing/hero-field.webp')})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundAttachment: { xs: 'scroll', md: 'fixed' },
@@ -39,7 +40,7 @@ export default function AuthPageShell({ title, subtitle, children, legalLinksDen
           <Stack direction="row" spacing={1.4} alignItems="center" justifyContent="center">
             <Box
               component="img"
-              src="/favicon.png"
+              src={publicAssetUrl('/favicon.png')}
               alt=""
               aria-hidden
               sx={{ width: { xs: 40, md: 48 }, height: 'auto', opacity: 0.95 }}

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -19,31 +19,32 @@ import { AuthApiError } from '../../auth/authApi';
 import { useAuth } from '../../auth/useAuth';
 import { useTranslation } from '../../i18n';
 import LegalLinks from '../../components/legal/LegalLinks';
+import { publicAssetUrl } from '../../utils/publicAssetUrl';
 
 const PRODUCT_TOUR_ITEMS = [
   {
     key: 'areas',
-    image: '/landing/screenshots/demo-areas.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-areas.webp'),
   },
   {
     key: 'cultures',
-    image: '/landing/screenshots/demo-cultures.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-cultures.webp'),
   },
   {
     key: 'plantingPlans',
-    image: '/landing/screenshots/demo-planting-plans.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-planting-plans.webp'),
   },
   {
     key: 'calendar',
-    image: '/landing/screenshots/demo-calendar.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-calendar.webp'),
   },
   {
     key: 'yieldOverview',
-    image: '/landing/screenshots/demo-yield-overview.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-yield-overview.webp'),
   },
   {
     key: 'seedDemand',
-    image: '/landing/screenshots/demo-seed-demand.webp',
+    image: publicAssetUrl('/landing/screenshots/demo-seed-demand.webp'),
   },
 ] as const;
 
@@ -226,7 +227,7 @@ export default function HomePage() {
           <Stack direction="row" spacing={1.4} alignItems="center" justifyContent="center">
             <Box
               component="img"
-              src="/favicon.png"
+              src={publicAssetUrl('/favicon.png')}
               alt=""
               aria-hidden
               sx={{
@@ -263,7 +264,7 @@ export default function HomePage() {
             px: 2,
             py: { xs: 4, md: 5 },
             overflow: 'hidden',
-            backgroundImage: 'url(/landing/hero-field.webp)',
+            backgroundImage: `url(${publicAssetUrl('/landing/hero-field.webp')})`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
           }}

--- a/frontend/src/utils/publicAssetUrl.ts
+++ b/frontend/src/utils/publicAssetUrl.ts
@@ -1,0 +1,6 @@
+export function publicAssetUrl(path: string, baseUrl = import.meta.env.BASE_URL): string {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const normalizedPath = path.replace(/^\/+/, '');
+
+  return `${normalizedBase}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary
- make public assets resolve through Vite BASE_URL for staging subpath deployments
- update landing/auth hero backgrounds, screenshots, logos, and favicon
- add unit coverage for base-aware public asset URLs

## Verification
- cd frontend && npx eslint src/utils/publicAssetUrl.ts src/__tests__/publicAssetUrl.test.ts src/pages/public/HomePage.tsx src/pages/auth/AuthPageShell.tsx src/components/layout/AppLogo.tsx src/navigation/RootLayout.tsx
- cd frontend && npm run test -- src/__tests__/publicAssetUrl.test.ts src/__tests__/App.test.tsx src/__tests__/LoginPageDeletionFlow.test.tsx src/__tests__/RegisterPage.test.tsx
- cd frontend && VITE_BASE_PATH=/openfarmplanner/ npm run build
- served dist under /openfarmplanner/ and verified hero image, screenshot image, and favicon return 200 and load in Playwright
- cd frontend && npm run build