### PR TITLE
refactor(frontend): move seed demand package-cell helpers into diagnostics

### DIFF
--- a/frontend/src/__tests__/seedDemandDiagnostics.test.ts
+++ b/frontend/src/__tests__/seedDemandDiagnostics.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { SeedDemand } from '../api/types';
 import {
   getPackageBlockerTooltip,
+  getPackageCellState,
   getRequiredAmountDiagnostic,
+  hasPackageCellTooltip,
   type SeedDemandTranslator,
 } from '../pages/seedDemandDiagnostics';
 
@@ -79,5 +81,42 @@ describe('seed demand diagnostics', () => {
       required_amount_value: 12.5,
       required_amount_unit: 'g',
     }), t)).toBeNull();
+  });
+});
+
+describe('getPackageCellState', () => {
+  it('returns "computed" when a package selection exists', () => {
+    expect(getPackageCellState(row({
+      required_amount_value: 10,
+      package_suggestion: { selection: [{ size_value: 5, size_unit: 'g', count: 2 }] },
+    } as Partial<SeedDemand>))).toBe('computed');
+  });
+
+  it('returns "unavailableRequirement" when the required amount is missing', () => {
+    expect(getPackageCellState(row({ required_amount_value: null }))).toBe('unavailableRequirement');
+  });
+
+  it('returns "chooseSupplier" when no supplier data is available', () => {
+    expect(getPackageCellState(row({
+      required_amount_value: 10,
+      supplier_options: [],
+    } as Partial<SeedDemand>))).toBe('chooseSupplier');
+  });
+
+  it('returns "calculationError" for a non-actionable blocker', () => {
+    expect(getPackageCellState(row({ package_blocker: 'unit_conversion_unavailable' }))).toBe('calculationError');
+  });
+});
+
+describe('hasPackageCellTooltip', () => {
+  it('is false when a package selection exists', () => {
+    expect(hasPackageCellTooltip(row({
+      required_amount_value: 10,
+      package_suggestion: { selection: [{ size_value: 5, size_unit: 'g', count: 1 }] },
+    } as Partial<SeedDemand>))).toBe(false);
+  });
+
+  it('is true when a blocker prevents a package suggestion', () => {
+    expect(hasPackageCellTooltip(row({ required_amount_value: null }))).toBe(true);
   });
 });

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -41,9 +41,10 @@ import { formatLocalizedNumber } from '../utils/numberLocalization';
 import { shouldOpenCustomContextMenu, suppressNativeContextMenu } from '../utils/contextMenu';
 import { TypeaheadSelect as Select } from '../components/inputs/TypeaheadSelect';
 import {
-  getEffectivePackageBlocker,
   getPackageBlockerTooltip,
+  getPackageCellState,
   getRequiredAmountDiagnostic,
+  hasPackageCellTooltip,
 } from './seedDemandDiagnostics';
 
 const formatUnit = (unit: 'g' | 'seeds', t: (key: string) => string): string => (
@@ -65,28 +66,6 @@ const formatPackageSelection = (row: SeedDemand, t: Translator): string => (
     .map((item) => `${formatSeedAmount(item.size_value)} ${formatUnit(item.size_unit, t)}${item.count > 1 ? ` × ${item.count}` : ''}`)
     .join(' + ')
 );
-
-type PackageCellState = 'computed' | 'chooseSupplier' | 'notConfigured' | 'unavailableRequirement' | 'calculationError';
-
-const getPackageCellState = (row: SeedDemand): PackageCellState => {
-  const blocker = getEffectivePackageBlocker(row);
-  if (!blocker) {
-    return 'computed';
-  }
-  switch (blocker) {
-    case 'supplier_data_missing':
-    case 'supplier_not_selected':
-      return 'chooseSupplier';
-    case 'package_sizes_missing':
-      return 'notConfigured';
-    case 'required_amount_unavailable':
-      return 'unavailableRequirement';
-    default:
-      return 'calculationError';
-  }
-};
-
-const hasPackageCellTooltip = (row: SeedDemand): boolean => getEffectivePackageBlocker(row) !== null;
 
 export default function SeedDemandPage() {
   useCommandContextTag('seedDemand');

--- a/frontend/src/pages/seedDemandDiagnostics.ts
+++ b/frontend/src/pages/seedDemandDiagnostics.ts
@@ -118,3 +118,31 @@ export const getPackageBlockerTooltip = (row: SeedDemand, t: SeedDemandTranslato
   };
   return t(keyByBlocker[blocker ?? ''] ?? 'seedDemand.noPackageCalculationPossibleTooltip');
 };
+
+export type PackageCellState =
+  | 'computed'
+  | 'chooseSupplier'
+  | 'notConfigured'
+  | 'unavailableRequirement'
+  | 'calculationError';
+
+export const getPackageCellState = (row: SeedDemand): PackageCellState => {
+  const blocker = getEffectivePackageBlocker(row);
+  if (!blocker) {
+    return 'computed';
+  }
+  switch (blocker) {
+    case 'supplier_data_missing':
+    case 'supplier_not_selected':
+      return 'chooseSupplier';
+    case 'package_sizes_missing':
+      return 'notConfigured';
+    case 'required_amount_unavailable':
+      return 'unavailableRequirement';
+    default:
+      return 'calculationError';
+  }
+};
+
+export const hasPackageCellTooltip = (row: SeedDemand): boolean =>
+  getEffectivePackageBlocker(row) !== null;


### PR DESCRIPTION
### Motivation
`SeedDemand.tsx` defined the pure helpers `getPackageCellState` and `hasPackageCellTooltip` locally, even though both are thin wrappers around `getEffectivePackageBlocker`, which already lives in `seedDemandDiagnostics.ts`. Keeping the blocker-to-UI-state mapping next to the blocker logic makes it cohesive and independently testable.

### Description
- Move `getPackageCellState`, `hasPackageCellTooltip`, and the `PackageCellState` type from `pages/SeedDemand.tsx` into `pages/seedDemandDiagnostics.ts`.
- Update the `SeedDemand.tsx` import accordingly (drops the now-indirect `getEffectivePackageBlocker` import).
- Extend `seedDemandDiagnostics.test.ts` with cases for the moved helpers.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean (one pre-existing `exhaustive-deps` warning in `SeedDemand.tsx`, unrelated to this change)
- `npx vitest run seedDemandDiagnostics` — 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_