### PR TITLE
refactor(frontend): extract row-validation helpers from DataGrid

### DIFF
--- a/frontend/src/__tests__/rowValidation.test.ts
+++ b/frontend/src/__tests__/rowValidation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { GridRowModes } from '@mui/x-data-grid';
+import type { GridRowModesModel } from '@mui/x-data-grid';
+import {
+  collectRowValidationErrors,
+  hasInvalidRowInEditMode,
+} from '../components/data-grid/rowValidation';
+
+interface TestRow {
+  id: number;
+  name: string;
+  [key: string]: unknown;
+}
+
+const rowsById = new Map<string, TestRow>([
+  ['1', { id: 1, name: 'valid' }],
+  ['2', { id: 2, name: '' }],
+]);
+
+const validateRow = (row: TestRow): string | null => (row.name ? null : 'Name required');
+
+describe('hasInvalidRowInEditMode', () => {
+  it('returns true when a row in edit mode fails validation', () => {
+    const model: GridRowModesModel = { 2: { mode: GridRowModes.Edit } };
+
+    expect(hasInvalidRowInEditMode(model, rowsById, validateRow)).toBe(true);
+  });
+
+  it('returns false when only valid rows are in edit mode', () => {
+    const model: GridRowModesModel = { 1: { mode: GridRowModes.Edit } };
+
+    expect(hasInvalidRowInEditMode(model, rowsById, validateRow)).toBe(false);
+  });
+
+  it('ignores rows that are not in edit mode', () => {
+    const model: GridRowModesModel = { 2: { mode: GridRowModes.View } };
+
+    expect(hasInvalidRowInEditMode(model, rowsById, validateRow)).toBe(false);
+  });
+
+  it('ignores edit-mode ids that are missing from the row map', () => {
+    const model: GridRowModesModel = { 99: { mode: GridRowModes.Edit } };
+
+    expect(hasInvalidRowInEditMode(model, rowsById, validateRow)).toBe(false);
+  });
+});
+
+describe('collectRowValidationErrors', () => {
+  it('keys per-field errors by row id and skips valid rows', () => {
+    const rows: TestRow[] = [
+      { id: 1, name: 'valid' },
+      { id: 2, name: '' },
+    ];
+    const getRowValidationErrors = (row: TestRow): Record<string, string> =>
+      row.name ? {} : { name: 'Name required' };
+
+    expect(collectRowValidationErrors(rows, getRowValidationErrors)).toEqual({
+      2: { name: 'Name required' },
+    });
+  });
+
+  it('returns an empty map when every row is valid', () => {
+    const rows: TestRow[] = [{ id: 1, name: 'a' }];
+
+    expect(collectRowValidationErrors(rows, () => ({}))).toEqual({});
+  });
+});

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -103,6 +103,10 @@ import {
 } from './dataGridUtils';
 import { mergeVisibleDateEditInputValues, readDraftRow } from './draftRowReaders';
 import {
+  collectRowValidationErrors,
+  hasInvalidRowInEditMode as hasInvalidRowInEditModeState,
+} from './rowValidation';
+import {
   focusKeyboardNavigableCell as focusDataGridKeyboardNavigableCell,
   getKeyboardNavigationTarget,
   getVerticalKeyboardNavigationTarget,
@@ -816,31 +820,12 @@ export function EditableDataGrid<T extends EditableRow>({
 
   const hasInvalidRowInEditMode = useMemo(() => {
     if (!hasRowsInEditMode) return false;
-    
-    // Find rows that are in edit mode
-    const editingRowIds = Object.entries(rowModesModel)
-      .filter(([, mode]) => mode.mode === GridRowModes.Edit)
-      .map(([id]) => id);
-    
-    // Check if any of those rows have validation errors
-    return editingRowIds.some(id => {
-      const row = rowsById.get(String(id));
-      if (!row) return false;
-      const validationError = validateRow(row);
-      return validationError !== null;
-    });
+    return hasInvalidRowInEditModeState(rowModesModel, rowsById, validateRow);
   }, [hasRowsInEditMode, rowModesModel, rowsById, validateRow]);
 
   const rowValidationErrors = useMemo(() => {
     if (!getRowValidationErrors) return {};
-    const errorsByRow: Record<string, Record<string, string>> = {};
-    for (const row of rows as T[]) {
-      const errors = getRowValidationErrors(row);
-      if (Object.keys(errors).length > 0) {
-        errorsByRow[String(row.id)] = errors;
-      }
-    }
-    return errorsByRow;
+    return collectRowValidationErrors(rows as T[], getRowValidationErrors);
   }, [getRowValidationErrors, rows]);
 
   /**

--- a/frontend/src/components/data-grid/rowValidation.ts
+++ b/frontend/src/components/data-grid/rowValidation.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure row-validation helpers used by the editable data grid.
+ *
+ * These functions derive validation state from rows and the caller-supplied
+ * validators without touching grid or component state, which keeps them
+ * independently testable and out of the DataGrid component body.
+ */
+
+import { GridRowModes } from '@mui/x-data-grid';
+import type { GridRowModesModel } from '@mui/x-data-grid';
+import type { EditableRow } from './types';
+
+/**
+ * Returns true when at least one row currently in edit mode fails validation.
+ */
+export function hasInvalidRowInEditMode<T extends EditableRow>(
+  rowModesModel: GridRowModesModel,
+  rowsById: ReadonlyMap<string, T>,
+  validateRow: (row: T) => string | null,
+): boolean {
+  return Object.entries(rowModesModel)
+    .filter(([, mode]) => mode.mode === GridRowModes.Edit)
+    .some(([rowId]) => {
+      const row = rowsById.get(String(rowId));
+      if (!row) {
+        return false;
+      }
+      return validateRow(row) !== null;
+    });
+}
+
+/**
+ * Builds a map of per-row field errors, keyed by row id, skipping rows that
+ * have no validation errors.
+ */
+export function collectRowValidationErrors<T extends EditableRow>(
+  rows: readonly T[],
+  getRowValidationErrors: (row: T) => Record<string, string>,
+): Record<string, Record<string, string>> {
+  const errorsByRow: Record<string, Record<string, string>> = {};
+  for (const row of rows) {
+    const errors = getRowValidationErrors(row);
+    if (Object.keys(errors).length > 0) {
+      errorsByRow[String(row.id)] = errors;
+    }
+  }
+  return errorsByRow;
+}


### PR DESCRIPTION
## Motivation

Continuing to slim `DataGrid.tsx`, this moves the two row-validation derivations into their own module so the logic is pure, independently testable, and out of the component body.

## Description

- Add `frontend/src/components/data-grid/rowValidation.ts` with:
  - `hasInvalidRowInEditMode(rowModesModel, rowsById, validateRow)` — true when any edit-mode row fails `validateRow`.
  - `collectRowValidationErrors(rows, getRowValidationErrors)` — a map of per-row field errors keyed by row id, skipping valid rows.
- The two `useMemo` hooks in `DataGrid.tsx` now delegate to these helpers while keeping their existing short-circuits (`hasRowsInEditMode` / missing `getRowValidationErrors`), so behavior is unchanged.

## Testing

- Added `frontend/src/__tests__/rowValidation.test.ts` (6 cases: edit-mode validity, non-edit and missing rows, per-row error collection).
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx vitest run` for `rowValidation` and `EditableDataGrid` — 60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_