### PR TITLE
refactor(frontend): extract getInitialInputValue from AreaM2EditCell

### DIFF
--- a/frontend/src/__tests__/areaM2EditCellValue.test.ts
+++ b/frontend/src/__tests__/areaM2EditCellValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getInitialInputValue } from '../components/data-grid/areaM2EditCellValue';
+
+describe('getInitialInputValue', () => {
+  it('keeps a non-numeric raw string verbatim (e.g. an area expression)', () => {
+    expect(getInitialInputValue('3x4', null, 'de-DE')).toBe('3x4');
+  });
+
+  it('locale-formats a numeric value without grouping', () => {
+    expect(getInitialInputValue(1234.5, null, 'de-DE')).toBe('1234,5');
+  });
+
+  it('parses and formats a numeric string', () => {
+    expect(getInitialInputValue('12.25', null, 'de-DE')).toBe('12,25');
+  });
+
+  it('rounds to at most two fraction digits', () => {
+    expect(getInitialInputValue(1.239, null, 'de-DE')).toBe('1,24');
+  });
+
+  it('uses the numeric fallback when the value is empty', () => {
+    expect(getInitialInputValue('', 7.5, 'de-DE')).toBe('7,5');
+    expect(getInitialInputValue(null, 7.5, 'de-DE')).toBe('7,5');
+  });
+
+  it('returns an empty string when neither value nor fallback is usable', () => {
+    expect(getInitialInputValue('', null, 'de-DE')).toBe('');
+    expect(getInitialInputValue(null, null, 'de-DE')).toBe('');
+  });
+});

--- a/frontend/src/components/data-grid/AreaM2EditCell.tsx
+++ b/frontend/src/components/data-grid/AreaM2EditCell.tsx
@@ -8,37 +8,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 import { TextField } from '@mui/material';
 import { useGridApiContext } from '@mui/x-data-grid';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
-import { formatLocalizedNumber } from '../../utils/numberLocalization';
-
-function getInitialInputValue(
-  value: unknown,
-  fallbackValue: number | null | undefined,
-  locale: string,
-): string {
-  if (typeof value === 'string' && value.trim() !== '' && Number.isNaN(Number(value))) {
-    return value;
-  }
-  const normalizedValue =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'string' && value.trim() !== ''
-        ? Number(value)
-        : null;
-  if (typeof normalizedValue === 'number' && !Number.isNaN(normalizedValue)) {
-    return formatLocalizedNumber(normalizedValue, locale, {
-      useGrouping: false,
-      maximumFractionDigits: 2,
-    });
-  }
-  if (typeof fallbackValue === 'number' && !Number.isNaN(fallbackValue)) {
-    return formatLocalizedNumber(fallbackValue, locale, {
-      useGrouping: false,
-      maximumFractionDigits: 2,
-    });
-  }
-  return '';
-}
-
+import { getInitialInputValue } from './areaM2EditCellValue';
 
 export interface AreaM2EditCellProps extends GridRenderEditCellParams {
   onLastEditedFieldChange: (field: 'area_m2') => void;

--- a/frontend/src/components/data-grid/areaM2EditCellValue.ts
+++ b/frontend/src/components/data-grid/areaM2EditCellValue.ts
@@ -1,0 +1,37 @@
+import { formatLocalizedNumber } from '../../utils/numberLocalization';
+
+/**
+ * Computes the initial string shown in the area (m²) edit cell input.
+ *
+ * A non-numeric raw string (e.g. an in-progress "3x4" area expression) is kept
+ * verbatim; numeric values are locale-formatted without grouping; otherwise a
+ * numeric fallback is used, and finally an empty string.
+ */
+export function getInitialInputValue(
+  value: unknown,
+  fallbackValue: number | null | undefined,
+  locale: string,
+): string {
+  if (typeof value === 'string' && value.trim() !== '' && Number.isNaN(Number(value))) {
+    return value;
+  }
+  const normalizedValue =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : null;
+  if (typeof normalizedValue === 'number' && !Number.isNaN(normalizedValue)) {
+    return formatLocalizedNumber(normalizedValue, locale, {
+      useGrouping: false,
+      maximumFractionDigits: 2,
+    });
+  }
+  if (typeof fallbackValue === 'number' && !Number.isNaN(fallbackValue)) {
+    return formatLocalizedNumber(fallbackValue, locale, {
+      useGrouping: false,
+      maximumFractionDigits: 2,
+    });
+  }
+  return '';
+}


### PR DESCRIPTION
### Motivation
`AreaM2EditCell.tsx` defined the pure `getInitialInputValue` helper inline. It has non-trivial branching (raw-string passthrough for in-progress area expressions, numeric locale formatting, numeric fallback), which is worth isolating and unit-testing rather than exercising only through the component.

### Description
- Add `components/data-grid/areaM2EditCellValue.ts` with `getInitialInputValue`.
- Import it into `AreaM2EditCell.tsx`; drops the now-unused `formatLocalizedNumber` import from the component.
- Add unit tests covering all branches (raw string, numeric value/string, rounding, fallback, empty).
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean (one pre-existing `set-state-in-effect` error in `AreaM2EditCell.tsx`, unrelated to this change)
- `npx vitest run areaM2EditCellValue` — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_