### PR TITLE
feat(frontend): make public pages indexable with robots.txt, sitemap and metadata

### DIFF
--- a/docs/seo-and-indexing.md
+++ b/docs/seo-and-indexing.md
@@ -1,0 +1,151 @@
+# SEO & Search-Engine Indexing
+
+OpenFarmPlanner's frontend is a client-rendered React SPA (Vite) that is
+deployed as static assets and served from the site root by the operations
+stack (see `OpenFarmPlanner-ops`). The Django backend is API-only and does
+**not** serve the SPA or any SEO artifact. Everything below is therefore
+produced by the **frontend build**.
+
+## What is indexable
+
+Indexable public pages (also the sitemap entries):
+
+| Path                   | Purpose                        |
+| ---------------------- | ------------------------------ |
+| `/`                    | Public landing page            |
+| `/impressum`           | Imprint (legal)                |
+| `/datenschutz`         | Privacy policy (legal)         |
+| `/nutzungsbedingungen` | Terms of service (legal)       |
+
+Explicitly **not** indexable (disallowed in `robots.txt` and served with a
+`noindex, nofollow` robots meta at runtime):
+
+- `/app/*` — the authenticated application
+- `/login`, `/register`, `/activate`, `/forgot-password`, `/reset-password`,
+  `/confirm-email-change`
+- `/invite/*`, `/invitation`
+
+The single source of truth for both lists is
+[`frontend/src/seo/seoConfig.ts`](../frontend/src/seo/seoConfig.ts)
+(`PUBLIC_INDEXABLE_ROUTES` and `NON_INDEXABLE_PATH_PREFIXES`). Add a new public
+route there and it flows automatically into the sitemap, the runtime canonical
+logic and the tests. When the planned public crop library (`/crops`, see
+[crop-library-architecture.md](crop-library-architecture.md)) ships, add its
+public routes to `PUBLIC_INDEXABLE_ROUTES`.
+
+## How robots.txt and sitemap.xml are generated
+
+They are **not** static files under `frontend/public/`. They are generated at
+build time by the Vite plugin
+[`frontend/build/seoPlugin.ts`](../frontend/build/seoPlugin.ts) from the
+central config, so the canonical domain and route list are never duplicated:
+
+- `generateBundle` emits `dist/robots.txt` and `dist/sitemap.xml`.
+- `transformIndexHtml` injects `<link rel="canonical">`, the `robots` meta and
+  the Open Graph / Twitter tags into `dist/index.html`, so crawlers get real
+  metadata from the very first (pre-JavaScript) HTML response.
+- `configureServer` / `configurePreviewServer` serve the same `/robots.txt` and
+  `/sitemap.xml` from `vite` (dev) and `vite preview`, so local verification
+  uses the same URLs as production.
+
+At runtime, [`frontend/src/seo/RouteSeo.tsx`](../frontend/src/seo/RouteSeo.tsx)
+keeps the canonical and `robots` meta correct during client-side navigation —
+in particular it sets `noindex, nofollow` on every private/app/auth route. This
+complements `robots.txt` (which prevents crawling) for crawlers that render
+JavaScript.
+
+## Environment variables
+
+| Variable               | Default                         | Effect                                                                                                    |
+| ---------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `VITE_PUBLIC_SITE_URL` | `https://openfarmplanner.org`   | Canonical origin used for canonical/OG URLs, the `robots.txt` `Sitemap:` line and sitemap `<loc>` values. |
+| `VITE_SEO_INDEXABLE`   | `true`                          | `false`/`0`/`no`/`off` → `robots.txt` becomes `Disallow: /` and a `noindex` meta is emitted.               |
+
+**Production** must build with `VITE_PUBLIC_SITE_URL=https://openfarmplanner.org`
+and `VITE_SEO_INDEXABLE` unset (or `true`).
+
+**Preview / staging / test** builds should set `VITE_SEO_INDEXABLE=false` so
+those hosts are deliberately kept out of search indexes. This is the only
+supported way to block indexing environment-dependently — never ship a blanket
+block to production.
+
+## Local verification
+
+Build and inspect the emitted artifacts:
+
+```bash
+cd frontend
+VITE_PUBLIC_SITE_URL=https://openfarmplanner.org npm run build
+cat dist/robots.txt
+cat dist/sitemap.xml
+grep -E 'canonical|robots|og:|twitter:' dist/index.html
+```
+
+Or serve the production build and check over HTTP (no external service needed):
+
+```bash
+cd frontend
+npm run build && npm run preview   # serves on http://localhost:4173
+curl -s http://localhost:4173/robots.txt
+curl -s http://localhost:4173/sitemap.xml
+curl -s http://localhost:4173/ | grep -E 'rel="canonical"|name="robots"'
+```
+
+Confirm a non-production build blocks indexing:
+
+```bash
+cd frontend
+VITE_SEO_INDEXABLE=false npm run build
+cat dist/robots.txt      # expect: Disallow: /
+grep 'name="robots"' dist/index.html   # expect: noindex, nofollow
+```
+
+Run the SEO tests:
+
+```bash
+cd frontend
+npx vitest run src/seo build
+```
+
+## Production diagnosis after deployment
+
+Run these against the live site (replace the host if verifying a preview):
+
+```bash
+# Status + redirect chain to the canonical URL (expect a single 200 at the end)
+curl -sSIL https://openfarmplanner.org/ | grep -iE '^HTTP/|^location:'
+
+# All host/scheme variants should end on exactly one canonical https URL
+for u in http://openfarmplanner.org https://openfarmplanner.org \
+         http://www.openfarmplanner.org https://www.openfarmplanner.org; do
+  echo "== $u =="; curl -sSIL "$u" | grep -iE '^HTTP/|^location:'
+done
+
+# robots.txt and sitemap.xml must return 200 and correct content types
+curl -sSI https://openfarmplanner.org/robots.txt
+curl -sSI https://openfarmplanner.org/sitemap.xml
+
+# The landing HTML must NOT contain a noindex directive and MUST have a canonical
+curl -s https://openfarmplanner.org/ | grep -iE 'rel="canonical"|name="robots"'
+
+# There must be no X-Robots-Tag: noindex response header (this is set by the
+# web server / proxy, i.e. in OpenFarmPlanner-ops, not in this repository)
+curl -sSI https://openfarmplanner.org/ | grep -i 'x-robots-tag'
+```
+
+### What this repository can and cannot fix
+
+- **Fixable here:** the initial HTML metadata (canonical, robots, OG/Twitter),
+  `robots.txt`, `sitemap.xml`, per-route `noindex` for private pages, and the
+  canonical-domain configuration. All covered above.
+- **Hosting / proxy / DNS (OpenFarmPlanner-ops):** any `X-Robots-Tag: noindex`
+  response header, HTTP→HTTPS and `www`→non-`www` redirects, TLS, and the actual
+  static serving of `robots.txt` / `sitemap.xml`. A previously-indexed site that
+  silently dropped out of Google — while still being found by other engines — is
+  most consistent with an `X-Robots-Tag: noindex` header (or a `robots.txt`
+  `Disallow: /`) introduced at the proxy, e.g. during a beta/demo phase. Verify
+  with the `curl` header checks above and remove any such directive in the ops
+  configuration.
+- **Google Search Console only:** submitting/pinging the sitemap, requesting
+  re-indexing, and reviewing the "Page indexing" / "Removals" reports and any
+  manual actions. These cannot be inspected from the codebase.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -14,6 +14,21 @@
 # know what you're doing:
 # VITE_API_BASE_URL=
 
+# VITE_PUBLIC_SITE_URL: Canonical, absolute public origin of the deployment.
+#
+# Single source of truth for the canonical/OG URLs, robots.txt Sitemap line and
+# the sitemap.xml <loc> entries. Set it to the production origin WITHOUT a
+# trailing path, e.g. https://openfarmplanner.org. Defaults to
+# https://openfarmplanner.org when unset.
+# VITE_PUBLIC_SITE_URL=https://openfarmplanner.org
+
+# VITE_SEO_INDEXABLE: Whether this deployment may be indexed by search engines.
+#
+# Defaults to true (production intent). Set to false on preview/staging/test
+# hosts to serve robots.txt with "Disallow: /" and add a noindex meta tag, so
+# non-production environments are deliberately kept out of search indexes.
+# VITE_SEO_INDEXABLE=true
+
 # DEV_BACKEND_ORIGIN: Optional Vite dev-server proxy target.
 # This is read by vite.config.ts on the development machine, not by the browser.
 # Keep VITE_API_BASE_URL unset for LAN testing unless you need direct browser

--- a/frontend/build/seoPlugin.test.ts
+++ b/frontend/build/seoPlugin.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { seoPlugin } from './seoPlugin';
+
+const SAMPLE_HTML = [
+  '<!doctype html>',
+  '<html lang="de">',
+  '  <head>',
+  '    <meta charset="UTF-8" />',
+  '    <title>OpenFarmPlanner</title>',
+  '  </head>',
+  '  <body><div id="root"></div></body>',
+  '</html>',
+  '',
+].join('\n');
+
+function callTransformIndexHtml(plugin: ReturnType<typeof seoPlugin>, html: string): string {
+  const hook = plugin.transformIndexHtml;
+  const fn = typeof hook === 'function' ? hook : hook?.handler;
+  const result = (fn as (h: string) => unknown)?.call(plugin, html);
+  return typeof result === 'string' ? result : String(result);
+}
+
+function collectEmittedFiles(plugin: ReturnType<typeof seoPlugin>) {
+  const emitted: { fileName: string; source: string }[] = [];
+  const ctx = {
+    emitFile: (file: { fileName?: string; source?: string }) => {
+      emitted.push({ fileName: file.fileName ?? '', source: String(file.source) });
+    },
+  };
+  const hook = plugin.generateBundle;
+  const fn = typeof hook === 'function' ? hook : hook?.handler;
+  (fn as (...args: unknown[]) => void)?.call(ctx);
+  return emitted;
+}
+
+describe('seoPlugin transformIndexHtml', () => {
+  it('injects canonical and OG tags into <head> for production', () => {
+    const plugin = seoPlugin({ VITE_PUBLIC_SITE_URL: 'https://openfarmplanner.org' });
+    const html = callTransformIndexHtml(plugin, SAMPLE_HTML);
+    expect(html).toContain('<link rel="canonical" href="https://openfarmplanner.org/" />');
+    expect(html).toContain('<meta name="robots" content="index, follow" />');
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('</head>');
+    // The original title survives.
+    expect(html).toContain('<title>OpenFarmPlanner</title>');
+    expect(html).not.toContain('noindex');
+  });
+
+  it('injects a noindex directive when the environment is not indexable', () => {
+    const plugin = seoPlugin({ VITE_SEO_INDEXABLE: 'false' });
+    const html = callTransformIndexHtml(plugin, SAMPLE_HTML);
+    expect(html).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+});
+
+describe('seoPlugin generateBundle', () => {
+  it('emits robots.txt and sitemap.xml', () => {
+    const plugin = seoPlugin({ VITE_PUBLIC_SITE_URL: 'https://openfarmplanner.org' });
+    const emitted = collectEmittedFiles(plugin);
+    const names = emitted.map((f) => f.fileName);
+    expect(names).toContain('robots.txt');
+    expect(names).toContain('sitemap.xml');
+
+    const robots = emitted.find((f) => f.fileName === 'robots.txt')!.source;
+    expect(robots).toContain('Sitemap: https://openfarmplanner.org/sitemap.xml');
+    expect(robots).not.toMatch(/^Disallow:\s*\/$/m);
+
+    const sitemap = emitted.find((f) => f.fileName === 'sitemap.xml')!.source;
+    expect(sitemap).toContain('<loc>https://openfarmplanner.org/</loc>');
+  });
+
+  it('emits a fully blocking robots.txt when not indexable', () => {
+    const plugin = seoPlugin({ VITE_SEO_INDEXABLE: '0' });
+    const robots = collectEmittedFiles(plugin).find((f) => f.fileName === 'robots.txt')!.source;
+    expect(robots).toMatch(/^Disallow:\s*\/$/m);
+  });
+});
+
+// Silence unused-import lint if vi ends up unused across environments.
+void vi;

--- a/frontend/build/seoPlugin.ts
+++ b/frontend/build/seoPlugin.ts
@@ -1,0 +1,81 @@
+/**
+ * Vite plugin wiring the SEO artifacts into the build and dev/preview servers.
+ *
+ * Responsibilities:
+ *   - inject canonical / Open Graph / Twitter / robots <head> tags into
+ *     index.html (build and dev), so crawlers get real metadata from the first
+ *     HTML response of this otherwise client-rendered SPA;
+ *   - emit /robots.txt and /sitemap.xml as build assets;
+ *   - serve /robots.txt and /sitemap.xml from the dev and preview servers so
+ *     the behaviour can be verified locally with the same URLs as production.
+ *
+ * The canonical domain and route lists come from seoConfig.ts; nothing here
+ * hardcodes the domain.
+ */
+
+import type { Plugin } from 'vite';
+import { resolveIndexable, resolveSiteUrl, type SeoEnv } from '../src/seo/seoConfig';
+import { buildHeadTags, buildRobotsTxt, buildSitemapXml } from '../src/seo/seoAssets';
+
+export function seoPlugin(env: SeoEnv = process.env as SeoEnv): Plugin {
+  const siteUrl = resolveSiteUrl(env);
+  const indexable = resolveIndexable(env);
+
+  const robotsTxt = buildRobotsTxt({ siteUrl, indexable });
+  const sitemapXml = buildSitemapXml({ siteUrl });
+  const headTags = buildHeadTags({ siteUrl, indexable });
+
+  return {
+    name: 'openfarmplanner-seo',
+
+    transformIndexHtml(html) {
+      const injection = `${headTags.map((tag) => `    ${tag}`).join('\n')}\n  </head>`;
+      return html.replace(/\s*<\/head>/, `\n${injection}`);
+    },
+
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'robots.txt',
+        source: robotsTxt,
+      });
+      this.emitFile({
+        type: 'asset',
+        fileName: 'sitemap.xml',
+        source: sitemapXml,
+      });
+    },
+
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url === '/robots.txt') {
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+          res.end(robotsTxt);
+          return;
+        }
+        if (req.url === '/sitemap.xml') {
+          res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+          res.end(sitemapXml);
+          return;
+        }
+        next();
+      });
+    },
+
+    configurePreviewServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url === '/robots.txt') {
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+          res.end(robotsTxt);
+          return;
+        }
+        if (req.url === '/sitemap.xml') {
+          res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+          res.end(sitemapXml);
+          return;
+        }
+        next();
+      });
+    },
+  };
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ export type { RootLayoutOutletContext, TopbarContextAction } from './navigation/
 import { buildInvitationAcceptPath } from './pages/invitationAcceptance';
 import { resolveRouterBasename } from './routerBasename';
 import RuntimeErrorState from './components/runtime/RuntimeErrorState';
+import RouteSeo from './seo/RouteSeo';
 import {
   isDynamicImportLoadError,
   reloadOnceForDynamicImportError,
@@ -154,11 +155,20 @@ function GlobalRuntimeErrorHandler({ children }: GlobalRuntimeErrorHandlerProps)
   return children;
 }
 
+function RootSeoLayout() {
+  return (
+    <>
+      <RouteSeo />
+      <Outlet />
+    </>
+  );
+}
+
 function createAppRouter(basename: string) {
   return createBrowserRouter([
     {
       path: '/',
-      element: <Outlet />,
+      element: <RootSeoLayout />,
       errorElement: <RouteErrorBoundary />,
       children: [
         {

--- a/frontend/src/seo/RouteSeo.tsx
+++ b/frontend/src/seo/RouteSeo.tsx
@@ -1,0 +1,66 @@
+/**
+ * Runtime, route-aware SEO metadata for the SPA.
+ *
+ * The build injects static canonical/robots tags for the initial HTML (the
+ * landing page). This component keeps them correct as the user (or a
+ * JavaScript-rendering crawler such as Googlebot) navigates client-side:
+ *
+ *   - public info pages keep `robots: index, follow` and get a per-path canonical;
+ *   - every private/auth/app route switches to `robots: noindex, nofollow`.
+ *
+ * It renders nothing and only mutates the document <head>. It complements — does
+ * not replace — robots.txt: robots.txt stops crawling of private paths, while
+ * this guards crawlers that render JS and ignore robots.txt.
+ */
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  buildCanonicalUrl,
+  isPathIndexable,
+  resolveIndexable,
+  resolveSiteUrl,
+} from './seoConfig';
+
+const SITE_URL = resolveSiteUrl(import.meta.env);
+const DEPLOYMENT_INDEXABLE = resolveIndexable(import.meta.env);
+
+function upsertMeta(name: string, content: string): void {
+  let element = document.head.querySelector<HTMLMetaElement>(
+    `meta[name="${name}"]`,
+  );
+  if (!element) {
+    element = document.createElement('meta');
+    element.setAttribute('name', name);
+    document.head.appendChild(element);
+  }
+  element.setAttribute('content', content);
+}
+
+function upsertCanonical(href: string): void {
+  let element = document.head.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]',
+  );
+  if (!element) {
+    element = document.createElement('link');
+    element.setAttribute('rel', 'canonical');
+    document.head.appendChild(element);
+  }
+  element.setAttribute('href', href);
+}
+
+/**
+ * Side-effect-only component. Mount once near the router root so it runs on
+ * every navigation.
+ */
+export default function RouteSeo(): null {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const indexable = isPathIndexable(pathname, DEPLOYMENT_INDEXABLE);
+    upsertMeta('robots', indexable ? 'index, follow' : 'noindex, nofollow');
+    upsertCanonical(buildCanonicalUrl(SITE_URL, pathname));
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/seo/__tests__/RouteSeo.test.tsx
+++ b/frontend/src/seo/__tests__/RouteSeo.test.tsx
@@ -1,0 +1,62 @@
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import RouteSeo from '../RouteSeo';
+
+function robotsContent(): string | null {
+  return document.head
+    .querySelector('meta[name="robots"]')
+    ?.getAttribute('content') ?? null;
+}
+
+function canonicalHref(): string | null {
+  return document.head
+    .querySelector('link[rel="canonical"]')
+    ?.getAttribute('href') ?? null;
+}
+
+afterEach(() => {
+  document.head.querySelectorAll('meta[name="robots"], link[rel="canonical"]').forEach(
+    (node) => node.remove(),
+  );
+});
+
+describe('RouteSeo', () => {
+  it('marks the public landing page as indexable with a root canonical', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteSeo />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(robotsContent()).toBe('index, follow'));
+    expect(canonicalHref()).toBe('https://openfarmplanner.org/');
+  });
+
+  it('marks a public info page as indexable with its canonical', async () => {
+    render(
+      <MemoryRouter initialEntries={['/impressum']}>
+        <RouteSeo />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(robotsContent()).toBe('index, follow'));
+    expect(canonicalHref()).toBe('https://openfarmplanner.org/impressum');
+  });
+
+  it('sets noindex on private app routes', async () => {
+    render(
+      <MemoryRouter initialEntries={['/app/dashboard']}>
+        <RouteSeo />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(robotsContent()).toBe('noindex, nofollow'));
+  });
+
+  it('sets noindex on authentication routes', async () => {
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <RouteSeo />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(robotsContent()).toBe('noindex, nofollow'));
+  });
+});

--- a/frontend/src/seo/__tests__/seoAssets.test.ts
+++ b/frontend/src/seo/__tests__/seoAssets.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildHeadTags,
+  buildRobotsTxt,
+  buildSitemapXml,
+} from '../seoAssets';
+import {
+  NON_INDEXABLE_PATH_PREFIXES,
+  PUBLIC_INDEXABLE_ROUTES,
+} from '../seoConfig';
+
+const SITE = 'https://openfarmplanner.org';
+
+describe('buildRobotsTxt (indexable production)', () => {
+  const robots = buildRobotsTxt({ siteUrl: SITE, indexable: true });
+
+  it('does not block the whole site', () => {
+    expect(robots).not.toMatch(/^Disallow:\s*\/\s*$/m);
+    expect(robots).toMatch(/^Allow:\s*\/$/m);
+  });
+
+  it('disallows every private prefix', () => {
+    for (const prefix of NON_INDEXABLE_PATH_PREFIXES) {
+      expect(robots).toContain(`Disallow: ${prefix}`);
+    }
+  });
+
+  it('advertises the sitemap with the canonical domain', () => {
+    expect(robots).toContain(`Sitemap: ${SITE}/sitemap.xml`);
+  });
+});
+
+describe('buildRobotsTxt (non-indexable environment)', () => {
+  const robots = buildRobotsTxt({ siteUrl: SITE, indexable: false });
+
+  it('blocks the whole site', () => {
+    expect(robots).toMatch(/^Disallow:\s*\/$/m);
+    expect(robots).toContain('User-agent: *');
+  });
+
+  it('does not advertise a sitemap', () => {
+    expect(robots).not.toContain('Sitemap:');
+  });
+});
+
+describe('buildSitemapXml', () => {
+  const sitemap = buildSitemapXml({ siteUrl: SITE, lastmod: '2026-01-01' });
+
+  it('is a valid urlset document', () => {
+    expect(sitemap).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(sitemap).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(sitemap).toContain('</urlset>');
+  });
+
+  it('contains exactly the public canonical routes', () => {
+    const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    expect(locs).toEqual([
+      `${SITE}/`,
+      `${SITE}/impressum`,
+      `${SITE}/datenschutz`,
+      `${SITE}/nutzungsbedingungen`,
+    ]);
+    expect(locs).toHaveLength(PUBLIC_INDEXABLE_ROUTES.length);
+  });
+
+  it('never lists private or auth routes', () => {
+    for (const prefix of NON_INDEXABLE_PATH_PREFIXES) {
+      expect(sitemap).not.toContain(`<loc>${SITE}${prefix}`);
+    }
+  });
+
+  it('uses the provided lastmod and well-formed priorities', () => {
+    expect(sitemap).toContain('<lastmod>2026-01-01</lastmod>');
+    expect(sitemap).toMatch(/<priority>1\.0<\/priority>/);
+  });
+});
+
+describe('buildHeadTags', () => {
+  it('emits a canonical using the production domain and index directive', () => {
+    const tags = buildHeadTags({ siteUrl: SITE, indexable: true }).join('\n');
+    expect(tags).toContain(`<link rel="canonical" href="${SITE}/" />`);
+    expect(tags).toContain('<meta name="robots" content="index, follow" />');
+    expect(tags).not.toContain('noindex');
+  });
+
+  it('emits Open Graph and Twitter preview tags', () => {
+    const tags = buildHeadTags({ siteUrl: SITE, indexable: true }).join('\n');
+    expect(tags).toContain('property="og:title"');
+    expect(tags).toContain('property="og:url"');
+    expect(tags).toContain(`property="og:image" content="${SITE}/landing/hero-field.webp"`);
+    expect(tags).toContain('name="twitter:card" content="summary_large_image"');
+  });
+
+  it('emits a noindex directive for non-indexable deployments', () => {
+    const tags = buildHeadTags({ siteUrl: SITE, indexable: false }).join('\n');
+    expect(tags).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+
+  it('escapes HTML-significant characters in text values', () => {
+    const tags = buildHeadTags({
+      siteUrl: SITE,
+      indexable: true,
+      description: 'A & B "quoted" <tag>',
+    }).join('\n');
+    expect(tags).toContain('&amp;');
+    expect(tags).toContain('&quot;');
+    expect(tags).not.toContain('"quoted"');
+  });
+});

--- a/frontend/src/seo/__tests__/seoConfig.test.ts
+++ b/frontend/src/seo/__tests__/seoConfig.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SITE_URL,
+  PUBLIC_INDEXABLE_ROUTES,
+  buildCanonicalUrl,
+  isPathIndexable,
+  normalizePathname,
+  resolveIndexable,
+  resolveSiteUrl,
+} from '../seoConfig';
+
+describe('resolveSiteUrl', () => {
+  it('defaults to the production domain when unset', () => {
+    expect(resolveSiteUrl({})).toBe(DEFAULT_SITE_URL);
+    expect(resolveSiteUrl({ VITE_PUBLIC_SITE_URL: '' })).toBe(DEFAULT_SITE_URL);
+    expect(resolveSiteUrl({ VITE_PUBLIC_SITE_URL: '   ' })).toBe(DEFAULT_SITE_URL);
+  });
+
+  it('strips trailing slashes and any path', () => {
+    expect(resolveSiteUrl({ VITE_PUBLIC_SITE_URL: 'https://example.org/' })).toBe(
+      'https://example.org',
+    );
+    expect(
+      resolveSiteUrl({ VITE_PUBLIC_SITE_URL: 'https://example.org/app/' }),
+    ).toBe('https://example.org');
+  });
+
+  it('keeps a non-standard port', () => {
+    expect(
+      resolveSiteUrl({ VITE_PUBLIC_SITE_URL: 'http://localhost:5173' }),
+    ).toBe('http://localhost:5173');
+  });
+
+  it('falls back to the default for invalid or non-http(s) input', () => {
+    expect(resolveSiteUrl({ VITE_PUBLIC_SITE_URL: 'not a url' })).toBe(
+      DEFAULT_SITE_URL,
+    );
+    expect(
+      resolveSiteUrl({ VITE_PUBLIC_SITE_URL: 'ftp://example.org' }),
+    ).toBe(DEFAULT_SITE_URL);
+  });
+});
+
+describe('resolveIndexable', () => {
+  it('defaults to indexable', () => {
+    expect(resolveIndexable({})).toBe(true);
+    expect(resolveIndexable({ VITE_SEO_INDEXABLE: '' })).toBe(true);
+    expect(resolveIndexable({ VITE_SEO_INDEXABLE: 'true' })).toBe(true);
+  });
+
+  it('blocks indexing for explicit falsey values', () => {
+    for (const value of ['false', '0', 'no', 'off', 'FALSE', 'Off']) {
+      expect(resolveIndexable({ VITE_SEO_INDEXABLE: value })).toBe(false);
+    }
+  });
+});
+
+describe('normalizePathname', () => {
+  it('keeps the root path as "/"', () => {
+    expect(normalizePathname('/')).toBe('/');
+  });
+
+  it('adds a leading slash and drops trailing slashes and query/hash', () => {
+    expect(normalizePathname('impressum')).toBe('/impressum');
+    expect(normalizePathname('/impressum/')).toBe('/impressum');
+    expect(normalizePathname('/impressum?ref=x')).toBe('/impressum');
+    expect(normalizePathname('/impressum#top')).toBe('/impressum');
+  });
+});
+
+describe('isPathIndexable', () => {
+  it('marks known public routes as indexable', () => {
+    for (const route of PUBLIC_INDEXABLE_ROUTES) {
+      expect(isPathIndexable(route.path)).toBe(true);
+    }
+  });
+
+  it('never indexes private app or auth routes', () => {
+    for (const path of [
+      '/app',
+      '/app/dashboard',
+      '/app/cultures',
+      '/login',
+      '/register',
+      '/activate/abc/def',
+      '/forgot-password',
+      '/reset-password',
+      '/confirm-email-change',
+      '/invite/token',
+      '/invitation',
+    ]) {
+      expect(isPathIndexable(path)).toBe(false);
+    }
+  });
+
+  it('does not index unknown paths', () => {
+    expect(isPathIndexable('/does-not-exist')).toBe(false);
+  });
+
+  it('blocks everything when the deployment is not indexable', () => {
+    expect(isPathIndexable('/', false)).toBe(false);
+    expect(isPathIndexable('/impressum', false)).toBe(false);
+  });
+});
+
+describe('buildCanonicalUrl', () => {
+  it('keeps a trailing slash only for the root', () => {
+    expect(buildCanonicalUrl('https://example.org', '/')).toBe(
+      'https://example.org/',
+    );
+    expect(buildCanonicalUrl('https://example.org', '/impressum')).toBe(
+      'https://example.org/impressum',
+    );
+    expect(buildCanonicalUrl('https://example.org', '/impressum/')).toBe(
+      'https://example.org/impressum',
+    );
+  });
+});

--- a/frontend/src/seo/seoAssets.ts
+++ b/frontend/src/seo/seoAssets.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure builders for SEO artifacts served at the site root:
+ *   - robots.txt
+ *   - sitemap.xml
+ *   - the canonical / Open Graph / Twitter / robots <head> tags injected into
+ *     the built index.html.
+ *
+ * Kept side-effect free and DOM-free so the Vite build and unit tests can call
+ * them directly. The canonical domain and route lists come exclusively from
+ * `seoConfig.ts`.
+ */
+
+import {
+  NON_INDEXABLE_PATH_PREFIXES,
+  PUBLIC_INDEXABLE_ROUTES,
+  SITE_LANGUAGE,
+  buildCanonicalUrl,
+  type PublicRoute,
+} from './seoConfig';
+
+export interface RobotsOptions {
+  siteUrl: string;
+  indexable: boolean;
+}
+
+/**
+ * Build robots.txt.
+ *
+ * When indexable: allow all user agents, explicitly disallow the private
+ * app/auth prefixes, and advertise the sitemap. When not indexable
+ * (preview/staging/test): block everything with `Disallow: /`.
+ */
+export function buildRobotsTxt({ siteUrl, indexable }: RobotsOptions): string {
+  if (!indexable) {
+    return [
+      '# This deployment is intentionally excluded from search engines',
+      '# (VITE_SEO_INDEXABLE=false). Production sets it to true.',
+      'User-agent: *',
+      'Disallow: /',
+      '',
+    ].join('\n');
+  }
+
+  const disallowLines = NON_INDEXABLE_PATH_PREFIXES.map(
+    (prefix) => `Disallow: ${prefix}`,
+  );
+
+  return [
+    '# OpenFarmPlanner robots.txt — generated at build time from seoConfig.ts',
+    'User-agent: *',
+    ...disallowLines,
+    'Allow: /',
+    '',
+    `Sitemap: ${siteUrl}/sitemap.xml`,
+    '',
+  ].join('\n');
+}
+
+export interface SitemapOptions {
+  siteUrl: string;
+  routes?: readonly PublicRoute[];
+  /** ISO date (YYYY-MM-DD) used for `<lastmod>`. Defaults to today (UTC). */
+  lastmod?: string;
+}
+
+function todayIsoUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Build a valid urlset sitemap.xml containing only public, canonical URLs. */
+export function buildSitemapXml({
+  siteUrl,
+  routes = PUBLIC_INDEXABLE_ROUTES,
+  lastmod = todayIsoUtc(),
+}: SitemapOptions): string {
+  const urlEntries = routes
+    .map((route) => {
+      const loc = buildCanonicalUrl(siteUrl, route.path);
+      return [
+        '  <url>',
+        `    <loc>${loc}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>${route.changefreq}</changefreq>`,
+        `    <priority>${route.priority.toFixed(1)}</priority>`,
+        '  </url>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urlEntries,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+export interface HeadTagsOptions {
+  siteUrl: string;
+  indexable: boolean;
+  title?: string;
+  description?: string;
+  /** Canonical path for the initially served document (the landing page). */
+  path?: string;
+  /** Absolute or root-relative path to the social preview image. */
+  imagePath?: string;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Build the list of <head> tags injected into index.html at build time.
+ *
+ * These give crawlers a canonical URL, Open Graph / Twitter preview metadata and
+ * an explicit robots directive from the very first (pre-JavaScript) HTML
+ * response, which is what a static SPA otherwise lacks.
+ */
+export function buildHeadTags(options: HeadTagsOptions): string[] {
+  const {
+    siteUrl,
+    indexable,
+    title = 'OpenFarmPlanner',
+    description = 'OpenFarmPlanner ist ein Open-Source-Anbauplaner für den Gemüsebau. Plane Kulturen, Anbauflächen und Anbauzeiträume an einem Ort.',
+    path = '/',
+    imagePath = '/landing/hero-field.webp',
+  } = options;
+
+  const canonical = buildCanonicalUrl(siteUrl, path);
+  const imageUrl = imagePath.startsWith('http')
+    ? imagePath
+    : `${siteUrl}${imagePath.startsWith('/') ? '' : '/'}${imagePath}`;
+
+  const t = escapeHtmlAttribute(title);
+  const d = escapeHtmlAttribute(description);
+
+  const tags = [
+    `<link rel="canonical" href="${canonical}" />`,
+    `<meta name="robots" content="${indexable ? 'index, follow' : 'noindex, nofollow'}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:site_name" content="OpenFarmPlanner" />`,
+    `<meta property="og:locale" content="${SITE_LANGUAGE === 'de' ? 'de_DE' : SITE_LANGUAGE}" />`,
+    `<meta property="og:title" content="${t}" />`,
+    `<meta property="og:description" content="${d}" />`,
+    `<meta property="og:url" content="${canonical}" />`,
+    `<meta property="og:image" content="${imageUrl}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${t}" />`,
+    `<meta name="twitter:description" content="${d}" />`,
+    `<meta name="twitter:image" content="${imageUrl}" />`,
+  ];
+
+  return tags;
+}

--- a/frontend/src/seo/seoConfig.ts
+++ b/frontend/src/seo/seoConfig.ts
@@ -1,0 +1,159 @@
+/**
+ * Central SEO configuration for OpenFarmPlanner.
+ *
+ * This module is the single source of truth for:
+ *   - the canonical public site URL (used for canonical/OG tags, robots.txt and
+ *     sitemap.xml), and
+ *   - which routes are publicly indexable versus which must be kept out of
+ *     search-engine indexes.
+ *
+ * It is intentionally free of DOM/React/Vite imports so it can be consumed both
+ * by the Vite build (to emit robots.txt / sitemap.xml and inject <head> tags)
+ * and by runtime React components, and unit-tested in isolation.
+ *
+ * The canonical domain is NOT hardcoded across the codebase — deployments set
+ * `VITE_PUBLIC_SITE_URL`; everything else derives from `resolveSiteUrl()`.
+ */
+
+/** Fallback canonical site URL when `VITE_PUBLIC_SITE_URL` is not provided. */
+export const DEFAULT_SITE_URL = 'https://openfarmplanner.org';
+
+/** Default document language of the public site (matches index.html `lang`). */
+export const SITE_LANGUAGE = 'de';
+
+/**
+ * A subset of `import.meta.env` / `process.env` this module reads. The index
+ * signature keeps it structurally compatible with both `ImportMetaEnv` and
+ * Node's `ProcessEnv` so callers can pass either directly.
+ */
+export interface SeoEnv {
+  VITE_PUBLIC_SITE_URL?: string;
+  VITE_SEO_INDEXABLE?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Normalize a configured site URL: trim, require an absolute http(s) origin and
+ * drop any trailing slash so callers can safely concatenate `${siteUrl}${path}`.
+ * Falls back to {@link DEFAULT_SITE_URL} for empty/invalid input.
+ */
+export function resolveSiteUrl(env: SeoEnv = {}): string {
+  const raw = (env.VITE_PUBLIC_SITE_URL ?? '').trim();
+  const candidate = raw.length > 0 ? raw : DEFAULT_SITE_URL;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    parsed = new URL(DEFAULT_SITE_URL);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    parsed = new URL(DEFAULT_SITE_URL);
+  }
+  // Keep only the origin (scheme + host + optional port); strip trailing slash.
+  return `${parsed.protocol}//${parsed.host}`;
+}
+
+/**
+ * Whether this deployment may be indexed by search engines.
+ *
+ * Defaults to `true` (production intent). Preview/staging/test hosts can opt out
+ * deliberately by setting `VITE_SEO_INDEXABLE=false` (also accepts `0`/`no`/`off`),
+ * which flips robots.txt to `Disallow: /` and adds a `noindex` meta tag — an
+ * explicit, environment-dependent block rather than an accidental one.
+ */
+export function resolveIndexable(env: SeoEnv = {}): boolean {
+  const raw = (env.VITE_SEO_INDEXABLE ?? '').trim().toLowerCase();
+  if (raw === '') {
+    return true;
+  }
+  return !['false', '0', 'no', 'off'].includes(raw);
+}
+
+export type ChangeFrequency =
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
+
+export interface PublicRoute {
+  /** Absolute path from the site root, always starting with `/`. */
+  path: string;
+  /** Sitemap `<changefreq>` hint. */
+  changefreq: ChangeFrequency;
+  /** Sitemap `<priority>` in the range [0.0, 1.0]. */
+  priority: number;
+}
+
+/**
+ * Publicly reachable, canonical, indexable routes.
+ *
+ * ONLY genuinely public information pages belong here — never login,
+ * registration, password reset, invitations, demo or in-app (`/app/*`) routes.
+ * When a new public route is added (e.g. the planned public crop library under
+ * `/crops`), add it here and it flows automatically into the sitemap.
+ */
+export const PUBLIC_INDEXABLE_ROUTES: readonly PublicRoute[] = [
+  { path: '/', changefreq: 'weekly', priority: 1.0 },
+  { path: '/impressum', changefreq: 'yearly', priority: 0.3 },
+  { path: '/datenschutz', changefreq: 'yearly', priority: 0.3 },
+  { path: '/nutzungsbedingungen', changefreq: 'yearly', priority: 0.3 },
+];
+
+/**
+ * Path prefixes that must never be indexed and are disallowed in robots.txt.
+ *
+ * These cover the authenticated application shell and all authentication /
+ * account-management flows. They intentionally do NOT include public info pages.
+ */
+export const NON_INDEXABLE_PATH_PREFIXES: readonly string[] = [
+  '/app',
+  '/login',
+  '/register',
+  '/activate',
+  '/forgot-password',
+  '/reset-password',
+  '/confirm-email-change',
+  '/invite',
+  '/invitation',
+];
+
+/** Normalize a pathname for comparison: ensure a leading slash and drop a
+ * trailing slash (except for the root path). Query/hash are ignored. */
+export function normalizePathname(pathname: string): string {
+  const [pathOnly] = pathname.split(/[?#]/, 1);
+  const withLeading = pathOnly.startsWith('/') ? pathOnly : `/${pathOnly}`;
+  if (withLeading.length > 1 && withLeading.endsWith('/')) {
+    return withLeading.replace(/\/+$/, '');
+  }
+  return withLeading;
+}
+
+/**
+ * Decide whether a concrete pathname should be indexable.
+ *
+ * A path is indexable only when the deployment is indexable AND the path is one
+ * of the known public routes AND it does not fall under a non-indexable prefix.
+ */
+export function isPathIndexable(pathname: string, indexable = true): boolean {
+  if (!indexable) {
+    return false;
+  }
+  const normalized = normalizePathname(pathname);
+  if (
+    NON_INDEXABLE_PATH_PREFIXES.some(
+      (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+    )
+  ) {
+    return false;
+  }
+  return PUBLIC_INDEXABLE_ROUTES.some((route) => route.path === normalized);
+}
+
+/** Build an absolute canonical URL for a given pathname. */
+export function buildCanonicalUrl(siteUrl: string, pathname: string): string {
+  const normalized = normalizePathname(pathname);
+  return normalized === '/' ? `${siteUrl}/` : `${siteUrl}${normalized}`;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_PUBLIC_SITE_URL?: string;
+  readonly VITE_SEO_INDEXABLE?: string;
 }
 
 interface ImportMeta {

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "build/**/*.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { seoPlugin } from './build/seoPlugin'
 
 function normalizeBasePath(input?: string): string {
   const value = input && input.trim().length > 0 ? input.trim() : '/'
@@ -24,7 +25,7 @@ const backendProxy = {
 // https://vite.dev/config/
 export default defineConfig({
   base: basePath,
-  plugins: [react()],
+  plugins: [react(), seoPlugin(process.env)],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -54,7 +55,7 @@ export default defineConfig({
     teardownTimeout: 5000,
     pool: process.env.CI ? 'forks' : 'threads',
     fileParallelism: !process.env.CI,
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'build/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
     server: {
       deps: {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Seed Demand Calculation: seed-demand-calculation.md
       - Versioning and History: versioning-and-history.md
       - Large-Dataset Rendering: large-dataset-rendering.md
+      - SEO & Indexing: seo-and-indexing.md
   - QA / Process:
       - QA Strategy: qa-strategy.md
       - Excluded Issues: qa-excluded-issues.md


### PR DESCRIPTION
The SPA shipped no canonical, robots, sitemap or per-route indexing
control, and the API-only backend serves none either. Add a build-time
SEO layer so search engines can reliably discover and index the public
site again while private app/auth routes stay excluded.

- Central config (frontend/src/seo/seoConfig.ts) as the single source of
  truth for the canonical origin and the indexable/non-indexable route
  lists; the canonical domain is configured via VITE_PUBLIC_SITE_URL and
  never hardcoded across the codebase.
- Vite plugin (frontend/build/seoPlugin.ts) emits robots.txt and
  sitemap.xml, injects canonical/robots/Open Graph/Twitter tags into the
  initial HTML, and serves the artifacts from dev and preview servers.
- RouteSeo keeps the canonical and robots meta correct on client-side
  navigation and sets noindex on private/app/auth routes.
- VITE_SEO_INDEXABLE=false lets preview/staging/test deployments block
  indexing deliberately (robots.txt Disallow: / + noindex meta).
- Tests for the config, generated artifacts, the plugin and RouteSeo;
  documentation in docs/seo-and-indexing.md incl. curl-based checks.

The plugin lives outside src/ so its vite/node imports don't pull Node's
global types into the app TypeScript project.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LBrd3H8w3SUtiXZA8jXyiB