### PR TITLE
fix: preserve base path when switching projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage/
 *.lcov
 
 # Test results / Playwright output
+.playwright-mcp/
 frontend/test-results/
 
 # Mutation testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,27 @@ Deploy scripts, cron/scheduling config, and infra are **not** in this repo — t
 - Assume SSH works unless push errors indicate otherwise.
 - Never commit directly to `main`. Always work on a feature/fix branch and open a pull request, even for small changes.
 
+## Release and Production Deploy Workflow
+- Production deploys must use an exact release tag in the `OpenFarmPlanner`
+  checkout. Before deploying production, run
+  `git describe --tags --exact-match HEAD` from this repo and confirm it
+  returns the intended `vX.Y.Z` tag.
+- If `HEAD` is not exactly tagged, do not proceed as though the build is a
+  release. Either deploy an existing tag intentionally, or create the release
+  through the repository's existing version/release flow first.
+- Use the existing version bump tooling for manual release preparation:
+  `make bump-version TYPE={feat|fix|breaking}`. This updates the central
+  backend version via `scripts/bump_version.py`; do not edit version files by
+  hand when the script applies.
+- The normal GitHub release flow is driven by Conventional Commits,
+  `release:*` labels, and `.github/workflows/release.yml`, which creates tags
+  using the `v{version}` format configured in `pyproject.toml`. If a merge to
+  `main` should have produced a release tag but did not, inspect and fix the
+  release workflow before production deploy instead of bypassing the tag check.
+- Use `--allow-untagged` for production only when the user explicitly asks for
+  an emergency untagged deploy and the final summary calls out the exact commit
+  that was deployed.
+
 ## Commit and PR Title Rules
 
 - Use Conventional Commits only:

--- a/frontend/src/__tests__/appRouteUrl.test.ts
+++ b/frontend/src/__tests__/appRouteUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { appRouteUrl } from '../utils/appRouteUrl';
+
+describe('appRouteUrl', () => {
+  it('keeps app routes at root for root deployments', () => {
+    expect(appRouteUrl('/app/dashboard', '/')).toBe('/app/dashboard');
+  });
+
+  it('prefixes app routes for subpath deployments', () => {
+    expect(appRouteUrl('/app/dashboard', '/openfarmplanner/')).toBe('/openfarmplanner/app/dashboard');
+  });
+
+  it('normalizes missing slashes in the base path and route path', () => {
+    expect(appRouteUrl('app/dashboard', '/openfarmplanner')).toBe('/openfarmplanner/app/dashboard');
+  });
+});

--- a/frontend/src/navigation/RootLayout.tsx
+++ b/frontend/src/navigation/RootLayout.tsx
@@ -94,6 +94,7 @@ import { OPEN_CREATE_PROJECT_EVENT } from '../projects/projectCreationFlow';
 import { useGlobalOverlayKeyboardScroll } from '../hooks/useDialogKeyboardScroll';
 import { useFocusRegion } from '../focus/useFocusManager';
 import { useTopbarActionsRouteReset } from '../hooks/useTopbarActionsRouteReset';
+import { appRouteUrl } from '../utils/appRouteUrl';
 import { publicAssetUrl } from '../utils/publicAssetUrl';
 import { KEYBOARD_NAV_ROUTES, MAIN_NAV_ITEMS, getKeyboardNavigationRouteFromPathname, normalizeMainRoutePath } from '../navigation/mainNavigation';
 import {
@@ -645,7 +646,7 @@ function RootLayout() {
 
   const applyProjectContextChange = useCallback(async (projectId: number): Promise<void> => {
     await switchActiveProject(projectId);
-    window.location.href = '/app/dashboard';
+    window.location.href = appRouteUrl('/app/dashboard');
   }, [switchActiveProject]);
 
   const closeCreateProjectDialog = (): void => {

--- a/frontend/src/utils/appRouteUrl.ts
+++ b/frontend/src/utils/appRouteUrl.ts
@@ -1,0 +1,10 @@
+export function appRouteUrl(path: string, baseUrl = import.meta.env.BASE_URL): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (!normalizedBase) {
+    return normalizedPath;
+  }
+
+  return `${normalizedBase}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary

- Preserve the configured Vite base path when a project switch triggers the deliberate full-page reload to the dashboard.
- Add a small `appRouteUrl` helper with regression coverage for root and subpath deployments.
- Document the release/tag preflight workflow in `AGENTS.md` and ignore Playwright MCP output.

## Root cause

The project switch flow used `window.location.href = '/app/dashboard'`. On staging, where the app is hosted below a base path, that absolute root URL escaped the React app and landed on the host site's `/app/dashboard` route.

## Validation

- `npm run test -- appRouteUrl App`
- `npx eslint src/utils/appRouteUrl.ts src/navigation/RootLayout.tsx src/__tests__/appRouteUrl.test.ts`

Note: full `npm run lint` still fails on existing unrelated lint issues, including `.vite/deps` and pre-existing React hook rule findings.