### PR TITLE
refactor(frontend): extract culture identity helpers from CultureForm

### DIFF
--- a/frontend/src/__tests__/cultureIdentity.test.ts
+++ b/frontend/src/__tests__/cultureIdentity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCultureIdentityKey,
+  normalizeCultureIdentityValue,
+} from '../cultures/cultureIdentity';
+
+describe('normalizeCultureIdentityValue', () => {
+  it('lowercases and collapses inner whitespace', () => {
+    expect(normalizeCultureIdentityValue('  Roma   Tomate ')).toBe('roma tomate');
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(normalizeCultureIdentityValue('')).toBeNull();
+    expect(normalizeCultureIdentityValue('   ')).toBeNull();
+    expect(normalizeCultureIdentityValue(null)).toBeNull();
+    expect(normalizeCultureIdentityValue(undefined)).toBeNull();
+  });
+});
+
+describe('buildCultureIdentityKey', () => {
+  it('builds a stable key from name and variety', () => {
+    expect(buildCultureIdentityKey('Tomate', 'Roma'))
+      .toBe(buildCultureIdentityKey(' tomate ', 'ROMA'));
+  });
+
+  it('returns null when either name or variety is missing', () => {
+    expect(buildCultureIdentityKey('Tomate', '')).toBeNull();
+    expect(buildCultureIdentityKey('', 'Roma')).toBeNull();
+    expect(buildCultureIdentityKey(null, null)).toBeNull();
+  });
+
+  it('does not collide across differently split name/variety pairs', () => {
+    expect(buildCultureIdentityKey('a b', 'c'))
+      .not.toBe(buildCultureIdentityKey('a', 'b c'));
+  });
+});

--- a/frontend/src/cultures/CultureForm.tsx
+++ b/frontend/src/cultures/CultureForm.tsx
@@ -39,6 +39,7 @@ import { ConfirmationDialog } from '../components/feedback/ConfirmationDialog';
 import { hasEffectiveCultureFormChanges } from './cultureFormChangeDetection';
 import { validateCulture } from './validation';
 import { normalizeSeedRateUnit } from './enumNormalization';
+import { buildCultureIdentityKey } from './cultureIdentity';
 import { TypeaheadSelect as Select } from '../components/inputs/TypeaheadSelect';
 import { BasicInfoSection } from './sections/BasicInfoSection';
 import { TimingSection } from './sections/TimingSection';
@@ -130,26 +131,6 @@ const EMPTY_CULTURE: Partial<Culture> = {
 };
 
 const DUPLICATE_CHECK_DEBOUNCE_MS = 400;
-
-const normalizeCultureIdentityValue = (value: string | undefined | null): string | null => {
-  if (!value) {
-    return null;
-  }
-  const normalized = value.split(/\s+/).filter(Boolean).join(' ').toLowerCase();
-  return normalized || null;
-};
-
-const buildCultureIdentityKey = (
-  name: string | undefined | null,
-  variety: string | undefined | null,
-): string | null => {
-  const normalizedName = normalizeCultureIdentityValue(name);
-  const normalizedVariety = normalizeCultureIdentityValue(variety);
-  if (!normalizedName || !normalizedVariety) {
-    return null;
-  }
-  return `${normalizedName}\u0000${normalizedVariety}`;
-};
 
 const buildInitialFormData = (culture?: Culture): Partial<Culture> => {
   if (!culture) {

--- a/frontend/src/cultures/cultureIdentity.ts
+++ b/frontend/src/cultures/cultureIdentity.ts
@@ -1,0 +1,27 @@
+// Identity helpers for detecting duplicate cultures by name + variety.
+// Normalization collapses whitespace and lowercases so that superficial
+// differences (extra spaces, casing) do not create distinct identities.
+
+// NUL separator avoids collisions between differently split name/variety pairs
+// (e.g. name "a b" + variety "c" vs. name "a" + variety "b c").
+const CULTURE_IDENTITY_SEPARATOR = String.fromCharCode(0);
+
+export const normalizeCultureIdentityValue = (value: string | undefined | null): string | null => {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.split(/\s+/).filter(Boolean).join(' ').toLowerCase();
+  return normalized || null;
+};
+
+export const buildCultureIdentityKey = (
+  name: string | undefined | null,
+  variety: string | undefined | null,
+): string | null => {
+  const normalizedName = normalizeCultureIdentityValue(name);
+  const normalizedVariety = normalizeCultureIdentityValue(variety);
+  if (!normalizedName || !normalizedVariety) {
+    return null;
+  }
+  return `${normalizedName}${CULTURE_IDENTITY_SEPARATOR}${normalizedVariety}`;
+};


### PR DESCRIPTION
### Motivation
`CultureForm.tsx` defined the pure duplicate-detection helpers `normalizeCultureIdentityValue` and `buildCultureIdentityKey` inline. They are self-contained, side-effect-free logic that is easier to reason about and test in its own module — matching the existing `src/cultures/*` helper-module pattern (`enumNormalization.ts`, `cultureFormChangeDetection.ts`, …).

### Description
- Add `src/cultures/cultureIdentity.ts` with `normalizeCultureIdentityValue` and `buildCultureIdentityKey`.
- Import them into `CultureForm.tsx`; all call sites are unchanged.
- The NUL key separator (previously an inline `` escape) is preserved via an explicit `CULTURE_IDENTITY_SEPARATOR = String.fromCharCode(0)` constant — same runtime string, more readable, and it documents why a NUL is used (collision safety between differently split name/variety pairs).
- Adds unit tests, including the collision-safety case.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `cultureIdentity` (new) and `CultureForm` — 5 + 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_