### PR TITLE
refactor(frontend): extract getSowingMonths from CultureDetail

### DIFF
--- a/frontend/src/__tests__/cultureDetailFormatters.test.ts
+++ b/frontend/src/__tests__/cultureDetailFormatters.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { Culture } from '../api/types';
+import { getSowingMonths } from '../cultures/cultureDetailFormatters';
+
+const culture = (overrides: Record<string, unknown>): Culture =>
+  ({ name: 'Test', ...overrides }) as unknown as Culture;
+
+describe('getSowingMonths', () => {
+  it('returns the explicit month array, filtering out-of-range values', () => {
+    expect(getSowingMonths(culture({ sowing_months: [0, 3, 4, 13, 12] }))).toEqual([3, 4, 12]);
+  });
+
+  it('wraps a single valid sowing month', () => {
+    expect(getSowingMonths(culture({ sowing_month: 5 }))).toEqual([5]);
+  });
+
+  it('returns an empty array for an out-of-range single month', () => {
+    expect(getSowingMonths(culture({ sowing_month: 0 }))).toEqual([]);
+  });
+
+  it('expands an inclusive start/end range', () => {
+    expect(getSowingMonths(culture({ sowing_start_month: 3, sowing_end_month: 6 }))).toEqual([3, 4, 5, 6]);
+  });
+
+  it('normalizes a reversed start/end range', () => {
+    expect(getSowingMonths(culture({ sowing_start_month: 6, sowing_end_month: 4 }))).toEqual([4, 5, 6]);
+  });
+
+  it('prefers the month array over the range shape', () => {
+    expect(getSowingMonths(culture({
+      sowing_months: [2],
+      sowing_start_month: 5,
+      sowing_end_month: 9,
+    }))).toEqual([2]);
+  });
+
+  it('returns an empty array when no sowing information is present', () => {
+    expect(getSowingMonths(culture({}))).toEqual([]);
+  });
+});

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -80,6 +80,7 @@ import {
   formatPackageSizes,
   formatSeedRateNumber,
   formatSeedUnitLabel,
+  getSowingMonths,
   type PersistedCultureFilters,
 } from './cultureDetailFormatters';
 
@@ -315,27 +316,6 @@ export function CultureDetail({
     const parsedGrowthDaysMax = filters.growthDaysMax ? Number(filters.growthDaysMax) : null;
     const parsedYieldMin = filters.yieldMin ? Number(filters.yieldMin) : null;
     const parsedYieldMax = filters.yieldMax ? Number(filters.yieldMax) : null;
-
-    const getSowingMonths = (culture: Culture): number[] => {
-      const dynamicCulture = culture as Culture & {
-        sowing_month?: number | null;
-        sowing_months?: number[] | null;
-        sowing_start_month?: number | null;
-        sowing_end_month?: number | null;
-      };
-      if (Array.isArray(dynamicCulture.sowing_months)) {
-        return dynamicCulture.sowing_months.filter((month) => Number.isInteger(month) && month >= 1 && month <= 12);
-      }
-      if (typeof dynamicCulture.sowing_month === 'number') {
-        return dynamicCulture.sowing_month >= 1 && dynamicCulture.sowing_month <= 12 ? [dynamicCulture.sowing_month] : [];
-      }
-      if (typeof dynamicCulture.sowing_start_month === 'number' && typeof dynamicCulture.sowing_end_month === 'number') {
-        const start = Math.min(dynamicCulture.sowing_start_month, dynamicCulture.sowing_end_month);
-        const end = Math.max(dynamicCulture.sowing_start_month, dynamicCulture.sowing_end_month);
-        return Array.from({ length: end - start + 1 }, (_, index) => start + index).filter((month) => month >= 1 && month <= 12);
-      }
-      return [];
-    };
 
     const normalizedQuery = filters.searchQuery.trim().toLowerCase();
     const selectedSupplierId = filters.selectedSupplierFilter ? Number(filters.selectedSupplierFilter) : null;

--- a/frontend/src/cultures/cultureDetailFormatters.ts
+++ b/frontend/src/cultures/cultureDetailFormatters.ts
@@ -3,6 +3,8 @@
  * culture detail view. Extracted verbatim from cultures/CultureDetail.tsx.
  */
 
+import type { Culture } from '../api/types';
+
 export const CULTURE_FILTERS_STORAGE_KEY = 'culturesDetailFiltersV1';
 
 export interface PersistedCultureFilters {
@@ -57,6 +59,31 @@ export function formatDistance(value: number | null | undefined, t: (key: string
   const factor = 10 ** decimals;
   const rounded = Math.round(value * factor) / factor;
   return rounded.toFixed(decimals);
+}
+
+/**
+ * Derives the set of sowing months (1-12) for a culture, supporting the
+ * month-array, single-month, and start/end-range shapes the API may provide.
+ */
+export function getSowingMonths(culture: Culture): number[] {
+  const dynamicCulture = culture as Culture & {
+    sowing_month?: number | null;
+    sowing_months?: number[] | null;
+    sowing_start_month?: number | null;
+    sowing_end_month?: number | null;
+  };
+  if (Array.isArray(dynamicCulture.sowing_months)) {
+    return dynamicCulture.sowing_months.filter((month) => Number.isInteger(month) && month >= 1 && month <= 12);
+  }
+  if (typeof dynamicCulture.sowing_month === 'number') {
+    return dynamicCulture.sowing_month >= 1 && dynamicCulture.sowing_month <= 12 ? [dynamicCulture.sowing_month] : [];
+  }
+  if (typeof dynamicCulture.sowing_start_month === 'number' && typeof dynamicCulture.sowing_end_month === 'number') {
+    const start = Math.min(dynamicCulture.sowing_start_month, dynamicCulture.sowing_end_month);
+    const end = Math.max(dynamicCulture.sowing_start_month, dynamicCulture.sowing_end_month);
+    return Array.from({ length: end - start + 1 }, (_, index) => start + index).filter((month) => month >= 1 && month <= 12);
+  }
+  return [];
 }
 
 export function formatSeedUnitLabel(unit: string | null | undefined): string {


### PR DESCRIPTION
### Motivation
`CultureDetail.tsx` defined `getSowingMonths` inline inside its filter `useMemo`. It is a pure function of the culture record with non-trivial branching (month-array, single-month, start/end-range shapes) — exactly the kind of logic worth isolating and unit-testing, and it fits the existing `cultureDetailFormatters` helper module.

### Description
- Move `getSowingMonths` from the `CultureDetail.tsx` filter memo into `cultures/cultureDetailFormatters.ts` (adds a `Culture` type import there).
- Import it back into `CultureDetail.tsx`; the filtering logic is otherwise unchanged.
- Add unit tests covering all input shapes and range normalization.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `cultureDetailFormatters` (new, 7 tests) and `CultureDetail` (21 tests) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_