### PR TITLE
refactor(frontend): centralize UTC ISO date helpers

### DIFF
--- a/frontend/src/__tests__/isoDate.test.ts
+++ b/frontend/src/__tests__/isoDate.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { addUtcDays, formatIsoDate, parseIsoDate } from '../utils/isoDate';
+
+describe('formatIsoDate', () => {
+  it('formats a UTC date as YYYY-MM-DD', () => {
+    expect(formatIsoDate(new Date(Date.UTC(2024, 4, 3)))).toBe('2024-05-03');
+  });
+
+  it('ignores the time-of-day component', () => {
+    expect(formatIsoDate(new Date(Date.UTC(2024, 0, 9, 23, 59, 59)))).toBe('2024-01-09');
+  });
+});
+
+describe('parseIsoDate', () => {
+  it('parses an ISO date into a UTC date', () => {
+    const parsed = parseIsoDate('2024-05-03');
+    expect(parsed?.getTime()).toBe(Date.UTC(2024, 4, 3));
+  });
+
+  it('returns null for empty or nullish input', () => {
+    expect(parseIsoDate('')).toBeNull();
+    expect(parseIsoDate(null)).toBeNull();
+    expect(parseIsoDate(undefined)).toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseIsoDate('not-a-date')).toBeNull();
+  });
+
+  it('round-trips with formatIsoDate', () => {
+    expect(formatIsoDate(parseIsoDate('2023-12-31') as Date)).toBe('2023-12-31');
+  });
+});
+
+describe('addUtcDays', () => {
+  it('adds days across a month boundary in UTC', () => {
+    expect(formatIsoDate(addUtcDays(new Date(Date.UTC(2024, 0, 30)), 3))).toBe('2024-02-02');
+  });
+
+  it('subtracts days with a negative offset', () => {
+    expect(formatIsoDate(addUtcDays(new Date(Date.UTC(2024, 2, 1)), -1))).toBe('2024-02-29');
+  });
+
+  it('does not mutate the input date', () => {
+    const original = new Date(Date.UTC(2024, 0, 1));
+    addUtcDays(original, 5);
+    expect(original.getTime()).toBe(Date.UTC(2024, 0, 1));
+  });
+});

--- a/frontend/src/cultures/exportUtils.ts
+++ b/frontend/src/cultures/exportUtils.ts
@@ -1,4 +1,5 @@
 import type { Culture } from '../api/types';
+import { formatIsoDate } from '../utils/isoDate';
 
 interface ExportEnvelopeBase {
   schemaVersion: 1;
@@ -48,8 +49,6 @@ export interface AllCulturesExport extends ExportEnvelopeBase {
   type: 'cultures';
   cultures: PortableCulture[];
 }
-
-const formatDate = (date = new Date()): string => date.toISOString().split('T')[0];
 
 export const slugifyFilenamePart = (value: string): string => {
   const normalized = value
@@ -102,14 +101,14 @@ export const toPortableCulture = (culture: Culture): PortableCulture => {
 
 export const buildSingleCultureExport = (culture: Culture, date = new Date()): SingleCultureExport => ({
   schemaVersion: 1,
-  exportedAt: formatDate(date),
+  exportedAt: formatIsoDate(date),
   type: 'culture',
   culture: toPortableCulture(culture),
 });
 
 export const buildAllCulturesExport = (cultures: Culture[], date = new Date()): AllCulturesExport => ({
   schemaVersion: 1,
-  exportedAt: formatDate(date),
+  exportedAt: formatIsoDate(date),
   type: 'cultures',
   cultures: cultures.map(toPortableCulture),
 });
@@ -132,7 +131,7 @@ export const downloadJsonFile = (data: object, filename: string): void => {
 export const buildSingleCultureFilename = (culture: Culture, date = new Date()): string => {
   const name = slugifyFilenamePart(culture.name);
   const variety = slugifyFilenamePart(culture.variety ?? '');
-  return `kultur_${name}_${variety}_${formatDate(date)}.json`;
+  return `kultur_${name}_${variety}_${formatIsoDate(date)}.json`;
 };
 
-export const buildAllCulturesFilename = (date = new Date()): string => `kulturen_export_${formatDate(date)}.json`;
+export const buildAllCulturesFilename = (date = new Date()): string => `kulturen_export_${formatIsoDate(date)}.json`;

--- a/frontend/src/cultures/spreadsheetExport.ts
+++ b/frontend/src/cultures/spreadsheetExport.ts
@@ -2,6 +2,7 @@ import * as XLSX from 'xlsx';
 import type { Culture } from '../api/types';
 import { toPortableCulture, slugifyFilenamePart } from './exportUtils';
 import { CULTURE_COLUMNS } from './spreadsheetColumns';
+import { formatIsoDate } from '../utils/isoDate';
 
 export type SpreadsheetExportFormat = 'xlsx' | 'ods' | 'csv';
 
@@ -59,8 +60,6 @@ export const exportCulturesToSpreadsheet = (
   triggerDownload(output, filename, MIME_TYPES[format]);
 };
 
-const formatDate = (date = new Date()): string => date.toISOString().split('T')[0];
-
 export const buildSpreadsheetFilename = (
   format: SpreadsheetExportFormat,
   scope: 'single' | 'all',
@@ -70,7 +69,7 @@ export const buildSpreadsheetFilename = (
   if (scope === 'single' && culture) {
     const supplier = slugifyFilenamePart(culture.supplier?.name ?? culture.seed_supplier ?? '');
     const variety = slugifyFilenamePart(culture.variety ?? '');
-    return `kultur_${supplier}_${variety}_${formatDate()}.${ext}`;
+    return `kultur_${supplier}_${variety}_${formatIsoDate()}.${ext}`;
   }
-  return `kulturen_export_${formatDate()}.${ext}`;
+  return `kulturen_export_${formatIsoDate()}.${ext}`;
 };

--- a/frontend/src/pages/ganttChartUtils.ts
+++ b/frontend/src/pages/ganttChartUtils.ts
@@ -1,5 +1,6 @@
 import type { Bed, Culture, Field, Location, PlantingPlan } from '../api/types';
 import { formatLocalizedNumber } from '../utils/numberLocalization';
+import { addUtcDays, formatIsoDate, parseIsoDate } from '../utils/isoDate';
 
 export interface GanttTask {
   id: string;
@@ -97,14 +98,7 @@ export interface OccupancyTooltipDetail {
 }
 
 export function parseDateString(dateStr: string): Date {
-  const [year, month, day] = dateStr.split('-').map(Number);
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-function addUtcDays(value: Date, days: number): Date {
-  const next = new Date(value);
-  next.setUTCDate(next.getUTCDate() + days);
-  return next;
+  return parseIsoDate(dateStr) ?? new Date(Number.NaN);
 }
 
 export function getDefaultCultureColor(cultureName: string): string {
@@ -677,8 +671,8 @@ export function buildSeedlingTaskGroups({
     };
     const aggregateKey = [
       plan.culture,
-      propagationStartDate.toISOString().slice(0, 10),
-      transplantDate.toISOString().slice(0, 10),
+      formatIsoDate(propagationStartDate),
+      formatIsoDate(transplantDate),
     ].join('|');
     const plantsCount = typeof plan.plants_count === 'number' ? plan.plants_count : null;
     const existingTask = aggregatedTasksByKey.get(aggregateKey);
@@ -692,7 +686,7 @@ export function buildSeedlingTaskGroups({
     }
 
     const task: GanttTask = {
-      id: `seedling-${plan.culture}-${propagationStartDate.toISOString().slice(0, 10)}-${transplantDate.toISOString().slice(0, 10)}`,
+      id: `seedling-${plan.culture}-${formatIsoDate(propagationStartDate)}-${formatIsoDate(transplantDate)}`,
       name: cultureLabel,
       startDate: propagationStartDate,
       endDate: transplantDate,

--- a/frontend/src/pages/locationDerivedTasks.ts
+++ b/frontend/src/pages/locationDerivedTasks.ts
@@ -1,4 +1,5 @@
 import type { Bed, Culture, Field, Location, PlantingPlan } from '../api/types';
+import { addUtcDays, formatIsoDate, parseIsoDate } from '../utils/isoDate';
 
 export type DerivedTaskType =
   | 'sowing'
@@ -18,21 +19,6 @@ export interface DerivedLocationTask {
 
 const DIRECT_SOWING = 'direct_sowing';
 const PRE_CULTIVATION = 'pre_cultivation';
-
-const toIsoDate = (value: Date): string => value.toISOString().slice(0, 10);
-
-const parseIsoDate = (value?: string | null): Date | null => {
-  if (!value) return null;
-  const [year, month, day] = value.split('-').map(Number);
-  const parsed = new Date(Date.UTC(year, month - 1, day));
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
-};
-
-const addDays = (value: Date, days: number): Date => {
-  const next = new Date(value);
-  next.setUTCDate(next.getUTCDate() + days);
-  return next;
-};
 
 const isDirectSowingPlan = (plan: PlantingPlan, culture?: Culture): boolean => {
   const planType = plan.cultivation_type || plan.culture_cultivation_type;
@@ -67,7 +53,7 @@ export function deriveLocationTasks({
   const cultureById = new Map(cultures.filter((culture): culture is Culture & { id: number } => typeof culture.id === 'number').map((culture) => [culture.id, culture]));
   const byLocation: Record<number, DerivedLocationTask[]> = {};
   const dedupe = new Set<string>();
-  const todayIso = toIsoDate(today);
+  const todayIso = formatIsoDate(today);
 
   const pushTask = (task: DerivedLocationTask): void => {
     if (task.date < todayIso) return;
@@ -92,7 +78,7 @@ export function deriveLocationTasks({
 
     pushTask({
       type: baseTaskType,
-      date: toIsoDate(plantingDate),
+      date: formatIsoDate(plantingDate),
       locationId: field.location,
       planId: plan.id,
       cultureName: plan.culture_name || culture?.name,
@@ -104,7 +90,7 @@ export function deriveLocationTasks({
     if (propagationDuration && propagationDuration > 0) {
       pushTask({
         type: 'propagationStart',
-        date: toIsoDate(addDays(plantingDate, -propagationDuration)),
+        date: formatIsoDate(addUtcDays(plantingDate, -propagationDuration)),
         locationId: field.location,
         planId: plan.id,
         cultureName: plan.culture_name || culture?.name,
@@ -117,7 +103,7 @@ export function deriveLocationTasks({
     if (growthDuration && growthDuration > 0) {
       pushTask({
         type: 'harvestStart',
-        date: toIsoDate(addDays(plantingDate, growthDuration)),
+        date: formatIsoDate(addUtcDays(plantingDate, growthDuration)),
         locationId: field.location,
         planId: plan.id,
         cultureName: plan.culture_name || culture?.name,

--- a/frontend/src/utils/isoDate.ts
+++ b/frontend/src/utils/isoDate.ts
@@ -1,0 +1,26 @@
+// UTC-based helpers for the ISO calendar-date format (YYYY-MM-DD) used across
+// planning data. Everything stays in UTC so date math never shifts a day across
+// DST boundaries or the viewer's local timezone.
+
+/** Formats a Date as an ISO calendar date (YYYY-MM-DD) in UTC. */
+export function formatIsoDate(date: Date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Parses an ISO calendar date (YYYY-MM-DD) into a UTC Date, or returns null for
+ * empty or invalid input.
+ */
+export function parseIsoDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** Returns a new Date shifted by the given number of days in UTC. */
+export function addUtcDays(value: Date, days: number): Date {
+  const next = new Date(value);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}


### PR DESCRIPTION
### Motivation
The same UTC date helpers were copy-pasted across several frontend modules: a `YYYY-MM-DD` formatter (`toISOString().split('T')[0]` / `.slice(0, 10)`), an ISO-date parser, and a UTC day-shift helper. This violates the DRY rule in `AGENTS.md` and makes the timezone-safe behavior easy to break in one place but not another.

### Description
- Add `frontend/src/utils/isoDate.ts` with `formatIsoDate`, `parseIsoDate`, and `addUtcDays` — all UTC-based so date math never shifts a day across DST or the viewer's local timezone.
- Reuse the shared helpers in:
  - `cultures/exportUtils.ts` and `cultures/spreadsheetExport.ts` (removed duplicated `formatDate`)
  - `pages/locationDerivedTasks.ts` (removed local `toIsoDate`, `parseIsoDate`, `addDays`)
  - `pages/ganttChartUtils.ts` (removed local `addUtcDays`, inlined `.slice(0, 10)` formatting; `parseDateString` now delegates to `parseIsoDate`)
- No behavior change — this is a structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npx vitest run` for `isoDate`, `ganttChartUtils`, `plantingPlansUtils`, `cultureExportUtils`, `locationDerivedTasks` — all pass (new `isoDate.test.ts` added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_