### PR TITLE
refactor(frontend): extract ProjectMenu and GlobalMenu from RootLayout

### DIFF
--- a/frontend/src/navigation/GlobalMenu.tsx
+++ b/frontend/src/navigation/GlobalMenu.tsx
@@ -1,0 +1,85 @@
+import { Divider, ListItemIcon, Menu, MenuItem } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
+import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import ExitToAppIcon from '@mui/icons-material/ExitToApp';
+import LogoutIcon from '@mui/icons-material/Logout';
+import { ACTION_MENU_ICON_PROPS, ACTION_MENU_ITEM_ICON_SX } from './topbarMenuStyles';
+
+interface GlobalMenuProps {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  historyLoading: boolean;
+  userLabel: string;
+  isMobile: boolean;
+  onClose: () => void;
+  onOpenProjectSwitcher: () => void;
+  onOpenCreateProject: () => void;
+  onOpenProjectSettings: () => void;
+  onOpenProjectHistory: () => Promise<void>;
+  onOpenAccountSettings: () => void;
+  onOpenShortcuts: () => void;
+  onOpenHelp: () => void;
+  canLeaveDemoProject: boolean;
+  isGuestDemoSession: boolean;
+  onLeaveDemoProject: () => Promise<void>;
+  onLogout: () => Promise<void>;
+  t: (key: string) => string;
+}
+
+export function GlobalMenu(props: GlobalMenuProps) {
+  const {
+    anchorEl,
+    open,
+    historyLoading,
+    userLabel,
+    isMobile,
+    onClose,
+    onOpenProjectSwitcher,
+    onOpenCreateProject,
+    onOpenProjectSettings,
+    onOpenProjectHistory,
+    onOpenAccountSettings,
+    onOpenShortcuts,
+    onOpenHelp,
+    canLeaveDemoProject,
+    isGuestDemoSession,
+    onLeaveDemoProject,
+    onLogout,
+    t,
+  } = props;
+
+  const wrap = (fn: () => void): () => void => () => { onClose(); fn(); };
+  const wrapAsync = (fn: () => Promise<void>): () => void => () => { onClose(); void fn(); };
+
+  const mobileMenuItems = [
+    <MenuItem key="mobile-section-project" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.projectActions')}</MenuItem>,
+    <MenuItem key="mobile-project-switcher" onClick={wrap(onOpenProjectSwitcher)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SwapHorizIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('projectSwitcher.ariaLabel')}</MenuItem>,
+    <MenuItem key="mobile-project-create" onClick={wrap(onOpenCreateProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.create')}</MenuItem>,
+    <MenuItem key="mobile-project-settings" onClick={wrap(onOpenProjectSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.settings')}</MenuItem>,
+    <MenuItem key="mobile-project-history" onClick={wrapAsync(onOpenProjectHistory)} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <Divider key="mobile-divider-project-app" />,
+    <MenuItem key="mobile-section-app" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.app')}</MenuItem>,
+    <MenuItem key="mobile-app-shortcuts" onClick={wrap(onOpenShortcuts)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.shortcuts')}</MenuItem>,
+    <MenuItem key="mobile-app-help" onClick={wrap(onOpenHelp)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.appHelp')}</MenuItem>,
+    <MenuItem key="mobile-app-account-settings" onClick={wrap(onOpenAccountSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
+    <Divider key="mobile-divider-app-account" />,
+    <MenuItem key="mobile-section-account" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.account')}</MenuItem>,
+    canLeaveDemoProject ? <MenuItem key="mobile-account-leave-demo" onClick={wrapAsync(onLeaveDemoProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><ExitToAppIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.leaveDemo')}</MenuItem> : null,
+    !isGuestDemoSession ? <MenuItem key="mobile-account-logout" onClick={wrapAsync(onLogout)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem> : null,
+  ];
+  const desktopMenuItems = [
+    <MenuItem key="desktop-project-settings" onClick={wrap(onOpenProjectSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.settings')}</MenuItem>,
+    <MenuItem key="desktop-history" onClick={wrapAsync(onOpenProjectHistory)} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
+    <Divider key="desktop-divider" />,
+    <MenuItem key="desktop-account-settings" onClick={wrap(onOpenAccountSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
+    <MenuItem key="desktop-shortcuts" onClick={wrap(onOpenShortcuts)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.shortcuts')}</MenuItem>,
+    <MenuItem key="desktop-help" onClick={wrap(onOpenHelp)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.appHelp')}</MenuItem>,
+    canLeaveDemoProject ? <MenuItem key="desktop-leave-demo" onClick={wrapAsync(onLeaveDemoProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><ExitToAppIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.leaveDemo')}</MenuItem> : null,
+    !isGuestDemoSession ? <MenuItem key="desktop-logout" onClick={wrapAsync(onLogout)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem> : null,
+  ];
+  return <Menu id="global-actions-menu" anchorEl={anchorEl} open={open} onClose={onClose}>{isMobile ? mobileMenuItems : desktopMenuItems}</Menu>;
+}

--- a/frontend/src/navigation/ProjectMenu.tsx
+++ b/frontend/src/navigation/ProjectMenu.tsx
@@ -1,0 +1,97 @@
+import { Divider, ListItemIcon, Menu, MenuItem, Stack } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import AddIcon from '@mui/icons-material/Add';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import { ACTION_MENU_ICON_PROPS, ACTION_MENU_ITEM_ICON_SX } from './topbarMenuStyles';
+
+interface ProjectMenuProps {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  memberships: { project_id: number; project_name: string; role: 'admin' | 'member' }[];
+  activeProjectId: number | null;
+  isSwitchingProject: boolean;
+  isCreatingDemoProject: boolean;
+  deletedProjectsCount: number;
+  onClose: () => void;
+  onSwitchProject: (projectId: number) => Promise<void>;
+  onOpenProjectSettings: () => void;
+  onOpenProjectSelection: () => void;
+  onOpenCreateProject: () => void;
+  onCreateDemoProject: () => void;
+  onOpenProjectTrash: () => void;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}
+
+export function ProjectMenu(props: ProjectMenuProps) {
+  const {
+    anchorEl,
+    open,
+    memberships,
+    activeProjectId,
+    isSwitchingProject,
+    isCreatingDemoProject,
+    deletedProjectsCount,
+    onClose,
+    onSwitchProject,
+    onOpenProjectSettings,
+    onOpenProjectSelection,
+    onOpenCreateProject,
+    onCreateDemoProject,
+    onOpenProjectTrash,
+    t,
+  } = props;
+
+  return (
+    <Menu
+      id="project-switcher-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+    >
+      {memberships.length === 0 ? (
+        <MenuItem disabled>{t('projectSwitcher.zeroProjects')}</MenuItem>
+      ) : (
+        memberships.map((membership) => (
+          <MenuItem
+            key={membership.project_id}
+            onClick={() => void onSwitchProject(membership.project_id)}
+            selected={membership.project_id === activeProjectId}
+            disabled={isSwitchingProject}
+          >
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
+              <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{membership.project_name}</span>
+              {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" /> : null}
+            </Stack>
+          </MenuItem>
+        ))
+      )}
+      <Divider />
+      <MenuItem onClick={onOpenProjectSelection}>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SwapHorizIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+        {t('project.switch')}
+      </MenuItem>
+      <MenuItem onClick={onOpenProjectSettings}>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+        {t('project.settings')}
+      </MenuItem>
+      <Divider />
+      <MenuItem onClick={onOpenCreateProject}>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+        {t('project.create')}
+      </MenuItem>
+      <MenuItem onClick={onCreateDemoProject} disabled={isCreatingDemoProject}>
+        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><PlayCircleOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+        {t('projectSwitcher.loadDemoProject')}
+      </MenuItem>
+      {deletedProjectsCount > 0 ? (
+        <MenuItem onClick={onOpenProjectTrash}>
+          <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><DeleteOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
+          {t('projectSwitcher.trash', { count: deletedProjectsCount })}
+        </MenuItem>
+      ) : null}
+    </Menu>
+  );
+}

--- a/frontend/src/navigation/RootLayout.tsx
+++ b/frontend/src/navigation/RootLayout.tsx
@@ -60,18 +60,10 @@ import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import PublicIcon from '@mui/icons-material/Public';
-import CheckIcon from '@mui/icons-material/Check';
 import AddIcon from '@mui/icons-material/Add';
-import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { ProjectMenu } from './ProjectMenu';
+import { GlobalMenu } from './GlobalMenu';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
-import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
-import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
-import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
-import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
-import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
-import LogoutIcon from '@mui/icons-material/Logout';
-import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 import { cultureAPI, projectAPI } from '../api/api';
 import type { CultureHistoryEntry } from '../api/types';
 import { MobileProjectSwitcherDialog } from './MobileProjectSwitcherDialog';
@@ -114,8 +106,6 @@ import {
 import { PanelLeft } from 'lucide-react';
 
 const CONTENT_ALIGNMENT_MODE = 'centered';
-const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
-const ACTION_MENU_ICON_PROPS = { fontSize: 'small' } as const;
 const HIERARCHY_CREATE_LOCATION_ACTION_ID = 'fields-global-add-location';
 const TOPBAR_ACTION_GROUP_GAP = 1.25;
 const COMPACT_TOPBAR_TOGGLE_SIZE = 44;
@@ -135,171 +125,6 @@ interface SnackbarState {
   actionLabel?: string;
   onAction?: () => void | Promise<void>;
 }
-
-interface ProjectMenuProps {
-  anchorEl: HTMLElement | null;
-  open: boolean;
-  memberships: { project_id: number; project_name: string; role: 'admin' | 'member' }[];
-  activeProjectId: number | null;
-  isSwitchingProject: boolean;
-  isCreatingDemoProject: boolean;
-  deletedProjectsCount: number;
-  onClose: () => void;
-  onSwitchProject: (projectId: number) => Promise<void>;
-  onOpenProjectSettings: () => void;
-  onOpenProjectSelection: () => void;
-  onOpenCreateProject: () => void;
-  onCreateDemoProject: () => void;
-  onOpenProjectTrash: () => void;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}
-
-function ProjectMenu(props: ProjectMenuProps) {
-  const {
-    anchorEl,
-    open,
-    memberships,
-    activeProjectId,
-    isSwitchingProject,
-    isCreatingDemoProject,
-    deletedProjectsCount,
-    onClose,
-    onSwitchProject,
-    onOpenProjectSettings,
-    onOpenProjectSelection,
-    onOpenCreateProject,
-    onCreateDemoProject,
-    onOpenProjectTrash,
-    t,
-  } = props;
-
-  return (
-    <Menu
-      id="project-switcher-menu"
-      anchorEl={anchorEl}
-      open={open}
-      onClose={onClose}
-    >
-      {memberships.length === 0 ? (
-        <MenuItem disabled>{t('projectSwitcher.zeroProjects')}</MenuItem>
-      ) : (
-        memberships.map((membership) => (
-          <MenuItem
-            key={membership.project_id}
-            onClick={() => void onSwitchProject(membership.project_id)}
-            selected={membership.project_id === activeProjectId}
-            disabled={isSwitchingProject}
-          >
-            <Stack direction="row" alignItems="center" spacing={1} sx={{ width: '100%' }}>
-              <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{membership.project_name}</span>
-              {membership.project_id === activeProjectId ? <CheckIcon fontSize="small" /> : null}
-            </Stack>
-          </MenuItem>
-        ))
-      )}
-      <Divider />
-      <MenuItem onClick={onOpenProjectSelection}>
-        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SwapHorizIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
-        {t('project.switch')}
-      </MenuItem>
-      <MenuItem onClick={onOpenProjectSettings}>
-        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
-        {t('project.settings')}
-      </MenuItem>
-      <Divider />
-      <MenuItem onClick={onOpenCreateProject}>
-        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
-        {t('project.create')}
-      </MenuItem>
-      <MenuItem onClick={onCreateDemoProject} disabled={isCreatingDemoProject}>
-        <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><PlayCircleOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
-        {t('projectSwitcher.loadDemoProject')}
-      </MenuItem>
-      {deletedProjectsCount > 0 ? (
-        <MenuItem onClick={onOpenProjectTrash}>
-          <ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><DeleteOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>
-          {t('projectSwitcher.trash', { count: deletedProjectsCount })}
-        </MenuItem>
-      ) : null}
-    </Menu>
-  );
-}
-
-interface GlobalMenuProps {
-  anchorEl: HTMLElement | null;
-  open: boolean;
-  historyLoading: boolean;
-  userLabel: string;
-  isMobile: boolean;
-  onClose: () => void;
-  onOpenProjectSwitcher: () => void;
-  onOpenCreateProject: () => void;
-  onOpenProjectSettings: () => void;
-  onOpenProjectHistory: () => Promise<void>;
-  onOpenAccountSettings: () => void;
-  onOpenShortcuts: () => void;
-  onOpenHelp: () => void;
-  canLeaveDemoProject: boolean;
-  isGuestDemoSession: boolean;
-  onLeaveDemoProject: () => Promise<void>;
-  onLogout: () => Promise<void>;
-  t: (key: string) => string;
-}
-
-function GlobalMenu(props: GlobalMenuProps) {
-  const {
-    anchorEl,
-    open,
-    historyLoading,
-    userLabel,
-    isMobile,
-    onClose,
-    onOpenProjectSwitcher,
-    onOpenCreateProject,
-    onOpenProjectSettings,
-    onOpenProjectHistory,
-    onOpenAccountSettings,
-    onOpenShortcuts,
-    onOpenHelp,
-    canLeaveDemoProject,
-    isGuestDemoSession,
-    onLeaveDemoProject,
-    onLogout,
-    t,
-  } = props;
-
-  const wrap = (fn: () => void): () => void => () => { onClose(); fn(); };
-  const wrapAsync = (fn: () => Promise<void>): () => void => () => { onClose(); void fn(); };
-
-  const mobileMenuItems = [
-    <MenuItem key="mobile-section-project" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.projectActions')}</MenuItem>,
-    <MenuItem key="mobile-project-switcher" onClick={wrap(onOpenProjectSwitcher)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SwapHorizIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('projectSwitcher.ariaLabel')}</MenuItem>,
-    <MenuItem key="mobile-project-create" onClick={wrap(onOpenCreateProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><AddIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.create')}</MenuItem>,
-    <MenuItem key="mobile-project-settings" onClick={wrap(onOpenProjectSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.settings')}</MenuItem>,
-    <MenuItem key="mobile-project-history" onClick={wrapAsync(onOpenProjectHistory)} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
-    <Divider key="mobile-divider-project-app" />,
-    <MenuItem key="mobile-section-app" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.app')}</MenuItem>,
-    <MenuItem key="mobile-app-shortcuts" onClick={wrap(onOpenShortcuts)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.shortcuts')}</MenuItem>,
-    <MenuItem key="mobile-app-help" onClick={wrap(onOpenHelp)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.appHelp')}</MenuItem>,
-    <MenuItem key="mobile-app-account-settings" onClick={wrap(onOpenAccountSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
-    <Divider key="mobile-divider-app-account" />,
-    <MenuItem key="mobile-section-account" disabled sx={{ opacity: 1, fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: 0.5 }}>{t('globalMenu.account')}</MenuItem>,
-    canLeaveDemoProject ? <MenuItem key="mobile-account-leave-demo" onClick={wrapAsync(onLeaveDemoProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><ExitToAppIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.leaveDemo')}</MenuItem> : null,
-    !isGuestDemoSession ? <MenuItem key="mobile-account-logout" onClick={wrapAsync(onLogout)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem> : null,
-  ];
-  const desktopMenuItems = [
-    <MenuItem key="desktop-project-settings" onClick={wrap(onOpenProjectSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('project.settings')}</MenuItem>,
-    <MenuItem key="desktop-history" onClick={wrapAsync(onOpenProjectHistory)} disabled={historyLoading}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HistoryOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.openVersionHistory')}</MenuItem>,
-    <Divider key="desktop-divider" />,
-    <MenuItem key="desktop-account-settings" onClick={wrap(onOpenAccountSettings)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><SettingsOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('accountSettings')}</MenuItem>,
-    <MenuItem key="desktop-shortcuts" onClick={wrap(onOpenShortcuts)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><KeyboardOutlinedIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.shortcuts')}</MenuItem>,
-    <MenuItem key="desktop-help" onClick={wrap(onOpenHelp)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><HelpOutlineIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('globalMenu.appHelp')}</MenuItem>,
-    canLeaveDemoProject ? <MenuItem key="desktop-leave-demo" onClick={wrapAsync(onLeaveDemoProject)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><ExitToAppIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.leaveDemo')}</MenuItem> : null,
-    !isGuestDemoSession ? <MenuItem key="desktop-logout" onClick={wrapAsync(onLogout)}><ListItemIcon sx={ACTION_MENU_ITEM_ICON_SX}><LogoutIcon {...ACTION_MENU_ICON_PROPS} /></ListItemIcon>{t('commandPalette.commands.logout')} {userLabel}</MenuItem> : null,
-  ];
-  return <Menu id="global-actions-menu" anchorEl={anchorEl} open={open} onClose={onClose}>{isMobile ? mobileMenuItems : desktopMenuItems}</Menu>;
-}
-
 
 function getCompactTopbarActionIcon(actionId: string): React.ReactNode {
   switch (actionId) {

--- a/frontend/src/navigation/topbarMenuStyles.ts
+++ b/frontend/src/navigation/topbarMenuStyles.ts
@@ -1,0 +1,5 @@
+// Shared styling for the topbar action menus (ProjectMenu, GlobalMenu):
+// the leading icon column and the icon size used inside their menu items.
+
+export const ACTION_MENU_ITEM_ICON_SX = { minWidth: 32, color: 'text.secondary' } as const;
+export const ACTION_MENU_ICON_PROPS = { fontSize: 'small' } as const;


### PR DESCRIPTION
### Motivation
`RootLayout.tsx` is the largest navigation file (~2100 lines). `ProjectMenu` and `GlobalMenu` are self-contained topbar menu components with clear props contracts, so they belong in their own modules.

### Description
- Move `ProjectMenu` → `src/navigation/ProjectMenu.tsx` and `GlobalMenu` → `src/navigation/GlobalMenu.tsx` (with their props interfaces).
- Move the shared `ACTION_MENU_ITEM_ICON_SX` and `ACTION_MENU_ICON_PROPS` constants into a new `src/navigation/topbarMenuStyles.ts`, imported by both menus.
- Drop the icon imports from `RootLayout.tsx` that were only used by the menus (keeping `AddIcon`, still used by the topbar); each menu module imports exactly the icons it needs.
- `RootLayout.tsx` shrinks from ~2105 to ~1930 lines; no markup or handler wiring changes.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run App` — 32 tests pass (these exercise the project switcher menu and navigation; the global menu is additionally covered by the e2e suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_