### PR TITLE
refactor(frontend): extract hierarchy name cell renderer into its own module

### DIFF
--- a/frontend/src/components/hierarchy/HierarchyColumns.tsx
+++ b/frontend/src/components/hierarchy/HierarchyColumns.tsx
@@ -10,9 +10,7 @@ import type {
   GridRenderEditCellParams,
 } from '@mui/x-data-grid';
 import type { TFunction } from 'i18next';
-import { Box, IconButton, Tooltip } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { Box } from '@mui/material';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 import type { HierarchyRow } from './utils/types';
@@ -23,7 +21,7 @@ import {
   type DimensionCellType,
 } from './utils/dimensionCellState';
 import { NotesCell } from '../data-grid/NotesCell';
-import { renderInlineActions } from './hierarchyRowActions';
+import { renderNameCell } from './hierarchyNameCell';
 import {
   NON_BLOCKING_TOOLTIP_PROPS,
   type HierarchyColumnOptions,
@@ -31,7 +29,6 @@ import {
 } from './hierarchyColumnShared';
 import { getPlainExcerpt } from '../data-grid/markdown';
 import { CALCULATED_COLUMN_CELL_CLASS, getCalculatedColumnProps } from '../data-grid/calculatedColumns';
-import { contextMenuActionsOverlaySx } from '../contextMenu/contextMenuIndicatorStyles';
 import { HierarchyLevelButtons } from './HierarchyLevelToggle';
 import { FullCellTooltip, FULL_CELL_TOOLTIP_CELL_CLASS } from '../data-grid/FullCellTooltip';
 
@@ -49,117 +46,10 @@ export const DEFAULT_HIERARCHY_COLUMN_WIDTHS: HierarchyColumnWidths = {
   notes: 220,
 };
 
-const EXPAND_ICON_SLOT_SIZE = 32;
 const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
 const renderImmediateEditInputCell = (
   params: GridRenderEditCellParams<HierarchyRow>,
 ): ReactElement => <GridEditInputCell {...params} debounceMs={0} />;
-
-function renderNameCell(
-  params: GridRenderCellParams<HierarchyRow>,
-  callbacks: NameCellCallbacks,
-  t: TFunction,
-  options: HierarchyColumnOptions,
-) {
-  const row = params.row;
-  const baseIndent = row.level * 24;
-  const hasChildren = row.hasChildren === true;
-  const hasExpandToggle = (row.type === 'location' || row.type === 'field') && hasChildren;
-  const isStandaloneRender = params.api === undefined;
-  const inlineActions = renderInlineActions(row, callbacks, t, options, isStandaloneRender);
-
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', pl: `${baseIndent}px`, width: '100%', gap: 0.5 }}>
-      <Box
-        sx={{
-          width: EXPAND_ICON_SLOT_SIZE,
-          minWidth: EXPAND_ICON_SLOT_SIZE,
-          height: EXPAND_ICON_SLOT_SIZE,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          mr: 1,
-          pointerEvents: hasExpandToggle ? 'auto' : 'none',
-        }}
-        data-testid="expand-icon-slot"
-      >
-        {hasExpandToggle ? (
-          <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')} {...NON_BLOCKING_TOOLTIP_PROPS}>
-            <IconButton
-              size="small"
-              aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
-              tabIndex={-1}
-              onClick={(event) => {
-                event.stopPropagation();
-                callbacks.onToggleExpand(row.id);
-              }}
-            >
-              {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-            </IconButton>
-          </Tooltip>
-        ) : (
-          <Box
-            aria-hidden="true"
-            sx={{ width: EXPAND_ICON_SLOT_SIZE, height: EXPAND_ICON_SLOT_SIZE, visibility: 'hidden' }}
-          >
-            <ChevronRightIcon />
-          </Box>
-        )}
-      </Box>
-
-      <Box
-        sx={{
-          position: 'relative',
-          display: 'inline-flex',
-          alignItems: 'center',
-          minWidth: 0,
-          width: '100%',
-          overflow: 'hidden',
-        }}
-        onContextMenu={(event) => {
-          callbacks.onOpenContextMenu(event, row);
-        }}
-      >
-        <Box
-          component="span"
-          data-testid="hierarchy-name-text"
-          sx={{
-            display: 'block',
-            flex: '1 1 auto',
-            minWidth: 0,
-            width: '100%',
-            maxWidth: 'none',
-            boxSizing: 'border-box',
-            fontWeight: row.type === 'location' ? 600 : 400,
-            fontSize: row.type === 'location' ? '1.02rem' : row.type === 'bed' ? '0.95rem' : '1rem',
-            color: 'text.primary',
-            bgcolor: 'transparent',
-            borderRadius: 0.5,
-            px: row.type === 'bed' ? 0.5 : 0,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {params.value}
-        </Box>
-
-        {inlineActions ? (
-          <Box
-            data-testid="hierarchy-name-actions-overlay"
-            sx={{
-              ...contextMenuActionsOverlaySx('.MuiDataGrid-row:hover &'),
-              ...(isStandaloneRender ? { opacity: 1, pointerEvents: 'auto' } : {}),
-              '.MuiDataGrid-row--editing:hover &': { opacity: 0, pointerEvents: 'none' },
-            }}
-          >
-            {inlineActions}
-          </Box>
-        ) : null}
-      </Box>
-    </Box>
-  );
-}
 
 /** Returns true when a dimension edit cell value is non-empty but invalid (non-numeric or negative). */
 export const isDimensionEditValueInvalid = (value: unknown): boolean => {

--- a/frontend/src/components/hierarchy/hierarchyNameCell.tsx
+++ b/frontend/src/components/hierarchy/hierarchyNameCell.tsx
@@ -1,0 +1,121 @@
+import { Box, IconButton, Tooltip } from '@mui/material';
+import type { GridRenderCellParams } from '@mui/x-data-grid';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import type { TFunction } from 'i18next';
+import type { HierarchyRow } from './utils/types';
+import { contextMenuActionsOverlaySx } from '../contextMenu/contextMenuIndicatorStyles';
+import { renderInlineActions } from './hierarchyRowActions';
+import {
+  NON_BLOCKING_TOOLTIP_PROPS,
+  type HierarchyColumnOptions,
+  type NameCellCallbacks,
+} from './hierarchyColumnShared';
+
+const EXPAND_ICON_SLOT_SIZE = 32;
+
+export function renderNameCell(
+  params: GridRenderCellParams<HierarchyRow>,
+  callbacks: NameCellCallbacks,
+  t: TFunction,
+  options: HierarchyColumnOptions,
+) {
+  const row = params.row;
+  const baseIndent = row.level * 24;
+  const hasChildren = row.hasChildren === true;
+  const hasExpandToggle = (row.type === 'location' || row.type === 'field') && hasChildren;
+  const isStandaloneRender = params.api === undefined;
+  const inlineActions = renderInlineActions(row, callbacks, t, options, isStandaloneRender);
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', pl: `${baseIndent}px`, width: '100%', gap: 0.5 }}>
+      <Box
+        sx={{
+          width: EXPAND_ICON_SLOT_SIZE,
+          minWidth: EXPAND_ICON_SLOT_SIZE,
+          height: EXPAND_ICON_SLOT_SIZE,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mr: 1,
+          pointerEvents: hasExpandToggle ? 'auto' : 'none',
+        }}
+        data-testid="expand-icon-slot"
+      >
+        {hasExpandToggle ? (
+          <Tooltip title={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')} {...NON_BLOCKING_TOOLTIP_PROPS}>
+            <IconButton
+              size="small"
+              aria-label={row.expanded ? t('tooltips.collapse') : t('tooltips.expand')}
+              tabIndex={-1}
+              onClick={(event) => {
+                event.stopPropagation();
+                callbacks.onToggleExpand(row.id);
+              }}
+            >
+              {row.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Box
+            aria-hidden="true"
+            sx={{ width: EXPAND_ICON_SLOT_SIZE, height: EXPAND_ICON_SLOT_SIZE, visibility: 'hidden' }}
+          >
+            <ChevronRightIcon />
+          </Box>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          position: 'relative',
+          display: 'inline-flex',
+          alignItems: 'center',
+          minWidth: 0,
+          width: '100%',
+          overflow: 'hidden',
+        }}
+        onContextMenu={(event) => {
+          callbacks.onOpenContextMenu(event, row);
+        }}
+      >
+        <Box
+          component="span"
+          data-testid="hierarchy-name-text"
+          sx={{
+            display: 'block',
+            flex: '1 1 auto',
+            minWidth: 0,
+            width: '100%',
+            maxWidth: 'none',
+            boxSizing: 'border-box',
+            fontWeight: row.type === 'location' ? 600 : 400,
+            fontSize: row.type === 'location' ? '1.02rem' : row.type === 'bed' ? '0.95rem' : '1rem',
+            color: 'text.primary',
+            bgcolor: 'transparent',
+            borderRadius: 0.5,
+            px: row.type === 'bed' ? 0.5 : 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {params.value}
+        </Box>
+
+        {inlineActions ? (
+          <Box
+            data-testid="hierarchy-name-actions-overlay"
+            sx={{
+              ...contextMenuActionsOverlaySx('.MuiDataGrid-row:hover &'),
+              ...(isStandaloneRender ? { opacity: 1, pointerEvents: 'auto' } : {}),
+              '.MuiDataGrid-row--editing:hover &': { opacity: 0, pointerEvents: 'none' },
+            }}
+          >
+            {inlineActions}
+          </Box>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
### Motivation
Continuing the `HierarchyColumns.tsx` decomposition (after #373). `renderNameCell` is the largest remaining render helper (~105 lines) and pairs naturally with the row actions it composes.

### Description
- Move `renderNameCell` (indentation, expand/collapse toggle, name text, hover action overlay) into `hierarchyNameCell.tsx`, carrying the `EXPAND_ICON_SLOT_SIZE` constant.
- It imports `renderInlineActions` from `hierarchyRowActions` and the shared types/const from `hierarchyColumnShared`.
- `HierarchyColumns.tsx` imports `renderNameCell` and drops the now-unused `ExpandMoreIcon`, `ChevronRightIcon`, `contextMenuActionsOverlaySx`, `IconButton`, `Tooltip`, and `renderInlineActions` imports; it shrinks from ~403 to ~293 lines (down from ~685 before this decomposition series).
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `hierarchyComponents`, `FieldsBedsPage`, and `FieldsBedsHierarchy.navigation` — 46 tests pass (expand/collapse, name rendering, inline actions, keyboard nav all covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_