### PR TITLE
refactor(frontend): extract culture identity-key helpers from CultureForm

### DIFF
--- a/frontend/src/__tests__/cultureIdentity.test.ts
+++ b/frontend/src/__tests__/cultureIdentity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCultureIdentityKey,
+  normalizeCultureIdentityValue,
+} from '../cultures/cultureIdentity';
+
+const SEPARATOR = String.fromCharCode(0);
+
+describe('normalizeCultureIdentityValue', () => {
+  it('collapses whitespace, trims, and lowercases', () => {
+    expect(normalizeCultureIdentityValue('  Roter   Mangold ')).toBe('roter mangold');
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(normalizeCultureIdentityValue('')).toBeNull();
+    expect(normalizeCultureIdentityValue('   ')).toBeNull();
+    expect(normalizeCultureIdentityValue(null)).toBeNull();
+    expect(normalizeCultureIdentityValue(undefined)).toBeNull();
+  });
+});
+
+describe('buildCultureIdentityKey', () => {
+  it('joins normalized name and variety with a stable separator', () => {
+    expect(buildCultureIdentityKey('Tomate', 'Roma')).toBe(`tomate${SEPARATOR}roma`);
+  });
+
+  it('treats casing and whitespace differences as the same identity', () => {
+    expect(buildCultureIdentityKey('  TOMATE ', 'roma')).toBe(
+      buildCultureIdentityKey('tomate', 'Roma'),
+    );
+  });
+
+  it('returns null when either name or variety is missing', () => {
+    expect(buildCultureIdentityKey('Tomate', '')).toBeNull();
+    expect(buildCultureIdentityKey('', 'Roma')).toBeNull();
+    expect(buildCultureIdentityKey(null, null)).toBeNull();
+  });
+});

--- a/frontend/src/cultures/CultureForm.tsx
+++ b/frontend/src/cultures/CultureForm.tsx
@@ -37,6 +37,7 @@ import { useActiveSaveShortcut } from '../hooks/useActiveSaveShortcut';
 import { useDialogKeyboardScroll } from '../hooks/useDialogKeyboardScroll';
 import { ConfirmationDialog } from '../components/feedback/ConfirmationDialog';
 import { hasEffectiveCultureFormChanges } from './cultureFormChangeDetection';
+import { buildCultureIdentityKey } from './cultureIdentity';
 import { validateCulture } from './validation';
 import { normalizeSeedRateUnit } from './enumNormalization';
 import { TypeaheadSelect as Select } from '../components/inputs/TypeaheadSelect';
@@ -130,26 +131,6 @@ const EMPTY_CULTURE: Partial<Culture> = {
 };
 
 const DUPLICATE_CHECK_DEBOUNCE_MS = 400;
-
-const normalizeCultureIdentityValue = (value: string | undefined | null): string | null => {
-  if (!value) {
-    return null;
-  }
-  const normalized = value.split(/\s+/).filter(Boolean).join(' ').toLowerCase();
-  return normalized || null;
-};
-
-const buildCultureIdentityKey = (
-  name: string | undefined | null,
-  variety: string | undefined | null,
-): string | null => {
-  const normalizedName = normalizeCultureIdentityValue(name);
-  const normalizedVariety = normalizeCultureIdentityValue(variety);
-  if (!normalizedName || !normalizedVariety) {
-    return null;
-  }
-  return `${normalizedName}\u0000${normalizedVariety}`;
-};
 
 const buildInitialFormData = (culture?: Culture): Partial<Culture> => {
   if (!culture) {

--- a/frontend/src/cultures/cultureIdentity.ts
+++ b/frontend/src/cultures/cultureIdentity.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for deriving a culture's identity key from its name and variety.
+ *
+ * The identity key is used to detect duplicate cultures regardless of casing or
+ * incidental whitespace differences. Keeping the normalization here makes the
+ * duplicate-detection rules testable and independent of the form component.
+ */
+
+// Null character joining the name and variety. Using an otherwise-unusable
+// character as the separator keeps identity keys unambiguous (e.g. it cannot be
+// produced by user input that contains spaces).
+const IDENTITY_KEY_SEPARATOR = String.fromCharCode(0);
+
+/**
+ * Normalizes a free-text identity value: collapses internal whitespace, trims,
+ * and lowercases. Returns null for empty input so callers can treat missing and
+ * blank values the same way.
+ */
+export function normalizeCultureIdentityValue(value: string | undefined | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const normalized = value.split(/\s+/).filter(Boolean).join(' ').toLowerCase();
+  return normalized || null;
+}
+
+/**
+ * Builds a stable duplicate-detection key from a culture's name and variety.
+ * Returns null when either part is missing, since an identity requires both.
+ */
+export function buildCultureIdentityKey(
+  name: string | undefined | null,
+  variety: string | undefined | null,
+): string | null {
+  const normalizedName = normalizeCultureIdentityValue(name);
+  const normalizedVariety = normalizeCultureIdentityValue(variety);
+  if (!normalizedName || !normalizedVariety) {
+    return null;
+  }
+  return `${normalizedName}${IDENTITY_KEY_SEPARATOR}${normalizedVariety}`;
+}


### PR DESCRIPTION
Superseded by #357, which extracted the same culture identity helpers (`normalizeCultureIdentityValue` / `buildCultureIdentityKey`) into `cultureIdentity.ts` and is already merged to `main`. Closing this duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)