### PR TITLE
refactor(frontend): extract YieldChartSegment into its own module

### DIFF
--- a/frontend/src/pages/YieldChartSegment.tsx
+++ b/frontend/src/pages/YieldChartSegment.tsx
@@ -1,0 +1,172 @@
+import {
+  memo,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type TouchEvent as ReactTouchEvent,
+} from "react";
+import { Box, Tooltip, Typography } from "@mui/material";
+import { ContextMenuIndicator } from "../components/contextMenu/ContextMenuIndicator";
+import { contextMenuIndicatorHostSx } from "../components/contextMenu/contextMenuIndicatorStyles";
+
+export interface YieldSegmentPayload {
+  cultureId: number;
+  cultureName: string;
+  periodLabel: string;
+  yieldValue: number;
+}
+
+interface YieldChartSegmentProps {
+  segmentKey: string;
+  columnIndex: number;
+  cultureIndex: number;
+  cultureId: number;
+  cultureName: string;
+  color: string;
+  yieldValue: number;
+  periodLabel: string;
+  heightPercent: number;
+  isTabbable: boolean;
+  isHovered: boolean;
+  isKeyboardTooltipOpen: boolean;
+  isTooltipSuppressed: boolean;
+  isPressed: boolean;
+  isDimmed: boolean;
+  tooltipPeriodLabel: string;
+  tooltipYieldLabel: string;
+  actionsLabel: string;
+  onFocusSegment: (segmentKey: string) => void;
+  onHoverStart: (segmentKey: string) => void;
+  onHoverEnd: (segmentKey: string) => void;
+  onKeyDownSegment: (
+    event: ReactKeyboardEvent,
+    columnIndex: number,
+    cultureIndex: number,
+    payload: YieldSegmentPayload,
+  ) => void;
+  onContextMenuOpen: (event: ReactMouseEvent | ReactTouchEvent, payload: YieldSegmentPayload) => void;
+  onTouchStartSegment: (event: ReactTouchEvent, payload: YieldSegmentPayload, segmentKey: string) => void;
+  onTouchEndSegment: () => void;
+  registerElement: (segmentKey: string, element: HTMLElement | null) => void;
+}
+
+/**
+ * A single stacked-bar segment (one culture within one period's column).
+ * Memoized so that hovering/focusing one segment only re-renders that
+ * segment (and whichever one it's replacing) instead of every segment in
+ * the chart — with many cultures/periods that's the difference between a
+ * handful of re-renders and thousands on every mouse move. Every prop here
+ * must therefore stay a primitive or a referentially stable callback (see
+ * the parent's useCallback hooks) for the memo comparison to actually skip
+ * unrelated segments.
+ */
+export const YieldChartSegment = memo(function YieldChartSegment({
+  segmentKey,
+  columnIndex,
+  cultureIndex,
+  cultureId,
+  cultureName,
+  color,
+  yieldValue,
+  periodLabel,
+  heightPercent,
+  isTabbable,
+  isHovered,
+  isKeyboardTooltipOpen,
+  isTooltipSuppressed,
+  isPressed,
+  isDimmed,
+  tooltipPeriodLabel,
+  tooltipYieldLabel,
+  actionsLabel,
+  onFocusSegment,
+  onHoverStart,
+  onHoverEnd,
+  onKeyDownSegment,
+  onContextMenuOpen,
+  onTouchStartSegment,
+  onTouchEndSegment,
+  registerElement,
+}: YieldChartSegmentProps) {
+  const payload: YieldSegmentPayload = { cultureId, cultureName, periodLabel, yieldValue };
+
+  return (
+    <Tooltip
+      // Always an explicit boolean (never `undefined`) — driven by hover and
+      // the keyboard (Space) toggle. Force-closed while a context menu is
+      // open, since the pointer may still technically be hovering the
+      // segment underneath it.
+      open={!isTooltipSuppressed && (isHovered || isKeyboardTooltipOpen)}
+      slotProps={{
+        tooltip: {
+          sx: {
+            minWidth: "12rem",
+            "& .MuiTypography-root": {
+              color: "inherit",
+            },
+            "& .MuiTypography-caption": {
+              fontSize: "inherit",
+              lineHeight: "inherit",
+            },
+            "& [data-yield-tooltip-label='true']": {
+              color: "rgba(255, 255, 255, 0.72)",
+            },
+          },
+        },
+      }}
+      title={
+        <Box>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+            {cultureName}
+          </Typography>
+          <Box sx={{ display: "grid", gridTemplateColumns: "auto 1fr", columnGap: 1, rowGap: 0.25 }}>
+            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
+              {tooltipPeriodLabel}:
+            </Typography>
+            <Typography variant="caption">{periodLabel}</Typography>
+            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
+              {tooltipYieldLabel}:
+            </Typography>
+            <Typography variant="caption">{yieldValue.toFixed(2)} kg</Typography>
+          </Box>
+        </Box>
+      }
+    >
+      <Box
+        ref={(element: HTMLElement | null) => registerElement(segmentKey, element)}
+        data-testid={`yield-bar-${segmentKey}`}
+        data-rmg-component="yield-segment"
+        role="button"
+        tabIndex={isTabbable ? 0 : -1}
+        aria-label={`${cultureName}, ${periodLabel}, ${yieldValue.toFixed(2)} kg`}
+        onFocus={() => onFocusSegment(segmentKey)}
+        onKeyDown={(event) => onKeyDownSegment(event, columnIndex, cultureIndex, payload)}
+        onMouseEnter={() => onHoverStart(segmentKey)}
+        onMouseLeave={() => onHoverEnd(segmentKey)}
+        data-long-pressing={isPressed ? "true" : undefined}
+        onContextMenu={(event) => onContextMenuOpen(event, payload)}
+        onTouchStart={(event) => onTouchStartSegment(event, payload, segmentKey)}
+        onTouchEnd={onTouchEndSegment}
+        onTouchMove={onTouchEndSegment}
+        sx={{
+          position: "relative",
+          width: "100%",
+          height: `${heightPercent}%`,
+          minHeight: yieldValue > 0 ? "2px" : 0,
+          backgroundColor: color,
+          opacity: isDimmed ? 0.28 : 1,
+          filter: isPressed ? "brightness(0.9)" : undefined,
+          transition: "filter 0.15s ease, opacity 0.15s ease",
+          ...contextMenuIndicatorHostSx,
+        }}
+      >
+        <ContextMenuIndicator
+          label={actionsLabel}
+          tabIndex={-1}
+          onClick={(event) => onContextMenuOpen(event, payload)}
+          withBackdrop
+          sx={{ position: "absolute", top: -2, right: -2 }}
+        />
+      </Box>
+    </Tooltip>
+  );
+});

--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 import {
@@ -10,7 +10,6 @@ import {
   Divider,
   MenuItem,
   Stack,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import {
@@ -26,14 +25,13 @@ import EmptyStateCard from "../components/project/EmptyStateCard";
 import ProjectRequiredState from "../components/project/ProjectRequiredState";
 import { useProjectRequirement } from "../hooks/useProjectRequirement";
 import { useTranslation } from "../i18n";
+import { YieldChartSegment } from "./YieldChartSegment";
 import { YieldFilterBar } from "./YieldFilterBar";
 import {
   shouldOpenCustomContextMenu,
   suppressNativeContextMenu,
   useLongPress,
 } from "../utils/contextMenu";
-import { ContextMenuIndicator } from "../components/contextMenu/ContextMenuIndicator";
-import { contextMenuIndicatorHostSx } from "../components/contextMenu/contextMenuIndicatorStyles";
 import { CustomContextMenu } from "../components/contextMenu/CustomContextMenu";
 import { useContextMenuPositionState } from "../components/contextMenu/useContextMenuPositionState";
 import { useFocusRegion } from "../focus/useFocusManager";
@@ -206,169 +204,6 @@ function useYieldChartData(
     };
   }, [locale, period, selectedCultureId, weeklyYield]);
 }
-
-interface YieldSegmentPayload {
-  cultureId: number;
-  cultureName: string;
-  periodLabel: string;
-  yieldValue: number;
-}
-
-interface YieldChartSegmentProps {
-  segmentKey: string;
-  columnIndex: number;
-  cultureIndex: number;
-  cultureId: number;
-  cultureName: string;
-  color: string;
-  yieldValue: number;
-  periodLabel: string;
-  heightPercent: number;
-  isTabbable: boolean;
-  isHovered: boolean;
-  isKeyboardTooltipOpen: boolean;
-  isTooltipSuppressed: boolean;
-  isPressed: boolean;
-  isDimmed: boolean;
-  tooltipPeriodLabel: string;
-  tooltipYieldLabel: string;
-  actionsLabel: string;
-  onFocusSegment: (segmentKey: string) => void;
-  onHoverStart: (segmentKey: string) => void;
-  onHoverEnd: (segmentKey: string) => void;
-  onKeyDownSegment: (
-    event: React.KeyboardEvent,
-    columnIndex: number,
-    cultureIndex: number,
-    payload: YieldSegmentPayload,
-  ) => void;
-  onContextMenuOpen: (event: React.MouseEvent | React.TouchEvent, payload: YieldSegmentPayload) => void;
-  onTouchStartSegment: (event: React.TouchEvent, payload: YieldSegmentPayload, segmentKey: string) => void;
-  onTouchEndSegment: () => void;
-  registerElement: (segmentKey: string, element: HTMLElement | null) => void;
-}
-
-/**
- * A single stacked-bar segment (one culture within one period's column).
- * Memoized so that hovering/focusing one segment only re-renders that
- * segment (and whichever one it's replacing) instead of every segment in
- * the chart — with many cultures/periods that's the difference between a
- * handful of re-renders and thousands on every mouse move. Every prop here
- * must therefore stay a primitive or a referentially stable callback (see
- * the parent's useCallback hooks) for the memo comparison to actually skip
- * unrelated segments.
- */
-const YieldChartSegment = memo(function YieldChartSegment({
-  segmentKey,
-  columnIndex,
-  cultureIndex,
-  cultureId,
-  cultureName,
-  color,
-  yieldValue,
-  periodLabel,
-  heightPercent,
-  isTabbable,
-  isHovered,
-  isKeyboardTooltipOpen,
-  isTooltipSuppressed,
-  isPressed,
-  isDimmed,
-  tooltipPeriodLabel,
-  tooltipYieldLabel,
-  actionsLabel,
-  onFocusSegment,
-  onHoverStart,
-  onHoverEnd,
-  onKeyDownSegment,
-  onContextMenuOpen,
-  onTouchStartSegment,
-  onTouchEndSegment,
-  registerElement,
-}: YieldChartSegmentProps) {
-  const payload: YieldSegmentPayload = { cultureId, cultureName, periodLabel, yieldValue };
-
-  return (
-    <Tooltip
-      // Always an explicit boolean (never `undefined`) — driven by hover and
-      // the keyboard (Space) toggle. Force-closed while a context menu is
-      // open, since the pointer may still technically be hovering the
-      // segment underneath it.
-      open={!isTooltipSuppressed && (isHovered || isKeyboardTooltipOpen)}
-      slotProps={{
-        tooltip: {
-          sx: {
-            minWidth: "12rem",
-            "& .MuiTypography-root": {
-              color: "inherit",
-            },
-            "& .MuiTypography-caption": {
-              fontSize: "inherit",
-              lineHeight: "inherit",
-            },
-            "& [data-yield-tooltip-label='true']": {
-              color: "rgba(255, 255, 255, 0.72)",
-            },
-          },
-        },
-      }}
-      title={
-        <Box>
-          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
-            {cultureName}
-          </Typography>
-          <Box sx={{ display: "grid", gridTemplateColumns: "auto 1fr", columnGap: 1, rowGap: 0.25 }}>
-            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
-              {tooltipPeriodLabel}:
-            </Typography>
-            <Typography variant="caption">{periodLabel}</Typography>
-            <Typography variant="caption" data-yield-tooltip-label="true" sx={{ fontWeight: 600 }}>
-              {tooltipYieldLabel}:
-            </Typography>
-            <Typography variant="caption">{yieldValue.toFixed(2)} kg</Typography>
-          </Box>
-        </Box>
-      }
-    >
-      <Box
-        ref={(element: HTMLElement | null) => registerElement(segmentKey, element)}
-        data-testid={`yield-bar-${segmentKey}`}
-        data-rmg-component="yield-segment"
-        role="button"
-        tabIndex={isTabbable ? 0 : -1}
-        aria-label={`${cultureName}, ${periodLabel}, ${yieldValue.toFixed(2)} kg`}
-        onFocus={() => onFocusSegment(segmentKey)}
-        onKeyDown={(event) => onKeyDownSegment(event, columnIndex, cultureIndex, payload)}
-        onMouseEnter={() => onHoverStart(segmentKey)}
-        onMouseLeave={() => onHoverEnd(segmentKey)}
-        data-long-pressing={isPressed ? "true" : undefined}
-        onContextMenu={(event) => onContextMenuOpen(event, payload)}
-        onTouchStart={(event) => onTouchStartSegment(event, payload, segmentKey)}
-        onTouchEnd={onTouchEndSegment}
-        onTouchMove={onTouchEndSegment}
-        sx={{
-          position: "relative",
-          width: "100%",
-          height: `${heightPercent}%`,
-          minHeight: yieldValue > 0 ? "2px" : 0,
-          backgroundColor: color,
-          opacity: isDimmed ? 0.28 : 1,
-          filter: isPressed ? "brightness(0.9)" : undefined,
-          transition: "filter 0.15s ease, opacity 0.15s ease",
-          ...contextMenuIndicatorHostSx,
-        }}
-      >
-        <ContextMenuIndicator
-          label={actionsLabel}
-          tabIndex={-1}
-          onClick={(event) => onContextMenuOpen(event, payload)}
-          withBackdrop
-          sx={{ position: "absolute", top: -2, right: -2 }}
-        />
-      </Box>
-    </Tooltip>
-  );
-});
 
 interface YieldDistributionChartProps {
   weeklyYield: YieldCalendarWeek[];


### PR DESCRIPTION
### Motivation
Continuing the `YieldOverview.tsx` decomposition (after #366). `YieldChartSegment` is a memoized, self-contained presentational component with a clear props contract, so it belongs in its own module.

### Description
- Move `YieldChartSegment` and its `YieldSegmentPayload` type into `src/pages/YieldChartSegment.tsx`.
- Import the React event types directly (aliased) instead of relying on the global `React` namespace.
- Drop the now-unused `Tooltip`, `ContextMenuIndicator`, `contextMenuIndicatorHostSx`, and `memo` imports from `YieldOverview.tsx`.
- `YieldOverview.tsx` shrinks to ~925 lines; the memoization contract and markup are unchanged.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run YieldOverview` — 20 tests pass (the segment is exercised through the page tests, including hover/keyboard/dim behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_