### PR TITLE
refactor(frontend): extract useYieldChartData hook into its own module

### DIFF
--- a/frontend/src/pages/YieldOverview.tsx
+++ b/frontend/src/pages/YieldOverview.tsx
@@ -35,32 +35,14 @@ import {
 import { CustomContextMenu } from "../components/contextMenu/CustomContextMenu";
 import { useContextMenuPositionState } from "../components/contextMenu/useContextMenuPositionState";
 import { useFocusRegion } from "../focus/useFocusManager";
-import { parseDateString } from "./ganttChartUtils";
+import { useYieldChartData } from "./useYieldChartData";
 import {
   ALL_CULTURES,
   formatCompactYield,
-  formatDateToAPI,
-  formatIsoWeek,
   getYieldAxisLabelStep,
-  mergeCultureYields,
   type ChartPeriod,
-  type YieldCalendarCulture,
   type YieldCultureMeta,
 } from "./yieldOverviewUtils";
-
-interface YieldChartCulture extends YieldCultureMeta {
-  totalYield: number;
-}
-
-interface YieldChartColumn {
-  id: string;
-  startDate: string;
-  primaryLabel: string;
-  secondaryLabel: string;
-  cultures: YieldCalendarCulture[];
-  totalYield: number;
-}
-
 interface YieldContextMenuPayload {
   cultureId: number;
   cultureName: string;
@@ -69,141 +51,6 @@ interface YieldContextMenuPayload {
 }
 
 const DEFAULT_LEGEND_CULTURE_LIMIT = 15;
-
-function useYieldChartData(
-  weeklyYield: YieldCalendarWeek[],
-  selectedCultureId: string,
-  period: ChartPeriod,
-  locale: string,
-) {
-  return useMemo(() => {
-    const cultureMeta = new Map<number, YieldCultureMeta>();
-    weeklyYield.forEach((week) => {
-      week.cultures.forEach((culture) => {
-        cultureMeta.set(culture.culture_id, {
-          id: culture.culture_id,
-          name: culture.culture_name,
-          color: culture.color,
-        });
-      });
-    });
-
-    const availableCultures = [...cultureMeta.values()].sort((left, right) =>
-      left.name.localeCompare(right.name, locale),
-    );
-    const selectedCulture =
-      selectedCultureId === ALL_CULTURES
-        ? null
-        : Number(selectedCultureId);
-    const filterCultures = (
-      cultures: YieldCalendarCulture[],
-    ): YieldCalendarCulture[] =>
-      selectedCulture === null
-        ? cultures
-        : cultures.filter((culture) => culture.culture_id === selectedCulture);
-
-    const sortedByStart = [...weeklyYield].sort((left, right) =>
-      left.week_start.localeCompare(right.week_start),
-    );
-    if (sortedByStart.length === 0) {
-      return {
-        chartData: [] as YieldChartColumn[],
-        chartCultures: [] as YieldChartCulture[],
-        availableCultures,
-        maxTotalYield: 0,
-      };
-    }
-
-    const startDate = parseDateString(sortedByStart[0].week_start);
-    const endDate = parseDateString(
-      sortedByStart[sortedByStart.length - 1].week_start,
-    );
-    const weekMap = new Map(weeklyYield.map((week) => [week.week_start, week]));
-    const weeklyColumns: YieldChartColumn[] = [];
-    const currentDate = new Date(startDate);
-
-    while (currentDate <= endDate) {
-      const weekStart = formatDateToAPI(currentDate);
-      const week = weekMap.get(weekStart);
-      const cultures = filterCultures(week?.cultures ?? []);
-      const weekStartDate = parseDateString(weekStart);
-      const isoWeek = week?.iso_week ?? formatIsoWeek(weekStartDate);
-      weeklyColumns.push({
-        id: isoWeek,
-        startDate: weekStart,
-        primaryLabel: isoWeek.split("-W")[1]
-          ? `W${isoWeek.split("-W")[1]}`
-          : isoWeek,
-        secondaryLabel: weekStartDate.toLocaleDateString(locale, {
-          month: "short",
-        }),
-        cultures,
-        totalYield: cultures.reduce((sum, culture) => sum + culture.yield, 0),
-      });
-      currentDate.setDate(currentDate.getDate() + 7);
-    }
-
-    const chartData =
-      period === "week"
-        ? weeklyColumns
-        : [...weeklyColumns.reduce((months, column) => {
-            const sourceDate = parseDateString(column.startDate);
-            const monthId = `${sourceDate.getFullYear()}-${String(sourceDate.getMonth() + 1).padStart(2, "0")}`;
-            const existing = months.get(monthId);
-            const cultures = mergeCultureYields([
-              ...(existing?.cultures ?? []),
-              ...column.cultures,
-            ]);
-            months.set(monthId, {
-              id: monthId,
-              startDate: `${monthId}-01`,
-              primaryLabel: sourceDate.toLocaleDateString(locale, {
-                month: "short",
-              }),
-              secondaryLabel: String(sourceDate.getFullYear()),
-              cultures,
-              totalYield: cultures.reduce(
-                (sum, culture) => sum + culture.yield,
-                0,
-              ),
-            });
-            return months;
-          }, new Map<string, YieldChartColumn>()).values()];
-
-    // The legend orders cultures by their total yield in the currently
-    // visible data (descending) rather than alphabetically, so the most
-    // relevant cultures always appear first — this also determines which
-    // ones are shown first once the legend is collapsed to a subset.
-    const totalYieldByCultureId = new Map<number, number>();
-    chartData.forEach((column) => {
-      column.cultures.forEach((culture) => {
-        totalYieldByCultureId.set(
-          culture.culture_id,
-          (totalYieldByCultureId.get(culture.culture_id) ?? 0) + culture.yield,
-        );
-      });
-    });
-    const chartCultures: YieldChartCulture[] = availableCultures
-      .filter((culture) => totalYieldByCultureId.has(culture.id))
-      .map((culture) => ({
-        ...culture,
-        totalYield: totalYieldByCultureId.get(culture.id) ?? 0,
-      }))
-      .sort((left, right) => (
-        right.totalYield - left.totalYield
-      ));
-
-    return {
-      chartData,
-      chartCultures,
-      availableCultures,
-      maxTotalYield: chartData.reduce(
-        (max, column) => Math.max(max, column.totalYield),
-        0,
-      ),
-    };
-  }, [locale, period, selectedCultureId, weeklyYield]);
-}
 
 interface YieldDistributionChartProps {
   weeklyYield: YieldCalendarWeek[];

--- a/frontend/src/pages/useYieldChartData.ts
+++ b/frontend/src/pages/useYieldChartData.ts
@@ -1,0 +1,166 @@
+import { useMemo } from "react";
+import { type YieldCalendarWeek } from "../api/api";
+import { parseDateString } from "./ganttChartUtils";
+import {
+  ALL_CULTURES,
+  formatDateToAPI,
+  formatIsoWeek,
+  mergeCultureYields,
+  type ChartPeriod,
+  type YieldCalendarCulture,
+  type YieldCultureMeta,
+} from "./yieldOverviewUtils";
+
+export interface YieldChartCulture extends YieldCultureMeta {
+  totalYield: number;
+}
+
+export interface YieldChartColumn {
+  id: string;
+  startDate: string;
+  primaryLabel: string;
+  secondaryLabel: string;
+  cultures: YieldCalendarCulture[];
+  totalYield: number;
+}
+
+/**
+ * Shapes the raw weekly yield rows into chart columns (grouped by week or
+ * month) plus the legend cultures ordered by total visible yield. Memoized on
+ * its inputs so the chart only recomputes when the data, filter, period, or
+ * locale changes.
+ */
+export function useYieldChartData(
+  weeklyYield: YieldCalendarWeek[],
+  selectedCultureId: string,
+  period: ChartPeriod,
+  locale: string,
+) {
+  return useMemo(() => {
+    const cultureMeta = new Map<number, YieldCultureMeta>();
+    weeklyYield.forEach((week) => {
+      week.cultures.forEach((culture) => {
+        cultureMeta.set(culture.culture_id, {
+          id: culture.culture_id,
+          name: culture.culture_name,
+          color: culture.color,
+        });
+      });
+    });
+
+    const availableCultures = [...cultureMeta.values()].sort((left, right) =>
+      left.name.localeCompare(right.name, locale),
+    );
+    const selectedCulture =
+      selectedCultureId === ALL_CULTURES
+        ? null
+        : Number(selectedCultureId);
+    const filterCultures = (
+      cultures: YieldCalendarCulture[],
+    ): YieldCalendarCulture[] =>
+      selectedCulture === null
+        ? cultures
+        : cultures.filter((culture) => culture.culture_id === selectedCulture);
+
+    const sortedByStart = [...weeklyYield].sort((left, right) =>
+      left.week_start.localeCompare(right.week_start),
+    );
+    if (sortedByStart.length === 0) {
+      return {
+        chartData: [] as YieldChartColumn[],
+        chartCultures: [] as YieldChartCulture[],
+        availableCultures,
+        maxTotalYield: 0,
+      };
+    }
+
+    const startDate = parseDateString(sortedByStart[0].week_start);
+    const endDate = parseDateString(
+      sortedByStart[sortedByStart.length - 1].week_start,
+    );
+    const weekMap = new Map(weeklyYield.map((week) => [week.week_start, week]));
+    const weeklyColumns: YieldChartColumn[] = [];
+    const currentDate = new Date(startDate);
+
+    while (currentDate <= endDate) {
+      const weekStart = formatDateToAPI(currentDate);
+      const week = weekMap.get(weekStart);
+      const cultures = filterCultures(week?.cultures ?? []);
+      const weekStartDate = parseDateString(weekStart);
+      const isoWeek = week?.iso_week ?? formatIsoWeek(weekStartDate);
+      weeklyColumns.push({
+        id: isoWeek,
+        startDate: weekStart,
+        primaryLabel: isoWeek.split("-W")[1]
+          ? `W${isoWeek.split("-W")[1]}`
+          : isoWeek,
+        secondaryLabel: weekStartDate.toLocaleDateString(locale, {
+          month: "short",
+        }),
+        cultures,
+        totalYield: cultures.reduce((sum, culture) => sum + culture.yield, 0),
+      });
+      currentDate.setDate(currentDate.getDate() + 7);
+    }
+
+    const chartData =
+      period === "week"
+        ? weeklyColumns
+        : [...weeklyColumns.reduce((months, column) => {
+            const sourceDate = parseDateString(column.startDate);
+            const monthId = `${sourceDate.getFullYear()}-${String(sourceDate.getMonth() + 1).padStart(2, "0")}`;
+            const existing = months.get(monthId);
+            const cultures = mergeCultureYields([
+              ...(existing?.cultures ?? []),
+              ...column.cultures,
+            ]);
+            months.set(monthId, {
+              id: monthId,
+              startDate: `${monthId}-01`,
+              primaryLabel: sourceDate.toLocaleDateString(locale, {
+                month: "short",
+              }),
+              secondaryLabel: String(sourceDate.getFullYear()),
+              cultures,
+              totalYield: cultures.reduce(
+                (sum, culture) => sum + culture.yield,
+                0,
+              ),
+            });
+            return months;
+          }, new Map<string, YieldChartColumn>()).values()];
+
+    // The legend orders cultures by their total yield in the currently
+    // visible data (descending) rather than alphabetically, so the most
+    // relevant cultures always appear first — this also determines which
+    // ones are shown first once the legend is collapsed to a subset.
+    const totalYieldByCultureId = new Map<number, number>();
+    chartData.forEach((column) => {
+      column.cultures.forEach((culture) => {
+        totalYieldByCultureId.set(
+          culture.culture_id,
+          (totalYieldByCultureId.get(culture.culture_id) ?? 0) + culture.yield,
+        );
+      });
+    });
+    const chartCultures: YieldChartCulture[] = availableCultures
+      .filter((culture) => totalYieldByCultureId.has(culture.id))
+      .map((culture) => ({
+        ...culture,
+        totalYield: totalYieldByCultureId.get(culture.id) ?? 0,
+      }))
+      .sort((left, right) => (
+        right.totalYield - left.totalYield
+      ));
+
+    return {
+      chartData,
+      chartCultures,
+      availableCultures,
+      maxTotalYield: chartData.reduce(
+        (max, column) => Math.max(max, column.totalYield),
+        0,
+      ),
+    };
+  }, [locale, period, selectedCultureId, weeklyYield]);
+}


### PR DESCRIPTION
### Motivation
Continuing the `YieldOverview.tsx` decomposition. `useYieldChartData` is a self-contained data-shaping hook (raw weekly rows → week/month chart columns + legend cultures ordered by total yield). Isolating it clarifies the page and sets it up for unit testing.

### Description
- Move `useYieldChartData` and its `YieldChartColumn` / `YieldChartCulture` types into `src/pages/useYieldChartData.ts`.
- `YieldDistributionChart` (still in the page) now imports the hook; `YieldContextMenuPayload` stays in the page (only the chart uses it).
- Drop the imports only the hook used from `YieldOverview.tsx` (`parseDateString`, `formatDateToAPI`, `formatIsoWeek`, `mergeCultureYields`, `YieldCalendarCulture`).
- `YieldOverview.tsx` shrinks from ~925 to ~772 lines.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `YieldOverview` (20) and `yieldOverviewUtils` (8) — all pass (the hook is exercised through the page tests: week/month grouping, legend ordering, expand/collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_