### PR TITLE
fix(frontend): use shared non-breaking area format in AreaAssignmentDialog

### DIFF
--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -60,7 +60,7 @@ describe('AreaAssignmentDialog', () => {
 
     expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveTextContent('Regenbogenland');
     expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveTextContent('8 Karotte + Zwiebel');
-    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent('5 (10,00 m²)');
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent(/5 \(10,00\s+m²\)/);
   });
 
   it('filters fields and beds when location changes', async () => {
@@ -89,7 +89,7 @@ describe('AreaAssignmentDialog', () => {
 
     await openSelect('Beet');
     const listbox = await screen.findByRole('listbox');
-    expect(within(listbox).getByRole('option', { name: '6 (8,00 m²)' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: /^6 \(8,00\s+m²\)$/ })).toBeInTheDocument();
     expect(within(listbox).queryByRole('option', { name: '5 (10,00 m²)' })).not.toBeInTheDocument();
   });
 
@@ -101,7 +101,7 @@ describe('AreaAssignmentDialog', () => {
     await openDialog();
     await openSelect('Beet');
     const listbox = await screen.findByRole('listbox');
-    expect(within(listbox).getByRole('option', { name: '5 (10,00 m²)' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: /^5 \(10,00\s+m²\)$/ })).toBeInTheDocument();
     expect(within(listbox).queryByRole('option', { name: '8 Karotte + Zwiebel | 5 (10,00 m²)' })).not.toBeInTheDocument();
   });
 
@@ -116,11 +116,11 @@ describe('AreaAssignmentDialog', () => {
     await openSelect('Parzelle');
     await userEvent.setup().click(screen.getByRole('option', { name: '5 Tomate' }));
     await openSelect('Beet');
-    await userEvent.setup().click(screen.getByRole('option', { name: '5 (12,50 m²)' }));
+    await userEvent.setup().click(screen.getByRole('option', { name: /^5 \(12,50\s+m²\)$/ }));
 
     expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveTextContent('Sonnengarten');
     expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveTextContent('5 Tomate');
-    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent('5 (12,50 m²)');
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent(/5 \(12,50\s+m²\)/);
   });
 
   it('applies the changed bed selection', async () => {
@@ -133,7 +133,7 @@ describe('AreaAssignmentDialog', () => {
     await openSelect('Parzelle');
     await userEvent.setup().click(screen.getByRole('option', { name: '9 Pastinake' }));
     await openSelect('Beet');
-    await userEvent.setup().click(screen.getByRole('option', { name: '6 (8,00 m²)' }));
+    await userEvent.setup().click(screen.getByRole('option', { name: /^6 \(8,00\s+m²\)$/ }));
     await userEvent.setup().click(screen.getByRole('button', { name: 'Übernehmen' }));
 
     expect(onApply).toHaveBeenCalledWith(102);
@@ -152,13 +152,13 @@ describe('AreaAssignmentDialog', () => {
     await openSelect('Parzelle');
     await userEvent.setup().click(screen.getByRole('option', { name: '9 Pastinake' }));
     await openSelect('Beet');
-    await userEvent.setup().click(screen.getByRole('option', { name: '6 (8,00 m²)' }));
+    await userEvent.setup().click(screen.getByRole('option', { name: /^6 \(8,00\s+m²\)$/ }));
     await userEvent.setup().click(screen.getByRole('button', { name: 'Abbrechen' }));
 
     expect(onApply).not.toHaveBeenCalled();
 
     await openDialog();
-    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent('5 (10,00 m²)');
+    expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveTextContent(/5 \(10,00\s+m²\)/);
   });
 
   it('keeps the location selector visible when only one selectable location exists', async () => {

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -21,7 +21,7 @@ import {
   collectHierarchyAvailability,
   filterFieldOptionsByLocation,
 } from './areaHierarchySelection';
-import { formatLocalizedNumber } from '../../utils/numberLocalization';
+import { formatAreaM2, toNumericValue } from '../../pages/plantingPlansUtils';
 import { TypeaheadSelect as Select } from '../inputs/TypeaheadSelect';
 import { mediumFieldSx } from '../forms/formLayout';
 
@@ -50,20 +50,6 @@ interface DialogKeyboardControl {
   focusTarget: HTMLElement | null;
   disabled: boolean;
 }
-
-const formatArea = (value: number, locale: string): string =>
-  `${formatLocalizedNumber(value, locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} m²`;
-
-const toNumericValue = (value: unknown): number | null => {
-  if (typeof value === 'number') {
-    return Number.isNaN(value) ? null : value;
-  }
-  if (typeof value === 'string' && value.trim() !== '') {
-    const parsed = Number(value);
-    return Number.isNaN(parsed) ? null : parsed;
-  }
-  return null;
-};
 
 const normalizeState = (
   bedId: number | null,
@@ -287,7 +273,7 @@ function AreaAssignmentDialogComponent({
     const areaSqm = toNumericValue(item.area_sqm);
     const label = areaSqm === null
       ? item.name
-      : `${item.name} (${formatArea(areaSqm, locale)})`;
+      : `${item.name} (${formatAreaM2(areaSqm, locale)})`;
     return label;
   };
 


### PR DESCRIPTION
### Motivation
`AreaAssignmentDialog` formatted bed areas with a local helper using a regular space (`"10,00 m²"`), while the rest of the app — including the sibling `AreaValidationDialog` — uses the shared `formatAreaM2`, which joins the value and unit with a non-breaking space so they never wrap onto separate lines. It also carried its own copy of `toNumericValue`, identical to the one in `plantingPlansUtils`.

### Description
- Replace the local `formatArea` with the shared `formatAreaM2`, giving area labels the same non-breaking spacing as the rest of the app.
- Reuse the shared `toNumericValue` from `plantingPlansUtils` and drop the duplicated local helper (and the now-unused `formatLocalizedNumber` import).
- Make the affected `AreaAssignmentDialog` test assertions whitespace-tolerant so they match the non-breaking space.

This is a small, deliberate user-visible change (non-breaking vs. regular space) that removes an inconsistency, plus a DRY cleanup.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean (two pre-existing `set-state-in-effect` errors in `AreaAssignmentDialog.tsx`, unrelated to this change)
- `npx vitest run AreaAssignmentDialog` — 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_