### PR TITLE
refactor(frontend): extract horizontal keyboard navigation target

### DIFF
--- a/frontend/src/__tests__/keyboardNavigation.test.ts
+++ b/frontend/src/__tests__/keyboardNavigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   focusKeyboardNavigableCell,
   getCellLocationFromDomTarget,
+  getHorizontalKeyboardNavigationTarget,
   resolveFocusedCellFromEvent,
 } from '../components/data-grid/keyboardNavigation';
 
@@ -61,6 +62,33 @@ describe('getCellLocationFromDomTarget', () => {
   it('returns null for targets outside a grid cell', () => {
     expect(getCellLocationFromDomTarget(null)).toBeNull();
     expect(getCellLocationFromDomTarget(document.createElement('span'))).toBeNull();
+  });
+});
+
+describe('getHorizontalKeyboardNavigationTarget', () => {
+  const fields = ['name', 'width_m', 'notes'];
+
+  it('moves to the next field when navigating forward', () => {
+    expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'name', 1)).toEqual({
+      id: 5,
+      field: 'width_m',
+    });
+  });
+
+  it('moves to the previous field when navigating backward', () => {
+    expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'width_m', -1)).toEqual({
+      id: 5,
+      field: 'name',
+    });
+  });
+
+  it('returns null at the row edges', () => {
+    expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'notes', 1)).toBeNull();
+    expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'name', -1)).toBeNull();
+  });
+
+  it('returns null when the current field is not navigable', () => {
+    expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'unknown', 1)).toBeNull();
   });
 });
 

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -111,6 +111,7 @@ import {
   getKeyboardNavigationTarget,
   getVerticalKeyboardNavigationTarget,
   getCellLocationFromDomTarget,
+  getHorizontalKeyboardNavigationTarget,
   isCellKeyboardNavigable,
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
@@ -777,20 +778,14 @@ export function EditableDataGrid<T extends EditableRow>({
     rowId: GridRowId,
     field: string,
     direction: 1 | -1,
-  ): { id: GridRowId; field: string } | null => {
-    const editableFields = getKeyboardNavigableFieldsForRow(rowId);
-    const fieldIndex = editableFields.indexOf(field);
-    if (fieldIndex === -1) {
-      return null;
-    }
-
-    const nextField = editableFields[fieldIndex + direction];
-    if (nextField) {
-      return { id: rowId, field: nextField };
-    }
-
-    return null;
-  }, [getKeyboardNavigableFieldsForRow]);
+  ): { id: GridRowId; field: string } | null => (
+    getHorizontalKeyboardNavigationTarget(
+      getKeyboardNavigableFieldsForRow(rowId),
+      rowId,
+      field,
+      direction,
+    )
+  ), [getKeyboardNavigableFieldsForRow]);
 
   const handleReadOnlyCellMouseDown = useCallback((event: React.MouseEvent<HTMLElement>): void => {
     const target = event.target;

--- a/frontend/src/components/data-grid/keyboardNavigation.ts
+++ b/frontend/src/components/data-grid/keyboardNavigation.ts
@@ -240,6 +240,26 @@ export function getVerticalKeyboardNavigationTarget<Row extends GridValidRowMode
   return null;
 }
 
+/**
+ * Resolves the next horizontally-adjacent navigable cell within the same row,
+ * given the row's already-computed ordered list of navigable fields. Returns
+ * null at the row edges. Pure function of its arguments.
+ */
+export function getHorizontalKeyboardNavigationTarget(
+  navigableFields: readonly string[],
+  rowId: GridRowId,
+  field: string,
+  direction: Direction,
+): CellLocation | null {
+  const fieldIndex = navigableFields.indexOf(field);
+  if (fieldIndex === -1) {
+    return null;
+  }
+
+  const nextField = navigableFields[fieldIndex + direction];
+  return nextField ? { id: rowId, field: nextField } : null;
+}
+
 export function focusKeyboardNavigableCell<Row extends GridValidRowModel>({
   api,
   cell,


### PR DESCRIPTION
## Motivation

`keyboardNavigation.ts` already owns the vertical navigation target helper (`getVerticalKeyboardNavigationTarget`), but the horizontal same-row lookup still lived inline in `DataGrid.tsx`. This moves it next to its sibling so all navigation-target logic sits in one module.

## Description

- Add `getHorizontalKeyboardNavigationTarget(navigableFields, rowId, field, direction)` to `frontend/src/components/data-grid/keyboardNavigation.ts` — a pure lookup that returns the next navigable field in the row (or null at the edges), given the row's already-computed ordered field list.
- `DataGrid.tsx` keeps a thin `useCallback` wrapper (`getHorizontalNavigationTarget`) that supplies the fields via `getKeyboardNavigableFieldsForRow`; the call site is unchanged.
- Behavior-preserving.

## Testing

- Extended `frontend/src/__tests__/keyboardNavigation.test.ts` with 4 cases (forward, backward, both edges, non-navigable field).
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx vitest run` for `keyboardNavigation` and `EditableDataGrid` — 65 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_