### PR TITLE
refactor(frontend): extract YieldFilterBar into its own module

### DIFF
--- a/frontend/src/pages/YieldFilterBar.tsx
+++ b/frontend/src/pages/YieldFilterBar.tsx
@@ -1,0 +1,136 @@
+import {
+  FormControl,
+  MenuItem,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
+import {
+  segmentedToggleButtonGroupSx,
+  segmentedToggleButtonSx,
+} from "../components/buttons/segmentedControlStyles";
+import { TypeaheadSelect as Select } from "../components/inputs/TypeaheadSelect";
+import { useTranslation } from "../i18n";
+import {
+  ALL_CULTURES,
+  type ChartPeriod,
+  type YieldCultureMeta,
+} from "./yieldOverviewUtils";
+
+interface YieldFilterBarProps {
+  cultures: YieldCultureMeta[];
+  selectedCultureId: string;
+  selectedYear: number;
+  period: ChartPeriod;
+  onCultureChange: (cultureId: string) => void;
+  onYearChange: (year: number) => void;
+  onPeriodChange: (period: ChartPeriod) => void;
+}
+
+export function YieldFilterBar({
+  cultures,
+  selectedCultureId,
+  selectedYear,
+  period,
+  onCultureChange,
+  onYearChange,
+  onPeriodChange,
+}: YieldFilterBarProps) {
+  const { t } = useTranslation("yieldOverview");
+  const currentYear = new Date().getFullYear();
+  const yearOptions = Array.from(
+    { length: 6 },
+    (_, index) => currentYear - 2 + index,
+  );
+
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      spacing={1.5}
+      alignItems={{ xs: "stretch", sm: "flex-start" }}
+      sx={{ width: "100%", flexWrap: "wrap" }}
+    >
+      <Stack spacing={0.5} sx={{ minWidth: { sm: 220 } }}>
+        <Typography
+          id="yield-culture-filter-label"
+          variant="caption"
+          color="text.secondary"
+          sx={{ lineHeight: 1 }}
+        >
+          {t("filters.culture")}
+        </Typography>
+        <FormControl size="small" fullWidth>
+          <Select
+            fullWidth
+            labelId="yield-culture-filter-label"
+            value={selectedCultureId}
+            onChange={(event) => onCultureChange(String(event.target.value))}
+          >
+            <MenuItem value={ALL_CULTURES}>{t("filters.allCultures")}</MenuItem>
+            {cultures.map((culture) => (
+              <MenuItem key={culture.id} value={String(culture.id)}>
+                {culture.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+
+      <Stack spacing={0.5} sx={{ minWidth: { sm: 120 } }}>
+        <Typography
+          id="yield-year-filter-label"
+          variant="caption"
+          color="text.secondary"
+          sx={{ lineHeight: 1 }}
+        >
+          {t("filters.year")}
+        </Typography>
+        <FormControl size="small" fullWidth>
+          <Select
+            fullWidth
+            labelId="yield-year-filter-label"
+            value={String(selectedYear)}
+            onChange={(event) => onYearChange(Number(event.target.value))}
+          >
+            {yearOptions.map((year) => (
+              <MenuItem key={year} value={String(year)}>
+                {year}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+
+      <Stack spacing={0.5}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ lineHeight: 1 }}
+        >
+          {t("filters.period")}
+        </Typography>
+        <ToggleButtonGroup
+          value={period}
+          exclusive
+          size="small"
+          color="primary"
+          aria-label={t("filters.period")}
+          sx={{ ...segmentedToggleButtonGroupSx, height: 40 }}
+          onChange={(_, value: ChartPeriod | null) => {
+            if (value !== null) {
+              onPeriodChange(value);
+            }
+          }}
+        >
+          <ToggleButton value="week" sx={segmentedToggleButtonSx}>
+            {t("filters.week")}
+          </ToggleButton>
+          <ToggleButton value="month" sx={segmentedToggleButtonSx}>
+            {t("filters.month")}
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Stack>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -8,11 +8,8 @@ import {
   Card,
   CardContent,
   Divider,
-  FormControl,
   MenuItem,
   Stack,
-  ToggleButton,
-  ToggleButtonGroup,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -22,18 +19,14 @@ import {
   type PlantingPlan,
   type YieldCalendarWeek,
 } from "../api/api";
-import {
-  segmentedToggleButtonGroupSx,
-  segmentedToggleButtonSx,
-} from "../components/buttons/segmentedControlStyles";
 import { copyTextToClipboardSilently } from "../components/data-grid";
 import PageContainer from "../components/layout/PageContainer";
 import PageSurface from "../components/layout/PageSurface";
 import EmptyStateCard from "../components/project/EmptyStateCard";
 import ProjectRequiredState from "../components/project/ProjectRequiredState";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
-import { TypeaheadSelect as Select } from "../components/inputs/TypeaheadSelect";
 import { useTranslation } from "../i18n";
+import { YieldFilterBar } from "./YieldFilterBar";
 import {
   shouldOpenCustomContextMenu,
   suppressNativeContextMenu,
@@ -46,6 +39,7 @@ import { useContextMenuPositionState } from "../components/contextMenu/useContex
 import { useFocusRegion } from "../focus/useFocusManager";
 import { parseDateString } from "./ganttChartUtils";
 import {
+  ALL_CULTURES,
   formatCompactYield,
   formatDateToAPI,
   formatIsoWeek,
@@ -53,13 +47,8 @@ import {
   mergeCultureYields,
   type ChartPeriod,
   type YieldCalendarCulture,
+  type YieldCultureMeta,
 } from "./yieldOverviewUtils";
-
-interface YieldCultureMeta {
-  id: number;
-  name: string;
-  color: string;
-}
 
 interface YieldChartCulture extends YieldCultureMeta {
   totalYield: number;
@@ -81,7 +70,6 @@ interface YieldContextMenuPayload {
   yieldValue: number;
 }
 
-const ALL_CULTURES = "all";
 const DEFAULT_LEGEND_CULTURE_LIMIT = 15;
 
 function useYieldChartData(
@@ -932,123 +920,6 @@ function YieldDistributionChart({
       </MenuItem>
     </CustomContextMenu>
     </>
-  );
-}
-
-interface YieldFilterBarProps {
-  cultures: YieldCultureMeta[];
-  selectedCultureId: string;
-  selectedYear: number;
-  period: ChartPeriod;
-  onCultureChange: (cultureId: string) => void;
-  onYearChange: (year: number) => void;
-  onPeriodChange: (period: ChartPeriod) => void;
-}
-
-function YieldFilterBar({
-  cultures,
-  selectedCultureId,
-  selectedYear,
-  period,
-  onCultureChange,
-  onYearChange,
-  onPeriodChange,
-}: YieldFilterBarProps) {
-  const { t } = useTranslation("yieldOverview");
-  const currentYear = new Date().getFullYear();
-  const yearOptions = Array.from(
-    { length: 6 },
-    (_, index) => currentYear - 2 + index,
-  );
-
-  return (
-    <Stack
-      direction={{ xs: "column", sm: "row" }}
-      spacing={1.5}
-      alignItems={{ xs: "stretch", sm: "flex-start" }}
-      sx={{ width: "100%", flexWrap: "wrap" }}
-    >
-      <Stack spacing={0.5} sx={{ minWidth: { sm: 220 } }}>
-        <Typography
-          id="yield-culture-filter-label"
-          variant="caption"
-          color="text.secondary"
-          sx={{ lineHeight: 1 }}
-        >
-          {t("filters.culture")}
-        </Typography>
-        <FormControl size="small" fullWidth>
-          <Select
-            fullWidth
-            labelId="yield-culture-filter-label"
-            value={selectedCultureId}
-            onChange={(event) => onCultureChange(String(event.target.value))}
-          >
-            <MenuItem value={ALL_CULTURES}>{t("filters.allCultures")}</MenuItem>
-            {cultures.map((culture) => (
-              <MenuItem key={culture.id} value={String(culture.id)}>
-                {culture.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Stack>
-
-      <Stack spacing={0.5} sx={{ minWidth: { sm: 120 } }}>
-        <Typography
-          id="yield-year-filter-label"
-          variant="caption"
-          color="text.secondary"
-          sx={{ lineHeight: 1 }}
-        >
-          {t("filters.year")}
-        </Typography>
-        <FormControl size="small" fullWidth>
-          <Select
-            fullWidth
-            labelId="yield-year-filter-label"
-            value={String(selectedYear)}
-            onChange={(event) => onYearChange(Number(event.target.value))}
-          >
-            {yearOptions.map((year) => (
-              <MenuItem key={year} value={String(year)}>
-                {year}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Stack>
-
-      <Stack spacing={0.5}>
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ lineHeight: 1 }}
-        >
-          {t("filters.period")}
-        </Typography>
-        <ToggleButtonGroup
-          value={period}
-          exclusive
-          size="small"
-          color="primary"
-          aria-label={t("filters.period")}
-          sx={{ ...segmentedToggleButtonGroupSx, height: 40 }}
-          onChange={(_, value: ChartPeriod | null) => {
-            if (value !== null) {
-              onPeriodChange(value);
-            }
-          }}
-        >
-          <ToggleButton value="week" sx={segmentedToggleButtonSx}>
-            {t("filters.week")}
-          </ToggleButton>
-          <ToggleButton value="month" sx={segmentedToggleButtonSx}>
-            {t("filters.month")}
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </Stack>
-    </Stack>
   );
 }
 

--- a/frontend/src/pages/yieldOverviewUtils.ts
+++ b/frontend/src/pages/yieldOverviewUtils.ts
@@ -2,6 +2,15 @@ import { type YieldCalendarWeek } from "../api/api";
 
 export type ChartPeriod = "week" | "month";
 
+/** Sentinel filter value representing "all cultures" in the yield overview. */
+export const ALL_CULTURES = "all";
+
+export interface YieldCultureMeta {
+  id: number;
+  name: string;
+  color: string;
+}
+
 export type YieldCalendarCulture = YieldCalendarWeek["cultures"][number];
 
 export function formatCompactYield(value: number, locale: string): string {


### PR DESCRIPTION
### Motivation
`YieldOverview.tsx` was ~1220 lines and bundled several sub-components inline. `YieldFilterBar` is a self-contained presentational component with a clear props contract — a good first step in decomposing the page into smaller modules.

### Description
- Move `YieldFilterBar` (and its `YieldFilterBarProps`) into `src/pages/YieldFilterBar.tsx`.
- Move the shared `ALL_CULTURES` constant and `YieldCultureMeta` type into `yieldOverviewUtils.ts` so both the page and the extracted component import them without a circular dependency.
- Drop the now-unused imports (`FormControl`, `ToggleButton`, `ToggleButtonGroup`, `TypeaheadSelect`, segmented-control styles) from `YieldOverview.tsx`.
- `YieldOverview.tsx` shrinks from ~1219 to ~1090 lines; no call site or markup changes.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `YieldOverview` (20) and `yieldOverviewUtils` (8) — all pass (YieldFilterBar is exercised through the page tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_