### PR TITLE
refactor(frontend): extract deterministic draft-row readers from DataGrid

### DIFF
--- a/frontend/src/__tests__/draftRowReaders.test.ts
+++ b/frontend/src/__tests__/draftRowReaders.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import type { GridApi, GridColDef } from '@mui/x-data-grid';
+import {
+  mergeVisibleDateEditInputValues,
+  readDraftRow,
+} from '../components/data-grid/draftRowReaders';
+
+interface TestRow {
+  id: number;
+  name: string;
+  sownAt?: unknown;
+  [key: string]: unknown;
+}
+
+const columns: GridColDef[] = [
+  { field: 'name' },
+  { field: 'sownAt', type: 'date' },
+];
+
+describe('readDraftRow', () => {
+  it('layers in-flight edit values over the base row', () => {
+    const api = {
+      getRowWithUpdatedValues: (_id: number, field: string) =>
+        field === 'name' ? { name: 'edited' } : null,
+    } as unknown as GridApi;
+
+    const baseRow: TestRow = { id: 1, name: 'original', sownAt: 'keep' };
+    const draft = readDraftRow(api, columns, baseRow, 1);
+
+    expect(draft).toEqual({ id: 1, name: 'edited', sownAt: 'keep' });
+    expect(baseRow.name).toBe('original');
+  });
+
+  it('ignores updated values that do not own the column field', () => {
+    const api = {
+      getRowWithUpdatedValues: () => ({ unrelated: 'x' }),
+    } as unknown as GridApi;
+
+    const draft = readDraftRow(api, columns, { id: 2, name: 'original' } as TestRow, 2);
+
+    expect(draft).toEqual({ id: 2, name: 'original' });
+  });
+});
+
+describe('mergeVisibleDateEditInputValues', () => {
+  it('returns the draft unchanged when no root element is available', () => {
+    const draftRow: TestRow = { id: 1, name: 'x' };
+    expect(mergeVisibleDateEditInputValues(null, columns, 1, draftRow)).toBe(draftRow);
+  });
+
+  it('merges parsed German date input text for editing date cells', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <div role="row" data-id="1">
+        <div data-field="sownAt" class="MuiDataGrid-cell--editing">
+          <input value="15.03.2026" />
+        </div>
+      </div>
+    `;
+
+    const draft = mergeVisibleDateEditInputValues(
+      root,
+      columns,
+      1,
+      { id: 1, name: 'x' } as TestRow,
+    );
+
+    expect(draft.sownAt).toBeInstanceOf(Date);
+    expect((draft.sownAt as Date).getFullYear()).toBe(2026);
+  });
+
+  it('leaves non-date columns and non-editing cells untouched', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <div role="row" data-id="1">
+        <div data-field="sownAt"><input value="15.03.2026" /></div>
+      </div>
+    `;
+
+    const draftRow: TestRow = { id: 1, name: 'x', sownAt: 'unchanged' };
+    const draft = mergeVisibleDateEditInputValues(root, columns, 1, draftRow);
+
+    expect(draft.sownAt).toBe('unchanged');
+  });
+});

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -101,7 +101,7 @@ import {
   prepareDataGridColumn,
   SaveBlockedError,
 } from './dataGridUtils';
-import { parseGermanDateText } from './GermanDateEditCell';
+import { mergeVisibleDateEditInputValues, readDraftRow } from './draftRowReaders';
 import {
   focusKeyboardNavigableCell as focusDataGridKeyboardNavigableCell,
   getKeyboardNavigationTarget,
@@ -1029,49 +1029,17 @@ export function EditableDataGrid<T extends EditableRow>({
     if (!baseRow) {
       return null;
     }
-
-    const draftRow = { ...baseRow } as Record<string, unknown>;
-    for (const column of columns) {
-      const rowWithUpdatedField = api.getRowWithUpdatedValues(rowId, column.field) as Record<string, unknown> | null;
-      if (rowWithUpdatedField && Object.prototype.hasOwnProperty.call(rowWithUpdatedField, column.field)) {
-        draftRow[column.field] = rowWithUpdatedField[column.field];
-      }
-    }
-    return draftRow as T;
+    return readDraftRow(api, columns, baseRow, rowId);
   }, [columns, gridApiRef, rowsById]);
 
-  const mergeVisibleEditInputValues = useCallback((rowId: GridRowId, draftRow: T): T => {
-    const root = gridApiRef.current?.rootElementRef?.current;
-    if (!root) {
-      return draftRow;
-    }
-
-    const rowElement = root.querySelector<HTMLElement>(`[role="row"][data-id="${cssEscape(String(rowId))}"]`);
-    if (!rowElement) {
-      return draftRow;
-    }
-
-    const nextDraft = { ...draftRow } as Record<string, unknown>;
-    for (const column of columns) {
-      if (column.type !== 'date') {
-        continue;
-      }
-
-      const cellElement = rowElement.querySelector<HTMLElement>(
-        `[data-field="${cssEscape(column.field)}"].MuiDataGrid-cell--editing`,
-      );
-      const inputElement = cellElement?.querySelector<HTMLInputElement | HTMLTextAreaElement>(
-        'input:not([type="hidden"]):not([aria-hidden="true"]), textarea',
-      );
-      const inputValue = inputElement?.value;
-      if (inputValue === undefined) {
-        continue;
-      }
-
-      nextDraft[column.field] = parseGermanDateText(inputValue) ?? inputValue;
-    }
-    return nextDraft as T;
-  }, [columns, gridApiRef]);
+  const mergeVisibleEditInputValues = useCallback((rowId: GridRowId, draftRow: T): T => (
+    mergeVisibleDateEditInputValues(
+      gridApiRef.current?.rootElementRef?.current ?? null,
+      columns,
+      rowId,
+      draftRow,
+    )
+  ), [columns, gridApiRef]);
 
   const applyDraftValues = useCallback(async (rowId: GridRowId, values: Partial<T>): Promise<void> => {
     const rowKey = String(rowId);

--- a/frontend/src/components/data-grid/draftRowReaders.ts
+++ b/frontend/src/components/data-grid/draftRowReaders.ts
@@ -1,0 +1,82 @@
+/**
+ * Deterministic readers that reconstruct the current draft state of a grid row.
+ *
+ * These helpers only read from the grid API and the rendered DOM; they never
+ * mutate grid or component state. Keeping them free of React state makes the
+ * draft-resolution logic independently testable and shrinks the DataGrid
+ * component module.
+ */
+
+import type { GridApi, GridColDef, GridRowId } from '@mui/x-data-grid';
+import { cssEscape } from './continuousScrollLayout';
+import { parseGermanDateText } from './GermanDateEditCell';
+import type { EditableRow } from './types';
+
+/**
+ * Layers any in-flight edit-cell values from the grid API on top of a base row.
+ * Returns a new row object without touching the grid or component state.
+ */
+export function readDraftRow<T extends EditableRow>(
+  api: GridApi,
+  columns: readonly GridColDef[],
+  baseRow: T,
+  rowId: GridRowId,
+): T {
+  const draftRow = { ...baseRow } as Record<string, unknown>;
+  for (const column of columns) {
+    const rowWithUpdatedField = api.getRowWithUpdatedValues(rowId, column.field) as
+      | Record<string, unknown>
+      | null;
+    if (
+      rowWithUpdatedField &&
+      Object.prototype.hasOwnProperty.call(rowWithUpdatedField, column.field)
+    ) {
+      draftRow[column.field] = rowWithUpdatedField[column.field];
+    }
+  }
+  return draftRow as T;
+}
+
+/**
+ * Reads the raw text of currently-open date edit inputs straight from the DOM
+ * and merges the parsed values into the draft row. This captures keystrokes
+ * that have not yet been committed to the grid's edit state.
+ */
+export function mergeVisibleDateEditInputValues<T extends EditableRow>(
+  root: HTMLElement | null,
+  columns: readonly GridColDef[],
+  rowId: GridRowId,
+  draftRow: T,
+): T {
+  if (!root) {
+    return draftRow;
+  }
+
+  const rowElement = root.querySelector<HTMLElement>(
+    `[role="row"][data-id="${cssEscape(String(rowId))}"]`,
+  );
+  if (!rowElement) {
+    return draftRow;
+  }
+
+  const nextDraft = { ...draftRow } as Record<string, unknown>;
+  for (const column of columns) {
+    if (column.type !== 'date') {
+      continue;
+    }
+
+    const cellElement = rowElement.querySelector<HTMLElement>(
+      `[data-field="${cssEscape(column.field)}"].MuiDataGrid-cell--editing`,
+    );
+    const inputElement = cellElement?.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+      'input:not([type="hidden"]):not([aria-hidden="true"]), textarea',
+    );
+    const inputValue = inputElement?.value;
+    if (inputValue === undefined) {
+      continue;
+    }
+
+    nextDraft[column.field] = parseGermanDateText(inputValue) ?? inputValue;
+  }
+  return nextDraft as T;
+}


### PR DESCRIPTION
## Motivation

`DataGrid.tsx` is the largest module in the frontend (~2.7k lines). Continuing the incremental extraction started in #348, this moves two more self-contained helpers out of the component so the file shrinks and the extracted logic becomes independently testable.

## Description

- Add `frontend/src/components/data-grid/draftRowReaders.ts` with two pure functions:
  - `readDraftRow` — layers in-flight edit-cell values from the grid API on top of a base row.
  - `mergeVisibleDateEditInputValues` — reads the raw text of open date edit inputs straight from the DOM and merges the parsed values into the draft row.
- Both readers only read from the grid API and the rendered DOM; they never mutate grid or component state, so the change is behavior-preserving.
- `DataGrid.tsx` keeps thin `useCallback` wrappers (`getDraftRow` / `mergeVisibleEditInputValues`) that resolve the base row and root element, then delegate. All call sites are unchanged.
- Remove the now-unused `parseGermanDateText` import from `DataGrid.tsx` (it moved with the reader).

## Testing

- Added `frontend/src/__tests__/draftRowReaders.test.ts` covering both readers (5 cases).
- `npx tsc -b` — passes.
- `npx eslint` on the changed files — clean.
- `npx vitest run` for the new tests plus the existing `EditableDataGrid` and `dataGridUtils` suites — 64 tests pass.
- `npx madge --circular` on the new module — no circular dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_