### PR TITLE
refactor(frontend): extract hierarchy dimension-cell state helpers

### DIFF
--- a/frontend/src/__tests__/dimensionCellState.test.ts
+++ b/frontend/src/__tests__/dimensionCellState.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { HierarchyRow } from '../components/hierarchy/utils/types';
+import {
+  calculateAreaValue,
+  getDimensionRowState,
+  isDimensionCellIncomplete,
+} from '../components/hierarchy/utils/dimensionCellState';
+
+const row = (overrides: Partial<HierarchyRow>): HierarchyRow =>
+  ({ id: 1, level: 0, type: 'bed', ...overrides }) as HierarchyRow;
+
+describe('calculateAreaValue', () => {
+  it('returns undefined for location rows', () => {
+    expect(calculateAreaValue(row({ type: 'location', area_sqm: 5 }))).toBeUndefined();
+  });
+
+  it('multiplies length and width, rounded to one decimal', () => {
+    expect(calculateAreaValue(row({ length_m: 2.5, width_m: 1.33 }))).toBe(3.3);
+  });
+
+  it('falls back to the stored area when a dimension is missing', () => {
+    expect(calculateAreaValue(row({ length_m: 2, area_sqm: 9 }))).toBe(9);
+  });
+});
+
+describe('getDimensionRowState', () => {
+  it('returns null for location rows', () => {
+    expect(getDimensionRowState(row({ type: 'location' }))).toBeNull();
+  });
+
+  it('reports which dimensions are present, parsing string values', () => {
+    expect(getDimensionRowState(row({ length_m: 2, width_m: null, area_sqm: '3,5' }))).toEqual({
+      hasLength: true,
+      hasWidth: false,
+      hasAreaValue: true,
+    });
+  });
+});
+
+describe('isDimensionCellIncomplete', () => {
+  const state = (over: Partial<ReturnType<typeof getDimensionRowState>>) => ({
+    hasLength: false,
+    hasWidth: false,
+    hasAreaValue: false,
+    ...over,
+  });
+
+  it('flags an empty length cell', () => {
+    expect(isDimensionCellIncomplete('length', state({ hasLength: false }))).toBe(true);
+    expect(isDimensionCellIncomplete('length', state({ hasLength: true }))).toBe(false);
+  });
+
+  it('treats the area cell as complete when a stored area exists', () => {
+    expect(isDimensionCellIncomplete('area', state({ hasAreaValue: true }))).toBe(false);
+  });
+
+  it('treats the area cell as complete when both length and width exist', () => {
+    expect(isDimensionCellIncomplete('area', state({ hasLength: true, hasWidth: true }))).toBe(false);
+  });
+
+  it('flags the area cell when neither an area nor a full length/width pair exists', () => {
+    expect(isDimensionCellIncomplete('area', state({ hasLength: true }))).toBe(true);
+  });
+});

--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -18,6 +18,12 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import type { HierarchyRow } from './utils/types';
+import {
+  calculateAreaValue,
+  getDimensionRowState,
+  isDimensionCellIncomplete,
+  type DimensionCellType,
+} from './utils/dimensionCellState';
 import { NotesCell } from '../data-grid/NotesCell';
 import { HierarchyAddIcon } from './HierarchyAddIcon';
 import { getPlainExcerpt } from '../data-grid/markdown';
@@ -382,28 +388,6 @@ function renderNameCell(
   );
 }
 
-const calculateAreaValue = (row: HierarchyRow): number | string | undefined => {
-  if (row.type === 'location') {
-    return undefined;
-  }
-
-  const length = typeof row.length_m === 'number' ? row.length_m : null;
-  const width = typeof row.width_m === 'number' ? row.width_m : null;
-  if (length !== null && width !== null) {
-    return Math.round(length * width * 10) / 10;
-  }
-
-  return row.area_sqm;
-};
-
-type DimensionCellType = 'length' | 'width' | 'area';
-
-interface DimensionRowState {
-  hasLength: boolean;
-  hasWidth: boolean;
-  hasAreaValue: boolean;
-}
-
 /** Returns true when a dimension edit cell value is non-empty but invalid (non-numeric or negative). */
 export const isDimensionEditValueInvalid = (value: unknown): boolean => {
   if (value === null || value === undefined) return false;
@@ -411,45 +395,6 @@ export const isDimensionEditValueInvalid = (value: unknown): boolean => {
   if (str === '') return false;
   const parsed = Number.parseFloat(str.replace(',', '.'));
   return !Number.isFinite(parsed) || parsed < 0;
-};
-
-const parseNumericValue = (value: unknown): number | undefined => {
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : undefined;
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const parsed = Number.parseFloat(trimmed.replace(',', '.'));
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
-};
-
-const getDimensionRowState = (row: HierarchyRow): DimensionRowState | null => {
-  if (row.type !== 'field' && row.type !== 'bed') {
-    return null;
-  }
-  const lengthValue = parseNumericValue(row.length_m);
-  const widthValue = parseNumericValue(row.width_m);
-  const areaValue = parseNumericValue(row.area_sqm);
-  return {
-    hasLength: Number.isFinite(lengthValue ?? NaN),
-    hasWidth: Number.isFinite(widthValue ?? NaN),
-    hasAreaValue: Number.isFinite(areaValue ?? NaN),
-  };
-};
-
-const isDimensionCellIncomplete = (type: DimensionCellType, rowState: DimensionRowState): boolean => {
-  if (type === 'length') {
-    return !rowState.hasLength;
-  }
-  if (type === 'width') {
-    return !rowState.hasWidth;
-  }
-  return !(rowState.hasAreaValue || (rowState.hasLength && rowState.hasWidth));
 };
 
 const getDimensionCellClassName = (row: HierarchyRow, type: DimensionCellType): string => {

--- a/frontend/src/components/hierarchy/utils/dimensionCellState.ts
+++ b/frontend/src/components/hierarchy/utils/dimensionCellState.ts
@@ -1,0 +1,71 @@
+// Pure dimension/area logic for the hierarchy grid: derives displayed area
+// values and per-cell completeness state (used to highlight missing dimensions).
+
+import type { HierarchyRow } from './types';
+
+export type DimensionCellType = 'length' | 'width' | 'area';
+
+export interface DimensionRowState {
+  hasLength: boolean;
+  hasWidth: boolean;
+  hasAreaValue: boolean;
+}
+
+/** Computed area for a row: length × width (rounded to 0.1) when both are set,
+ * otherwise the stored area value. Locations have no area. */
+export const calculateAreaValue = (row: HierarchyRow): number | string | undefined => {
+  if (row.type === 'location') {
+    return undefined;
+  }
+
+  const length = typeof row.length_m === 'number' ? row.length_m : null;
+  const width = typeof row.width_m === 'number' ? row.width_m : null;
+  if (length !== null && width !== null) {
+    return Math.round(length * width * 10) / 10;
+  }
+
+  return row.area_sqm;
+};
+
+const parseNumericValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number.parseFloat(trimmed.replace(',', '.'));
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+/** Which dimensions a field/bed row currently has. Returns null for row types
+ * (e.g. locations) that do not carry dimensions. */
+export const getDimensionRowState = (row: HierarchyRow): DimensionRowState | null => {
+  if (row.type !== 'field' && row.type !== 'bed') {
+    return null;
+  }
+  const lengthValue = parseNumericValue(row.length_m);
+  const widthValue = parseNumericValue(row.width_m);
+  const areaValue = parseNumericValue(row.area_sqm);
+  return {
+    hasLength: Number.isFinite(lengthValue ?? NaN),
+    hasWidth: Number.isFinite(widthValue ?? NaN),
+    hasAreaValue: Number.isFinite(areaValue ?? NaN),
+  };
+};
+
+/** A dimension cell is incomplete when its own value is missing; the area cell
+ * is complete if an area is stored or both length and width are present. */
+export const isDimensionCellIncomplete = (type: DimensionCellType, rowState: DimensionRowState): boolean => {
+  if (type === 'length') {
+    return !rowState.hasLength;
+  }
+  if (type === 'width') {
+    return !rowState.hasWidth;
+  }
+  return !(rowState.hasAreaValue || (rowState.hasLength && rowState.hasWidth));
+};


### PR DESCRIPTION
### Motivation
`HierarchyColumns.tsx` mixed pure dimension/area logic (area computation and per-cell completeness state used to highlight missing dimensions) in with column/render definitions. Isolating it makes the rules explicit and unit-testable, next to the existing `hierarchy/utils` modules.

### Description
- Add `components/hierarchy/utils/dimensionCellState.ts` with `calculateAreaValue`, `getDimensionRowState`, `isDimensionCellIncomplete`, their `DimensionCellType`/`DimensionRowState` types, and the module-private numeric parser.
- `HierarchyColumns.tsx` imports these; `getDimensionCellClassName` stays in the component (it depends on CSS class constants) and now consumes the extracted helpers.
- Add unit tests covering area computation, row-state derivation (incl. string parsing), and the length/width/area completeness rules.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `dimensionCellState` (new, 9 tests) and `hierarchyComponents` (17 tests) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_