### PR TITLE
fix: localize planning culture labels

### DIFF
--- a/backend/farm/planning/serializers.py
+++ b/backend/farm/planning/serializers.py
@@ -5,11 +5,14 @@ from datetime import date
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
+from config.languages import DEFAULT_LANGUAGE_CODE, resolve_request_language
+from crops.models import CropSpecies
 from farm.common.serializer_fields import (
     AuditUserSerializer,
     _resolve_active_project_from_serializer,
 )
-from farm.models import PlantingPlan, Task
+from farm.models import Culture, PlantingPlan, Task
+from farm.services.demo_project import find_demo_culture_species, is_demo_project_description
 
 
 class PlantingPlanSerializer(serializers.ModelSerializer):
@@ -18,6 +21,8 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
     # a culture chosen yet) — see get_attribute in rest_framework/fields.py.
     culture_name = serializers.CharField(source='culture.name', read_only=True, allow_null=True)
     culture_variety = serializers.CharField(source='culture.variety', read_only=True, allow_blank=True, allow_null=True)
+    culture_display_name = serializers.SerializerMethodField(read_only=True)
+    culture_display_language_code = serializers.SerializerMethodField(read_only=True)
     culture_display_color = serializers.CharField(source='culture.display_color', read_only=True, allow_blank=True, allow_null=True)
     culture_propagation_duration_days = serializers.IntegerField(source='culture.propagation_duration_days', read_only=True, allow_null=True)
     culture_cultivation_type = serializers.CharField(source='culture.cultivation_type', read_only=True, allow_blank=True, allow_null=True)
@@ -55,6 +60,38 @@ class PlantingPlanSerializer(serializers.ModelSerializer):
 
     def get_bed_name(self, obj: PlantingPlan) -> str | None:
         return obj.bed.name if obj.bed else None
+
+    def _request_language(self) -> str:
+        request = self.context.get('request')
+        if request is None:
+            return DEFAULT_LANGUAGE_CODE
+        return resolve_request_language(request)
+
+    def _get_culture_species(self, culture: Culture) -> CropSpecies | None:
+        if culture.crop_species_id:
+            return culture.crop_species
+        if not is_demo_project_description(culture.project.description if culture.project_id else None):
+            return None
+
+        cache = self.context.setdefault('_demo_culture_species_by_name', {})
+        if culture.name not in cache:
+            cache[culture.name] = find_demo_culture_species(culture.name)
+        return cache[culture.name]
+
+    def _get_localized_culture_name(self, obj: PlantingPlan) -> tuple[str | None, str]:
+        culture = obj.culture
+        if culture is None:
+            return None, ''
+        species = self._get_culture_species(culture)
+        if species is None:
+            return culture.name, ''
+        return species.localized_name(self._request_language())
+
+    def get_culture_display_name(self, obj: PlantingPlan) -> str | None:
+        return self._get_localized_culture_name(obj)[0]
+
+    def get_culture_display_language_code(self, obj: PlantingPlan) -> str:
+        return self._get_localized_culture_name(obj)[1]
 
     def get_harvest_date(self, obj: PlantingPlan) -> date | None:
         """Return harvest start only when culture growth timing is known."""

--- a/backend/farm/planning/views.py
+++ b/backend/farm/planning/views.py
@@ -89,7 +89,8 @@ class PlantingPlanViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.Mod
     """
     queryset = (
         PlantingPlan.objects
-        .select_related('culture', 'bed', 'created_by', 'updated_by')
+        .select_related('culture', 'culture__crop_species', 'culture__project', 'bed', 'created_by', 'updated_by')
+        .prefetch_related('culture__crop_species__translations')
         .annotate(note_attachment_count=Count('attachments'))
         .order_by('-planting_date')
     )

--- a/backend/farm/services/demo_project.py
+++ b/backend/farm/services/demo_project.py
@@ -12,6 +12,8 @@ from django.utils.text import slugify
 
 from accounts.models import UserProjectSettings
 from config.languages import UI_LANGUAGE_AUTO, normalize_language_tag, parse_accept_language
+from crops.models import CropSpecies
+from crops.services import find_species_by_common_name
 from farm.models import (
     Bed,
     BedLayout,
@@ -210,6 +212,23 @@ def reset_project_demo_data(project: Project) -> None:
 def is_demo_project_description(description: str | None) -> bool:
     """Return whether a project description marks one of the demo templates."""
     return (description or '') in DEMO_PROJECT_DESCRIPTIONS
+
+
+def find_demo_culture_species(name: str | None) -> CropSpecies | None:
+    """Resolve a demo crop name through all language variants in the template."""
+    species = find_species_by_common_name(name)
+    if species is not None:
+        return species
+
+    for text in DEMO_TEXT.values():
+        for culture_key, culture_text in text['cultures'].items():
+            if culture_text[0] != name:
+                continue
+            for fallback_text in DEMO_TEXT.values():
+                species = find_species_by_common_name(fallback_text['cultures'][culture_key][0])
+                if species is not None:
+                    return species
+    return None
 
 
 def resolve_demo_language(language_code: str | None) -> str:
@@ -727,6 +746,7 @@ def _create_cultures(project: Project, suppliers: dict[str, Supplier], *, langua
         culture = Culture.objects.create(
             name=spec.name,
             variety=spec.variety,
+            crop_species=find_demo_culture_species(spec.name),
             crop_family=spec.crop_family,
             nutrient_demand=spec.nutrient_demand,
             cultivation_types=spec.cultivation_types,

--- a/backend/farm/tests/test_demo_project.py
+++ b/backend/farm/tests/test_demo_project.py
@@ -33,6 +33,7 @@ class DemoProjectServiceTests(TestCase):
         self.assertEqual(Supplier.objects.filter(project=result.project).count(), 3)
         self.assertEqual(FieldLayout.objects.filter(project=result.project).count(), 4)
         self.assertEqual(BedLayout.objects.filter(project=result.project).count(), 12)
+        self.assertEqual(Culture.objects.filter(project=result.project, crop_species__isnull=False).count(), 8)
         self.assertTrue(
             Culture.objects.filter(
                 project=result.project,

--- a/backend/farm/tests/test_planting_plan_api.py
+++ b/backend/farm/tests/test_planting_plan_api.py
@@ -4,7 +4,9 @@ import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 
+from crops.models import CropSpecies, CropSpeciesTranslation
 from farm.models import Bed, Culture, Field, Location, PlantingPlan, Project, ProjectMembership
+from farm.services.demo_project import DEMO_PROJECT_DESCRIPTION
 
 User = get_user_model()
 
@@ -50,11 +52,110 @@ def test_planting_plan_list_includes_culture_propagation_metadata():
     assert response.status_code == 200
     row = response.json()['results'][0]
     assert row['culture_name'] == 'Salat'
+    assert row['culture_display_name'] == 'Salat'
+    assert row['culture_display_language_code'] == ''
     assert row['culture_variety'] == 'Bijella'
     assert row['culture_display_color'] == '#00aa44'
     assert row['culture_propagation_duration_days'] == 25
     assert row['culture_cultivation_type'] == 'pre_cultivation'
     assert row['culture_cultivation_types'] == ['pre_cultivation', 'direct_sowing']
+
+
+@pytest.mark.django_db
+def test_planting_plan_list_localizes_linked_culture_species_name():
+    user = User.objects.create_user(
+        username='localized-plan-user',
+        email='localized-plan@example.com',
+        password='testpass',
+        is_active=True,
+    )
+    project = Project.objects.create(name='Localized Project', slug='localized-project')
+    ProjectMembership.objects.create(user=user, project=project, role='admin')
+
+    species = CropSpecies.objects.get(name_normalized='karotte')
+    CropSpeciesTranslation.objects.update_or_create(
+        species=species,
+        language_code='de',
+        defaults={'common_name': 'Karotte'},
+    )
+    CropSpeciesTranslation.objects.update_or_create(
+        species=species,
+        language_code='en',
+        defaults={'common_name': 'Carrot'},
+    )
+    location = Location.objects.create(name='Hof', project=project)
+    field = Field.objects.create(name='Nordfeld', location=location, project=project)
+    bed = Bed.objects.create(name='Beet A', field=field, project=project)
+    culture = Culture.objects.create(
+        name='Karotte',
+        variety='Nantaise 2',
+        crop_species=species,
+        project=project,
+    )
+    PlantingPlan.objects.create(
+        culture=culture,
+        bed=bed,
+        planting_date=date(2026, 3, 12),
+        project=project,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    client.defaults['HTTP_X_PROJECT_ID'] = str(project.id)
+
+    response = client.get('/openfarmplanner/api/planting-plans/', HTTP_ACCEPT_LANGUAGE='en')
+
+    assert response.status_code == 200
+    row = response.json()['results'][0]
+    assert row['culture_name'] == 'Karotte'
+    assert row['culture_display_name'] == 'Carrot'
+    assert row['culture_display_language_code'] == 'en'
+    assert row['culture_variety'] == 'Nantaise 2'
+
+
+@pytest.mark.django_db
+def test_planting_plan_list_localizes_legacy_demo_culture_names():
+    user = User.objects.create_user(
+        username='legacy-demo-plan-user',
+        email='legacy-demo-plan@example.com',
+        password='testpass',
+        is_active=True,
+    )
+    project = Project.objects.create(
+        name='Legacy Demo Project',
+        slug='legacy-demo-project',
+        description=DEMO_PROJECT_DESCRIPTION,
+    )
+    ProjectMembership.objects.create(user=user, project=project, role='admin')
+
+    species = CropSpecies.objects.get(name='Rote Rübe')
+    CropSpeciesTranslation.objects.update_or_create(
+        species=species,
+        language_code='en',
+        defaults={'common_name': 'Beetroot'},
+    )
+    location = Location.objects.create(name='Hof', project=project)
+    field = Field.objects.create(name='Nordfeld', location=location, project=project)
+    bed = Bed.objects.create(name='Beet A', field=field, project=project)
+    culture = Culture.objects.create(name='Rote Bete', variety='Robuschka', project=project)
+    PlantingPlan.objects.create(
+        culture=culture,
+        bed=bed,
+        planting_date=date(2026, 3, 12),
+        project=project,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    client.defaults['HTTP_X_PROJECT_ID'] = str(project.id)
+
+    response = client.get('/openfarmplanner/api/planting-plans/', HTTP_ACCEPT_LANGUAGE='en')
+
+    assert response.status_code == 200
+    row = response.json()['results'][0]
+    assert row['culture_name'] == 'Rote Bete'
+    assert row['culture_display_name'] == 'Beetroot'
+    assert row['culture_display_language_code'] == 'en'
 
 
 @pytest.mark.django_db

--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -21,9 +21,11 @@ The demo data exists in German and English. The authenticated API and guest
 demo resolve the language from the request/UI language and create new demo
 projects with matching project, location, field, bed, crop, crop-family, and
 plan-note text. Existing demo projects are user-entered project content after
-creation and are not translated in place. The management command defaults to
-German for existing screenshot workflows and accepts `--language en` for the
-English fixture.
+creation and are not translated in place. Demo cultures are linked to
+`CropSpecies` when a matching species exists, so planning read views can show
+localized crop names without rewriting the stored demo records. The management
+command defaults to German for existing screenshot workflows and accepts
+`--language en` for the English fixture.
 
 The public landing page also starts an isolated anonymous guest project from this template. Guest workspaces are editable but session-bound, reset on the next browser session, and removed after their short server-side retention period by `cleanup_guest_demo_sessions`. This is separate from the persistent personal demo project.
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -11,6 +11,12 @@ i18n bug, so each has its own storage and its own rules:
 | **Public crop-library content** | the library | yes, via translation rows | `CropSpeciesTranslation`, `PublicCultureTranslation` |
 | **User project content** | the user's project | **never** | the project tables, verbatim |
 
+Project culture records keep their stored `Culture.name` unchanged for editing,
+history, and exports. Read-only planning surfaces may additionally show a
+localized species display name when the culture is linked to `CropSpecies`;
+the API exposes that as `culture_display_name` beside the verbatim
+`culture_name`.
+
 ---
 
 ## 1. UI language

--- a/frontend/src/__tests__/AccountSettingsPage.test.tsx
+++ b/frontend/src/__tests__/AccountSettingsPage.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { updatePublicDisplayName } from '../auth/authApi';
 import AccountSettingsPage from '../pages/AccountSettingsPage';
 import { DEV_ONBOARDING_PREVIEW_STORAGE_KEY } from '../projects/devOnboardingPreview';
 
@@ -116,6 +118,17 @@ describe('AccountSettingsPage', () => {
 
     expect(moderatorRequestApiMocks.create).toHaveBeenCalledWith('Ich kenne mich mit Kulturarten aus.');
     expect(await screen.findByText('Deine Anfrage wird geprüft.')).toBeInTheDocument();
+  });
+
+  it('saves the public display name with Enter', async () => {
+    render(<MemoryRouter><AccountSettingsPage /></MemoryRouter>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Namen festlegen' }));
+    const input = screen.getByLabelText('Name bei Veröffentlichungen');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Martin Stipsitz{Enter}');
+
+    expect(updatePublicDisplayName).toHaveBeenCalledWith('Martin Stipsitz');
   });
 
   it('describes the moderator role in terms of reviewing proposals, not approving all public culture edits (BUG-M03 copy regression guard)', async () => {

--- a/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
+++ b/frontend/src/__tests__/NotesDrawerAttachments.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NotesDrawer } from '../components/data-grid/NotesDrawer';

--- a/frontend/src/__tests__/ganttChartUtils.test.ts
+++ b/frontend/src/__tests__/ganttChartUtils.test.ts
@@ -190,6 +190,41 @@ describe('buildSeedlingTaskGroups', () => {
     expect(groups[0].tasks[0].startDate.toISOString()).toContain('2026-04-15');
   });
 
+  it('prefers localized planting plan culture names in seedling labels', () => {
+    const groups = buildSeedlingTaskGroups({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [
+        {
+          id: 77,
+          name: 'Karotte',
+          variety: 'Nantaise 2',
+          propagation_duration_days: 21,
+          cultivation_type: 'pre_cultivation',
+        },
+      ],
+      plantingPlans: [
+        {
+          id: 9,
+          culture: 77,
+          culture_name: 'Karotte',
+          culture_display_name: 'Carrot',
+          culture_variety: 'Nantaise 2',
+          bed: 100,
+          planting_date: '2026-05-10',
+          cultivation_type: 'pre_cultivation',
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe('Carrot (Nantaise 2)');
+    expect(groups[0].tasks[0].name).toBe('Carrot (Nantaise 2)');
+    expect(groups[0].tasks[0].cultureName).toBe('Carrot');
+  });
+
   it('ignores direct sowings and incomplete propagation data', () => {
     const groups = buildSeedlingTaskGroups({
       locations,
@@ -257,6 +292,34 @@ describe('buildSeedlingTaskGroups', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].tasks).toHaveLength(2);
     expect(groups[0].tasks[0].name).toBe('Salat (Bijella)');
+  });
+
+  it('prefers localized planting plan culture names in occupancy labels', () => {
+    const groups = buildFieldOccupancyTaskGroups({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [
+        {
+          id: 21,
+          culture: 42,
+          culture_name: 'Karotte',
+          culture_display_name: 'Carrot',
+          culture_variety: 'Nantaise 2',
+          bed: 100,
+          planting_date: '2026-03-01',
+          harvest_date: '2026-04-15',
+          harvest_end_date: '2026-04-30',
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].tasks[0].name).toBe('Carrot (Nantaise 2)');
+    expect(groups[0].tasks[0].cultureName).toBe('Carrot');
+    expect(groups[0].tasks[1].name).toBe('Carrot (Nantaise 2) (Ernte)');
   });
 
   it('omits location level in occupancy hierarchy when only one used location exists', () => {
@@ -551,6 +614,33 @@ describe('buildFieldOccupancyHierarchy', () => {
     expect(bedNode?.tasks).toHaveLength(2);
     expect(bedNode?.tasks[0].name).toBe('Salat (Bijella)');
     expect(bedNode?.tasks[1].name).toBe('Salat (Bijella) (Ernte)');
+  });
+
+  it('prefers localized planting plan culture names in hierarchy task labels', () => {
+    const nodes = buildFieldOccupancyHierarchy({
+      locations,
+      fields,
+      beds,
+      displayYear: 2026,
+      cultures: [],
+      plantingPlans: [
+        {
+          id: 21,
+          culture: 42,
+          culture_name: 'Karotte',
+          culture_display_name: 'Carrot',
+          culture_variety: 'Nantaise 2',
+          bed: 100,
+          planting_date: '2026-03-01',
+          harvest_date: '2026-04-15',
+          harvest_end_date: '2026-04-30',
+        },
+      ],
+    });
+
+    const bedNode = nodes.find((n) => n.type === 'bed');
+    expect(bedNode?.tasks[0].name).toBe('Carrot (Nantaise 2)');
+    expect(bedNode?.tasks[1].name).toBe('Carrot (Nantaise 2) (Ernte)');
   });
 
   it('returns an empty list when there are no locations', () => {

--- a/frontend/src/__tests__/locationDerivedTasks.test.ts
+++ b/frontend/src/__tests__/locationDerivedTasks.test.ts
@@ -54,6 +54,35 @@ describe('deriveLocationTasks', () => {
     expect(tasks[1][0].date).toBe('2026-04-12');
   });
 
+  it('prefers localized planting plan culture names', () => {
+    const cultures: Culture[] = [
+      { id: 5, name: 'Karotte', cultivation_types: ['direct_sowing'], growth_duration_days: 60 },
+    ];
+    const plans: PlantingPlan[] = [
+      {
+        id: 99,
+        culture: 5,
+        culture_name: 'Karotte',
+        culture_display_name: 'Carrot',
+        bed: 100,
+        planting_date: '2026-04-12',
+        cultivation_type: 'direct_sowing',
+      },
+    ];
+
+    const tasks = deriveLocationTasks({
+      locations,
+      fields,
+      beds,
+      plantingPlans: plans,
+      cultures,
+      today: new Date('2026-04-01'),
+    });
+
+    expect(tasks[1][0].cultureName).toBe('Carrot');
+    expect(tasks[1][1].cultureName).toBe('Carrot');
+  });
+
   it('skips duplicates and tasks with missing relation data', () => {
     const cultures: Culture[] = [{ id: 6, name: 'Salat', cultivation_types: ['direct_sowing'] }];
     const plans: PlantingPlan[] = [

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -512,6 +512,8 @@ export interface PlantingPlan {
   culture: number | null;
   cultivation_type?: CultivationType | '';
   culture_name?: string | null;
+  culture_display_name?: string | null;
+  culture_display_language_code?: string | null;
   culture_variety?: string | null;
   culture_display_color?: string | null;
   culture_propagation_duration_days?: number | null;

--- a/frontend/src/components/forms/formLayout.ts
+++ b/frontend/src/components/forms/formLayout.ts
@@ -13,6 +13,13 @@ const responsiveFieldWidth = (desktopWidth: number) => ({
   alignItems: 'flex-start',
 } as const);
 
+const stackedFieldWidth = (desktopWidth: number) => ({
+  width: { xs: '100%', sm: desktopWidth },
+  maxWidth: '100%',
+  minWidth: 0,
+  alignItems: 'flex-start',
+} as const);
+
 /** Numbers, dates, versions, priorities, and other short values. */
 export const compactFieldSx = responsiveFieldWidth(180);
 
@@ -22,8 +29,14 @@ export const smallFieldSx = responsiveFieldWidth(224);
 /** Families, suppliers, coordinates, and other moderately long values. */
 export const mediumFieldSx = responsiveFieldWidth(300);
 
+/** Column-stacked variant of `mediumFieldSx` without a flex-basis height. */
+export const mediumStackedFieldSx = stackedFieldWidth(300);
+
 /** Names, email addresses, URLs, and other potentially long single-line values. */
 export const wideFieldSx = responsiveFieldWidth(400);
+
+/** Column-stacked variant of `wideFieldSx` without a flex-basis height. */
+export const wideSingleColumnFieldSx = stackedFieldWidth(400);
 
 /**
  * Multiline fields stacked vertically (not inside `formRowSx`'s row flex).

--- a/frontend/src/pages/AccountSettingsPage.tsx
+++ b/frontend/src/pages/AccountSettingsPage.tsx
@@ -28,7 +28,11 @@ import { useTranslation } from '../i18n';
 import { useNavigationBlocker } from '../hooks/useNavigationBlocker';
 import { enableDevOnboardingPreview } from '../projects/devOnboardingPreview';
 import { clearContextMenuHintDismissals } from '../components/data-grid';
-import { mediumFieldSx, wideFieldSx, wideStackedFieldSx } from '../components/forms/formLayout';
+import {
+  mediumStackedFieldSx,
+  wideSingleColumnFieldSx,
+  wideStackedFieldSx,
+} from '../components/forms/formLayout';
 import { actionButtonSx, useSectionSubmit } from './accountSettingsForm';
 import {
   InlineEditor,
@@ -256,7 +260,7 @@ export default function AccountSettingsPage() {
                 label={t('displayName')}
                 value={displayName}
                 onChange={(event) => setDisplayName(event.target.value)}
-                sx={wideFieldSx}
+                sx={wideSingleColumnFieldSx}
                 slotProps={{ htmlInput: { maxLength: 255 } }}
               />
             </InlineEditor>
@@ -294,7 +298,7 @@ export default function AccountSettingsPage() {
                 label={t('publicProfile.publicDisplayName')}
                 value={publicDisplayName}
                 onChange={(event) => setPublicDisplayName(event.target.value)}
-                sx={wideFieldSx}
+                sx={wideSingleColumnFieldSx}
                 helperText={t('publicProfile.helperText')}
                 slotProps={{ htmlInput: { maxLength: 255 } }}
               />
@@ -386,7 +390,7 @@ export default function AccountSettingsPage() {
             <TextField
               label={t('security.newEmail')}
               type="email"
-              sx={wideFieldSx}
+              sx={wideSingleColumnFieldSx}
               value={newEmail}
               onChange={(event) => setNewEmail(event.target.value)}
             />
@@ -394,7 +398,7 @@ export default function AccountSettingsPage() {
               <TextField
                 label={t('currentPassword')}
                 type="password"
-                sx={mediumFieldSx}
+                sx={mediumStackedFieldSx}
                 value={emailPassword}
                 onChange={(event) => setEmailPassword(event.target.value)}
               />
@@ -412,21 +416,21 @@ export default function AccountSettingsPage() {
             <TextField
               label={t('currentPassword')}
               type="password"
-              sx={mediumFieldSx}
+              sx={mediumStackedFieldSx}
               value={currentPassword}
               onChange={(event) => setCurrentPassword(event.target.value)}
             />
             <TextField
               label={t('security.newPassword')}
               type="password"
-              sx={mediumFieldSx}
+              sx={mediumStackedFieldSx}
               value={newPassword}
               onChange={(event) => setNewPassword(event.target.value)}
             />
             <TextField
               label={t('security.repeatNewPassword')}
               type="password"
-              sx={mediumFieldSx}
+              sx={mediumStackedFieldSx}
               value={repeatPassword}
               onChange={(event) => setRepeatPassword(event.target.value)}
             />
@@ -488,7 +492,7 @@ export default function AccountSettingsPage() {
             <Typography>{t('restoreDescription')}</Typography>
             {hasPassword ? (
               <TextField
-                sx={mediumFieldSx}
+                sx={mediumStackedFieldSx}
                 type="password"
                 label={t('currentPassword')}
                 value={deletePassword}
@@ -496,7 +500,7 @@ export default function AccountSettingsPage() {
               />
             ) : null}
             <TextField
-              sx={wideFieldSx}
+              sx={wideSingleColumnFieldSx}
               label={t('deletePhraseLabel')}
               value={deleteConfirmationText}
               onChange={(event) => setDeleteConfirmationText(event.target.value)}

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -778,11 +778,12 @@ function PlantingPlans() {
 
   const getCultureLabel = (row: PlantingPlanRow): string => {
     const linkedCulture = cultures.find((culture) => culture.id === row.culture);
-    if (row.culture_name) {
-      if (linkedCulture?.variety && !row.culture_name.includes(`(${linkedCulture.variety})`)) {
-        return `${row.culture_name} (${linkedCulture.variety})`;
+    const cultureDisplayName = row.culture_display_name || row.culture_name;
+    if (cultureDisplayName) {
+      if (linkedCulture?.variety && !cultureDisplayName.includes(`(${linkedCulture.variety})`)) {
+        return `${cultureDisplayName} (${linkedCulture.variety})`;
       }
-      return row.culture_name;
+      return cultureDisplayName;
     }
     const fallback = cultureOptions.find((option) => option.value === row.culture);
     return fallback?.label ?? "—";
@@ -1546,7 +1547,7 @@ function PlantingPlans() {
         ) : null}
 
         {!shouldShowPrerequisiteState && <PageSurface
-          variant="fullWorkspace"
+          variant={isMobile ? "fullWorkspace" : "contentFit"}
           sx={isMobile ? { position: 'fixed', top: '-9999px', left: 0, width: '100vw', height: 1, overflow: 'hidden', pointerEvents: 'none', visibility: 'hidden' } : undefined}
         >
           <EditableDataGrid<PlantingPlanRow>

--- a/frontend/src/pages/accountSettingsCards.tsx
+++ b/frontend/src/pages/accountSettingsCards.tsx
@@ -2,7 +2,7 @@
 // alerts, the inline editor wrapper, and the settings card shell.
 
 import { Alert, Button, Card, CardContent, Collapse, Stack, Typography, type SxProps, type Theme } from '@mui/material';
-import type { ReactNode } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import { useTranslation } from '../i18n';
 import { actionButtonSx, type SectionSubmit } from './accountSettingsForm';
 
@@ -28,15 +28,24 @@ interface InlineEditorProps {
 
 export function InlineEditor({ open, saveLabel, onSave, onCancel, submitting, saveDisabled = false, sx, children }: InlineEditorProps) {
   const { t } = useTranslation('account');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (submitting || saveDisabled) {
+      return;
+    }
+    onSave();
+  };
+
   return (
     <Collapse in={open} unmountOnExit>
-      <Stack spacing={2} sx={sx}>
+      <Stack component="form" spacing={2} sx={sx} onSubmit={handleSubmit}>
         {children}
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
-          <Button variant="contained" onClick={onSave} disabled={submitting || saveDisabled} sx={actionButtonSx}>
+          <Button type="submit" variant="contained" disabled={submitting || saveDisabled} sx={actionButtonSx}>
             {saveLabel}
           </Button>
-          <Button variant="text" onClick={onCancel} disabled={submitting} sx={actionButtonSx}>
+          <Button type="button" variant="text" onClick={onCancel} disabled={submitting} sx={actionButtonSx}>
             {t('cancel')}
           </Button>
         </Stack>

--- a/frontend/src/pages/ganttChartUtils.ts
+++ b/frontend/src/pages/ganttChartUtils.ts
@@ -149,6 +149,10 @@ export function formatCultureDisplayLabel(cultureName?: string | null, variety?:
   return normalizedCultureName || normalizedVariety || 'Unbekannte Kultur';
 }
 
+function getPlanCultureDisplayName(plan: Pick<PlantingPlan, 'culture_display_name' | 'culture_name'>): string {
+  return plan.culture_display_name || plan.culture_name || '';
+}
+
 export function formatSeedlingTooltipTitle(task: Pick<GanttTask, 'cultureName' | 'cultureVariety' | 'name'>): string {
   return formatCultureDisplayLabel(task.cultureName || task.name, task.cultureVariety);
 }
@@ -165,11 +169,11 @@ export function formatPlantCount(value: number): string {
   return formatLocalizedNumber(value, 'de-DE', { maximumFractionDigits: 0 });
 }
 
-function formatCultureLabel(culture?: Culture, fallbackName?: string | null): string {
+function formatCultureLabel(culture?: Culture, fallbackName?: string | null, fallbackVariety?: string | null): string {
   if (!culture) {
     return fallbackName || 'Unbekannte Kultur';
   }
-  return formatCultureDisplayLabel(culture.name, culture.variety);
+  return formatCultureDisplayLabel(fallbackName || culture.name, fallbackVariety || culture.variety);
 }
 
 export function buildOccupancyTooltipDetails(task: Pick<
@@ -317,9 +321,10 @@ export function buildFieldOccupancyTaskGroups({
           const harvestEndDate = plan.harvest_end_date
             ? parseDateString(plan.harvest_end_date)
             : harvestStartDate;
-          const baseColor = getCultureColor(cultures, plan.culture, plan.culture_name || '', plan.culture_display_color);
+          const cultureDisplayName = getPlanCultureDisplayName(plan);
+          const baseColor = getCultureColor(cultures, plan.culture, cultureDisplayName, plan.culture_display_color);
           const cultureLabel = formatCultureDisplayLabel(
-            plan.culture_name || `Culture ${plan.culture}`,
+            cultureDisplayName || `Culture ${plan.culture}`,
             plan.culture_variety,
           );
 
@@ -331,7 +336,7 @@ export function buildFieldOccupancyTaskGroups({
             color: baseColor,
             percent: 100,
             plantingPlanId: plan.id,
-            cultureName: plan.culture_name ?? undefined,
+            cultureName: cultureDisplayName || undefined,
             cultureVariety: plan.culture_variety ?? undefined,
             areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
             notes: plan.notes,
@@ -348,7 +353,7 @@ export function buildFieldOccupancyTaskGroups({
               color: baseColor.startsWith('#') ? `${baseColor}CC` : baseColor,
               percent: 100,
               plantingPlanId: plan.id,
-              cultureName: plan.culture_name ?? undefined,
+              cultureName: cultureDisplayName || undefined,
               cultureVariety: plan.culture_variety ?? undefined,
               areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
               notes: plan.notes,
@@ -482,9 +487,10 @@ export function buildFieldOccupancyHierarchy({
       const harvestEndDate = plan.harvest_end_date
         ? parseDateString(plan.harvest_end_date)
         : harvestStartDate;
-      const baseColor = getCultureColor(cultures, plan.culture, plan.culture_name || '', plan.culture_display_color);
+      const cultureDisplayName = getPlanCultureDisplayName(plan);
+      const baseColor = getCultureColor(cultures, plan.culture, cultureDisplayName, plan.culture_display_color);
       const cultureLabel = formatCultureDisplayLabel(
-        plan.culture_name || `Culture ${plan.culture}`,
+        cultureDisplayName || `Culture ${plan.culture}`,
         plan.culture_variety,
       );
 
@@ -496,7 +502,7 @@ export function buildFieldOccupancyHierarchy({
         color: baseColor,
         percent: 100,
         plantingPlanId: plan.id,
-        cultureName: plan.culture_name ?? undefined,
+        cultureName: cultureDisplayName || undefined,
         cultureVariety: plan.culture_variety ?? undefined,
         areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
         notes: plan.notes,
@@ -513,7 +519,7 @@ export function buildFieldOccupancyHierarchy({
           color: baseColor.startsWith('#') ? `${baseColor}CC` : baseColor,
           percent: 100,
           plantingPlanId: plan.id,
-          cultureName: plan.culture_name ?? undefined,
+          cultureName: cultureDisplayName || undefined,
           cultureVariety: plan.culture_variety ?? undefined,
           areaUsage: plan.area_usage_sqm ? Number(plan.area_usage_sqm) : undefined,
           notes: plan.notes,
@@ -660,9 +666,10 @@ export function buildSeedlingTaskGroups({
       return;
     }
 
+    const cultureDisplayName = getPlanCultureDisplayName(plan);
     const cultureLabel = culture
-      ? formatCultureLabel(culture, plan.culture_name)
-      : formatCultureDisplayLabel(plan.culture_name || `Kultur ${plan.culture}`, plan.culture_variety);
+      ? formatCultureLabel(culture, cultureDisplayName || null, plan.culture_variety)
+      : formatCultureDisplayLabel(cultureDisplayName || `Kultur ${plan.culture}`, plan.culture_variety);
     const groupId = `culture-${plan.culture}`;
     const group = groupsByCulture.get(groupId) ?? {
       id: groupId,
@@ -693,7 +700,7 @@ export function buildSeedlingTaskGroups({
       color: getCultureColor(cultures, plan.culture, cultureLabel, plan.culture_display_color),
       percent: 100,
       plantingPlanId: plan.id,
-      cultureName: culture?.name || plan.culture_name || cultureLabel,
+      cultureName: cultureDisplayName || culture?.name || cultureLabel,
       cultureVariety: culture?.variety || plan.culture_variety || undefined,
       propagationStartDate,
       propagationDurationDays,

--- a/frontend/src/pages/locationDerivedTasks.ts
+++ b/frontend/src/pages/locationDerivedTasks.ts
@@ -20,6 +20,10 @@ export interface DerivedLocationTask {
 const DIRECT_SOWING = 'direct_sowing';
 const PRE_CULTIVATION = 'pre_cultivation';
 
+const getPlanCultureDisplayName = (plan: PlantingPlan): string | undefined => (
+  plan.culture_display_name || plan.culture_name || undefined
+);
+
 const isDirectSowingPlan = (plan: PlantingPlan, culture?: Culture): boolean => {
   const planType = plan.cultivation_type || plan.culture_cultivation_type;
   if (planType === DIRECT_SOWING) return true;
@@ -73,6 +77,7 @@ export function deriveLocationTasks({
     const plantingDate = parseIsoDate(plan.planting_date);
     if (!plantingDate) return;
     const culture = cultureById.get(plan.culture);
+    const cultureName = getPlanCultureDisplayName(plan) || culture?.name;
     const direct = isDirectSowingPlan(plan, culture);
     const baseTaskType: DerivedTaskType = direct ? 'sowing' : 'planting';
 
@@ -81,7 +86,7 @@ export function deriveLocationTasks({
       date: formatIsoDate(plantingDate),
       locationId: field.location,
       planId: plan.id,
-      cultureName: plan.culture_name || culture?.name,
+      cultureName,
       bedName: plan.bed_name || bed.name,
       fieldName: field.name,
     });
@@ -93,7 +98,7 @@ export function deriveLocationTasks({
         date: formatIsoDate(addUtcDays(plantingDate, -propagationDuration)),
         locationId: field.location,
         planId: plan.id,
-        cultureName: plan.culture_name || culture?.name,
+        cultureName,
         bedName: plan.bed_name || bed.name,
         fieldName: field.name,
       });
@@ -106,7 +111,7 @@ export function deriveLocationTasks({
         date: formatIsoDate(addUtcDays(plantingDate, growthDuration)),
         locationId: field.location,
         planId: plan.id,
-        cultureName: plan.culture_name || culture?.name,
+        cultureName,
         bedName: plan.bed_name || bed.name,
         fieldName: field.name,
       });


### PR DESCRIPTION
## Summary

- Add localized `culture_display_name` / `culture_display_language_code` fields to planting-plan API responses while preserving verbatim `culture_name` for stored project data.
- Use the localized display name in planting plans, occupancy calendar, seedling calendar, and derived location tasks.
- Link newly generated demo cultures to matching crop species and resolve legacy demo crop names through the bilingual demo template.
- Document the project-content vs. crop-species display-name boundary.

## Root Cause

Planting plans and calendar helpers rendered `culture_name`, which is the stored project `Culture.name`. Demo cultures were created from the language-specific template text, and older demo projects did not always carry a `crop_species` link. When the UI language changed to English, the UI chrome switched, but these read views still displayed the stored German project names.

## Validation

- `cd backend && pdm run test farm/tests/test_planting_plan_api.py farm/tests/test_demo_project.py`
- `cd backend && pdm run test`
- `cd frontend && npm run test -- src/__tests__/ganttChartUtils.test.ts src/__tests__/locationDerivedTasks.test.ts`
- `cd frontend && npm run test`
- `cd frontend && npm run lint` (passes with existing warnings)

Note: `npm run test` still prints existing jsdom warnings for unimplemented canvas/media browser APIs.