### PR TITLE
fix: stop logging invitation tokens verbatim (CWE-532)

### DIFF
--- a/backend/farm/services/project_invitations.py
+++ b/backend/farm/services/project_invitations.py
@@ -108,6 +108,18 @@ def normalize_email(email: str) -> str:
     return ProjectInvitation.normalize_email(email)
 
 
+def _mask_token(token: str | None) -> str:
+    """Mask an invitation token for logging.
+
+    Invitation tokens are bearer-style credentials; writing them verbatim to
+    application logs (CWE-532) would let anyone with log access reuse them.
+    Keep only a short, non-reversible prefix for correlation.
+    """
+    if not token:
+        return '***'
+    return f'{token[:6]}…' if len(token) > 6 else '***'
+
+
 def mask_email(email: str) -> str:
     """Mask an email for public display.
 
@@ -191,7 +203,7 @@ def get_invitation_by_token(token: str) -> ProjectInvitation:
         .first()
     )
     if not invitation:
-        logger.warning('Invitation token lookup failed', extra={'token': token})
+        logger.warning('Invitation token lookup failed', extra={'token': _mask_token(token)})
         raise InvitationFlowError('invalid_token', 'Invalid invitation token.')
     return invitation
 
@@ -228,20 +240,20 @@ def accept_invitation(*, invitation: ProjectInvitation, user: User) -> Invitatio
     :return: Accept result.
     """
     if normalize_email(user.email) != invitation.email_normalized:
-        logger.warning('Invitation accept rejected due to email mismatch', extra={'user_id': user.id, 'token': invitation.token, 'invitation_email': invitation.email_normalized, 'user_email': normalize_email(user.email)})
+        logger.warning('Invitation accept rejected due to email mismatch', extra={'user_id': user.id, 'invitation_id': invitation.pk, 'token': _mask_token(invitation.token), 'invitation_email': invitation.email_normalized, 'user_email': normalize_email(user.email)})
         raise InvitationFlowError('email_mismatch', 'Invitation belongs to another email address.')
 
     with transaction.atomic():
         locked = ProjectInvitation.objects.select_for_update().get(pk=invitation.pk)
 
         if locked.resolved_status == 'expired':
-            logger.warning('Invitation accept rejected because invitation expired', extra={'user_id': user.id, 'token': locked.token})
+            logger.warning('Invitation accept rejected because invitation expired', extra={'user_id': user.id, 'invitation_id': locked.pk, 'token': _mask_token(locked.token)})
             raise InvitationFlowError('expired', 'Invitation has expired.')
         if locked.status == ProjectInvitation.STATUS_REVOKED:
-            logger.warning('Invitation accept rejected because invitation was revoked', extra={'user_id': user.id, 'token': locked.token})
+            logger.warning('Invitation accept rejected because invitation was revoked', extra={'user_id': user.id, 'invitation_id': locked.pk, 'token': _mask_token(locked.token)})
             raise InvitationFlowError('revoked', 'Invitation was revoked.')
         if locked.status == ProjectInvitation.STATUS_ACCEPTED:
-            logger.warning('Invitation accept rejected because invitation was already used', extra={'user_id': user.id, 'token': locked.token, 'project_id': locked.project_id})
+            logger.warning('Invitation accept rejected because invitation was already used', extra={'user_id': user.id, 'invitation_id': locked.pk, 'token': _mask_token(locked.token), 'project_id': locked.project_id})
             raise InvitationFlowError('accepted', 'Invitation has already been used.')
 
         existing_membership = ProjectMembership.objects.filter(
@@ -249,7 +261,7 @@ def accept_invitation(*, invitation: ProjectInvitation, user: User) -> Invitatio
             user=user,
         ).first()
         if existing_membership is not None:
-            logger.info('Invitation accept found existing project membership', extra={'user_id': user.id, 'token': locked.token, 'project_id': locked.project_id})
+            logger.info('Invitation accept found existing project membership', extra={'user_id': user.id, 'invitation_id': locked.pk, 'token': _mask_token(locked.token), 'project_id': locked.project_id})
             locked.status = ProjectInvitation.STATUS_ACCEPTED
             locked.accepted_by = user
             locked.accepted_at = locked.accepted_at or timezone.now()
@@ -262,7 +274,7 @@ def accept_invitation(*, invitation: ProjectInvitation, user: User) -> Invitatio
             role=locked.role,
         )
 
-        logger.info('Invitation accepted and membership created', extra={'user_id': user.id, 'token': locked.token, 'project_id': locked.project_id, 'membership_id': membership.id})
+        logger.info('Invitation accepted and membership created', extra={'user_id': user.id, 'invitation_id': locked.pk, 'token': _mask_token(locked.token), 'project_id': locked.project_id, 'membership_id': membership.id})
         locked.status = ProjectInvitation.STATUS_ACCEPTED
         locked.accepted_by = user
         locked.accepted_at = timezone.now()

--- a/backend/farm/tests/test_invitation_logging.py
+++ b/backend/farm/tests/test_invitation_logging.py
@@ -1,0 +1,35 @@
+"""Tests ensuring invitation tokens are not written verbatim to logs (CWE-532)."""
+
+from django.test import SimpleTestCase, TestCase
+
+from farm.services.project_invitations import (
+    InvitationFlowError,
+    _mask_token,
+    get_invitation_by_token,
+)
+
+
+class MaskTokenTest(SimpleTestCase):
+    def test_masks_long_token_to_short_prefix(self):
+        token = 'abcdef0123456789verylongtoken'
+        masked = _mask_token(token)
+        self.assertNotEqual(masked, token)
+        self.assertNotIn('0123456789', masked)
+        self.assertTrue(masked.startswith('abcdef'))
+
+    def test_short_or_empty_tokens_are_fully_hidden(self):
+        self.assertEqual(_mask_token(''), '***')
+        self.assertEqual(_mask_token(None), '***')
+        self.assertEqual(_mask_token('short'), '***')
+
+
+class InvitationTokenLoggingTest(TestCase):
+    def test_failed_lookup_does_not_log_raw_token(self):
+        raw_token = 'super-secret-invitation-token-value-1234567890'
+        with self.assertLogs('farm.services.project_invitations', level='WARNING') as captured:
+            with self.assertRaises(InvitationFlowError):
+                get_invitation_by_token(raw_token)
+
+        joined = '\n'.join(captured.output)
+        # The full bearer token must never appear in log output.
+        self.assertNotIn(raw_token, joined)


### PR DESCRIPTION
## Summary

Follow-up hardening from the security audit (separate from the already-merged #340).

The invitation service wrote **raw invitation tokens** into application log records on every accept/lookup path — success and failure. Invitation tokens are bearer-style credentials, so anyone with log access could reuse them (CWE-532: *Insertion of Sensitive Information into Log File*). Their real-world impact is bounded by the email-match check enforced on acceptance, but they should never be written to logs in the first place.

## Changes

- Add `_mask_token()` in `farm/services/project_invitations.py`, which reduces a token to a short, non-reversible prefix (`abcdef…`, or `***` for short/empty input).
- Apply it to all 7 `logger.*(... token ...)` calls. Where a `locked`/`invitation` row is available, also log a non-secret `invitation_id` so operators keep a stable correlation key.
- The token returned to the frontend in `build_public_status` (the invite UI needs it) is intentionally unchanged — only log output is masked.

## Tests

- New `farm/tests/test_invitation_logging.py`:
  - unit tests for the masking helper (long token → prefix; short/empty → `***`),
  - an `assertLogs` regression test asserting the raw token never appears in log output on a failed lookup.
- `test_invitation_logging` + `test_projects_api` (all invitation flows): 47 tests green. Logging-only change, no behavioral impact on the invitation flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MXwF5AmWiN74HTicYD2Ts

---
_Generated by [Claude Code](https://claude.ai/code/session_011MXwF5AmWiN74HTicYD2Ts)_