### PR TITLE
fix: prevent production language flicker

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -49,6 +49,15 @@ which is exactly the behaviour those users had before the setting existed.
   `localStorage` so the next page load starts in the right language instead of
   flashing the wrong one.
 
+Production public pages are prerendered as German HTML for SEO. Before the SPA
+bundle loads, `frontend/index.html` runs a small synchronous preboot resolver
+with the same local-storage/browser/fallback priority used by
+`resolveInitialLanguage()`. If that resolver selects English, it updates
+`<html lang>` immediately and hides the German prerendered root until React has
+committed the first app render. This prevents the production-only flash where
+an English visitor could briefly see the German prerendered landing page while
+the hashed JavaScript assets were still loading.
+
 ### Guest chooses a language, then signs in
 
 | Account preference | Result |

--- a/docs/seo-and-indexing.md
+++ b/docs/seo-and-indexing.md
@@ -87,20 +87,36 @@ Every other route (`/app/*`, `/login`, `/register`, password reset,
 invitations, ...) is untouched — only the four files above are written. The
 browser then boots the exact same SPA bundle as before
 (`createRoot(...).render(...)`, no hydration) and takes over normal
-client-side routing/i18n immediately; there is nothing route- or
-language-specific baked into the JS bundle itself, only the initial markup.
+client-side routing/i18n immediately; there is no route-specific content baked
+into the JS bundle itself, only the initial markup.
 
-Because the app hardcodes German (`SITE_LANGUAGE = 'de'` in `seoConfig.ts`,
-`i18next`'s `lng`/`fallbackLng` both `'de'`, no client-side language
-detection), the prerendered HTML and the first client render are always in
-the same language — there is no content-language flash to guard against
-today. If language detection is ever added, prerendering must be revisited
-together with it.
+The prerendered public HTML uses the site's canonical SEO language
+(`SITE_LANGUAGE = 'de'` in `seoConfig.ts`). Runtime UI language is still
+user-specific, so an English visitor must not see the German prerendered body
+while the production bundle is loading. `frontend/index.html` therefore runs a
+tiny synchronous language preboot before first paint: it reads
+`localStorage["ui.language"]`, then `navigator.languages`/`navigator.language`,
+falls back to English, sets `<html lang>`, and hides the prerendered root when
+the initial UI language is not German. React removes that guard in a
+`useLayoutEffect` after the first committed app render, so the first visible
+client-rendered frame is already in the resolved language.
 
 `PRERENDER_OUT_DIR` (default `dist`) tells the script which build output
 directory to prerender into, mirroring `vite build --outDir`; ops sets this
 alongside `VITE_BASE_PATH` when building into `dist-production`/`dist-staging`
 (see `OpenFarmPlanner-ops/deploy/deploy_frontend.sh`).
+
+Production must serve the generated files with distinct cache policies:
+
+- HTML documents (`index.html`, `app-shell.html`, prerendered route
+  `index.html` files) are revalidated (`Cache-Control: no-cache`) so each
+  deploy immediately delivers the current hashed asset references.
+- Vite content-hashed JavaScript/CSS/assets under `assets/` may be long-lived
+  and immutable because a content change creates a new filename.
+- Non-hashed JSON resources, including legacy public locale files under
+  `public/locales/`, are revalidated rather than cached immutably.
+- There is no service worker in the frontend build, so stale startup behavior
+  should be debugged through the browser/proxy/static-host cache layers.
 
 **Local verification caveat:** `vite preview`'s static file server only
 resolves a route's prerendered `index.html` for a *trailing-slash* request

--- a/frontend/e2e/public-page-prerendering.spec.ts
+++ b/frontend/e2e/public-page-prerendering.spec.ts
@@ -22,6 +22,20 @@ function distPathFor(routePath: string): string {
     : path.join(distDir, routePath.replace(/^\//, ''), 'index.html');
 }
 
+async function holdJavaScriptRequests(page: import('@playwright/test').Page): Promise<() => void> {
+  let release: () => void = () => {};
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await page.route(/\/assets\/.*\.js$/, async (route) => {
+    await barrier;
+    await route.continue();
+  });
+
+  return release;
+}
+
 test.describe('public page prerendering', () => {
   test('build produces a real index.html for every public route', () => {
     for (const route of PUBLIC_INDEXABLE_ROUTES) {
@@ -89,6 +103,48 @@ test.describe('public page prerendering', () => {
     const html = readFileSync(appShellPath, 'utf-8');
     expect(html).toMatch(/<div id="root">\s*<\/div>/);
     expect(html).not.toMatch(/<h1[^>]*>[^<]+<\/h1>/);
+  });
+
+  test('English browser language hides German prerendered landing text until the SPA is ready', async ({ browser }) => {
+    const context = await browser.newContext({ locale: 'en-US' });
+    const page = await context.newPage();
+    const releaseJavaScript = await holdJavaScriptRequests(page);
+
+    await page.goto('/', { waitUntil: 'commit' });
+    await page.waitForFunction(() => document.documentElement.dataset.initialUiLanguage === 'en');
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveClass(/ofp-hide-prerender/);
+    await expect(page.getByText('Open-Source-Anbauplaner für den Gemüsebau.')).not.toBeVisible();
+    await expect(page.getByText('Open-source crop planning for vegetable production.')).not.toBeVisible();
+
+    releaseJavaScript();
+
+    await expect(page.getByText('Open-source crop planning for vegetable production.')).toBeVisible();
+    await expect(page.getByText('Open-Source-Anbauplaner für den Gemüsebau.')).not.toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).not.toHaveClass(/ofp-hide-prerender/);
+    await context.close();
+  });
+
+  test('a persisted English language hides German prerendered landing text before app code loads', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('ui.language', 'en');
+    });
+    const releaseJavaScript = await holdJavaScriptRequests(page);
+
+    await page.goto('/', { waitUntil: 'commit' });
+    await page.waitForFunction(() => document.documentElement.dataset.initialUiLanguage === 'en');
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveClass(/ofp-hide-prerender/);
+    await expect(page.getByText('Open-Source-Anbauplaner für den Gemüsebau.')).not.toBeVisible();
+
+    releaseJavaScript();
+
+    await expect(page.getByText('Open-source crop planning for vegetable production.')).toBeVisible();
+    await expect(page.getByText('Open-Source-Anbauplaner für den Gemüsebau.')).not.toBeVisible();
+    await expect(page.locator('html')).not.toHaveClass(/ofp-hide-prerender/);
   });
 
   test('a JS-disabled browser sees the real privacy policy content, not a blank shell', async ({ browser }) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,67 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      (function () {
+        var supported = { de: true, en: true };
+        var fallback = 'en';
+
+        function normalize(value) {
+          var normalized = String(value || '').trim().toLowerCase().replace(/_/g, '-');
+          if (!normalized) {
+            return null;
+          }
+          var base = normalized.split('-')[0];
+          return supported[base] ? base : null;
+        }
+
+        function readStoredPreference() {
+          try {
+            var stored = window.localStorage.getItem('ui.language');
+            if (stored === null) {
+              return null;
+            }
+            var normalized = String(stored || '').trim().toLowerCase();
+            if (normalized === 'auto') {
+              return 'auto';
+            }
+            return normalize(normalized);
+          } catch (error) {
+            return null;
+          }
+        }
+
+        function detectBrowserLanguage() {
+          var candidates = [];
+          if (Array.isArray(navigator.languages)) {
+            candidates = candidates.concat(navigator.languages);
+          }
+          if (navigator.language) {
+            candidates.push(navigator.language);
+          }
+          for (var i = 0; i < candidates.length; i += 1) {
+            var language = normalize(candidates[i]);
+            if (language) {
+              return language;
+            }
+          }
+          return fallback;
+        }
+
+        var preference = readStoredPreference();
+        var language = preference && preference !== 'auto' ? preference : detectBrowserLanguage();
+        document.documentElement.lang = language;
+        document.documentElement.dataset.initialUiLanguage = language;
+        if (language !== 'de') {
+          document.documentElement.classList.add('ofp-hide-prerender');
+        }
+      }());
+    </script>
+    <style>
+      html.ofp-hide-prerender #root {
+        visibility: hidden;
+      }
+    </style>
     <title>OpenFarmPlanner</title>
     <!-- The meta description (and canonical/robots/OG/Twitter tags) are
          injected at build time by build/seoPlugin.ts from seoConfig.ts /

--- a/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
+++ b/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NotesDrawer } from '../components/data-grid/NotesDrawer';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,19 +10,22 @@ import { CommandProvider } from './commands/CommandProvider'
 import { AuthProvider } from './auth/AuthContext'
 import { FocusManagerProvider } from './focus/FocusManager'
 import LanguageSynchronizer from './i18n/LanguageSynchronizer'
+import PrerenderLanguageVisibilityGate from './startup/PrerenderLanguageVisibilityGate'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <AuthProvider>
-        <LanguageSynchronizer />
-        <FocusManagerProvider>
-          <CommandProvider>
-            <App />
-          </CommandProvider>
-        </FocusManagerProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <PrerenderLanguageVisibilityGate>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <AuthProvider>
+          <LanguageSynchronizer />
+          <FocusManagerProvider>
+            <CommandProvider>
+              <App />
+            </CommandProvider>
+          </FocusManagerProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </PrerenderLanguageVisibilityGate>
   </StrictMode>,
 )

--- a/frontend/src/startup/PrerenderLanguageVisibilityGate.tsx
+++ b/frontend/src/startup/PrerenderLanguageVisibilityGate.tsx
@@ -1,0 +1,13 @@
+import { useLayoutEffect, type ReactNode } from 'react';
+
+interface PrerenderLanguageVisibilityGateProps {
+  children: ReactNode;
+}
+
+export default function PrerenderLanguageVisibilityGate({ children }: PrerenderLanguageVisibilityGateProps) {
+  useLayoutEffect(() => {
+    document.documentElement.classList.remove('ofp-hide-prerender');
+  }, []);
+
+  return children;
+}


### PR DESCRIPTION
## Summary
- add a synchronous language preboot in `index.html` before React/Vite assets load
- hide German prerendered public HTML for non-German initial sessions until React has committed the first app render
- add production-preview Playwright regressions for English browser language and persisted English hard reloads with hashed JS intentionally held back
- update i18n/SEO docs with the production prerender root cause and cache expectations

## Root Cause
Production public pages are build-time prerendered in the canonical SEO language, German. On a slow or cached production reload, the browser could paint that static German landing-page HTML before the hashed JavaScript bundle initialized i18n and replaced the root with the English React render. Local Vite dev does not serve this prerendered body, which is why the flicker was production-only.

The translation bundles themselves are statically imported and available synchronously; the visible flicker happened before React mounted, not because English JSON loaded late or because `/auth/me/` was required for the landing page language.

## Deployment Note
A companion ops PR is required for production cache/fallback headers so HTML and non-hashed JSON revalidate while hashed assets remain immutable.

## Checks
- `cd frontend && npm run build`
- `cd frontend && npm run lint` (passes with existing warnings)
- `cd frontend && npm run test -- src/__tests__/languageResolution.test.ts src/__tests__/i18n.test.ts build/prerenderSeo.test.ts`
- `cd frontend && npx playwright test e2e/public-page-prerendering.spec.ts --grep "English browser language|persisted English|SPA takes over|JS-disabled browser sees the landing"`
- `cd frontend && npx playwright test e2e/public-page-prerendering.spec.ts`
- `cd frontend && npm run test` reached 1697/1698 passing; `PublicCropLibraryPage.test.tsx > keeps the saved public culture details when a stale list refresh resolves later` failed once as a timing flake, and passed when rerun in isolation with `npm run test -- src/__tests__/PublicCropLibraryPage.test.tsx -t "keeps the saved public culture details when a stale list refresh resolves later"`
