### PR TITLE
Fix guest demo multi-tab bugs, translation drift, and desktop camera capture

### DIFF
--- a/frontend/src/__tests__/AuthContext.test.tsx
+++ b/frontend/src/__tests__/AuthContext.test.tsx
@@ -29,6 +29,7 @@ const baseUser: AuthUser = {
 };
 
 const getMeMock = vi.hoisted(() => vi.fn(async () => baseUser));
+const logoutMock = vi.hoisted(() => vi.fn(async () => undefined));
 const startGuestDemoMock = vi.hoisted(() => vi.fn(async () => ({
   ...baseUser,
   id: 2,
@@ -46,7 +47,7 @@ vi.mock('../auth/authApi', () => ({
   login: vi.fn(),
   startGuestDemo: startGuestDemoMock,
   endGuestDemo: vi.fn(),
-  logout: vi.fn(),
+  logout: logoutMock,
   register: vi.fn(),
   activate: vi.fn(),
   resendActivation: vi.fn(),
@@ -72,6 +73,7 @@ function GuestDemoStartProbe() {
   return (
     <>
       <button type="button" onClick={() => { void auth?.startGuestDemo(); }}>Start demo</button>
+      <button type="button" onClick={() => { void auth?.refreshUser(); }}>Refresh</button>
       <div data-testid="active-project-id">{auth?.activeProjectId ?? 'none'}</div>
     </>
   );
@@ -216,5 +218,27 @@ describe('AuthProvider cross-tab project sync', () => {
     });
 
     await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('none'));
+  });
+
+  it('drops its own view of a foreign guest demo session without logging out the tab that owns it', async () => {
+    // Simulates a second, already-open tab: its sessionStorage never learned
+    // about the demo this tab didn't start, but the (tab-shared) session
+    // cookie now belongs to that other demo after a resync reload.
+    sessionStorage.setItem('guestDemoSessionId', '999');
+
+    render(<AuthProvider><GuestDemoStartProbe /></AuthProvider>);
+    await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('1'));
+
+    getMeMock.mockResolvedValueOnce({
+      ...baseUser,
+      id: 2,
+      is_guest_demo: true,
+      guest_demo_session_id: 77,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('none'));
+
+    expect(getMeMock).toHaveBeenCalledTimes(2);
+    expect(logoutMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/AuthContext.test.tsx
+++ b/frontend/src/__tests__/AuthContext.test.tsx
@@ -155,6 +155,28 @@ describe('AuthProvider cross-tab project sync', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 
+  it('does not reload a guest demo tab when another tab changes activeProjectId', async () => {
+    // Two tabs each running their own demo share one session cookie, so
+    // starting a second demo silently replaces the first tab's session.
+    // Reloading in reaction to that project-id change would make the first
+    // tab pick up the second tab's project, changing the value again and
+    // making the second tab reload too — an infinite ping-pong. Guest demo
+    // tabs must not participate in this cross-tab resync at all.
+    const reloadSpy = stubLocationReload();
+
+    render(<AuthProvider><GuestDemoStartProbe /></AuthProvider>);
+    fireEvent.click(screen.getByRole('button', { name: 'Start demo' }));
+    await waitFor(() => expect(screen.getByTestId('active-project-id')).toHaveTextContent('2'));
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'activeProjectId',
+      oldValue: '2',
+      newValue: '3',
+    }));
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
   it('does not probe the auth session on the public landing page', async () => {
     window.history.pushState({}, '', '/');
 

--- a/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
+++ b/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NotesDrawer } from '../components/data-grid/NotesDrawer';
@@ -60,6 +60,26 @@ describe('NotesDrawer attachments', () => {
     expect(stopTrack).toHaveBeenCalled();
     cameraInput.remove();
   });
+
+  it('offers a file-picker fallback if the camera never produces a frame', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+    const stopTrack = vi.fn();
+    const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true });
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<NotesDrawer open title="Notes" value="" onChange={() => {}} onSave={() => {}} onClose={() => {}} noteId={1} />);
+    fireEvent.click(screen.getByText('Foto aufnehmen'));
+
+    // jsdom's <video> never produces a real frame on its own, so the "still
+    // no signal after a few seconds" fallback fires for real here — this
+    // waits out the actual timeout rather than faking it.
+    expect(await screen.findByText(/kein Kamerabild/, {}, { timeout: 6000 })).toBeInTheDocument();
+    const fallbackButton = screen.getByRole('button', { name: 'Stattdessen Datei wählen' });
+    fireEvent.click(fallbackButton);
+    expect(stopTrack).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
 
   it('falls back to the file picker on a touch device without opening the webcam', () => {
     vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));

--- a/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
+++ b/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NotesDrawer } from '../components/data-grid/NotesDrawer';
@@ -37,6 +37,55 @@ describe('NotesDrawer attachments', () => {
     expect(cameraInput).not.toBeNull();
     expect(cameraInput?.getAttribute('capture')).toBe('environment');
     expect(cameraInput?.accept).toBe('image/*');
+  });
+
+  it('opens the webcam directly on desktop instead of the file picker', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+    const stopTrack = vi.fn();
+    const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true });
+    const cameraInput = document.createElement('input');
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click');
+
+    render(<NotesDrawer open title="Notes" value="" onChange={() => {}} onSave={() => {}} onClose={() => {}} noteId={1} />);
+    fireEvent.click(screen.getByText('Foto aufnehmen'));
+
+    const captureButton = await screen.findByRole('button', { name: 'Aufnehmen' });
+    expect(captureButton).toBeInTheDocument();
+    expect(getUserMedia).toHaveBeenCalledWith({ video: { facingMode: 'environment' } });
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    const dialog = captureButton.closest('[role="dialog"]') as HTMLElement;
+    fireEvent.click(within(dialog).getByText('Abbrechen'));
+    expect(stopTrack).toHaveBeenCalled();
+    cameraInput.remove();
+  });
+
+  it('falls back to the file picker on a touch device without opening the webcam', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+    const getUserMedia = vi.fn();
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true });
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<NotesDrawer open title="Notes" value="" onChange={() => {}} onSave={() => {}} onClose={() => {}} noteId={1} />);
+    fireEvent.click(screen.getByText('Foto aufnehmen'));
+
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: 'Aufnehmen' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the file picker when the webcam cannot be opened', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+    const getUserMedia = vi.fn().mockRejectedValue(new Error('Permission denied'));
+    Object.defineProperty(navigator, 'mediaDevices', { value: { getUserMedia }, configurable: true });
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<NotesDrawer open title="Notes" value="" onChange={() => {}} onSave={() => {}} onClose={() => {}} noteId={1} />);
+    fireEvent.click(screen.getByText('Foto aufnehmen'));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('button', { name: 'Aufnehmen' })).not.toBeInTheDocument();
   });
 
   it('opens interactive crop dialog after file select', () => {

--- a/frontend/src/__tests__/languageResolution.test.ts
+++ b/frontend/src/__tests__/languageResolution.test.ts
@@ -13,6 +13,7 @@ import {
   FALLBACK_LANGUAGE,
   LANGUAGE_STORAGE_KEY,
   detectBrowserLanguage,
+  getLanguageDisplayName,
   getLanguageLabel,
   normalizeLanguagePreference,
   normalizeLanguageTag,
@@ -129,5 +130,22 @@ describe('getLanguageLabel', () => {
   it('names each language in that language, not in the UI language', () => {
     expect(getLanguageLabel('de')).toBe('Deutsch');
     expect(getLanguageLabel('en')).toBe('English');
+  });
+});
+
+describe('getLanguageDisplayName', () => {
+  it('names a language in the given display language, not in the language being named', () => {
+    expect(getLanguageDisplayName('de', 'en')).toBe('German');
+    expect(getLanguageDisplayName('en', 'de')).toBe('Englisch');
+  });
+
+  it('names a language in itself when display and named language match', () => {
+    expect(getLanguageDisplayName('de', 'de')).toBe('Deutsch');
+    expect(getLanguageDisplayName('en', 'en')).toBe('English');
+  });
+
+  it('falls back to the raw code for an empty or unrecognized value', () => {
+    expect(getLanguageDisplayName(null, 'en')).toBe('');
+    expect(getLanguageDisplayName(undefined, 'en')).toBe('');
   });
 });

--- a/frontend/src/__tests__/publicCultureDisplay.test.ts
+++ b/frontend/src/__tests__/publicCultureDisplay.test.ts
@@ -134,18 +134,18 @@ describe('getPublicCultureDescription', () => {
 });
 
 describe('getFallbackNotice', () => {
-  it('names the language the content actually came from', () => {
+  it('names the language the content actually came from, localized into the current UI language', () => {
     const localized = getPublicCultureName(
       buildCulture({ display_name: 'Tomato', display_language_code: 'en' }),
       'de',
       MISSING_NAME,
     );
 
-    const notice = getFallbackNotice(localized, t);
+    const notice = getFallbackNotice(localized, t, 'de');
 
     expect(notice).not.toBeNull();
-    expect(notice?.label).toContain('English');
-    expect(notice?.tooltip).toContain('English');
+    expect(notice?.label).toContain('Englisch');
+    expect(notice?.tooltip).toContain('Englisch');
   });
 
   it('shows no notice when the content is in the current language', () => {
@@ -155,6 +155,6 @@ describe('getFallbackNotice', () => {
       MISSING_NAME,
     );
 
-    expect(getFallbackNotice(localized, t)).toBeNull();
+    expect(getFallbackNotice(localized, t, 'de')).toBeNull();
   });
 });

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -124,7 +124,11 @@ export function AuthProvider({
         return null;
       }
       if (me.is_guest_demo && String(me.guest_demo_session_id) !== window.sessionStorage.getItem(GUEST_DEMO_SESSION_KEY)) {
-        await logoutRequest();
+        // The session cookie now belongs to a guest demo this tab didn't start
+        // (sessionStorage, unlike the cookie, isn't shared across tabs — e.g. a
+        // stale tab reloaded after another tab started a fresh demo). Only drop
+        // this tab's own view of it; a real server-side logout would end the
+        // *shared* session and sign the other, perfectly valid tab out too.
         clearAuthenticatedUser();
         return null;
       }

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -179,7 +179,18 @@ export function AuthProvider({
   // header (read fresh from localStorage per request, see httpClient.ts) are not: if
   // another tab switches the active project, this tab would keep showing stale data
   // while its own requests silently target the new project. Reload to resync.
+  //
+  // Guest demo sessions are excluded: the browser's session cookie is shared
+  // across tabs, so two tabs each running their own demo can't stay
+  // independently authenticated — starting a second demo silently replaces
+  // the first tab's session. Without this guard, that project-id change
+  // makes the first tab reload, which then resolves to the second tab's
+  // project, which makes *that* tab reload in turn, forever.
+  const isGuestDemo = Boolean(user?.is_guest_demo);
   useEffect(() => {
+    if (isGuestDemo) {
+      return undefined;
+    }
     function handleStorageChange(event: StorageEvent): void {
       if (event.key !== "activeProjectId" || event.newValue === event.oldValue) {
         return;
@@ -188,7 +199,7 @@ export function AuthProvider({
     }
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
-  }, []);
+  }, [isGuestDemo]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/src/components/data-grid/NotesDrawer.tsx
+++ b/frontend/src/components/data-grid/NotesDrawer.tsx
@@ -101,11 +101,14 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
   const [pendingPreviewUrl, setPendingPreviewUrl] = useState<string | null>(null);
   const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [cropRect, setCropRect] = useState<CropRect | null>(null);
+  const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
 
   const textFieldRef = useRef<HTMLTextAreaElement>(null);
   const cropImageRef = useRef<HTMLImageElement>(null);
   const dragRef = useRef<{ mode: DragMode; startX: number; startY: number; initialRect: CropRect } | null>(null);
   const attachmentsSectionRef = useRef<HTMLDivElement>(null);
+  const cameraFileInputRef = useRef<HTMLInputElement>(null);
+  const cameraVideoRef = useRef<HTMLVideoElement>(null);
 
   const loadAttachments = async (): Promise<void> => {
     if (!noteId) return;
@@ -152,6 +155,53 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
     setPendingPreviewUrl(nextUrl);
     setCropRect(null);
     setSourceSize(null);
+  };
+
+  const closeCamera = (): void => {
+    cameraStream?.getTracks().forEach((track) => track.stop());
+    setCameraStream(null);
+  };
+
+  useEffect(() => closeCamera, []);
+
+  useEffect(() => {
+    if (cameraVideoRef.current) {
+      cameraVideoRef.current.srcObject = cameraStream;
+    }
+  }, [cameraStream]);
+
+  const handleTakePhotoClick = async (): Promise<void> => {
+    // Touch devices already get the native camera app via the file input's
+    // `capture` attribute below — a better experience than a custom in-page
+    // stream. Desktop browsers ignore that attribute and just show a file
+    // picker (see the "Choose from gallery" button), so open the webcam
+    // directly there instead, falling back to the file picker if unavailable.
+    const isLikelyTouchDevice = typeof window.matchMedia !== 'function' || window.matchMedia('(pointer: coarse)').matches;
+    if (isLikelyTouchDevice || !navigator.mediaDevices?.getUserMedia) {
+      cameraFileInputRef.current?.click();
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      setCameraStream(stream);
+    } catch {
+      cameraFileInputRef.current?.click();
+    }
+  };
+
+  const handleCameraCapture = (): void => {
+    const video = cameraVideoRef.current;
+    if (!video || !video.videoWidth) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob((blob) => {
+      if (blob) openCropDialog(new File([blob], 'camera-photo.jpg', { type: 'image/jpeg' }));
+      closeCamera();
+    }, 'image/jpeg', 0.92);
   };
 
   const handleFormat = (format: MarkdownFormat): void => {
@@ -383,9 +433,10 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
               }}
             >
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ width: '100%' }}>
-                <Button variant="outlined" component="label" sx={{ flex: 1, minHeight: 40 }}>
+                <Button variant="outlined" sx={{ flex: 1, minHeight: 40 }} onClick={() => { void handleTakePhotoClick(); }}>
                   {t('notesDrawer.takePhoto')}
                   <input
+                    ref={cameraFileInputRef}
                     type="file"
                     accept="image/*"
                     capture="environment"
@@ -393,6 +444,7 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
                     onChange={(e) => {
                       const file = e.target.files?.[0];
                       if (file) openCropDialog(file);
+                      e.target.value = '';
                     }}
                   />
                 </Button>
@@ -510,6 +562,17 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
           <Button onClick={clearPendingSelection}>{t('actions.cancel')}</Button>
           <Button onClick={resetCrop}>{t('actions.reset')}</Button>
           <Button onClick={() => void handleUpload()} disabled={uploading || !pendingFile} variant="contained">{t('actions.save')}</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(cameraStream)} onClose={closeCamera} maxWidth="md" fullWidth>
+        <DialogTitle>{t('notesDrawer.camera.title')}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', justifyContent: 'center', backgroundColor: '#111', p: 0 }}>
+          <video ref={cameraVideoRef} autoPlay playsInline muted style={{ width: '100%', maxHeight: '70vh' }} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeCamera}>{t('actions.cancel')}</Button>
+          <Button onClick={handleCameraCapture} variant="contained">{t('notesDrawer.camera.capture')}</Button>
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/components/data-grid/NotesDrawer.tsx
+++ b/frontend/src/components/data-grid/NotesDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { KeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import {
   Drawer,
@@ -102,6 +102,8 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
   const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
   const [cropRect, setCropRect] = useState<CropRect | null>(null);
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
+  const [cameraReady, setCameraReady] = useState<boolean>(false);
+  const [cameraTimedOut, setCameraTimedOut] = useState<boolean>(false);
 
   const textFieldRef = useRef<HTMLTextAreaElement>(null);
   const cropImageRef = useRef<HTMLImageElement>(null);
@@ -157,23 +159,41 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
     setSourceSize(null);
   };
 
+  const cameraStreamRef = useRef<MediaStream | null>(null);
+
   const closeCamera = (): void => {
-    cameraStream?.getTracks().forEach((track) => track.stop());
+    cameraStreamRef.current?.getTracks().forEach((track) => track.stop());
+    cameraStreamRef.current = null;
     setCameraStream(null);
+    setCameraReady(false);
+    setCameraTimedOut(false);
   };
 
-  useEffect(() => closeCamera, []);
+  // Stop any active stream if the drawer unmounts while the camera is open.
+  useEffect(() => () => cameraStreamRef.current?.getTracks().forEach((track) => track.stop()), []);
 
-  useEffect(() => {
-    const video = cameraVideoRef.current;
-    if (!video) return;
-    video.srcObject = cameraStream;
-    if (cameraStream) {
-      // Some browsers don't honor the `autoPlay` attribute when srcObject is
-      // assigned imperatively after mount; without this the preview stays black.
-      void video.play().catch(() => {});
-    }
-  }, [cameraStream]);
+  // A ref callback rather than a `[cameraStream]` effect: the <video> lives
+  // inside a MUI Dialog, which can mount its content one render after `open`
+  // flips to true. An effect keyed on `cameraStream` can fire while the node
+  // is still null and never re-run once it exists, leaving the preview
+  // permanently black. This runs exactly when the node is actually attached.
+  const attachCameraVideo = useCallback((node: HTMLVideoElement | null) => {
+    cameraVideoRef.current = node;
+    if (!node || !cameraStreamRef.current) return undefined;
+    node.srcObject = cameraStreamRef.current;
+    // Some browsers don't honor the `autoPlay` attribute when srcObject is
+    // assigned imperatively; without this the preview stays black. play()
+    // isn't guaranteed to return a promise in every environment (e.g. jsdom).
+    void node.play()?.catch(() => {});
+    // A stream can be granted by the browser without ever producing a real
+    // frame (camera locked by another app, virtual/remote-desktop camera with
+    // no signal, ...). Without this, Capture would silently do nothing and
+    // the user would be stuck looking at a black box with no explanation.
+    const timeoutId = window.setTimeout(() => {
+      if (!node.videoWidth) setCameraTimedOut(true);
+    }, 4000);
+    return () => window.clearTimeout(timeoutId);
+  }, []);
 
   const handleTakePhotoClick = async (): Promise<void> => {
     // Touch devices already get the native camera app via the file input's
@@ -188,10 +208,18 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
     }
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      cameraStreamRef.current = stream;
+      setCameraReady(false);
+      setCameraTimedOut(false);
       setCameraStream(stream);
     } catch {
       cameraFileInputRef.current?.click();
     }
+  };
+
+  const handleCameraFallbackToFilePicker = (): void => {
+    closeCamera();
+    cameraFileInputRef.current?.click();
   };
 
   const handleCameraCapture = (): void => {
@@ -572,12 +600,35 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
 
       <Dialog open={Boolean(cameraStream)} onClose={closeCamera} maxWidth="md" fullWidth>
         <DialogTitle>{t('notesDrawer.camera.title')}</DialogTitle>
-        <DialogContent sx={{ display: 'flex', justifyContent: 'center', backgroundColor: '#111', p: 0 }}>
-          <video ref={cameraVideoRef} autoPlay playsInline muted style={{ width: '100%', maxHeight: '70vh' }} />
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 0 }}>
+          {cameraTimedOut ? (
+            <Alert severity="warning" sx={{ m: 2 }}>
+              {t('notesDrawer.camera.noSignal')}
+            </Alert>
+          ) : null}
+          <Box sx={{ position: 'relative', display: 'flex', justifyContent: 'center', backgroundColor: '#111' }}>
+            <video
+              ref={attachCameraVideo}
+              autoPlay
+              playsInline
+              muted
+              onLoadedMetadata={() => setCameraReady(true)}
+              style={{ width: '100%', maxHeight: '70vh' }}
+            />
+            {!cameraReady && !cameraTimedOut ? (
+              <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <CircularProgress sx={{ color: 'white' }} />
+              </Box>
+            ) : null}
+          </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={closeCamera}>{t('actions.cancel')}</Button>
-          <Button onClick={handleCameraCapture} variant="contained">{t('notesDrawer.camera.capture')}</Button>
+          {cameraTimedOut ? (
+            <Button onClick={handleCameraFallbackToFilePicker} variant="contained">{t('notesDrawer.camera.useFilePicker')}</Button>
+          ) : (
+            <Button onClick={handleCameraCapture} variant="contained" disabled={!cameraReady}>{t('notesDrawer.camera.capture')}</Button>
+          )}
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/components/data-grid/NotesDrawer.tsx
+++ b/frontend/src/components/data-grid/NotesDrawer.tsx
@@ -165,8 +165,13 @@ export function NotesDrawer({ open, title, value, onChange, onSave, onClose, has
   useEffect(() => closeCamera, []);
 
   useEffect(() => {
-    if (cameraVideoRef.current) {
-      cameraVideoRef.current.srcObject = cameraStream;
+    const video = cameraVideoRef.current;
+    if (!video) return;
+    video.srcObject = cameraStream;
+    if (cameraStream) {
+      // Some browsers don't honor the `autoPlay` attribute when srcObject is
+      // assigned imperatively after mount; without this the preview stays black.
+      void video.play().catch(() => {});
     }
   }, [cameraStream]);
 

--- a/frontend/src/crops/pages/PublicCropLibraryPage.tsx
+++ b/frontend/src/crops/pages/PublicCropLibraryPage.tsx
@@ -54,6 +54,7 @@ import { useAuth } from '../../auth/useAuth';
 import PageContainer from '../../components/layout/PageContainer';
 import { DetailPageActions } from '../../components/layout/DetailPageActions';
 import { useTranslation } from '../../i18n';
+import { getLanguageDisplayName } from '../../i18n/languages';
 import { showGlobalSnackbar } from '../../utils/globalSnackbar';
 import { stripCitationMarkers } from '../../components/data-grid/markdown';
 import { useCultureListKeyboardNavigation } from '../../cultures/useCultureListKeyboardNavigation';
@@ -348,11 +349,11 @@ function getSeedingRequirementTypeLabel(value: PublicCulture['seeding_requiremen
   return '';
 }
 
-function getLanguageLabel(code: string | null | undefined, t: (key: string, options?: Record<string, unknown>) => string, fallback: string): string {
+function getLanguageLabel(code: string | null | undefined, displayLanguage: string, fallback: string): string {
   if (!code) {
     return fallback;
   }
-  return t(`library.publishWizard.languages.${code}`, { defaultValue: code });
+  return getLanguageDisplayName(code, displayLanguage);
 }
 
 function formatSeedPackages(
@@ -1201,8 +1202,8 @@ export default function PublicCropLibraryPage() {
     [language, selectedCulture, t],
   );
   const nameFallbackNotice = useMemo(
-    () => getFallbackNotice(selectedCultureName, t),
-    [selectedCultureName, t],
+    () => getFallbackNotice(selectedCultureName, t, language),
+    [selectedCultureName, t, language],
   );
   const selectedCultureDescription = useMemo(
     () => (selectedCulture
@@ -1211,8 +1212,8 @@ export default function PublicCropLibraryPage() {
     [language, selectedCulture],
   );
   const descriptionFallbackNotice = useMemo(
-    () => getFallbackNotice(selectedCultureDescription, t),
-    [selectedCultureDescription, t],
+    () => getFallbackNotice(selectedCultureDescription, t, language),
+    [selectedCultureDescription, t, language],
   );
   const selectedTopic = useMemo(
     () => topics.find((topic) => topic.id === selectedTopicId) ?? null,
@@ -2210,7 +2211,7 @@ export default function PublicCropLibraryPage() {
 
                       <DetailSection title={t('library.page.sections.metadata')}>
                         <DetailGrid>
-                          <DetailRow label={t('library.page.fields.originalLanguage')} value={getLanguageLabel(selectedCulture.original_language_code, t, t('library.page.notSpecified'))} />
+                          <DetailRow label={t('library.page.fields.originalLanguage')} value={getLanguageLabel(selectedCulture.original_language_code, i18n.resolvedLanguage ?? i18n.language, t('library.page.notSpecified'))} />
                           <DetailRow label={t('library.page.fields.publishedAt')} value={formatDate(selectedCulture.published_at)} />
                           <DetailRow label={t('library.page.fields.updatedAt')} value={formatDate(selectedCulture.updated_at)} />
                         </DetailGrid>

--- a/frontend/src/crops/publicCultureDisplay.ts
+++ b/frontend/src/crops/publicCultureDisplay.ts
@@ -15,7 +15,7 @@
 import type { TFunction } from 'i18next';
 
 import type { PublicCulture } from '../api/types';
-import { normalizeLanguageTag, type SupportedLanguage } from '../i18n/languages';
+import { getLanguageDisplayName, normalizeLanguageTag, type SupportedLanguage } from '../i18n/languages';
 
 export interface LocalizedText {
   /** The text to render. Never empty, never `undefined`/`null`/a raw id. */
@@ -100,11 +100,12 @@ export function getPublicCultureTitle(
 export function getFallbackNotice(
   localized: LocalizedText,
   t: TFunction,
+  displayLanguage: string,
 ): { label: string; tooltip: string } | null {
   if (!localized.isFallback || !localized.languageCode) {
     return null;
   }
-  const languageName = t(`library.translation.languageNames.${localized.languageCode}`);
+  const languageName = getLanguageDisplayName(localized.languageCode, displayLanguage);
   return {
     label: t('library.translation.fallbackNotice', { language: languageName }),
     tooltip: t('library.translation.fallbackNoticeTooltip', { language: languageName }),

--- a/frontend/src/i18n/languages.ts
+++ b/frontend/src/i18n/languages.ts
@@ -148,3 +148,25 @@ export function resolveInitialLanguage(): SupportedLanguage {
 export function getLanguageLabel(code: SupportedLanguage): string {
   return SUPPORTED_LANGUAGES.find((entry) => entry.code === code)?.label ?? code;
 }
+
+/**
+ * Human-readable name for an arbitrary ISO 639-1 language code (not just
+ * `SUPPORTED_LANGUAGES` — e.g. a crop's `original_language_code`), localized
+ * into `displayLanguage` (typically the current UI language). "German" in the
+ * English UI, "Deutsch" in the German UI, regardless of which language is
+ * being named.
+ *
+ * Falls back to the raw code if `Intl.DisplayNames` is unavailable or the
+ * code isn't a language it recognizes, rather than showing nothing.
+ */
+export function getLanguageDisplayName(code: string | null | undefined, displayLanguage: string): string {
+  if (!code) {
+    return '';
+  }
+  try {
+    const displayNames = new Intl.DisplayNames([displayLanguage], { type: 'language' });
+    return displayNames.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -92,7 +92,9 @@
     "uploadFailed": "Hochladen fehlgeschlagen. Bitte versuche es erneut.",
     "camera": {
       "title": "Foto aufnehmen",
-      "capture": "Aufnehmen"
+      "capture": "Aufnehmen",
+      "noSignal": "Es kommt kein Kamerabild an. Sie wird möglicherweise von einer anderen App verwendet oder ist in dieser Umgebung nicht verfügbar.",
+      "useFilePicker": "Stattdessen Datei wählen"
     },
     "tabs": {
       "edit": "Bearbeiten",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -90,6 +90,10 @@
     "cropSourceAlt": "Zuschneidequelle",
     "backendUnavailable": "Bildverarbeitung ist auf dem Server derzeit nicht verfügbar. Bitte installiere Pillow und starte das Backend neu.",
     "uploadFailed": "Hochladen fehlgeschlagen. Bitte versuche es erneut.",
+    "camera": {
+      "title": "Foto aufnehmen",
+      "capture": "Aufnehmen"
+    },
     "tabs": {
       "edit": "Bearbeiten",
       "preview": "Vorschau"

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -878,10 +878,6 @@
         "duplicates": "Dublettenprüfung",
         "license": "Lizenz"
       },
-      "languages": {
-        "de": "Deutsch",
-        "en": "English"
-      },
       "fields": {
         "variety": "Sorte",
         "growth_duration_days": "Kulturdauer",
@@ -909,11 +905,7 @@
       "descriptionPlaceholder": "Beschreibung und Anbauhinweise in dieser Sprache…",
       "atLeastOneRequired": "Mindestens eine Sprachversion muss eine Beschreibung enthalten.",
       "saveError": "Die Sprachversionen konnten nicht gespeichert werden.",
-      "saveSuccess": "Die Sprachversionen wurden gespeichert.",
-      "languageNames": {
-        "de": "Deutsch",
-        "en": "English"
-      }
+      "saveSuccess": "Die Sprachversionen wurden gespeichert."
     },
     "commands": {
       "focusSearch": "Kulturbibliothek durchsuchen (/)",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -90,6 +90,10 @@
     "cropSourceAlt": "Crop source",
     "backendUnavailable": "Image processing is currently unavailable on the server. Please install Pillow and restart the backend.",
     "uploadFailed": "Upload failed. Please try again.",
+    "camera": {
+      "title": "Take photo",
+      "capture": "Capture"
+    },
     "tabs": {
       "edit": "Edit",
       "preview": "Preview"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -92,7 +92,9 @@
     "uploadFailed": "Upload failed. Please try again.",
     "camera": {
       "title": "Take photo",
-      "capture": "Capture"
+      "capture": "Capture",
+      "noSignal": "No camera image is coming through. It may be in use by another app, or unavailable in this environment.",
+      "useFilePicker": "Choose file instead"
     },
     "tabs": {
       "edit": "Edit",

--- a/frontend/src/i18n/locales/en/cultures.json
+++ b/frontend/src/i18n/locales/en/cultures.json
@@ -878,10 +878,6 @@
         "duplicates": "Duplicate check",
         "license": "License"
       },
-      "languages": {
-        "de": "Deutsch",
-        "en": "English"
-      },
       "fields": {
         "variety": "Variety",
         "growth_duration_days": "Growth duration",
@@ -909,11 +905,7 @@
       "descriptionPlaceholder": "Description and growing notes in this language…",
       "atLeastOneRequired": "At least one language version must contain a description.",
       "saveError": "The language versions could not be saved.",
-      "saveSuccess": "The language versions were saved.",
-      "languageNames": {
-        "de": "Deutsch",
-        "en": "English"
-      }
+      "saveSuccess": "The language versions were saved."
     },
     "commands": {
       "focusSearch": "Search the crop library (/)",

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -113,15 +113,15 @@
     },
     "privacy": {
       "title": "Privacy policy",
-      "version": "Status: July 15, 2026",
+      "version": "Status: July 17, 2026",
       "sections": {
         "controller": {
           "title": "Controller",
           "content": "Responsible for data processing on this website:\n\nMartin Stipsitz\nBurgenlandstraße 44A / 9\n9500 Villach\nAustria\n\nEmail: info@openfarmplanner.org"
         },
         "generalNotice": {
-          "title": "General information on data processing",
-          "content": "We take the protection of your personal data seriously. We process your data confidentially and in accordance with applicable data protection laws and this privacy policy.\n\nUsing OpenFarmPlanner is generally possible without providing personal data. If personal data is collected (for example during registration), this is done on a voluntary basis."
+          "title": "General information",
+          "content": "We process your personal data confidentially and in accordance with the applicable data protection laws and this privacy policy. This privacy policy supplements the terms of service of OpenFarmPlanner. For questions about the processing of personal data, this privacy policy is exclusively authoritative.\n\nYou can use the OpenFarmPlanner landing page without providing any personal data. As soon as you create a user account and use the application, we process the data described in the following sections. For each processing activity, the legal basis stated there under Art. 6(1) GDPR is authoritative."
         },
         "hosting": {
           "title": "Hosting",
@@ -140,9 +140,9 @@
           "title": "Registration and user account",
           "content": "To use OpenFarmPlanner, you can create a user account. The following data may be processed:",
           "bullets": {
-            "emailAddress": "Email address",
-            "nameOptional": "Name (optional)",
-            "encryptedPassword": "Password (stored in encrypted form)"
+            "emailAddress": "Email address (visible to other members of the same project in the member list; never published publicly)",
+            "nameOptional": "Display name (optional)",
+            "encryptedPassword": "Password (stored securely hashed – not viewable by us in plain text)"
           },
           "legalBasis": "Legal basis: Art. 6(1)(b) GDPR (performance of a contract)"
         },
@@ -172,7 +172,7 @@
             "accountActivation": "Account activation",
             "passwordReset": "Password reset",
             "projectInvitations": "Project invitations",
-            "systemNotifications": "System notifications"
+            "systemNotifications": "other communication related to your user account, such as system notifications"
           },
           "legalBasis": "Legal basis: Art. 6(1)(b) GDPR"
         },
@@ -206,14 +206,14 @@
         },
         "rights": {
           "title": "Your rights",
-          "content": "You have the following rights:",
+          "content": "As a data subject, you have the following rights under the GDPR:",
           "bullets": {
-            "access": "Access to stored data",
-            "rectification": "Correction of incorrect data",
-            "deletion": "Deletion of your data",
-            "restriction": "Restriction of processing",
-            "portability": "Data portability",
-            "objection": "Objection to processing",
+            "access": "Access to the data stored about you (Art. 15 GDPR)",
+            "rectification": "Rectification of inaccurate data (Art. 16 GDPR)",
+            "deletion": "Erasure of your data (Art. 17 GDPR)",
+            "restriction": "Restriction of processing (Art. 18 GDPR)",
+            "portability": "Data portability (Art. 20 GDPR)",
+            "objection": "Objection to processing based on legitimate interest (Art. 21 GDPR)",
             "consentWithdrawal": "Withdrawal of a consent you have given, with effect for the future, without affecting the lawfulness of processing carried out until then (Art. 7(3) GDPR)"
           },
           "contact": "You can correct your account data, export your data, and request account deletion directly in the account settings. For exceptional cases that are not covered by these self-service functions, the controller remains reachable at info@openfarmplanner.org."
@@ -231,7 +231,7 @@
     "terms": {
       "title": "Terms of Service",
       "print": "Print / save as PDF",
-      "version": "Status: July 15, 2026",
+      "version": "Status: July 17, 2026",
       "sections": {
         "provider": {
           "title": "Provider and contact",
@@ -259,11 +259,11 @@
         },
         "publicLibrary": {
           "title": "Public crop library",
-          "content": "You can voluntarily publish individual crop records from a private project to the public crop library. This library is visible to all logged-in users and entries can be imported into their own projects. Which data is published, that only your freely chosen public display name or, if not set, no name (anonymous) appears as author, and how you can undo a publication is explained in the Privacy Policy, section \"Public crop library\".\n\nBy publishing, you confirm that the published information is accurate to the best of your knowledge and that you are entitled to publish it."
+          "content": "You can voluntarily publish individual crop records from a private project into the public crop library. This library is intended as a collaboratively built, permanently maintained knowledge base for agricultural and horticultural crop data. Published entries are visible to other users, can be imported into their own projects, and may in the long term be reused through features such as version histories, collaborative editing, comments, ratings, public APIs, or data exports.\n\nBy publishing, you confirm that the published information is accurate to the best of your knowledge, contains no personal data of third parties, and that you are entitled to publish it permanently under the open license named in these terms of service."
         },
         "contributionLicense": {
-          "title": "Rights to published crop data",
-          "content": "When you publish a crop record to the public crop library, you grant OpenFarmPlanner a simple, unlimited right in time and territory to display this information to all logged-in users, enable its import into their own projects, and technically store and process the information for that purpose.\n\nYou remain the owner of your rights to the data. You can revoke this use at any time with effect for the future (see the \"Content removal\" section); copies that other users imported into their own project before revocation or removal of the entry are not affected, because they continue to exist independently in the respective project and can be edited there independently."
+          "title": "Open license for published crop data",
+          "content": "When you publish a crop record to the public crop library, you license the published crop data under the Creative Commons Attribution-ShareAlike 4.0 International license (CC BY-SA 4.0). This license in particular allows third parties to reproduce, distribute, edit, and combine the published crop data with other data, and to use it commercially, provided the license terms are followed. These terms include, in particular, appropriate attribution, an indication of the license, and sharing modified versions under the same or compatible terms.\n\nOnce validly granted, the license is irrevocable under its terms. OpenFarmPlanner may permanently store and display the published crop data, include it in search and import features, make it available in public data exports or APIs, technically process it, and further develop it as part of the collaborative crop library. You remain the owner of any rights you hold in your contribution; however, the open license enables its permanent use by OpenFarmPlanner and third parties."
         },
         "prohibitedContent": {
           "title": "Prohibited content and behavior",
@@ -281,7 +281,7 @@
         },
         "contentRemoval": {
           "title": "Content removal",
-          "content": "We reserve the right to remove or block published content in the public crop library in whole or in part if there are concrete indications of a violation of these Terms of Service or applicable law, for example following a notice within the meaning of Art. 16 of the EU Digital Services Act. Notices of allegedly unlawful content can be sent at any time to info@openfarmplanner.org. We are not obliged to carry out general, proactive monitoring of published content.\n\nYou can request removal of an entry you published at any time by contacting info@openfarmplanner.org."
+          "content": "Published entries in the crop library are generally intended to remain permanently and are not removed as a normal user feature on request. However, we reserve the right to remove, block, or anonymize published content in whole or in part, or to correct it in the future through moderation or versioning features, where there are concrete indications of a violation of these terms of service or applicable law. This applies in particular to legal violations, personal data in the published record, spam, obvious abuse, misleading information, or a moderation decision.\n\nYou can report suspected unlawful or problematic content at any time to info@openfarmplanner.org. We are not obliged to carry out general, proactive monitoring of published content."
         },
         "accountSuspension": {
           "title": "Suspension of user accounts",

--- a/frontend/src/pages/CulturesPublishingWizardDialog.tsx
+++ b/frontend/src/pages/CulturesPublishingWizardDialog.tsx
@@ -25,6 +25,7 @@ import { cropSpeciesAPI, cultureAPI, type Culture } from '../api/api';
 import type { CropSpecies, PublishPublicCulturePreview } from '../api/types';
 import { useTranslation } from '../i18n';
 import i18n from '../i18n/config';
+import { getLanguageDisplayName } from '../i18n/languages';
 
 interface CulturesPublishingWizardDialogProps {
   open: boolean;
@@ -239,7 +240,7 @@ export function CulturesPublishingWizardDialog({
                 }}
               >
                 {LANGUAGE_CODES.map((code) => (
-                  <MenuItem key={code} value={code}>{t(`library.publishWizard.languages.${code}`)}</MenuItem>
+                  <MenuItem key={code} value={code}>{getLanguageDisplayName(code, i18n.resolvedLanguage ?? i18n.language)}</MenuItem>
                 ))}
               </Select>
             </FormControl>


### PR DESCRIPTION
## Summary
- Fix the English privacy policy/terms of service translations, which had drifted from the German original (the legally controlling version) — most seriously, the crop-data license section and content-removal section stated contradictory terms.
- Fix a guest-demo bug where starting a demo in a second tab would silently end the session in another open tab (shared cookies + a cross-tab resync mechanism not meant for anonymous demo sessions), bouncing the user back to `/login`.
- Fix a follow-on infinite reload loop between two tabs each running their own guest demo, caused by the same resync mechanism.
- Add a desktop "take photo" flow that opens the webcam directly via `getUserMedia` instead of just showing the file picker (which is all `capture="environment"` does on desktop), with a fallback to the file picker if no camera is available/granted, and a "no signal" fallback if the stream never produces a frame.

## Test plan
- [x] `npx vitest run` (frontend) — 1668/1668 passing (one pre-existing unrelated flaky timeout re-ran clean)
- [x] `npx tsc --noEmit`
- [x] Manual two-tab reproduction against the running dev server confirmed both the login-bounce and the reload-loop are fixed
- [x] Camera capture manually verified after switching to a ref-callback attach (the actual root cause of the black-preview bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)