### PR TITLE
refactor(frontend): extract account settings form primitives

### DIFF
--- a/frontend/src/pages/AccountSettingsPage.tsx
+++ b/frontend/src/pages/AccountSettingsPage.tsx
@@ -2,9 +2,6 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
-  Collapse,
   Dialog,
   DialogActions,
   DialogContent,
@@ -13,10 +10,8 @@ import {
   Stack,
   TextField,
   Typography,
-  type SxProps,
-  type Theme,
 } from '@mui/material';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   changePassword,
@@ -31,105 +26,12 @@ import { useNavigationBlocker } from '../hooks/useNavigationBlocker';
 import { enableDevOnboardingPreview } from '../projects/devOnboardingPreview';
 import { clearContextMenuHintDismissals } from '../components/data-grid';
 import { mediumFieldSx, wideFieldSx } from '../components/forms/formLayout';
-
-const actionButtonSx = { width: { xs: '100%', sm: 'auto' } } as const;
-
-interface SectionSubmit {
-  message: string | null;
-  error: string | null;
-  submitting: boolean;
-  submit: (action: () => Promise<{ detail: string }>, onSuccess?: () => void | Promise<void>) => Promise<void>;
-  clearError: () => void;
-}
-
-function useSectionSubmit(genericErrorMessage: string): SectionSubmit {
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  const submit = async (
-    action: () => Promise<{ detail: string }>,
-    onSuccess?: () => void | Promise<void>,
-  ): Promise<void> => {
-    setSubmitting(true);
-    setMessage(null);
-    setError(null);
-    try {
-      const response = await action();
-      setMessage(response.detail);
-      await onSuccess?.();
-    } catch (error) {
-      setError(error instanceof Error ? error.message : genericErrorMessage);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return { message, error, submitting, submit, clearError: () => setError(null) };
-}
-
-function SectionAlerts({ message, error }: Pick<SectionSubmit, 'message' | 'error'>) {
-  return (
-    <>
-      {message ? <Alert severity="success">{message}</Alert> : null}
-      {error ? <Alert severity="error">{error}</Alert> : null}
-    </>
-  );
-}
-
-interface InlineEditorProps {
-  open: boolean;
-  saveLabel: ReactNode;
-  onSave: () => void;
-  onCancel: () => void;
-  submitting: boolean;
-  saveDisabled?: boolean;
-  sx?: SxProps<Theme>;
-  children: ReactNode;
-}
-
-function InlineEditor({ open, saveLabel, onSave, onCancel, submitting, saveDisabled = false, sx, children }: InlineEditorProps) {
-  const { t } = useTranslation('account');
-  return (
-    <Collapse in={open} unmountOnExit>
-      <Stack spacing={2} sx={sx}>
-        {children}
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
-          <Button variant="contained" onClick={onSave} disabled={submitting || saveDisabled} sx={actionButtonSx}>
-            {saveLabel}
-          </Button>
-          <Button variant="text" onClick={onCancel} disabled={submitting} sx={actionButtonSx}>
-            {t('cancel')}
-          </Button>
-        </Stack>
-      </Stack>
-    </Collapse>
-  );
-}
-
-interface SettingsCardProps {
-  title: ReactNode;
-  description?: ReactNode;
-  children: ReactNode;
-}
-
-function SettingsCard({ title, description, children }: SettingsCardProps) {
-  return (
-    <Card>
-      <CardContent>
-        <Typography variant="h6" sx={{ mb: description ? 0.5 : 2 }}>
-          {title}
-        </Typography>
-        {description ? (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {description}
-          </Typography>
-        ) : null}
-        {children}
-      </CardContent>
-    </Card>
-  );
-}
+import { actionButtonSx, useSectionSubmit } from './accountSettingsForm';
+import {
+  InlineEditor,
+  SectionAlerts,
+  SettingsCard,
+} from './accountSettingsCards';
 
 export default function AccountSettingsPage() {
   const { user, requestAccountDeletion, refreshUser } = useAuth();

--- a/frontend/src/pages/accountSettingsCards.tsx
+++ b/frontend/src/pages/accountSettingsCards.tsx
@@ -1,0 +1,70 @@
+// Presentational building blocks for the account settings page: success/error
+// alerts, the inline editor wrapper, and the settings card shell.
+
+import { Alert, Button, Card, CardContent, Collapse, Stack, Typography, type SxProps, type Theme } from '@mui/material';
+import type { ReactNode } from 'react';
+import { useTranslation } from '../i18n';
+import { actionButtonSx, type SectionSubmit } from './accountSettingsForm';
+
+export function SectionAlerts({ message, error }: Pick<SectionSubmit, 'message' | 'error'>) {
+  return (
+    <>
+      {message ? <Alert severity="success">{message}</Alert> : null}
+      {error ? <Alert severity="error">{error}</Alert> : null}
+    </>
+  );
+}
+
+interface InlineEditorProps {
+  open: boolean;
+  saveLabel: ReactNode;
+  onSave: () => void;
+  onCancel: () => void;
+  submitting: boolean;
+  saveDisabled?: boolean;
+  sx?: SxProps<Theme>;
+  children: ReactNode;
+}
+
+export function InlineEditor({ open, saveLabel, onSave, onCancel, submitting, saveDisabled = false, sx, children }: InlineEditorProps) {
+  const { t } = useTranslation('account');
+  return (
+    <Collapse in={open} unmountOnExit>
+      <Stack spacing={2} sx={sx}>
+        {children}
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+          <Button variant="contained" onClick={onSave} disabled={submitting || saveDisabled} sx={actionButtonSx}>
+            {saveLabel}
+          </Button>
+          <Button variant="text" onClick={onCancel} disabled={submitting} sx={actionButtonSx}>
+            {t('cancel')}
+          </Button>
+        </Stack>
+      </Stack>
+    </Collapse>
+  );
+}
+
+interface SettingsCardProps {
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+}
+
+export function SettingsCard({ title, description, children }: SettingsCardProps) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" sx={{ mb: description ? 0.5 : 2 }}>
+          {title}
+        </Typography>
+        {description ? (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {description}
+          </Typography>
+        ) : null}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/accountSettingsForm.ts
+++ b/frontend/src/pages/accountSettingsForm.ts
@@ -1,0 +1,40 @@
+// Non-component form helpers for the account settings page: the shared action
+// button width style and the per-section submit-state hook.
+
+import { useState } from 'react';
+
+export const actionButtonSx = { width: { xs: '100%', sm: 'auto' } } as const;
+
+export interface SectionSubmit {
+  message: string | null;
+  error: string | null;
+  submitting: boolean;
+  submit: (action: () => Promise<{ detail: string }>, onSuccess?: () => void | Promise<void>) => Promise<void>;
+  clearError: () => void;
+}
+
+export function useSectionSubmit(genericErrorMessage: string): SectionSubmit {
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async (
+    action: () => Promise<{ detail: string }>,
+    onSuccess?: () => void | Promise<void>,
+  ): Promise<void> => {
+    setSubmitting(true);
+    setMessage(null);
+    setError(null);
+    try {
+      const response = await action();
+      setMessage(response.detail);
+      await onSuccess?.();
+    } catch (error) {
+      setError(error instanceof Error ? error.message : genericErrorMessage);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return { message, error, submitting, submit, clearError: () => setError(null) };
+}


### PR DESCRIPTION
### Motivation
`AccountSettingsPage.tsx` mixed several reusable settings-form primitives inline: the shared action-button style, the per-section submit-state hook, and the `SectionAlerts` / `InlineEditor` / `SettingsCard` presentational components. Extracting them shrinks the page and makes the toolkit reusable (e.g. for a future `ProjectSettingsPage` cleanup).

### Description
- `accountSettingsForm.ts` (non-components): `actionButtonSx`, `SectionSubmit` type, `useSectionSubmit` hook.
- `accountSettingsCards.tsx` (components): `SectionAlerts`, `InlineEditor`, `SettingsCard` — importing `actionButtonSx`/`SectionSubmit` from the `.ts` module.
- The split keeps each file fast-refresh clean (no mixing of component and non-component exports).
- `AccountSettingsPage.tsx` imports the pieces it uses and drops the now-unused `Card`, `CardContent`, `Collapse`, `SxProps`, `Theme`, and `ReactNode` imports; it shrinks from ~505 to ~407 lines.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run AccountSettingsPage` — 2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_