### PR TITLE
refactor(frontend): extract seed demand formatters into seedDemandFormat

### DIFF
--- a/frontend/src/__tests__/seedDemandFormat.test.ts
+++ b/frontend/src/__tests__/seedDemandFormat.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { SeedDemand } from '../api/types';
+import {
+  formatPackageSelection,
+  formatRequiredSeedAmount,
+  formatSeedAmount,
+  formatUnit,
+} from '../pages/seedDemandFormat';
+
+const t = (key: string): string => {
+  const labels: Record<string, string> = {
+    'seedDemand.unitSeeds': 'Korn',
+    'seedDemand.unitGrams': 'g',
+  };
+  return labels[key] ?? key;
+};
+
+describe('formatUnit', () => {
+  it('maps unit codes to localized labels', () => {
+    expect(formatUnit('seeds', t)).toBe('Korn');
+    expect(formatUnit('g', t)).toBe('g');
+  });
+});
+
+describe('formatSeedAmount', () => {
+  it('formats numbers with the German locale', () => {
+    expect(formatSeedAmount(1234.5)).toBe('1.234,5');
+  });
+});
+
+describe('formatRequiredSeedAmount', () => {
+  it('always renders two fraction digits', () => {
+    expect(formatRequiredSeedAmount(12)).toBe('12,00');
+  });
+});
+
+describe('formatPackageSelection', () => {
+  it('joins the selected packages and appends counts above one', () => {
+    const row = {
+      package_suggestion: {
+        selection: [
+          { size_value: 50, size_unit: 'g', count: 1 },
+          { size_value: 1000, size_unit: 'seeds', count: 3 },
+        ],
+      },
+    } as unknown as SeedDemand;
+
+    expect(formatPackageSelection(row, t)).toBe('50 g + 1.000 Korn × 3');
+  });
+
+  it('returns an empty string when there is no selection', () => {
+    expect(formatPackageSelection({} as SeedDemand, t)).toBe('');
+  });
+});

--- a/frontend/src/pages/SeedDemand.tsx
+++ b/frontend/src/pages/SeedDemand.tsx
@@ -37,7 +37,6 @@ import EmptyStateCard from '../components/project/EmptyStateCard';
 import { ContextMenuHint, FullCellTooltip, TableCopyMenuItems, useContextMenuHint } from '../components/data-grid';
 import { handleContextMenuKeyboardNavigation } from '../components/data-grid/contextMenuFocus';
 import { getFirstMissingProjectSetupStep, getTranslatedProjectSetupActions } from './requirementFlow';
-import { formatLocalizedNumber } from '../utils/numberLocalization';
 import { shouldOpenCustomContextMenu, suppressNativeContextMenu } from '../utils/contextMenu';
 import { TypeaheadSelect as Select } from '../components/inputs/TypeaheadSelect';
 import {
@@ -46,26 +45,11 @@ import {
   getRequiredAmountDiagnostic,
   hasPackageCellTooltip,
 } from './seedDemandDiagnostics';
-
-const formatUnit = (unit: 'g' | 'seeds', t: (key: string) => string): string => (
-  unit === 'seeds' ? t('seedDemand.unitSeeds') : t('seedDemand.unitGrams')
-);
-
-const formatSeedAmount = (value: number, options?: Intl.NumberFormatOptions): string => (
-  formatLocalizedNumber(value, 'de-DE', options)
-);
-
-const formatRequiredSeedAmount = (value: number): string => (
-  formatSeedAmount(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-);
-
-type Translator = (key: string, options?: Record<string, unknown>) => string;
-
-const formatPackageSelection = (row: SeedDemand, t: Translator): string => (
-  (row.package_suggestion?.selection ?? [])
-    .map((item) => `${formatSeedAmount(item.size_value)} ${formatUnit(item.size_unit, t)}${item.count > 1 ? ` × ${item.count}` : ''}`)
-    .join(' + ')
-);
+import {
+  formatPackageSelection,
+  formatRequiredSeedAmount,
+  formatUnit,
+} from './seedDemandFormat';
 
 export default function SeedDemandPage() {
   useCommandContextTag('seedDemand');

--- a/frontend/src/pages/seedDemandFormat.ts
+++ b/frontend/src/pages/seedDemandFormat.ts
@@ -1,0 +1,21 @@
+import type { SeedDemand } from '../api/types';
+import { formatLocalizedNumber } from '../utils/numberLocalization';
+import type { SeedDemandTranslator } from './seedDemandDiagnostics';
+
+export const formatUnit = (unit: 'g' | 'seeds', t: SeedDemandTranslator): string => (
+  unit === 'seeds' ? t('seedDemand.unitSeeds') : t('seedDemand.unitGrams')
+);
+
+export const formatSeedAmount = (value: number, options?: Intl.NumberFormatOptions): string => (
+  formatLocalizedNumber(value, 'de-DE', options)
+);
+
+export const formatRequiredSeedAmount = (value: number): string => (
+  formatSeedAmount(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+);
+
+export const formatPackageSelection = (row: SeedDemand, t: SeedDemandTranslator): string => (
+  (row.package_suggestion?.selection ?? [])
+    .map((item) => `${formatSeedAmount(item.size_value)} ${formatUnit(item.size_unit, t)}${item.count > 1 ? ` × ${item.count}` : ''}`)
+    .join(' + ')
+);


### PR DESCRIPTION
### Motivation
Following #355, `SeedDemand.tsx` still held its pure display formatters inline. Extracting them keeps the page component focused on rendering and makes the formatting logic (including the package-selection string composition) independently testable — consistent with the new `seedDemandDiagnostics` module.

### Description
- Add `pages/seedDemandFormat.ts` with `formatUnit`, `formatSeedAmount`, `formatRequiredSeedAmount`, and `formatPackageSelection`.
- Reuse the existing `SeedDemandTranslator` type from `seedDemandDiagnostics` instead of a local `Translator` alias.
- Update `SeedDemand.tsx` to import them; drops its now-unused `formatLocalizedNumber` import.
- Adds unit tests for the extracted formatters.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean (one pre-existing `exhaustive-deps` warning in `SeedDemand.tsx`, unrelated)
- `npx vitest run` for `seedDemandFormat` (new) and `seedDemandDiagnostics` — 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_