### PR TITLE
refactor(frontend): extract focused-cell resolver into keyboardNavigation

### DIFF
--- a/frontend/src/__tests__/keyboardNavigation.test.ts
+++ b/frontend/src/__tests__/keyboardNavigation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { focusKeyboardNavigableCell } from '../components/data-grid/keyboardNavigation';
+import {
+  focusKeyboardNavigableCell,
+  resolveFocusedCellFromEvent,
+} from '../components/data-grid/keyboardNavigation';
 
 describe('keyboardNavigation', () => {
   it('focuses the edit input inside a focused editable cell', () => {
@@ -27,5 +30,51 @@ describe('keyboardNavigation', () => {
     expect(document.activeElement).toBe(input);
 
     cellElement.remove();
+  });
+});
+
+describe('resolveFocusedCellFromEvent', () => {
+  it('prefers the grid focus state when a cell is tracked', () => {
+    const api = { state: { focus: { cell: { id: 7, field: 'width_m' } } } };
+
+    const result = resolveFocusedCellFromEvent(api, { target: null });
+
+    expect(result).toEqual({ id: 7, field: 'width_m' });
+  });
+
+  it('falls back to the event target DOM and parses a numeric row id', () => {
+    const row = document.createElement('div');
+    row.setAttribute('role', 'row');
+    row.dataset.id = '42';
+    const cell = document.createElement('div');
+    cell.setAttribute('role', 'gridcell');
+    cell.dataset.field = 'name';
+    row.append(cell);
+
+    const result = resolveFocusedCellFromEvent(null, { target: cell });
+
+    expect(result).toEqual({ id: 42, field: 'name' });
+  });
+
+  it('keeps a non-numeric row id as a string', () => {
+    const row = document.createElement('div');
+    row.setAttribute('role', 'row');
+    row.dataset.id = 'draft-1';
+    const cell = document.createElement('div');
+    cell.setAttribute('role', 'gridcell');
+    cell.dataset.field = 'name';
+    row.append(cell);
+
+    expect(resolveFocusedCellFromEvent(null, { target: cell })).toEqual({
+      id: 'draft-1',
+      field: 'name',
+    });
+  });
+
+  it('returns null when the target is not resolvable to a cell', () => {
+    expect(resolveFocusedCellFromEvent(null, { target: null })).toBeNull();
+    expect(
+      resolveFocusedCellFromEvent(undefined, { target: document.createElement('span') }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -109,6 +109,7 @@ import {
   isCellKeyboardNavigable,
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
+  resolveFocusedCellFromEvent,
 } from './keyboardNavigation';
 import { useSpreadsheetEditStarter } from './keyboardEditing';
 import type {
@@ -696,32 +697,9 @@ export function EditableDataGrid<T extends EditableRow>({
     }
   }, [gridApiRef]);
 
-  const getFocusedCellFromEvent = useCallback((event: KeyboardEvent): { id: GridRowId; field: string } | null => {
-    const api = gridApiRef.current;
-    const focusedCell = api?.state.focus.cell;
-    if (focusedCell) {
-      return focusedCell;
-    }
-
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) {
-      return null;
-    }
-
-    const cellElement = target.closest<HTMLElement>('[role="gridcell"][data-field]');
-    const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
-    const field = cellElement?.dataset.field;
-    const id = rowElement?.dataset.id;
-    if (!field || id === undefined) {
-      return null;
-    }
-
-    const numericId = Number(id);
-    return {
-      id: Number.isNaN(numericId) ? id : numericId,
-      field,
-    };
-  }, [gridApiRef]);
+  const getFocusedCellFromEvent = useCallback((event: KeyboardEvent): { id: GridRowId; field: string } | null => (
+    resolveFocusedCellFromEvent(gridApiRef.current, event)
+  ), [gridApiRef]);
 
   const isActionCellKeyboardNavigable = useCallback((params: GridCellParams<T>): boolean => (
     notesFieldNames.includes(params.field)

--- a/frontend/src/components/data-grid/keyboardNavigation.ts
+++ b/frontend/src/components/data-grid/keyboardNavigation.ts
@@ -285,3 +285,42 @@ export function preventReadOnlyCellMouseFocus(event: MouseEvent<HTMLElement>): v
 export function isInteractiveCellTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && Boolean(target.closest(INTERACTIVE_CELL_TARGET_SELECTOR));
 }
+
+interface FocusStateApi {
+  state?: { focus?: { cell?: CellLocation | null } };
+}
+
+/**
+ * Resolves the currently focused cell for a keyboard event: it prefers the
+ * grid's tracked focus state and falls back to walking up from the event
+ * target's DOM when the grid has not recorded a focused cell. Pure read; it
+ * never mutates the grid or the DOM.
+ */
+export function resolveFocusedCellFromEvent(
+  api: FocusStateApi | null | undefined,
+  event: { target: EventTarget | null },
+): CellLocation | null {
+  const focusedCell = api?.state?.focus?.cell;
+  if (focusedCell) {
+    return focusedCell;
+  }
+
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+
+  const cellElement = target.closest<HTMLElement>('[role="gridcell"][data-field]');
+  const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
+  const field = cellElement?.dataset.field;
+  const id = rowElement?.dataset.id;
+  if (!field || id === undefined) {
+    return null;
+  }
+
+  const numericId = Number(id);
+  return {
+    id: Number.isNaN(numericId) ? id : numericId,
+    field,
+  };
+}


### PR DESCRIPTION
## Motivation

Continuing the incremental slimming of `DataGrid.tsx`, this moves the focused-cell resolution logic into the existing `keyboardNavigation.ts` module, where the other keyboard-navigation helpers already live.

## Description

- Add `resolveFocusedCellFromEvent(api, event)` to `frontend/src/components/data-grid/keyboardNavigation.ts`. It prefers the grid's tracked focus state (`api.state.focus.cell`) and falls back to walking up from the event target's DOM (`[role="row"][data-id]` / `[role="gridcell"][data-field]`), parsing a numeric row id when possible.
- The function is a pure read — it never mutates grid or DOM state — so the change is behavior-preserving.
- `DataGrid.tsx` keeps a thin `useCallback` wrapper (`getFocusedCellFromEvent`) that forwards the current grid API; the call site is unchanged.

## Testing

- Extended `frontend/src/__tests__/keyboardNavigation.test.ts` with 4 cases covering the focus-state path, the DOM fallback (numeric and string ids), and the null cases.
- `npx tsc -b` — passes.
- `npx eslint` on the changed files — clean.
- `npx vitest run` for `keyboardNavigation` and `EditableDataGrid` suites — 59 tests pass.
- `npx madge --circular` — no circular dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_