### PR TITLE
refactor(frontend): extract CultivationTypeEditCell into its own module

### DIFF
--- a/frontend/src/pages/CultivationTypeEditCell.tsx
+++ b/frontend/src/pages/CultivationTypeEditCell.tsx
@@ -1,0 +1,99 @@
+import { memo, useCallback } from "react";
+import { Box, MenuItem, TextField } from "@mui/material";
+import type { GridRenderEditCellParams } from "@mui/x-data-grid";
+import { useClosedSelectTypeahead } from "../components/inputs/selectTypeahead";
+import { normalizeCultivationType } from "./plantingPlansUtils";
+import type { CultivationTypeSelectOption } from "./usePlantingPlanHierarchy";
+
+interface CultivationTypeEditCellProps extends GridRenderEditCellParams {
+  options: CultivationTypeSelectOption[];
+  placeholder: string;
+}
+
+export const CultivationTypeEditCell = memo(function CultivationTypeEditCell({
+  id,
+  field,
+  value,
+  hasFocus,
+  api,
+  options,
+  placeholder,
+}: CultivationTypeEditCellProps) {
+  const selectedValue = normalizeCultivationType(value) ?? "";
+  const selectedOption = options.find((option) => option.value === selectedValue);
+  const handleTypeaheadSelect = useCallback((nextValue: string | string[]): void => {
+    const nextSelectedValue = Array.isArray(nextValue) ? nextValue[0] : nextValue;
+    void api.setEditCellValue({
+      id,
+      field,
+      value: nextSelectedValue,
+    });
+  }, [api, field, id]);
+  const handleSelectKeyDown = useClosedSelectTypeahead<string>({
+    options,
+    value: selectedValue,
+    onSelect: handleTypeaheadSelect,
+  });
+
+  return (
+    <TextField
+      select
+      fullWidth
+      size="small"
+      autoFocus={hasFocus}
+      value={selectedValue}
+      slotProps={{
+        htmlInput: {
+          tabIndex: hasFocus ? 0 : -1,
+        },
+        select: {
+          displayEmpty: true,
+          onKeyDown: handleSelectKeyDown,
+          renderValue: () => selectedOption?.label ?? (
+            <Box
+              component="span"
+              sx={{
+                display: "block",
+                minWidth: 0,
+                overflow: "hidden",
+                color: "text.disabled",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {placeholder}
+            </Box>
+          ),
+        },
+      }}
+      sx={{
+        "& .MuiSelect-select": {
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        },
+      }}
+      onChange={async (event) => {
+        await api.setEditCellValue({
+          id,
+          field,
+          value: event.target.value,
+        });
+      }}
+    >
+      {options.map((option) => (
+        <MenuItem key={option.value} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}, (previous, next) => (
+  previous.id === next.id
+  && previous.field === next.field
+  && previous.value === next.value
+  && previous.hasFocus === next.hasFocus
+  && previous.options === next.options
+  && previous.placeholder === next.placeholder
+));

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -7,14 +7,13 @@
  * @returns The Planting Plans page component
  */
 
-import { memo, useCallback, useState, useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import { useCallback, useState, useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react";
 import { isTypingInEditableElement } from "../hooks/useKeyboardShortcuts";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import type {
   GridCellParams,
   GridColDef,
   GridRenderCellParams,
-  GridRenderEditCellParams,
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
@@ -22,9 +21,7 @@ import {
   Button,
   CircularProgress,
   IconButton,
-  MenuItem,
   Stack,
-  TextField,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -43,7 +40,8 @@ import {
   buildBedDisplayLabel,
   getAllowedCultivationTypesForCulture,
 } from "./plantingPlansUtils";
-import { usePlantingPlanHierarchy, type CultivationTypeSelectOption } from "./usePlantingPlanHierarchy";
+import { usePlantingPlanHierarchy } from "./usePlantingPlanHierarchy";
+import { CultivationTypeEditCell } from "./CultivationTypeEditCell";
 import PageContainer from "../components/layout/PageContainer";
 import PageSurface from "../components/layout/PageSurface";
 import { AlertSnackbar } from "../components/feedback/AlertSnackbar";
@@ -94,7 +92,6 @@ import {
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
 import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 import EmptyStateCard from "../components/project/EmptyStateCard";
-import { useClosedSelectTypeahead } from "../components/inputs/selectTypeahead";
 
 export {
   collectHierarchyAvailability,
@@ -139,99 +136,6 @@ const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
 
 const CULTURE_COLUMN_MAX_WIDTH = 280;
 const BED_COLUMN_MAX_WIDTH = 220;
-
-interface CultivationTypeEditCellProps extends GridRenderEditCellParams {
-  options: CultivationTypeSelectOption[];
-  placeholder: string;
-}
-
-const CultivationTypeEditCell = memo(function CultivationTypeEditCell({
-  id,
-  field,
-  value,
-  hasFocus,
-  api,
-  options,
-  placeholder,
-}: CultivationTypeEditCellProps) {
-  const selectedValue = normalizeCultivationType(value) ?? "";
-  const selectedOption = options.find((option) => option.value === selectedValue);
-  const handleTypeaheadSelect = useCallback((nextValue: string | string[]): void => {
-    const nextSelectedValue = Array.isArray(nextValue) ? nextValue[0] : nextValue;
-    void api.setEditCellValue({
-      id,
-      field,
-      value: nextSelectedValue,
-    });
-  }, [api, field, id]);
-  const handleSelectKeyDown = useClosedSelectTypeahead<string>({
-    options,
-    value: selectedValue,
-    onSelect: handleTypeaheadSelect,
-  });
-
-  return (
-    <TextField
-      select
-      fullWidth
-      size="small"
-      autoFocus={hasFocus}
-      value={selectedValue}
-      slotProps={{
-        htmlInput: {
-          tabIndex: hasFocus ? 0 : -1,
-        },
-        select: {
-          displayEmpty: true,
-          onKeyDown: handleSelectKeyDown,
-          renderValue: () => selectedOption?.label ?? (
-            <Box
-              component="span"
-              sx={{
-                display: "block",
-                minWidth: 0,
-                overflow: "hidden",
-                color: "text.disabled",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {placeholder}
-            </Box>
-          ),
-        },
-      }}
-      sx={{
-        "& .MuiSelect-select": {
-          minWidth: 0,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        },
-      }}
-      onChange={async (event) => {
-        await api.setEditCellValue({
-          id,
-          field,
-          value: event.target.value,
-        });
-      }}
-    >
-      {options.map((option) => (
-        <MenuItem key={option.value} value={option.value}>
-          {option.label}
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-}, (previous, next) => (
-  previous.id === next.id
-  && previous.field === next.field
-  && previous.value === next.value
-  && previous.hasFocus === next.hasFocus
-  && previous.options === next.options
-  && previous.placeholder === next.placeholder
-));
 
 export { buildBedDisplayLabel } from "./plantingPlansUtils";
 


### PR DESCRIPTION
### Motivation
`PlantingPlans.tsx` is one of the largest page files (~2000 lines). `CultivationTypeEditCell` is a self-contained memoized DataGrid edit cell with a clear props contract — a good candidate to move into its own module.

### Description
- Move `CultivationTypeEditCell` and its `CultivationTypeEditCellProps` into `src/pages/CultivationTypeEditCell.tsx`, preserving the custom `memo` comparator.
- Drop the imports that were only used by it from `PlantingPlans.tsx` (`memo`, `TextField`, `MenuItem`, `GridRenderEditCellParams`, `useClosedSelectTypeahead`, and the `CultivationTypeSelectOption` type).
- No call site or markup changes.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean (the pre-existing `react-refresh/only-export-components` findings on `PlantingPlans.tsx` come from its existing util re-exports and are unchanged by this PR)
- `npx vitest run` for the PlantingPlans suites (escapeFocus, areaValidation, projectRequired, rawInputCells) and `plantingPlansUtils` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_