### PR TITLE
fix: harden public guest demo

### DIFF
--- a/backend/accounts/demo_access.py
+++ b/backend/accounts/demo_access.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from .models import GuestDemoSession
+
+GUEST_DEMO_FORBIDDEN_CODE = 'guest_demo_restricted'
+GUEST_DEMO_FORBIDDEN_DETAIL = 'This action is not available in the public demo.'
+
+
+def is_active_guest_demo_user(user: Any) -> bool:
+    """Return whether the user belongs to a temporary guest demo account."""
+    if not getattr(user, 'is_authenticated', False):
+        return False
+    return GuestDemoSession.objects.filter(user=user).exists()
+
+
+def guest_demo_forbidden_response() -> Response:
+    """Build the standard response for demo-restricted side effects."""
+    return Response(
+        {
+            'detail': GUEST_DEMO_FORBIDDEN_DETAIL,
+            'code': GUEST_DEMO_FORBIDDEN_CODE,
+        },
+        status=status.HTTP_403_FORBIDDEN,
+    )

--- a/backend/accounts/guest_demo.py
+++ b/backend/accounts/guest_demo.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
-
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
@@ -57,10 +55,3 @@ def delete_guest_demo_session(session: GuestDemoSession) -> None:
     project.delete()
     user.delete()
 
-
-def is_active_guest_demo_user(user: Any) -> bool:
-    """Return whether a user belongs to an unexpired guest demo session."""
-    try:
-        return user.guest_demo_session.expires_at > timezone.now()
-    except GuestDemoSession.DoesNotExist:
-        return False

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -7,11 +7,12 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.validators import UnicodeUsernameValidator
-from django.utils import timezone, translation
+from django.utils import translation
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from accounts.demo_access import is_active_guest_demo_user
 from config.languages import UI_LANGUAGE_AUTO, UI_LANGUAGE_VALUES
 from crops.permissions import is_public_library_moderator
 from farm.models import ProjectMembership
@@ -19,7 +20,7 @@ from farm.project_context import resolve_project_for_user
 from farm.services.demo_project import is_demo_project_description
 
 from .consent import get_pending_consent_documents, has_accepted_current, record_acceptance
-from .models import AccountDeletionRequest, DocumentConsent, GuestDemoSession, PublicProfile
+from .models import AccountDeletionRequest, DocumentConsent, PublicProfile
 
 User = get_user_model()
 _username_validator = UnicodeUsernameValidator()
@@ -174,10 +175,7 @@ class UserSerializer(serializers.ModelSerializer):
         return [] if self.get_is_guest_demo(obj) else get_pending_consent_documents(obj)
 
     def get_is_guest_demo(self, obj: User) -> bool:
-        try:
-            return obj.guest_demo_session.expires_at > timezone.now()
-        except GuestDemoSession.DoesNotExist:
-            return False
+        return is_active_guest_demo_user(obj)
 
     def get_guest_demo_session_id(self, obj: User) -> int | None:
         return obj.guest_demo_session.id if self.get_is_guest_demo(obj) else None

--- a/backend/accounts/tests/test_guest_demo.py
+++ b/backend/accounts/tests/test_guest_demo.py
@@ -17,7 +17,7 @@ from rest_framework.throttling import ScopedRateThrottle
 from accounts.guest_demo import create_guest_demo_session
 from accounts.models import GuestDemoSession
 from accounts.views import GuestDemoStartView, LoginView
-from farm.models import Culture, Project
+from farm.models import Culture, Project, ProjectInvitation
 from farm.services.demo_project import DEMO_PROJECT_NAME_EN
 
 User = get_user_model()
@@ -111,6 +111,24 @@ class GuestDemoApiTests(TestCase):
 
         self.assertNotEqual(first.data['resolved_project_id'], second.data['resolved_project_id'])
 
+    def test_restarting_guest_demo_deletes_previous_workspace(self) -> None:
+        first = self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+        first_project_id = first.data['resolved_project_id']
+
+        second = self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(first_project_id, second.data['resolved_project_id'])
+        self.assertFalse(Project.objects.filter(id=first_project_id).exists())
+
     def test_end_deletes_current_guest_workspace(self) -> None:
         started = self.client.post(
             '/openfarmplanner/api/auth/guest-demo/start/',
@@ -123,6 +141,92 @@ class GuestDemoApiTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Project.objects.filter(id=project_id).exists())
+
+    def test_end_deletes_guest_workspace_when_session_marker_is_missing(self) -> None:
+        started = self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+        project_id = started.data['resolved_project_id']
+        session = self.client.session
+        del session['guest_demo_session_id']
+        session.save()
+
+        response = self.client.post('/openfarmplanner/api/auth/guest-demo/end/', {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Project.objects.filter(id=project_id).exists())
+
+    def test_expired_guest_demo_still_cannot_create_additional_projects_before_cleanup(self) -> None:
+        started = self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+        demo_session = GuestDemoSession.objects.get(id=started.data['guest_demo_session_id'])
+        demo_session.expires_at = timezone.now() - timedelta(minutes=1)
+        demo_session.save(update_fields=['expires_at'])
+
+        response = self.client.post(
+            '/openfarmplanner/api/projects/',
+            {'name': 'Expired guest project'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(Project.objects.filter(name='Expired guest project').exists())
+
+    def test_guest_demo_cannot_create_additional_projects(self) -> None:
+        self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+
+        response = self.client.post(
+            '/openfarmplanner/api/projects/',
+            {'name': 'Extra demo project'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(Project.objects.filter(name='Extra demo project').exists())
+
+    def test_guest_demo_cannot_send_project_invitations(self) -> None:
+        started = self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+
+        response = self.client.post(
+            f"/openfarmplanner/api/projects/{started.data['resolved_project_id']}/invitations/",
+            {'email': 'invitee@example.com', 'role': 'member'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(ProjectInvitation.objects.filter(email_normalized='invitee@example.com').exists())
+
+    def test_guest_demo_cannot_request_account_email_change(self) -> None:
+        self.client.post(
+            '/openfarmplanner/api/auth/guest-demo/start/',
+            {},
+            format='json',
+        )
+
+        response = self.client.post(
+            '/openfarmplanner/api/auth/account/change-email/',
+            {'new_email': 'guest@example.com', 'current_password': ''},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
 
     def test_expired_session_is_removed_by_cleanup_command(self) -> None:
         demo_session = create_guest_demo_session()

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -24,6 +24,7 @@ from farm.services.demo_project import resolve_demo_request_language
 
 from .consent import record_acceptance
 from .data_export import build_personal_data_export
+from .demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from .emails import (
     _send_activation_email,
     _send_email_change_confirmation_email,
@@ -187,8 +188,15 @@ class GuestDemoStartView(APIView):
     throttle_scope = 'guest_demo_start'
 
     def post(self, request: Request) -> Response:
+        existing_guest_demo = (
+            GuestDemoSession.objects.filter(user=request.user).first()
+            if request.user.is_authenticated
+            else None
+        )
         if request.user.is_authenticated:
             logout(request)
+        if existing_guest_demo is not None:
+            delete_guest_demo_session(existing_guest_demo)
         demo_session = create_guest_demo_session(language_code=resolve_demo_request_language(request))
         login(request, demo_session.user)
         request.session['guest_demo_session_id'] = demo_session.id
@@ -201,6 +209,8 @@ class GuestDemoEndView(APIView):
     def post(self, request: Request) -> Response:
         demo_id = request.session.get('guest_demo_session_id')
         demo_session = GuestDemoSession.objects.filter(id=demo_id, user=request.user).first()
+        if demo_session is None:
+            demo_session = GuestDemoSession.objects.filter(user=request.user).first()
         logout(request)
         if demo_session is not None:
             delete_guest_demo_session(demo_session)
@@ -259,6 +269,8 @@ class ConsentAcceptView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = ConsentAcceptSerializer(data=request.data)
         _validate_serializer_in_german(serializer)
         record_acceptance(request.user, serializer.validated_data['document'])
@@ -277,6 +289,8 @@ class AccountProfileView(APIView):
 
 class AccountPublicProfileView(APIView):
     def patch(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = AccountPublicProfileSerializer(data=request.data, context={'request': request})
         _validate_serializer_in_german(serializer)
         public_display_name = serializer.validated_data['public_display_name'].strip()
@@ -321,6 +335,8 @@ class AccountEmailChangeRequestView(APIView):
     throttle_scope = 'auth_password_reset_request'
 
     def post(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = AccountEmailChangeRequestSerializer(data=request.data, context={'request': request})
         _validate_serializer_in_german(serializer)
 
@@ -397,6 +413,8 @@ class AccountEmailChangeConfirmView(APIView):
 
 class AccountPasswordChangeView(APIView):
     def post(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = AccountPasswordChangeSerializer(data=request.data, context={'request': request})
         _validate_serializer_in_german(serializer)
 
@@ -413,6 +431,8 @@ class AccountDeleteRequestView(APIView):
     """Mark the authenticated account for delayed deletion after password confirmation."""
 
     def post(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = AccountDeleteRequestSerializer(data=request.data)
         _validate_serializer_in_german(serializer)
 
@@ -515,6 +535,9 @@ class AccountDataExportView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request: Request) -> JsonResponse:
+        if is_active_guest_demo_user(request.user):
+            forbidden = guest_demo_forbidden_response()
+            return JsonResponse(forbidden.data, status=forbidden.status_code)
         payload = build_personal_data_export(request.user)
         response = JsonResponse(payload, json_dumps_params={'indent': 2})
         response['Content-Disposition'] = 'attachment; filename="openfarmplanner-data-export.json"'

--- a/backend/crops/tests/test_views.py
+++ b/backend/crops/tests/test_views.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase as DRFAPITestCase
 
+from accounts.guest_demo import create_guest_demo_session
 from crops.models import CropSpecies, PublicLibraryModeratorRequest
 from crops.permissions import grant_public_library_moderator_access
 from farm.models import PublicCulture
@@ -104,6 +105,16 @@ class CropViewSetTest(DRFAPITestCase):
         proposal = CropSpecies.objects.get(name='Tree onion')
         self.assertEqual(proposal.proposed_by, self.user)
 
+    def test_guest_demo_user_cannot_create_species_proposal(self):
+        demo_session = create_guest_demo_session()
+        self.client.force_authenticate(user=demo_session.user)
+
+        response = self.client.post('/openfarmplanner/api/crop-species/', {'name': 'Demo species'})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(CropSpecies.objects.filter(name='Demo species').exists())
+
     def test_normal_user_cannot_list_or_review_species_proposals(self):
         proposal = CropSpecies.objects.create(name='Tree onion', status=CropSpecies.STATUS_PROPOSED, proposed_by=self.user)
         self.client.force_authenticate(user=self.user)
@@ -197,6 +208,20 @@ class CropViewSetTest(DRFAPITestCase):
         self.assertEqual(duplicate_response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(mine_response.data['is_moderator'])
         self.assertEqual(mine_response.data['request']['status'], PublicLibraryModeratorRequest.STATUS_PENDING)
+
+    def test_guest_demo_user_cannot_request_moderator_access(self):
+        demo_session = create_guest_demo_session()
+        self.client.force_authenticate(user=demo_session.user)
+
+        response = self.client.post(
+            '/openfarmplanner/api/public-library/moderator-requests/',
+            {'motivation': 'Demo request'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(PublicLibraryModeratorRequest.objects.filter(user=demo_session.user).exists())
 
     def test_admin_can_approve_moderator_request_without_staff_rights_for_user(self):
         admin = User.objects.create_user(

--- a/backend/crops/views.py
+++ b/backend/crops/views.py
@@ -17,6 +17,7 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from accounts.demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from . import services
 from .models import CropSpecies, PublicLibraryModeratorRequest
 from .permissions import (
@@ -59,6 +60,8 @@ class CropSpeciesViewSet(viewsets.ModelViewSet):
         return queryset
 
     def create(self, request, *args, **kwargs):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         species = serializer.save(status=CropSpecies.STATUS_PROPOSED, proposed_by=request.user)
@@ -165,6 +168,8 @@ class PublicLibraryModeratorRequestViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         if is_public_library_moderator(request.user):
             return Response(
                 {

--- a/backend/farm/cultures/views/cultures.py
+++ b/backend/farm/cultures/views/cultures.py
@@ -11,6 +11,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from accounts.demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from accounts.consent import has_accepted_current, record_acceptance
 from accounts.models import DocumentConsent
 from farm.common.mixins import ProjectScopedMixin
@@ -495,6 +496,8 @@ class CultureViewSet(ProjectScopedMixin, viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path='publish-public')
     def publish_public(self, request, pk=None):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         culture = self.get_object()
         if not culture.name.strip():
             return Response({'detail': 'Name is required for publishing.'}, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/farm/cultures/views/public.py
+++ b/backend/farm/cultures/views/public.py
@@ -12,6 +12,7 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from accounts.demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from crops.permissions import is_public_library_moderator
 from crops.services import find_exact_crop_match
 from farm.models import (
@@ -124,6 +125,12 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
         return is_public_library_moderator(user)
 
     @staticmethod
+    def _guest_demo_write_forbidden(request: Request) -> Response | None:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
+        return None
+
+    @staticmethod
     def _proposal_status_error() -> Response:
         return Response(
             {'detail': 'Only pending change proposals can be reviewed.', 'code': 'proposal_not_pending'},
@@ -142,6 +149,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
         )
 
     def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         partial = kwargs.pop('partial', False)
         public_culture = self.get_object()
         serializer = PublicCultureUpdateSerializer(public_culture, data=request.data, partial=partial)
@@ -168,6 +177,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
         return self.update(request, *args, **kwargs)
 
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self._get_public_culture_for_status_action()
         try:
             hard_delete_public_culture(public_culture=public_culture, user=request.user)
@@ -225,6 +236,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
                 ),
             })
 
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         serializer = PublicCultureTranslationsUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         try:
@@ -269,6 +282,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
             return Response(serializer.data)
 
         topic_serializer = PublicCultureDiscussionTopicSerializer(data=request.data)
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         topic_serializer.is_valid(raise_exception=True)
         comment_serializer = PublicCultureDiscussionCommentSerializer(data={'body': request.data.get('body', '')})
         comment_serializer.is_valid(raise_exception=True)
@@ -310,6 +325,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
                     'visible_reply_exists': visible_reply_exists,
                 },
             ).data)
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         serializer = PublicCultureDiscussionCommentSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         parent = serializer.validated_data.get('parent')
@@ -320,6 +337,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['patch', 'delete'], url_path=r'discussion-comments/(?P<comment_id>[^/.]+)')
     def discussion_comment(self, request: Request, pk: int | None = None, comment_id: str | None = None) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self.get_object()
         comment = get_object_or_404(PublicCultureDiscussionComment.objects.select_related('topic'), pk=comment_id, topic__public_culture=public_culture)
         may_moderate = self._is_moderator(request.user)
@@ -359,6 +378,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path='revert')
     def revert(self, request: Request, pk: int | None = None) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self.get_object()
         serializer = PublicCultureRevertSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -385,6 +406,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
             serializer = PublicCultureChangeProposalSerializer(proposals, many=True)
             return Response(serializer.data)
 
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         serializer = PublicCultureChangeProposalSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         proposal = serializer.save(public_culture=public_culture, proposed_by=request.user)
@@ -392,6 +415,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path=r'change-proposals/(?P<proposal_id>[^/.]+)/approve')
     def approve_change_proposal(self, request: Request, pk: int | None = None, proposal_id: str | None = None) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         if not self._is_moderator(request.user):
             return Response({'detail': 'Moderator privileges are required.', 'code': 'moderator_required'}, status=status.HTTP_403_FORBIDDEN)
 
@@ -420,6 +445,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path=r'change-proposals/(?P<proposal_id>[^/.]+)/reject')
     def reject_change_proposal(self, request: Request, pk: int | None = None, proposal_id: str | None = None) -> Response:
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         if not self._is_moderator(request.user):
             return Response({'detail': 'Moderator privileges are required.', 'code': 'moderator_required'}, status=status.HTTP_403_FORBIDDEN)
 
@@ -440,6 +467,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path='withdraw')
     def withdraw(self, request, pk=None):
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self._get_public_culture_for_status_action()
         try:
             updated = withdraw_public_culture(public_culture=public_culture, user=request.user)
@@ -451,6 +480,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path='remove')
     def remove(self, request, pk=None):
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self._get_public_culture_for_status_action()
         try:
             updated = remove_public_culture(
@@ -466,6 +497,8 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=['post'], url_path='hard-delete')
     def hard_delete(self, request, pk=None):
+        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
+            return forbidden
         public_culture = self._get_public_culture_for_status_action()
         try:
             hard_delete_public_culture(public_culture=public_culture, user=request.user)

--- a/backend/farm/notes/views.py
+++ b/backend/farm/notes/views.py
@@ -6,6 +6,7 @@ from rest_framework import parsers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from accounts.demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from farm.history import _current_actor_label, _serialize_instance, record_entity_revision
 from farm.image_processing import (
     ImageProcessingBackendUnavailableError,
@@ -37,6 +38,8 @@ class MediaFileUploadView(APIView):
     parser_classes = [parsers.MultiPartParser, parsers.FormParser]
 
     def post(self, request):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         active_project = get_active_project_or_400(request)
         upload = request.FILES.get('file')
         if upload is None:
@@ -86,6 +89,8 @@ class NoteAttachmentListCreateView(APIView):
         return Response(serializer.data)
 
     def post(self, request, note_id: int):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         active_project = get_active_project_or_400(request)
         plan = get_object_or_404(PlantingPlan, pk=note_id, project=active_project)
 

--- a/backend/farm/projects/views.py
+++ b/backend/farm/projects/views.py
@@ -15,6 +15,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from accounts.demo_access import guest_demo_forbidden_response, is_active_guest_demo_user
 from accounts.models import UserProjectSettings
 from config.frontend_urls import build_public_frontend_url
 from farm.models import AgentLoginToken, Location, Project, ProjectInvitation, ProjectMembership
@@ -217,6 +218,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
             )
         return queryset.filter(deleted_at__isnull=True)
 
+    def create(self, request: Request, *args: object, **kwargs: object) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
+        return super().create(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         project = serializer.save(slug=_build_unique_project_slug(serializer.validated_data['name']))
         if not Location.objects.filter(project=project).exists():
@@ -237,6 +243,8 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=['post'], url_path='create-demo')
     def create_demo(self, request: Request) -> Response:
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         try:
             result = create_personal_demo_project(user=request.user, language_code=resolve_demo_request_language(request))
         except Exception:  # noqa: BLE001
@@ -338,6 +346,8 @@ class ProjectInvitationView(APIView):
         return Response(ProjectInvitationSerializer(invitations, many=True).data)
 
     def post(self, request, project_id: int):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         require_project_admin(request.user, project_id, request=request)
         serializer = ProjectInvitationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -428,6 +438,8 @@ class AcceptProjectInvitationByTokenView(APIView):
     throttle_scope = 'invitation_accept'
 
     def post(self, request, token: str):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         logger.info('Invitation accept endpoint reached', extra={'user_id': request.user.id, 'path': request.path})
         try:
             invitation = get_invitation_by_token(token)
@@ -470,6 +482,8 @@ class AcceptPendingProjectInvitationView(APIView):
     throttle_scope = 'invitation_accept'
 
     def post(self, request):
+        if is_active_guest_demo_user(request.user):
+            return guest_demo_forbidden_response()
         logger.info('Pending invitation accept endpoint reached', extra={'user_id': request.user.id, 'path': request.path})
         try:
             result = accept_pending_invitation_from_session(session=request.session, user=request.user)

--- a/backend/farm/tests/test_note_attachments_processing.py
+++ b/backend/farm/tests/test_note_attachments_processing.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from accounts.guest_demo import create_guest_demo_session
 from farm.image_processing import MAX_IMAGE_SIDE
 from farm.models import Location, Field, Bed, Culture, PlantingPlan, NoteAttachment, Project, ProjectMembership
 
@@ -91,3 +92,21 @@ class NoteAttachmentProcessingApiTest(APITestCase):
                 delete_response = self.client.delete(f'/openfarmplanner/api/attachments/{attachment_id}/')
                 self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
                 self.assertFalse(NoteAttachment.objects.filter(pk=attachment_id).exists())
+
+    def test_guest_demo_user_cannot_upload_note_attachment(self):
+        demo_session = create_guest_demo_session()
+        plan = PlantingPlan.objects.filter(project=demo_session.project).first()
+        self.client.force_authenticate(user=demo_session.user)
+        self.client.defaults['HTTP_X_PROJECT_ID'] = str(demo_session.project_id)
+
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root, MEDIA_URL='/media/'):
+                response = self.client.post(
+                    f'/openfarmplanner/api/notes/{plan.id}/attachments/',
+                    {'image': self._image_file(1200, 900)},
+                    format='multipart',
+                )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(NoteAttachment.objects.filter(project=demo_session.project).exists())

--- a/backend/farm/tests/test_public_cultures_api.py
+++ b/backend/farm/tests/test_public_cultures_api.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase as DRFAPITestCase
 
+from accounts.guest_demo import create_guest_demo_session
 from accounts.models import DocumentConsent
 from crops.models import CropSpecies
 from crops.permissions import grant_public_library_moderator_access
@@ -81,6 +82,22 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['code'], 'public_library_terms_required')
+        self.assertEqual(PublicCulture.objects.count(), 0)
+
+    def test_guest_demo_user_cannot_publish_to_public_library(self):
+        demo_session = create_guest_demo_session()
+        demo_culture = Culture.objects.filter(project=demo_session.project).first()
+        self.client.force_authenticate(user=demo_session.user)
+        self.client.defaults['HTTP_X_PROJECT_ID'] = str(demo_session.project_id)
+
+        response = self.client.post(
+            f'/openfarmplanner/api/cultures/{demo_culture.id}/publish-public/',
+            {'accepted_public_library_terms': True},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
         self.assertEqual(PublicCulture.objects.count(), 0)
 
     def test_publish_preview_reports_quality_gate_status(self):
@@ -489,6 +506,23 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
         self.assertEqual(list_response.status_code, status.HTTP_200_OK)
         self.assertIn(create_response.status_code, {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN})
 
+    def test_guest_demo_user_can_read_but_cannot_create_public_discussions(self):
+        public_culture = PublicCulture.objects.create(name='Lettuce', variety='Bijella', status='published', created_by=self.user)
+        demo_session = create_guest_demo_session()
+        self.client.force_authenticate(user=demo_session.user)
+
+        list_response = self.client.get(f'/openfarmplanner/api/public-cultures/{public_culture.id}/discussion-topics/')
+        create_response = self.client.post(
+            f'/openfarmplanner/api/public-cultures/{public_culture.id}/discussion-topics/',
+            {'title': 'Demo topic', 'body': 'Demo text'},
+            format='json',
+        )
+
+        self.assertEqual(list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(create_response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(create_response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(PublicCultureDiscussionTopic.objects.filter(public_culture=public_culture).exists())
+
     def test_comment_owner_can_edit_and_soft_delete_but_other_user_cannot(self):
         public_culture = PublicCulture.objects.create(name='Tomato', variety='Roma', status='published', created_by=self.user)
         topic = PublicCultureDiscussionTopic.objects.create(public_culture=public_culture, title='Spacing', created_by=self.user)
@@ -813,6 +847,21 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
         self.assertEqual(proposal.status, PublicCultureChangeProposal.STATUS_PENDING)
         self.assertEqual(proposal.proposed_by, self.user)
         self.assertEqual(proposal.proposed_data['notes'], 'Prefers warm protected conditions.')
+
+    def test_guest_demo_user_cannot_create_change_proposal(self):
+        public_culture = PublicCulture.objects.create(name='Lettuce', variety='Bijella', status='published', created_by=self.user)
+        demo_session = create_guest_demo_session()
+        self.client.force_authenticate(user=demo_session.user)
+
+        response = self.client.post(
+            f'/openfarmplanner/api/public-cultures/{public_culture.id}/change-proposals/',
+            {'summary': 'Demo proposal', 'proposed_data': {'notes': 'Demo edit'}},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'guest_demo_restricted')
+        self.assertFalse(PublicCultureChangeProposal.objects.filter(public_culture=public_culture).exists())
 
     def test_change_proposal_rejects_unsupported_fields(self):
         public_culture = PublicCulture.objects.create(name='Tomato', variety='Roma', status='published', created_by=self.user)

--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -25,7 +25,66 @@ creation and are not translated in place. The management command defaults to
 German for existing screenshot workflows and accepts `--language en` for the
 English fixture.
 
-The public landing page also starts an isolated anonymous guest project from this template. Guest workspaces are editable but session-bound, reset on the next browser session, and removed after their short server-side retention period by `cleanup_guest_demo_sessions`. This is separate from the persistent personal demo project.
+The public landing page also starts an isolated anonymous guest project from
+this template. Guest workspaces are editable but session-bound, reset on the
+next browser session, and removed after their short server-side retention
+period by `cleanup_guest_demo_sessions`. This is separate from the persistent
+personal demo project.
+
+## Public demo architecture
+
+OpenFarmPlanner can provide a public demo with the current codebase. The
+recommended and implemented architecture is an isolated anonymous guest
+workspace per visitor:
+
+- The landing page starts the demo through
+  `/api/auth/guest-demo/start/` and routes the visitor directly into the app.
+- The backend creates a random temporary user, a random temporary project, a
+  normal project membership, and demo data from the same reusable template as
+  onboarding and screenshots.
+- The temporary project is editable so visitors can test real workflows, but
+  all records remain separated from production user projects by the normal
+  project tenant boundary.
+- Guest sessions expire after 8 hours and are deleted, together with their
+  user and project data, by the `cleanup_guest_demo_sessions` management
+  command. Production cron should run this command regularly; the ops repo
+  schedules it every 30 minutes.
+- The frontend stores the guest session id in `sessionStorage`. A new browser
+  session starts a fresh workspace instead of reusing old demo data.
+
+Alternatives considered:
+
+- **Public shared demo account:** Low implementation effort, but every visitor
+  would see and edit the same data. This creates data-loss, vandalism, privacy,
+  and credential-sharing problems.
+- **Read-only demo mode:** Safe and cheap to maintain, but it does not let
+  visitors try the spreadsheet editing, planning, and project-management flows
+  that define the product.
+- **Separate periodically reset demo database:** Strong isolation, but it adds
+  deployment complexity, data synchronization, and another operational surface
+  for a small project.
+- **Anonymous per-session guest workspace:** Slightly more backend work, but it
+  reuses the existing tenancy model and demo template, gives realistic editable
+  behavior, and keeps operations simple through automatic cleanup.
+
+Risk controls:
+
+- Demo start is rate-limited through `GUEST_DEMO_THROTTLE_RATE`
+  (`10/hour` by default outside development, `1000/minute` in development).
+- Guest users cannot create additional projects, send project invitations,
+  accept invitations into real projects, change account email/password,
+  request account deletion/export, create public profiles, upload media,
+  publish to the public crop library, write public-library discussions or
+  change proposals, create crop-species proposals, or request moderator access.
+- Demo-created users use `example.invalid` email addresses and unusable
+  passwords.
+- Data growth is bounded by the start throttle, the 8-hour retention window,
+  and the scheduled cleanup command.
+
+Expected implementation effort for this architecture is low to medium because
+it reuses existing project scoping, authentication sessions, and demo seeding.
+The main ongoing maintenance cost is keeping the demo template realistic and
+ensuring the cleanup cron remains deployed.
 
 The frontend opens the first-project onboarding automatically only while the
 authenticated user's project membership list is empty. Loading the demo project


### PR DESCRIPTION
## Summary

- Documents the public demo architecture decision and alternatives.
- Adds backend guest-demo guards for abuse-prone side effects: extra projects, invitations, account changes, media uploads, public-library writes, crop-species proposals, and moderator requests.
- Keeps expired-but-not-yet-cleaned guest demo accounts restricted until cleanup deletes them.
- Deletes the previous temporary guest workspace immediately when a visitor starts a fresh guest demo, and makes `Demo verlassen` robust if the session marker is missing.
- Adds regression tests for guest-demo restrictions and cleanup behavior.

## Companion ops change

- Companion PR: https://github.com/stipsitzm/OpenFarmPlanner-ops/pull/8
- It schedules `cleanup_guest_demo_sessions` every 30 minutes so expired guest workspaces are removed promptly.

## Validation

- `cd backend && pdm run test accounts/tests/test_guest_demo.py farm/tests/test_public_cultures_api.py farm/tests/test_note_attachments_processing.py crops/tests/test_views.py farm/tests/test_demo_project.py farm/tests/test_projects_api.py` (`146 passed`)
- `cd backend && pdm run test config/tests/test_throttle_settings.py` (`9 passed`)
- `cd backend && pdm run python manage.py check`
- `cd frontend && npx vitest run src/__tests__/App.test.tsx src/__tests__/AuthContext.test.tsx src/auth/authApi.test.ts` (`53 passed`)

## Known issue

- `cd frontend && npm run lint` currently fails on an unrelated pre-existing unused `act` import in `frontend/src/__tests__/NotesDrawerAttachments.test.tsx`; no frontend files are changed in this PR.
