### PR TITLE
refactor(frontend): extract useOccupancyHierarchyFilter hook from GanttChart

### DIFF
--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -72,7 +72,6 @@ import {
   GANTT_VIEWPORT_BOTTOM_MARGIN_PX,
   GANTT_VIEWPORT_MIN_HEIGHT_PX,
   OCCUPANCY_COMPACT_ROW_HEIGHT,
-  OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD,
   type SyntheticMousePoint,
   addTimelinePeriod,
   addTimelinePeriodLarge,
@@ -100,7 +99,6 @@ import {
   toSyntheticMousePoint,
 } from './ganttChartState';
 import {
-  buildFieldOccupancyHierarchy,
   buildOccupancyTooltipDetails,
   buildSeedlingTaskGroups,
   buildSeedlingTooltipDetails,
@@ -113,15 +111,14 @@ import {
 } from './ganttChartUtils';
 import { useGanttContextMenu } from './useGanttContextMenu';
 import { useGanttTaskActions } from './useGanttTaskActions';
+import { useOccupancyHierarchyFilter } from './useOccupancyHierarchyFilter';
 import { getFirstMissingCultivationPlanRequirement, getTranslatedProjectSetupActions } from './requirementFlow';
 import {
   getSegmentedActionButtonSx,
   segmentedButtonGroupSx,
 } from '../components/buttons/segmentedControlStyles';
 import { getGanttRenderWindow } from './ganttRenderWindow';
-import { useExpandedState } from '../components/hierarchy/hooks/useExpandedState';
 import { collectVisibleIdsWithAncestors, flattenTreeRows } from '../components/hierarchy/utils/treeRows';
-import { useHierarchyLevelToggle } from '../components/hierarchy/hooks/useHierarchyLevelToggle';
 import { HierarchyLevelButtons } from '../components/hierarchy/HierarchyLevelToggle';
 import { CalendarFiltersPopover } from '../components/gantt/CalendarFiltersPopover';
 import { OccupancyFilterRow } from '../components/gantt/OccupancyFilterRow';
@@ -188,9 +185,6 @@ function GanttChartPage() {
 
   // Standort/Parzelle/Beet tree: filter + search state for the occupancy view
   const [occupancySearchText, setOccupancySearchText] = useState('');
-  const [occupancyLocationFilter, setOccupancyLocationFilter] = useState<number | 'all'>('all');
-  const [occupancyFieldFilter, setOccupancyFieldFilter] = useState<number | 'all'>('all');
-  const [onlyOccupiedBeds, setOnlyOccupiedBeds] = useState(true);
 
   // Seedling (Anzucht) view: search-only, no hierarchy/location filters —
   // it's a flat, culture-grouped list, not tied to a specific bed/field.
@@ -217,16 +211,6 @@ function GanttChartPage() {
     return () => window.cancelAnimationFrame(frame);
   }, [mobileSearchOpen]);
 
-  const occupancyTreeStorageKey = activeProjectId
-    ? `occupancyTree.${activeProjectId}`
-    : 'occupancyTree';
-  const {
-    expandedRows: expandedHierarchyIds,
-    hasPersistedState: hasPersistedHierarchyExpansion,
-    toggleExpand: toggleHierarchyExpand,
-    expandAll: expandAllHierarchy,
-  } = useExpandedState(occupancyTreeStorageKey);
-  const hasInitiallyExpandedHierarchyRef = useRef(false);
 
   const [ganttRenderKey, setGanttRenderKey] = useState(0);
   const [ganttScrollTop, setGanttScrollTop] = useState(0);
@@ -241,6 +225,30 @@ function GanttChartPage() {
   const [displayYear] = useState(currentYear);
   const startDate = useMemo(() => new Date(displayYear, 0, 1), [displayYear]);
   const endDate = useMemo(() => new Date(displayYear, 11, 31), [displayYear]);
+
+  const {
+    occupancyHierarchyNodes,
+    occupancyLocationFilter,
+    setOccupancyLocationFilter,
+    occupancyFieldFilter,
+    setOccupancyFieldFilter,
+    onlyOccupiedBeds,
+    setOnlyOccupiedBeds,
+    occupancyFieldOptions,
+    activeHierarchyFilterCount,
+    resetOccupancyHierarchyFilters,
+    expandedHierarchyIds,
+    toggleHierarchyExpand,
+    hierarchyLevelToggle,
+  } = useOccupancyHierarchyFilter({
+    locations,
+    fields,
+    beds,
+    plantingPlans,
+    cultures,
+    displayYear,
+    activeProjectId,
+  });
 
   const ganttStateStorageKey = useMemo(
     () => (canUseStoredCalendarView ? getGanttStateStorageKey(activeProjectId) : null),
@@ -643,63 +651,8 @@ function GanttChartPage() {
     addPlantingPlanForBed,
   }, t);
 
-  const occupancyHierarchyNodes = useMemo<OccupancyHierarchyNode[]>(() => buildFieldOccupancyHierarchy({
-    locations,
-    fields,
-    beds,
-    plantingPlans,
-    cultures,
-    displayYear,
-  }), [beds, cultures, displayYear, fields, locations, plantingPlans]);
-
-  // Default expansion — once per project, until the user manually
-  // expands/collapses something (which then persists via useExpandedState's
-  // sessionStorage backing). For small farms (few locations/fields/beds
-  // combined), fully expanding is more useful than hiding everything behind
-  // a chevron. Once the tree grows past a size where that would get
-  // unwieldy, fall back to locations-open/fields-collapsed so the view
-  // stays scannable.
-  useEffect(() => {
-    if (
-      !hasPersistedHierarchyExpansion
-      && !hasInitiallyExpandedHierarchyRef.current
-      && occupancyHierarchyNodes.length > 0
-    ) {
-      const canFullyExpand = occupancyHierarchyNodes.length <= OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD;
-      const idsToExpand = occupancyHierarchyNodes
-        .filter((node) => node.type === 'location' || (canFullyExpand && node.type === 'field'))
-        .map((node) => node.id);
-      expandAllHierarchy(idsToExpand);
-      hasInitiallyExpandedHierarchyRef.current = true;
-    }
-  }, [expandAllHierarchy, hasPersistedHierarchyExpansion, occupancyHierarchyNodes]);
-
-  const hierarchyLevelToggle = useHierarchyLevelToggle(
-    occupancyHierarchyNodes,
-    expandedHierarchyIds,
-    expandAllHierarchy,
-  );
-
-  const occupancyFieldOptions = useMemo(
-    () => (occupancyLocationFilter === 'all'
-      ? []
-      : occupancyHierarchyNodes.filter(
-        (node) => node.type === 'field' && node.locationId === occupancyLocationFilter,
-      )),
-    [occupancyHierarchyNodes, occupancyLocationFilter],
-  );
-  const activeHierarchyFilterCount = [
-    occupancyLocationFilter !== 'all',
-    occupancyFieldFilter !== 'all',
-    onlyOccupiedBeds,
-  ].filter(Boolean).length;
   const activeSearchText = calendarMode === 'occupancy' ? occupancySearchText.trim() : seedlingSearchText.trim();
   const isCalendarFilterPopoverOpen = Boolean(calendarFilterAnchorEl);
-  const resetOccupancyHierarchyFilters = useCallback(() => {
-    setOccupancyLocationFilter('all');
-    setOccupancyFieldFilter('all');
-    setOnlyOccupiedBeds(false);
-  }, []);
   const clearActiveSearch = useCallback(() => {
     if (calendarMode === 'occupancy') {
       setOccupancySearchText('');

--- a/frontend/src/pages/useOccupancyHierarchyFilter.ts
+++ b/frontend/src/pages/useOccupancyHierarchyFilter.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Bed, Culture, Field, Location, PlantingPlan } from '../api/api';
+import { useExpandedState } from '../components/hierarchy/hooks/useExpandedState';
+import { useHierarchyLevelToggle } from '../components/hierarchy/hooks/useHierarchyLevelToggle';
+import { OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD } from './ganttChartState';
+import { buildFieldOccupancyHierarchy, type OccupancyHierarchyNode } from './ganttChartUtils';
+
+interface UseOccupancyHierarchyFilterParams {
+  locations: Location[];
+  fields: Field[];
+  beds: Bed[];
+  plantingPlans: PlantingPlan[];
+  cultures: Culture[];
+  displayYear: number;
+  activeProjectId: number | null;
+}
+
+/**
+ * Occupancy (Standort/Parzelle/Beet) tree state for the Gantt calendar's
+ * occupancy view: the location/field/"only occupied beds" filters, the
+ * persisted expand/collapse state (with a one-time default expansion), the
+ * level toggle, and the derived hierarchy nodes / field options / active
+ * filter count. Search text stays in the page (it is shared with the seedling
+ * view).
+ */
+export function useOccupancyHierarchyFilter({
+  locations,
+  fields,
+  beds,
+  plantingPlans,
+  cultures,
+  displayYear,
+  activeProjectId,
+}: UseOccupancyHierarchyFilterParams) {
+  const [occupancyLocationFilter, setOccupancyLocationFilter] = useState<number | 'all'>('all');
+  const [occupancyFieldFilter, setOccupancyFieldFilter] = useState<number | 'all'>('all');
+  const [onlyOccupiedBeds, setOnlyOccupiedBeds] = useState(true);
+
+  const occupancyTreeStorageKey = activeProjectId
+    ? `occupancyTree.${activeProjectId}`
+    : 'occupancyTree';
+  const {
+    expandedRows: expandedHierarchyIds,
+    hasPersistedState: hasPersistedHierarchyExpansion,
+    toggleExpand: toggleHierarchyExpand,
+    expandAll: expandAllHierarchy,
+  } = useExpandedState(occupancyTreeStorageKey);
+  const hasInitiallyExpandedHierarchyRef = useRef(false);
+
+  const occupancyHierarchyNodes = useMemo<OccupancyHierarchyNode[]>(() => buildFieldOccupancyHierarchy({
+    locations,
+    fields,
+    beds,
+    plantingPlans,
+    cultures,
+    displayYear,
+  }), [beds, cultures, displayYear, fields, locations, plantingPlans]);
+
+  // Default expansion — once per project, until the user manually
+  // expands/collapses something (which then persists via useExpandedState's
+  // sessionStorage backing). For small farms (few locations/fields/beds
+  // combined), fully expanding is more useful than hiding everything behind
+  // a chevron. Once the tree grows past a size where that would get
+  // unwieldy, fall back to locations-open/fields-collapsed so the view
+  // stays scannable.
+  useEffect(() => {
+    if (
+      !hasPersistedHierarchyExpansion
+      && !hasInitiallyExpandedHierarchyRef.current
+      && occupancyHierarchyNodes.length > 0
+    ) {
+      const canFullyExpand = occupancyHierarchyNodes.length <= OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD;
+      const idsToExpand = occupancyHierarchyNodes
+        .filter((node) => node.type === 'location' || (canFullyExpand && node.type === 'field'))
+        .map((node) => node.id);
+      expandAllHierarchy(idsToExpand);
+      hasInitiallyExpandedHierarchyRef.current = true;
+    }
+  }, [expandAllHierarchy, hasPersistedHierarchyExpansion, occupancyHierarchyNodes]);
+
+  const hierarchyLevelToggle = useHierarchyLevelToggle(
+    occupancyHierarchyNodes,
+    expandedHierarchyIds,
+    expandAllHierarchy,
+  );
+
+  const occupancyFieldOptions = useMemo(
+    () => (occupancyLocationFilter === 'all'
+      ? []
+      : occupancyHierarchyNodes.filter(
+        (node) => node.type === 'field' && node.locationId === occupancyLocationFilter,
+      )),
+    [occupancyHierarchyNodes, occupancyLocationFilter],
+  );
+  const activeHierarchyFilterCount = [
+    occupancyLocationFilter !== 'all',
+    occupancyFieldFilter !== 'all',
+    onlyOccupiedBeds,
+  ].filter(Boolean).length;
+  const resetOccupancyHierarchyFilters = useCallback(() => {
+    setOccupancyLocationFilter('all');
+    setOccupancyFieldFilter('all');
+    setOnlyOccupiedBeds(false);
+  }, []);
+
+  return {
+    occupancyHierarchyNodes,
+    occupancyLocationFilter,
+    setOccupancyLocationFilter,
+    occupancyFieldFilter,
+    setOccupancyFieldFilter,
+    onlyOccupiedBeds,
+    setOnlyOccupiedBeds,
+    occupancyFieldOptions,
+    activeHierarchyFilterCount,
+    resetOccupancyHierarchyFilters,
+    expandedHierarchyIds,
+    toggleHierarchyExpand,
+    hierarchyLevelToggle,
+  };
+}


### PR DESCRIPTION
### Motivation
Continuing the `GanttChart.tsx` decomposition into the more coupled internals. The occupancy (Standort/Parzelle/Beet) tree — its filters, expansion state, and derived data — is a cohesive concern that can move into a dedicated hook.

### Description
- Add `pages/useOccupancyHierarchyFilter.ts` bundling: the location/field/"only occupied beds" filter state, the persisted expand/collapse state (`useExpandedState`) with the one-time default-expansion effect, the level toggle (`useHierarchyLevelToggle`), and the derived `occupancyHierarchyNodes`, `occupancyFieldOptions`, `activeHierarchyFilterCount`, and `resetOccupancyHierarchyFilters`.
- The hook takes the loaded data (`locations`, `fields`, `beds`, `plantingPlans`, `cultures`), `displayYear`, and `activeProjectId`; it returns the state, setters, and derived values the page consumes in task-group building and the filter UI.
- Search text stays in the page (it's shared with the seedling view), so only the tree/filter concern moved.
- `GanttChart` drops the now-unused `useExpandedState`, `useHierarchyLevelToggle`, `buildFieldOccupancyHierarchy`, and `OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD` imports; it shrinks from ~2209 to ~2162 lines.
- No behavior change — structural refactor only.

### Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` for `GanttChart` (47) and `useHierarchyLevelToggle` (6) — 53 pass. The GanttChart suite exercises the occupancy tree, its filters, and the Standort/Field/Beet context menus, covering the moved wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTrRD13dkBbUB7b9dN1jr)_