### PR TITLE
refactor(frontend): dedupe grid cell DOM resolution

### DIFF
--- a/frontend/src/__tests__/keyboardNavigation.test.ts
+++ b/frontend/src/__tests__/keyboardNavigation.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   focusKeyboardNavigableCell,
+  getCellLocationFromDomTarget,
   resolveFocusedCellFromEvent,
 } from '../components/data-grid/keyboardNavigation';
+
+function buildGridCell(rowId: string, field: string): HTMLElement {
+  const row = document.createElement('div');
+  row.setAttribute('role', 'row');
+  row.dataset.id = rowId;
+  const cell = document.createElement('div');
+  cell.setAttribute('role', 'gridcell');
+  cell.dataset.field = field;
+  row.append(cell);
+  return cell;
+}
 
 describe('keyboardNavigation', () => {
   it('focuses the edit input inside a focused editable cell', () => {
@@ -33,6 +45,25 @@ describe('keyboardNavigation', () => {
   });
 });
 
+describe('getCellLocationFromDomTarget', () => {
+  it('resolves a cell and parses a numeric row id', () => {
+    const cell = buildGridCell('42', 'name');
+
+    expect(getCellLocationFromDomTarget(cell)).toEqual({ id: 42, field: 'name' });
+  });
+
+  it('keeps a non-numeric row id as a string', () => {
+    const cell = buildGridCell('draft-1', 'name');
+
+    expect(getCellLocationFromDomTarget(cell)).toEqual({ id: 'draft-1', field: 'name' });
+  });
+
+  it('returns null for targets outside a grid cell', () => {
+    expect(getCellLocationFromDomTarget(null)).toBeNull();
+    expect(getCellLocationFromDomTarget(document.createElement('span'))).toBeNull();
+  });
+});
+
 describe('resolveFocusedCellFromEvent', () => {
   it('prefers the grid focus state when a cell is tracked', () => {
     const api = { state: { focus: { cell: { id: 7, field: 'width_m' } } } };
@@ -42,31 +73,11 @@ describe('resolveFocusedCellFromEvent', () => {
     expect(result).toEqual({ id: 7, field: 'width_m' });
   });
 
-  it('falls back to the event target DOM and parses a numeric row id', () => {
-    const row = document.createElement('div');
-    row.setAttribute('role', 'row');
-    row.dataset.id = '42';
-    const cell = document.createElement('div');
-    cell.setAttribute('role', 'gridcell');
-    cell.dataset.field = 'name';
-    row.append(cell);
-
-    const result = resolveFocusedCellFromEvent(null, { target: cell });
-
-    expect(result).toEqual({ id: 42, field: 'name' });
-  });
-
-  it('keeps a non-numeric row id as a string', () => {
-    const row = document.createElement('div');
-    row.setAttribute('role', 'row');
-    row.dataset.id = 'draft-1';
-    const cell = document.createElement('div');
-    cell.setAttribute('role', 'gridcell');
-    cell.dataset.field = 'name';
-    row.append(cell);
+  it('falls back to the event target DOM when no cell is tracked', () => {
+    const cell = buildGridCell('42', 'name');
 
     expect(resolveFocusedCellFromEvent(null, { target: cell })).toEqual({
-      id: 'draft-1',
+      id: 42,
       field: 'name',
     });
   });

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -106,6 +106,7 @@ import {
   focusKeyboardNavigableCell as focusDataGridKeyboardNavigableCell,
   getKeyboardNavigationTarget,
   getVerticalKeyboardNavigationTarget,
+  getCellLocationFromDomTarget,
   isCellKeyboardNavigable,
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
@@ -796,21 +797,16 @@ export function EditableDataGrid<T extends EditableRow>({
       return;
     }
 
-    const cellElement = target.closest<HTMLElement>('[role="gridcell"][data-field]');
-    const rowElement = target.closest<HTMLElement>('[role="row"][data-id]');
-    const field = cellElement?.dataset.field;
-    const id = rowElement?.dataset.id;
-    if (!field || id === undefined) {
+    const cellLocation = getCellLocationFromDomTarget(target);
+    if (!cellLocation) {
       return;
     }
 
-    const numericId = Number(id);
-    const rowId = Number.isNaN(numericId) ? id : numericId;
     if (isCellKeyboardNavigable<T>({
       api: gridApiRef.current,
-      field,
+      field: cellLocation.field,
       isActionCell: isActionCellKeyboardNavigable,
-      rowId,
+      rowId: cellLocation.id,
     })) {
       return;
     }

--- a/frontend/src/components/data-grid/keyboardNavigation.ts
+++ b/frontend/src/components/data-grid/keyboardNavigation.ts
@@ -291,21 +291,11 @@ interface FocusStateApi {
 }
 
 /**
- * Resolves the currently focused cell for a keyboard event: it prefers the
- * grid's tracked focus state and falls back to walking up from the event
- * target's DOM when the grid has not recorded a focused cell. Pure read; it
- * never mutates the grid or the DOM.
+ * Walks up from a DOM event target to the enclosing grid cell and resolves its
+ * row id and field. Row ids are returned as numbers when they parse cleanly and
+ * kept as strings otherwise. Pure read; it never mutates the grid or the DOM.
  */
-export function resolveFocusedCellFromEvent(
-  api: FocusStateApi | null | undefined,
-  event: { target: EventTarget | null },
-): CellLocation | null {
-  const focusedCell = api?.state?.focus?.cell;
-  if (focusedCell) {
-    return focusedCell;
-  }
-
-  const target = event.target;
+export function getCellLocationFromDomTarget(target: EventTarget | null): CellLocation | null {
   if (!(target instanceof HTMLElement)) {
     return null;
   }
@@ -323,4 +313,22 @@ export function resolveFocusedCellFromEvent(
     id: Number.isNaN(numericId) ? id : numericId,
     field,
   };
+}
+
+/**
+ * Resolves the currently focused cell for a keyboard event: it prefers the
+ * grid's tracked focus state and falls back to walking up from the event
+ * target's DOM when the grid has not recorded a focused cell. Pure read; it
+ * never mutates the grid or the DOM.
+ */
+export function resolveFocusedCellFromEvent(
+  api: FocusStateApi | null | undefined,
+  event: { target: EventTarget | null },
+): CellLocation | null {
+  const focusedCell = api?.state?.focus?.cell;
+  if (focusedCell) {
+    return focusedCell;
+  }
+
+  return getCellLocationFromDomTarget(event.target);
 }


### PR DESCRIPTION
## Motivation

`resolveFocusedCellFromEvent` (added in #352) and `DataGrid`'s `handleReadOnlyCellMouseDown` both walked up from a DOM target to the enclosing grid cell using identical logic — the same `[role="row"][data-id]` / `[role="gridcell"][data-field]` selectors and numeric row-id parsing. This removes that duplication.

## Description

- Add `getCellLocationFromDomTarget(target)` to `frontend/src/components/data-grid/keyboardNavigation.ts` — a pure read that resolves a DOM target to its `{ id, field }` cell location, keeping numeric row ids as numbers and non-numeric ids as strings.
- `resolveFocusedCellFromEvent` now delegates its DOM-fallback branch to the shared helper.
- `DataGrid.handleReadOnlyCellMouseDown` uses the same helper instead of its own inline copy.
- Behavior-preserving — no call-site behavior changes.

## Testing

- Reworked `frontend/src/__tests__/keyboardNavigation.test.ts` to cover `getCellLocationFromDomTarget` directly and keep the `resolveFocusedCellFromEvent` cases via a shared DOM builder.
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx vitest run` for `keyboardNavigation` and `EditableDataGrid` — 61 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_