### PR TITLE
feat: add shareable demo link

### DIFF
--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -86,6 +86,15 @@ it reuses existing project scoping, authentication sessions, and demo seeding.
 The main ongoing maintenance cost is keeping the demo template realistic and
 ensuring the cleanup cron remains deployed.
 
+`/demo` is the shareable public entry point for emails and software
+directories. It deliberately does **not** auto-start a guest session on page
+load: email clients, link scanners and preview bots may request the URL, and a
+GET request must not create temporary projects or consume the guest-demo rate
+limit. Visitors explicitly start the demo from the page, which then uses the
+same guest-demo API flow as the landing-page button. The route is reachable but
+non-indexable (`noindex` at runtime and disallowed in `robots.txt`) because its
+purpose is direct sharing rather than search traffic.
+
 The frontend opens the first-project onboarding automatically only while the
 authenticated user's project membership list is empty. Loading the demo project
 from the project switcher remains a separate action.

--- a/docs/seo-and-indexing.md
+++ b/docs/seo-and-indexing.md
@@ -23,6 +23,8 @@ Explicitly **not** indexable (disallowed in `robots.txt` and served with a
 - `/app/*` — the authenticated application
 - `/login`, `/register`, `/activate`, `/forgot-password`, `/reset-password`,
   `/confirm-email-change`
+- `/demo` — shareable guest-demo entry page; direct links are supported, but
+  the route is not intended for search indexing
 - `/invite/*`, `/invitation`
 
 The single source of truth for both lists is

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import {
 
 
 const HomePage = React.lazy(() => import('./pages/public/HomePage'));
+const DemoPage = React.lazy(() => import('./pages/public/DemoPage'));
 const ImprintPage = React.lazy(() => import('./pages/public/ImprintPage'));
 const PrivacyPolicyPage = React.lazy(() => import('./pages/public/PrivacyPolicyPage'));
 const TermsOfServicePage = React.lazy(() => import('./pages/public/TermsOfServicePage'));
@@ -177,6 +178,10 @@ function createAppRouter(basename: string) {
         {
           index: true,
           element: withLazyFallback(<HomePage />),
+        },
+        {
+          path: 'demo',
+          element: withLazyFallback(<DemoPage />),
         },
         {
           path: 'impressum',

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -269,6 +269,37 @@ describe('App', () => {
     });
   });
 
+  it('renders the shareable demo link without starting a session automatically', async () => {
+    window.history.pushState({}, '', '/demo');
+
+    render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
+
+    expect(await screen.findByRole('heading', { name: 'Demo ausprobieren' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Demo jetzt starten' })).toBeInTheDocument();
+    expect(authState.startGuestDemo).not.toHaveBeenCalled();
+  });
+
+  it('starts the public guest demo from the shareable demo link', async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, '', '/demo');
+
+    authState.startGuestDemo.mockImplementationOnce(async () => {
+      const demoUser = createGuestDemoUser();
+      authState.user = demoUser;
+      authState.activeProjectId = demoUser.resolved_project_id;
+      return demoUser;
+    });
+
+    render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
+
+    await user.click(await screen.findByRole('button', { name: 'Demo jetzt starten' }));
+
+    await waitFor(() => {
+      expect(authState.startGuestDemo).toHaveBeenCalledTimes(1);
+      expect(window.location.pathname).toBe('/app/fields-beds');
+    });
+  });
+
   it('prevents duplicate public guest demo requests while one is running', async () => {
     let resolveRequest: (value: AuthUser) => void = () => {};
     authState.startGuestDemo.mockImplementationOnce(() => new Promise((resolve) => {

--- a/frontend/src/i18n/locales/de/home.json
+++ b/frontend/src/i18n/locales/de/home.json
@@ -36,6 +36,14 @@
       }
     }
   },
+  "demoPage": {
+    "title": "Demo ausprobieren",
+    "subtitle": "Teste OpenFarmPlanner sofort mit einem temporären Beispielprojekt.",
+    "description": "Der Link kann direkt geteilt werden. Ein Demo-Arbeitsbereich wird erst erstellt, wenn du die Demo aktiv startest.",
+    "startAction": "Demo jetzt starten",
+    "backToLanding": "Zur Startseite",
+    "safetyNote": "Die Demo benötigt keine Registrierung. Änderungen werden automatisch wieder gelöscht und sind nicht für echte Produktivdaten gedacht."
+  },
   "statusNote": "OpenFarmPlanner befindet sich aktuell in der Beta-Phase und wird laufend weiterentwickelt.",
   "statusOpenSource": {
     "text": "Als Open-Source-Projekt freuen wir uns über Feedback, Ideen und Mitentwicklung.",
@@ -309,6 +317,7 @@
   "seo": {
     "titles": {
       "landing": "OpenFarmPlanner – Anbauplanung für den Gemüsebau",
+      "demo": "Demo ausprobieren – OpenFarmPlanner",
       "imprint": "Impressum – OpenFarmPlanner",
       "privacy": "Datenschutzerklärung – OpenFarmPlanner",
       "terms": "Nutzungsbedingungen – OpenFarmPlanner",

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -36,6 +36,14 @@
       }
     }
   },
+  "demoPage": {
+    "title": "Try the demo",
+    "subtitle": "Test OpenFarmPlanner instantly with a temporary example project.",
+    "description": "This link can be shared directly. A demo workspace is created only when you actively start the demo.",
+    "startAction": "Start demo now",
+    "backToLanding": "Back to home",
+    "safetyNote": "The demo does not require registration. Changes are deleted automatically and are not intended for real production data."
+  },
   "statusNote": "OpenFarmPlanner is currently in beta and is being continuously improved.",
   "statusOpenSource": {
     "text": "As an open-source project, we welcome feedback, ideas, and contributions.",
@@ -309,6 +317,7 @@
   "seo": {
     "titles": {
       "landing": "OpenFarmPlanner – planting planning for vegetable growing",
+      "demo": "Try the demo – OpenFarmPlanner",
       "imprint": "Imprint – OpenFarmPlanner",
       "privacy": "Privacy policy – OpenFarmPlanner",
       "terms": "Terms of service – OpenFarmPlanner",

--- a/frontend/src/pages/public/DemoPage.tsx
+++ b/frontend/src/pages/public/DemoPage.tsx
@@ -1,0 +1,229 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router';
+
+import HeroImage from '../../components/HeroImage';
+import LegalLinks from '../../components/legal/LegalLinks';
+import { PublicLanguageSwitcher } from '../../i18n/LanguageSwitcher';
+import { useTranslation } from '../../i18n';
+import { publicAssetUrl } from '../../utils/publicAssetUrl';
+import { useGuestDemoStart } from './useGuestDemoStart';
+
+const HERO_TEXT_SHADOW = '0 1px 3px rgba(0,0,0,0.7), 0 2px 12px rgba(0,0,0,0.5)';
+
+export default function DemoPage() {
+  const { t } = useTranslation('home');
+  const {
+    isStartingDemo,
+    demoStartError,
+    isDemoRetryBlocked,
+    isDemoButtonDisabled,
+    compactRetryTime,
+    startDemo,
+  } = useGuestDemoStart();
+
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', bgcolor: 'background.default' }}>
+      <Box component="main" sx={{ flex: 1 }}>
+        <Container maxWidth="lg" sx={{ width: '100%', pt: { xs: 1.5, md: 2 }, pb: { xs: 2.5, md: 3 } }}>
+          <Stack
+            component="header"
+            direction="row"
+            spacing={{ xs: 0.75, sm: 2 }}
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ minHeight: 48 }}
+          >
+            <Button
+              component={RouterLink}
+              to="/"
+              color="inherit"
+              startIcon={<ArrowBackIcon fontSize="small" />}
+              sx={{
+                minHeight: 44,
+                px: { xs: 0.75, sm: 1 },
+                textTransform: 'none',
+                fontWeight: 500,
+              }}
+            >
+              {t('demoPage.backToLanding')}
+            </Button>
+            <PublicLanguageSwitcher dense />
+          </Stack>
+        </Container>
+
+        <Box
+          component="section"
+          sx={{
+            position: 'relative',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            px: 2,
+            py: { xs: 5, md: 7 },
+            overflow: 'hidden',
+            bgcolor: '#0d1f12',
+            minHeight: { xs: 'calc(100vh - 180px)', md: 'calc(100vh - 190px)' },
+            '@media (max-height: 480px)': {
+              py: 2,
+              minHeight: 'auto',
+            },
+          }}
+        >
+          <HeroImage alt={t('landing.heroImageAlt')} />
+          <Box
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              width: '100%',
+              maxWidth: 680,
+              mx: 'auto',
+              px: { xs: 3, sm: 4, md: 5 },
+              py: { xs: 3.5, sm: 4, md: 4.5 },
+              borderRadius: { xs: 4, md: 6 },
+              border: '1px solid rgba(255,255,255,0.28)',
+              backgroundColor: 'rgba(8,24,14,0.52)',
+              backdropFilter: 'blur(18px)',
+              WebkitBackdropFilter: 'blur(18px)',
+              boxShadow: '0 12px 40px rgba(0,0,0,0.28)',
+              '@media (max-height: 480px)': {
+                py: 2.5,
+              },
+            }}
+          >
+            <Stack spacing={{ xs: 2.1, md: 2.4 }} alignItems="center">
+              <Box
+                component="img"
+                src={publicAssetUrl('/favicon.png')}
+                alt=""
+                aria-hidden
+                sx={{
+                  width: { xs: 44, md: 52 },
+                  height: 'auto',
+                  opacity: 0.95,
+                }}
+              />
+              <Typography
+                variant="h2"
+                component="h1"
+                sx={{
+                  fontSize: { xs: '2rem', md: '2.7rem' },
+                  fontWeight: 600,
+                  lineHeight: 1.1,
+                  color: '#fff',
+                  textShadow: HERO_TEXT_SHADOW,
+                  '@media (max-height: 480px)': {
+                    fontSize: '1.7rem',
+                  },
+                }}
+              >
+                {t('demoPage.title')}
+              </Typography>
+              <Typography
+                variant="h6"
+                sx={{
+                  maxWidth: 560,
+                  fontWeight: 500,
+                  lineHeight: 1.4,
+                  color: '#fff',
+                  textShadow: HERO_TEXT_SHADOW,
+                  '@media (max-height: 480px)': {
+                    fontSize: '1rem',
+                  },
+                }}
+              >
+                {t('demoPage.subtitle')}
+              </Typography>
+              <Typography
+                sx={{
+                  maxWidth: 600,
+                  lineHeight: 1.65,
+                  color: 'rgba(255,255,255,0.94)',
+                  textShadow: HERO_TEXT_SHADOW,
+                  '@media (max-height: 480px)': {
+                    display: 'none',
+                  },
+                }}
+              >
+                {t('demoPage.description')}
+              </Typography>
+
+              <Button
+                variant="contained"
+                size="large"
+                disabled={isDemoButtonDisabled}
+                startIcon={isStartingDemo ? <CircularProgress color="inherit" size={18} /> : <PlayArrowIcon />}
+                onClick={() => {
+                  void startDemo();
+                }}
+                sx={{
+                  minHeight: 48,
+                  borderRadius: 2,
+                  px: { xs: 2.4, sm: 3.5 },
+                  whiteSpace: 'nowrap',
+                  boxShadow: (theme) => theme.shadows[3],
+                }}
+              >
+                {isStartingDemo
+                  ? t('landing.actions.startingDemo')
+                  : isDemoRetryBlocked
+                    ? t('landing.actions.demoAvailableIn', { time: compactRetryTime })
+                    : t('demoPage.startAction')}
+              </Button>
+
+              {demoStartError ? (
+                <Alert
+                  severity="error"
+                  sx={{
+                    width: '100%',
+                    maxWidth: 560,
+                    minHeight: 48,
+                    textAlign: 'left',
+                    color: 'error.dark',
+                    bgcolor: 'rgba(255,255,255,0.96)',
+                    border: '1px solid',
+                    borderColor: 'error.light',
+                    '& .MuiAlert-icon': {
+                      color: 'error.main',
+                    },
+                  }}
+                >
+                  {demoStartError}
+                </Alert>
+              ) : null}
+
+              <Typography
+                sx={{
+                  maxWidth: 560,
+                  fontSize: { xs: '0.88rem', md: '0.94rem' },
+                  lineHeight: 1.55,
+                  color: 'rgba(255,255,255,0.9)',
+                  textShadow: HERO_TEXT_SHADOW,
+                }}
+              >
+                {t('demoPage.safetyNote')}
+              </Typography>
+            </Stack>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box component="footer" sx={{ py: 2.5 }}>
+        <Container maxWidth="md">
+          <LegalLinks sx={{ justifyContent: 'center' }} />
+        </Container>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -11,17 +11,15 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { SyntheticEvent } from 'react';
-import type { TFunction } from 'i18next';
-import { Link as RouterLink, useNavigate } from 'react-router';
-import { AuthApiError } from '../../auth/authApi';
-import { useAuth } from '../../auth/useAuth';
+import { Link as RouterLink } from 'react-router';
 import { useTranslation } from '../../i18n';
 import LegalLinks from '../../components/legal/LegalLinks';
 import HeroImage from '../../components/HeroImage';
 import { publicAssetUrl } from '../../utils/publicAssetUrl';
 import { PublicLanguageSwitcher } from '../../i18n/LanguageSwitcher';
+import { useGuestDemoStart } from './useGuestDemoStart';
 
 const PRODUCT_TOUR_ITEMS = [
   {
@@ -71,7 +69,6 @@ const PRODUCT_TOUR_ITEMS = [
 type ProductTourKey = (typeof PRODUCT_TOUR_ITEMS)[number]['key'];
 
 const HERO_TEXT_SHADOW = '0 1px 3px rgba(0,0,0,0.7), 0 2px 12px rgba(0,0,0,0.5)';
-const RETRY_DETAIL_PATTERN = /available in (\d+(?:\.\d+)?) seconds/i;
 
 // Single glassmorphism card behind all hero content (heading, description,
 // buttons, beta note, GitHub link) - one clearly-bounded, semi-transparent
@@ -93,69 +90,6 @@ const HERO_CARD_SX = {
   boxShadow: '0 12px 40px rgba(0,0,0,0.28)',
 };
 
-function parsePositiveSeconds(value: unknown): number | null {
-  const parsed = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return null;
-  }
-  return Math.ceil(parsed);
-}
-
-function getRetrySeconds(error: AuthApiError): number | null {
-  const explicitRetry = parsePositiveSeconds(error.retryAfterSeconds);
-  if (explicitRetry !== null) {
-    return explicitRetry;
-  }
-
-  const payloadRetry = parsePositiveSeconds(error.payload?.retry_after);
-  if (payloadRetry !== null) {
-    return payloadRetry;
-  }
-
-  if (typeof error.payload?.detail !== 'string') {
-    return null;
-  }
-
-  const match = RETRY_DETAIL_PATTERN.exec(error.payload.detail);
-  return match ? parsePositiveSeconds(match[1]) : null;
-}
-
-function formatRetryTime(seconds: number, t: TFunction<'home'>): string {
-  if (seconds < 60) {
-    return t('landing.retryTime.lessThanMinute');
-  }
-
-  const totalMinutes = Math.ceil(seconds / 60);
-  if (totalMinutes < 60) {
-    return t('landing.retryTime.minutes', { count: totalMinutes });
-  }
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (minutes === 0) {
-    return t('landing.retryTime.hours', { count: hours });
-  }
-  return t('landing.retryTime.hoursAndMinutes', { hours, minutes });
-}
-
-function formatCompactRetryTime(seconds: number, t: TFunction<'home'>): string {
-  if (seconds < 60) {
-    return t('landing.retryTime.compact.lessThanMinute');
-  }
-
-  const totalMinutes = Math.ceil(seconds / 60);
-  if (totalMinutes < 60) {
-    return t('landing.retryTime.compact.minutes', { count: totalMinutes });
-  }
-
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (minutes === 0) {
-    return t('landing.retryTime.compact.hours', { count: hours });
-  }
-  return t('landing.retryTime.compact.hoursAndMinutes', { hours, minutes });
-}
-
 /**
  * Public landing page with refined spacing and modern visual hierarchy.
  *
@@ -163,83 +97,21 @@ function formatCompactRetryTime(seconds: number, t: TFunction<'home'>): string {
  */
 export default function HomePage() {
   const { t, i18n } = useTranslation('home');
-  const navigate = useNavigate();
-  const { startGuestDemo } = useAuth();
-  const [isStartingDemo, setIsStartingDemo] = useState(false);
-  const [demoStartError, setDemoStartError] = useState<string | null>(null);
-  const [retryAvailableAt, setRetryAvailableAt] = useState<number | null>(null);
-  const [currentTime, setCurrentTime] = useState(() => Date.now());
+  const {
+    isStartingDemo,
+    demoStartError,
+    isDemoRetryBlocked,
+    isDemoButtonDisabled,
+    compactRetryTime,
+    startDemo,
+  } = useGuestDemoStart();
   const [activeTourKey, setActiveTourKey] = useState<ProductTourKey>('areas');
   const activeTourItem = PRODUCT_TOUR_ITEMS.find((item) => item.key === activeTourKey) ?? PRODUCT_TOUR_ITEMS[0];
   const screenshotLanguage = (i18n.resolvedLanguage ?? i18n.language ?? 'de').split('-')[0] === 'en' ? 'en' : 'de';
   const activeTourImage = activeTourItem.images[screenshotLanguage];
-  const retryRemainingSeconds = retryAvailableAt === null
-    ? 0
-    : Math.max(0, Math.ceil((retryAvailableAt - currentTime) / 1000));
-  const isDemoRetryBlocked = retryRemainingSeconds > 0;
-  const isDemoButtonDisabled = isStartingDemo || isDemoRetryBlocked;
-
-  useEffect(() => {
-    if (retryAvailableAt === null) {
-      return undefined;
-    }
-
-    if (retryAvailableAt <= Date.now()) {
-      setRetryAvailableAt(null);
-      return undefined;
-    }
-
-    const intervalId = window.setInterval(() => {
-      const nextTime = Date.now();
-      setCurrentTime(nextTime);
-      if (retryAvailableAt <= nextTime) {
-        setRetryAvailableAt(null);
-      }
-    }, 1000);
-
-    return () => window.clearInterval(intervalId);
-  }, [retryAvailableAt]);
 
   const handleTourChange = (_event: SyntheticEvent, value: ProductTourKey): void => {
     setActiveTourKey(value);
-  };
-
-  const handleStartDemo = async (): Promise<void> => {
-    if (isDemoButtonDisabled) {
-      return;
-    }
-
-    setIsStartingDemo(true);
-    setDemoStartError(null);
-    try {
-      await startGuestDemo();
-      navigate('/app/fields-beds');
-    } catch (error) {
-      if (error instanceof AuthApiError && error.status === 429) {
-        const retrySeconds = getRetrySeconds(error);
-        if (retrySeconds !== null) {
-          const retryUntil = Date.now() + retrySeconds * 1000;
-          setCurrentTime(Date.now());
-          setRetryAvailableAt(retryUntil);
-          setDemoStartError(t('landing.actions.demoRateLimitedWithTime', {
-            time: formatRetryTime(retrySeconds, t),
-          }));
-        } else {
-          setDemoStartError(t('landing.actions.demoRateLimited'));
-        }
-      } else if (error instanceof AuthApiError && error.isNetworkError) {
-        setDemoStartError(t('landing.actions.demoNetworkError'));
-      } else if (error instanceof AuthApiError && error.status !== undefined && error.status >= 500) {
-        setDemoStartError(t('landing.actions.demoServerError'));
-      } else if (error instanceof AuthApiError && error.code === 'unexpected_response') {
-        setDemoStartError(t('landing.actions.demoUnexpectedResponse'));
-      } else {
-        console.error('Error starting guest demo:', error);
-        setDemoStartError(t('landing.actions.demoStartError'));
-      }
-    } finally {
-      setIsStartingDemo(false);
-    }
   };
 
   return (
@@ -392,7 +264,7 @@ export default function HomePage() {
                   variant="text"
                   disabled={isDemoButtonDisabled}
                   onClick={() => {
-                    void handleStartDemo();
+                    void startDemo();
                   }}
                   sx={{
                     minHeight: 34,
@@ -423,7 +295,7 @@ export default function HomePage() {
                     </Stack>
                   ) : isDemoRetryBlocked ? (
                     t('landing.actions.demoAvailableIn', {
-                      time: formatCompactRetryTime(retryRemainingSeconds, t),
+                      time: compactRetryTime,
                     })
                   ) : (
                     t('landing.actions.demoWithoutRegistration')

--- a/frontend/src/pages/public/useGuestDemoStart.ts
+++ b/frontend/src/pages/public/useGuestDemoStart.ts
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import type { TFunction } from 'i18next';
+import { useNavigate } from 'react-router';
+
+import { AuthApiError } from '../../auth/authApi';
+import { useAuth } from '../../auth/useAuth';
+import { useTranslation } from '../../i18n';
+
+const RETRY_DETAIL_PATTERN = /available in (\d+(?:\.\d+)?) seconds/i;
+
+function parsePositiveSeconds(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return Math.ceil(parsed);
+}
+
+function getRetrySeconds(error: AuthApiError): number | null {
+  const explicitRetry = parsePositiveSeconds(error.retryAfterSeconds);
+  if (explicitRetry !== null) {
+    return explicitRetry;
+  }
+
+  const payloadRetry = parsePositiveSeconds(error.payload?.retry_after);
+  if (payloadRetry !== null) {
+    return payloadRetry;
+  }
+
+  if (typeof error.payload?.detail !== 'string') {
+    return null;
+  }
+
+  const match = RETRY_DETAIL_PATTERN.exec(error.payload.detail);
+  return match ? parsePositiveSeconds(match[1]) : null;
+}
+
+function formatRetryTime(seconds: number, t: TFunction<'home'>): string {
+  if (seconds < 60) {
+    return t('landing.retryTime.lessThanMinute');
+  }
+
+  const totalMinutes = Math.ceil(seconds / 60);
+  if (totalMinutes < 60) {
+    return t('landing.retryTime.minutes', { count: totalMinutes });
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) {
+    return t('landing.retryTime.hours', { count: hours });
+  }
+  return t('landing.retryTime.hoursAndMinutes', { hours, minutes });
+}
+
+function formatCompactRetryTime(seconds: number, t: TFunction<'home'>): string {
+  if (seconds < 60) {
+    return t('landing.retryTime.compact.lessThanMinute');
+  }
+
+  const totalMinutes = Math.ceil(seconds / 60);
+  if (totalMinutes < 60) {
+    return t('landing.retryTime.compact.minutes', { count: totalMinutes });
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) {
+    return t('landing.retryTime.compact.hours', { count: hours });
+  }
+  return t('landing.retryTime.compact.hoursAndMinutes', { hours, minutes });
+}
+
+export interface GuestDemoStartState {
+  isStartingDemo: boolean;
+  demoStartError: string | null;
+  retryRemainingSeconds: number;
+  isDemoRetryBlocked: boolean;
+  isDemoButtonDisabled: boolean;
+  compactRetryTime: string | null;
+  startDemo: () => Promise<void>;
+}
+
+export function useGuestDemoStart(): GuestDemoStartState {
+  const { t } = useTranslation('home');
+  const navigate = useNavigate();
+  const { startGuestDemo } = useAuth();
+  const [isStartingDemo, setIsStartingDemo] = useState(false);
+  const [demoStartError, setDemoStartError] = useState<string | null>(null);
+  const [retryAvailableAt, setRetryAvailableAt] = useState<number | null>(null);
+  const [currentTime, setCurrentTime] = useState(() => Date.now());
+  const retryRemainingSeconds = retryAvailableAt === null
+    ? 0
+    : Math.max(0, Math.ceil((retryAvailableAt - currentTime) / 1000));
+  const isDemoRetryBlocked = retryRemainingSeconds > 0;
+  const isDemoButtonDisabled = isStartingDemo || isDemoRetryBlocked;
+  const compactRetryTime = isDemoRetryBlocked ? formatCompactRetryTime(retryRemainingSeconds, t) : null;
+
+  useEffect(() => {
+    if (retryAvailableAt === null) {
+      return undefined;
+    }
+
+    if (retryAvailableAt <= Date.now()) {
+      setRetryAvailableAt(null);
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      const nextTime = Date.now();
+      setCurrentTime(nextTime);
+      if (retryAvailableAt <= nextTime) {
+        setRetryAvailableAt(null);
+      }
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [retryAvailableAt]);
+
+  const startDemo = async (): Promise<void> => {
+    if (isDemoButtonDisabled) {
+      return;
+    }
+
+    setIsStartingDemo(true);
+    setDemoStartError(null);
+    try {
+      await startGuestDemo();
+      navigate('/app/fields-beds');
+    } catch (error) {
+      if (error instanceof AuthApiError && error.status === 429) {
+        const retrySeconds = getRetrySeconds(error);
+        if (retrySeconds !== null) {
+          const retryUntil = Date.now() + retrySeconds * 1000;
+          setCurrentTime(Date.now());
+          setRetryAvailableAt(retryUntil);
+          setDemoStartError(t('landing.actions.demoRateLimitedWithTime', {
+            time: formatRetryTime(retrySeconds, t),
+          }));
+        } else {
+          setDemoStartError(t('landing.actions.demoRateLimited'));
+        }
+      } else if (error instanceof AuthApiError && error.isNetworkError) {
+        setDemoStartError(t('landing.actions.demoNetworkError'));
+      } else if (error instanceof AuthApiError && error.status !== undefined && error.status >= 500) {
+        setDemoStartError(t('landing.actions.demoServerError'));
+      } else if (error instanceof AuthApiError && error.code === 'unexpected_response') {
+        setDemoStartError(t('landing.actions.demoUnexpectedResponse'));
+      } else {
+        console.error('Error starting guest demo:', error);
+        setDemoStartError(t('landing.actions.demoStartError'));
+      }
+    } finally {
+      setIsStartingDemo(false);
+    }
+  };
+
+  return {
+    isStartingDemo,
+    demoStartError,
+    retryRemainingSeconds,
+    isDemoRetryBlocked,
+    isDemoButtonDisabled,
+    compactRetryTime,
+    startDemo,
+  };
+}

--- a/frontend/src/seo/RouteSeo.tsx
+++ b/frontend/src/seo/RouteSeo.tsx
@@ -35,6 +35,7 @@ import { FALLBACK_LANGUAGE, normalizeLanguageTag } from '../i18n/languages';
  */
 const ROUTE_TITLE_KEYS: Record<string, string> = {
   '/': 'seo.titles.landing',
+  '/demo': 'seo.titles.demo',
   '/impressum': 'seo.titles.imprint',
   '/datenschutz': 'seo.titles.privacy',
   '/nutzungsbedingungen': 'seo.titles.terms',

--- a/frontend/src/seo/__tests__/RouteSeo.test.tsx
+++ b/frontend/src/seo/__tests__/RouteSeo.test.tsx
@@ -59,4 +59,13 @@ describe('RouteSeo', () => {
     );
     await waitFor(() => expect(robotsContent()).toBe('noindex, nofollow'));
   });
+
+  it('sets noindex on the shareable demo start route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/demo']}>
+        <RouteSeo />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(robotsContent()).toBe('noindex, nofollow'));
+  });
 });

--- a/frontend/src/seo/__tests__/seoConfig.test.ts
+++ b/frontend/src/seo/__tests__/seoConfig.test.ts
@@ -80,6 +80,7 @@ describe('isPathIndexable', () => {
       '/app',
       '/app/dashboard',
       '/app/cultures',
+      '/demo',
       '/login',
       '/register',
       '/activate/abc/def',

--- a/frontend/src/seo/seoConfig.ts
+++ b/frontend/src/seo/seoConfig.ts
@@ -102,7 +102,8 @@ export interface PublicRoute {
  * Publicly reachable, canonical, indexable routes.
  *
  * ONLY genuinely public information pages belong here — never login,
- * registration, password reset, invitations, demo or in-app (`/app/*`) routes.
+ * registration, password reset, invitations, demo-start or in-app (`/app/*`)
+ * routes.
  * When a new public route is added (e.g. the planned public crop library under
  * `/crops`), add it here and it flows automatically into the sitemap and,
  * via `build/prerender.ts`, into build-time prerendered HTML.
@@ -135,11 +136,13 @@ export const PUBLIC_INDEXABLE_ROUTES: readonly PublicRoute[] = [
 /**
  * Path prefixes that must never be indexed and are disallowed in robots.txt.
  *
- * These cover the authenticated application shell and all authentication /
- * account-management flows. They intentionally do NOT include public info pages.
+ * These cover the authenticated application shell, the shareable demo-start
+ * page and all authentication / account-management flows. They intentionally
+ * do NOT include public info pages.
  */
 export const NON_INDEXABLE_PATH_PREFIXES: readonly string[] = [
   '/app',
+  '/demo',
   '/login',
   '/register',
   '/activate',


### PR DESCRIPTION
## Summary
- add a shareable public `/demo` route for email/software-directory links
- keep demo session creation behind an explicit button click, so link scanners and previews cannot create temporary projects
- reuse the existing guest-demo start/rate-limit/error handling through a shared hook used by the landing page and the demo page
- mark `/demo` as non-indexable and document the route in the demo/SEO docs

## Intended Link
After deployment, the shareable demo entry URL is:

`https://openfarmplanner.org/demo`

## Notes
The route does not auto-start the demo on page load. This avoids accidental guest sessions from email clients, bots, and link unfurlers. Visitors click the page's start button to create the temporary guest demo workspace.

## Checks
- `cd frontend && npm run test -- src/__tests__/App.test.tsx src/__tests__/i18nKeyParity.test.ts src/seo/__tests__/seoConfig.test.ts src/seo/__tests__/RouteSeo.test.tsx src/seo/__tests__/seoAssets.test.ts`
- `cd frontend && npm run lint` (passes with existing warnings)
- `cd frontend && npm run build`
- production-preview browser check for `/demo` at 1280x800, 390x844, and 844x390
