### PR TITLE
refactor(frontend): extract pure yield helpers from YieldOverview

### DIFF
--- a/frontend/src/__tests__/yieldOverviewUtils.test.ts
+++ b/frontend/src/__tests__/yieldOverviewUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatCompactYield,
+  formatDateToAPI,
+  formatIsoWeek,
+  getYieldAxisLabelStep,
+  mergeCultureYields,
+  type YieldCalendarCulture,
+} from '../pages/yieldOverviewUtils';
+
+describe('formatCompactYield', () => {
+  it('keeps one fraction digit for small values', () => {
+    expect(formatCompactYield(4.25, 'en-US')).toBe('4.3');
+  });
+
+  it('drops fraction digits for values of ten or more', () => {
+    expect(formatCompactYield(12.7, 'en-US')).toBe('13');
+  });
+});
+
+describe('formatDateToAPI', () => {
+  it('formats a date as YYYY-MM-DD with zero padding', () => {
+    expect(formatDateToAPI(new Date(2024, 0, 5))).toBe('2024-01-05');
+  });
+});
+
+describe('formatIsoWeek', () => {
+  it('returns the ISO week for a mid-year date', () => {
+    // 2024-01-04 falls in ISO week 1.
+    expect(formatIsoWeek(new Date(2024, 0, 4))).toBe('2024-W01');
+  });
+
+  it('assigns the last days of the year to the first ISO week when applicable', () => {
+    // 2019-12-30 belongs to ISO week 1 of 2020.
+    expect(formatIsoWeek(new Date(2019, 11, 30))).toBe('2020-W01');
+  });
+});
+
+describe('mergeCultureYields', () => {
+  it('sums yields for entries sharing a culture id', () => {
+    const cultures = [
+      { culture_id: 1, yield: 2 },
+      { culture_id: 2, yield: 5 },
+      { culture_id: 1, yield: 3 },
+    ] as unknown as YieldCalendarCulture[];
+
+    const merged = mergeCultureYields(cultures);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((entry) => entry.culture_id === 1)?.yield).toBe(5);
+    expect(merged.find((entry) => entry.culture_id === 2)?.yield).toBe(5);
+  });
+});
+
+describe('getYieldAxisLabelStep', () => {
+  it('returns 1 when there is enough room per column', () => {
+    expect(getYieldAxisLabelStep(1000, 10, 'week')).toBe(1);
+  });
+
+  it('increases the step when columns get too narrow', () => {
+    expect(getYieldAxisLabelStep(100, 20, 'week')).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -46,11 +46,14 @@ import { useContextMenuPositionState } from "../components/contextMenu/useContex
 import { useFocusRegion } from "../focus/useFocusManager";
 import { parseDateString } from "./ganttChartUtils";
 import {
+  formatCompactYield,
+  formatDateToAPI,
+  formatIsoWeek,
   getYieldAxisLabelStep,
+  mergeCultureYields,
   type ChartPeriod,
+  type YieldCalendarCulture,
 } from "./yieldOverviewUtils";
-
-type YieldCalendarCulture = YieldCalendarWeek["cultures"][number];
 
 interface YieldCultureMeta {
   id: number;
@@ -80,51 +83,6 @@ interface YieldContextMenuPayload {
 
 const ALL_CULTURES = "all";
 const DEFAULT_LEGEND_CULTURE_LIMIT = 15;
-
-function formatCompactYield(value: number, locale: string): string {
-  const formatter = new Intl.NumberFormat(locale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: value < 10 ? 1 : 0,
-  });
-
-  return formatter.format(value);
-}
-
-function formatDateToAPI(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function formatIsoWeek(date: Date): string {
-  const utcDate = new Date(
-    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
-  );
-  const day = utcDate.getUTCDay() || 7;
-  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
-  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
-  const weekNumber = Math.ceil(
-    ((utcDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
-  );
-  return `${utcDate.getUTCFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
-}
-
-function mergeCultureYields(
-  cultures: YieldCalendarCulture[],
-): YieldCalendarCulture[] {
-  const totals = new Map<number, YieldCalendarCulture>();
-
-  cultures.forEach((culture) => {
-    const existing = totals.get(culture.culture_id);
-    totals.set(culture.culture_id, {
-      ...culture,
-      yield: (existing?.yield ?? 0) + culture.yield,
-    });
-  });
-
-  return [...totals.values()];
-}
 
 function useYieldChartData(
   weeklyYield: YieldCalendarWeek[],

--- a/frontend/src/pages/yieldOverviewUtils.ts
+++ b/frontend/src/pages/yieldOverviewUtils.ts
@@ -1,4 +1,56 @@
+import { type YieldCalendarWeek } from "../api/api";
+
 export type ChartPeriod = "week" | "month";
+
+export type YieldCalendarCulture = YieldCalendarWeek["cultures"][number];
+
+export function formatCompactYield(value: number, locale: string): string {
+  const formatter = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: value < 10 ? 1 : 0,
+  });
+
+  return formatter.format(value);
+}
+
+/** Formats a Date as YYYY-MM-DD using the local calendar date. */
+export function formatDateToAPI(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** Returns the ISO-8601 week identifier (e.g. "2024-W05") for the given date. */
+export function formatIsoWeek(date: Date): string {
+  const utcDate = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
+  const day = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(
+    ((utcDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${utcDate.getUTCFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
+}
+
+/** Sums the yields of culture entries sharing the same culture id. */
+export function mergeCultureYields(
+  cultures: YieldCalendarCulture[],
+): YieldCalendarCulture[] {
+  const totals = new Map<number, YieldCalendarCulture>();
+
+  cultures.forEach((culture) => {
+    const existing = totals.get(culture.culture_id);
+    totals.set(culture.culture_id, {
+      ...culture,
+      yield: (existing?.yield ?? 0) + culture.yield,
+    });
+  });
+
+  return [...totals.values()];
+}
 
 const WEEK_LABEL_MIN_WIDTH = 36;
 const MONTH_LABEL_MIN_WIDTH = 56;


### PR DESCRIPTION
### Motivation
`YieldOverview.tsx` mixed several pure, side-effect-free helpers in with the page component. The repository already has a dedicated `yieldOverviewUtils.ts` module (with `getYieldAxisLabelStep`), so these helpers belong there — keeping the component focused and the logic independently testable.

### Description
- Move `formatCompactYield`, `formatDateToAPI`, `formatIsoWeek`, and `mergeCultureYields` (plus the `YieldCalendarCulture` type alias) from `pages/YieldOverview.tsx` into `pages/yieldOverviewUtils.ts`.
- Import them back into `YieldOverview.tsx`; no call sites change.
- `formatDateToAPI` intentionally keeps its local-calendar-date semantics (it is not the UTC `formatIsoDate` helper).
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `yieldOverviewUtils` (new tests) and `YieldOverview` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_