### PR TITLE
feat: restore structure summary in the occupancy calendar

### DIFF
--- a/frontend/src/__tests__/GanttChart.test.tsx
+++ b/frontend/src/__tests__/GanttChart.test.tsx
@@ -8,6 +8,7 @@ import { CommandProvider } from '../commands/CommandProvider';
 import { FocusManagerProvider } from '../focus/FocusManager';
 import GanttChartPage from '../pages/GanttChart';
 import { getGanttRenderWindow } from '../pages/ganttRenderWindow';
+import i18n from '../i18n/config';
 
 const mocks = vi.hoisted(() => ({
   locationList: vi.fn(),
@@ -192,7 +193,7 @@ vi.mock('../gantt-chart/src', () => ({
       tasks: Array<Record<string, unknown> & { id: string; name: string; plantingPlanId?: number }>;
       isExpandable?: boolean;
       isExpanded?: boolean;
-      emptyRowLabel?: string;
+      metaLabel?: string;
       rowHeightOverride?: number;
       bedId?: number;
       fieldId?: number;
@@ -286,7 +287,7 @@ vi.mock('../gantt-chart/src', () => ({
               {group.isExpanded ? 'collapse' : 'expand'}
             </button>
           ) : null}
-          {group.emptyRowLabel ? <span data-testid={`meta-${group.name}`}>{group.emptyRowLabel}</span> : null}
+          {group.metaLabel ? <span data-testid={`meta-${group.name}`}>{group.metaLabel}</span> : null}
           <span data-testid={`row-height-${group.name}`}>{group.rowHeightOverride ?? 'auto'}</span>
           {props.onGroupContextMenu ? (
             <button
@@ -1523,6 +1524,111 @@ describe('GanttChartPage', () => {
         data: { results: [{ id: 1, name: 'Karotte' }, { id: 2, name: 'Tomate' }] },
       });
     };
+
+    describe('structure summary meta line', () => {
+      it('shows Parzellen/Beete/belegt under a Standort and Beete/belegt under a Parzelle', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+
+        expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 Parzelle · 1 Beet · 1 belegt');
+        expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('1 Beet · 1 belegt');
+      });
+
+      it('does not put a meta line on Beet rows', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+
+        expect(screen.queryByTestId('meta-Karottenbeet')).not.toBeInTheDocument();
+      });
+
+      it('counts the empty Beet only once "Nur belegte Beete" is switched off', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+        // Filtered view: the pruned Leerbeet must not be counted, otherwise the
+        // Standort would claim two Beete above a single visible Beet row.
+        expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 Parzelle · 1 Beet · 1 belegt');
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Nur belegte Beete' }));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 Parzelle · 2 Beete · 1 belegt');
+        });
+        expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('2 Beete · 1 belegt');
+      });
+
+      it('narrows the counts to the beds a search actually matches', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Nur belegte Beete' }));
+        await screen.findByText('Leerbeet');
+        expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('2 Beete · 1 belegt');
+
+        fireEvent.change(screen.getByPlaceholderText('Suche nach Kultur, Beet, Parzelle oder Standort…'), {
+          target: { value: 'Karottenbeet' },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('1 Beet · 1 belegt');
+        });
+        expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 Parzelle · 1 Beet · 1 belegt');
+      });
+
+      it('keeps the counts stable when a level is collapsed', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Nur belegte Beete' }));
+        await screen.findByText('Leerbeet');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Eine Hierarchieebene ausblenden' }));
+
+        await waitFor(() => {
+          expect(screen.queryByText('Karottenbeet')).not.toBeInTheDocument();
+        });
+        // Collapsing hides rows; it does not remove beds from the structure.
+        expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 Parzelle · 2 Beete · 1 belegt');
+        expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('2 Beete · 1 belegt');
+      });
+
+      it('restricts the counts to the selected Standort', async () => {
+        setUpMultiLocationFixture();
+        renderWithAuth();
+
+        await screen.findByText('Karottenbeet');
+
+        fireEvent.mouseDown(screen.getByText('Alle Standorte'));
+        fireEvent.click(await screen.findByRole('option', { name: 'Pacht' }));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('meta-Pacht')).toHaveTextContent('1 Parzelle · 1 Beet · 1 belegt');
+        });
+        expect(screen.queryByTestId('meta-Hof')).not.toBeInTheDocument();
+      });
+
+      it('localizes the meta line in English', async () => {
+        await i18n.changeLanguage('en');
+        try {
+          setUpMultiLocationFixture();
+          renderWithAuth();
+
+          await screen.findByText('Karottenbeet');
+
+          expect(screen.getByTestId('meta-Hof')).toHaveTextContent('1 field · 1 bed · 1 occupied');
+          expect(screen.getByTestId('meta-Nordfeld')).toHaveTextContent('1 bed · 1 occupied');
+        } finally {
+          await i18n.changeLanguage('de');
+        }
+      });
+    });
 
     it('search finds a matching bed and keeps its parent Standort/Parzelle visible while hiding unrelated branches', async () => {
       setUpMultiLocationFixture();

--- a/frontend/src/__tests__/gantt-chart/TaskList.metaLabel.test.tsx
+++ b/frontend/src/__tests__/gantt-chart/TaskList.metaLabel.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { GanttChart, ViewMode, type TaskGroup } from "../../gantt-chart/src";
+import { TREE_INDENT_PX, TREE_META_LABEL_OFFSET_PX } from "../../gantt-chart/src/utils";
+
+const treeRows: TaskGroup[] = [
+  {
+    id: "location-1",
+    name: "Hof",
+    depth: 0,
+    isExpandable: true,
+    isExpanded: true,
+    metaLabel: "2 Parzellen · 6 Beete · 5 belegt",
+    rowHeightOverride: 40,
+    tasks: [],
+  },
+  {
+    id: "field-10",
+    name: "Nordfeld",
+    depth: 1,
+    isExpandable: true,
+    isExpanded: true,
+    metaLabel: "3 Beete · 2 belegt",
+    rowHeightOverride: 40,
+    tasks: [],
+  },
+  {
+    id: "bed-100",
+    name: "Beet 1",
+    depth: 2,
+    tasks: [
+      {
+        id: "task-1",
+        name: "Karotte",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 0, 10),
+      },
+    ],
+  },
+];
+
+const renderTree = (tasks: TaskGroup[] = treeRows) =>
+  render(<GanttChart tasks={tasks} viewMode={ViewMode.MONTH} viewModes={false} />);
+
+const metaElements = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>('[data-rmg-component="task-group-meta"]'));
+
+describe("TaskList structure meta line", () => {
+  test("renders a group's metaLabel as its own line under the row name", () => {
+    const { container } = renderTree();
+
+    expect(metaElements(container).map((element) => element.textContent)).toEqual([
+      "2 Parzellen · 6 Beete · 5 belegt",
+      "3 Beete · 2 belegt",
+    ]);
+  });
+
+  test("keeps the meta line inside the row it belongs to", () => {
+    const { container } = renderTree();
+
+    const [locationMeta] = metaElements(container);
+    expect(locationMeta.closest('[data-rmg-component="task-group"]'))
+      .toHaveAttribute("data-group-id", "location-1");
+  });
+
+  test("indents the meta line to line up with the name at each depth", () => {
+    const { container } = renderTree();
+
+    const [locationMeta, fieldMeta] = metaElements(container);
+    expect(locationMeta).toHaveStyle({ paddingLeft: `${TREE_META_LABEL_OFFSET_PX}px` });
+    expect(fieldMeta).toHaveStyle({
+      paddingLeft: `${TREE_INDENT_PX + TREE_META_LABEL_OFFSET_PX}px`,
+    });
+  });
+
+  test("adds no meta line for rows without a metaLabel", () => {
+    const { container } = renderTree();
+
+    const bedRow = container.querySelector('[data-group-id="bed-100"]');
+    expect(bedRow?.querySelector('[data-rmg-component="task-group-meta"]')).toBeNull();
+  });
+
+  test("ignores a blank metaLabel instead of rendering an empty line", () => {
+    const { container } = renderTree([
+      { ...treeRows[0], metaLabel: "   " },
+      treeRows[2],
+    ]);
+
+    expect(metaElements(container)).toHaveLength(0);
+  });
+
+  test("renders no meta line for flat (non-tree) groups", () => {
+    const { container } = renderTree([
+      {
+        id: "group-1",
+        name: "Beet 1",
+        metaLabel: "3 Beete · 2 belegt",
+        tasks: [
+          {
+            id: "task-1",
+            name: "Karotte",
+            startDate: new Date(2026, 0, 1),
+            endDate: new Date(2026, 0, 10),
+          },
+        ],
+      },
+    ]);
+
+    expect(metaElements(container)).toHaveLength(0);
+  });
+
+  test("keeps the row name rendered next to the meta line", () => {
+    renderTree();
+
+    expect(screen.getByText("Hof")).toBeInTheDocument();
+    expect(screen.getByText("Nordfeld")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/occupancyStructureSummary.test.ts
+++ b/frontend/src/__tests__/occupancyStructureSummary.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+
+import i18n from '../i18n/config';
+import type { OccupancyHierarchyNode } from '../pages/ganttChartUtils';
+import {
+  buildOccupancyStructureSummaries,
+  formatOccupancyStructureSummary,
+} from '../pages/occupancyStructureSummary';
+
+const location = (
+  id: number,
+  name: string,
+): OccupancyHierarchyNode => ({
+  id: `location-${id}`,
+  parentId: null,
+  type: 'location',
+  name,
+  locationId: id,
+  tasks: [],
+  // Deliberately wrong on purpose: the summary must be derived from the node
+  // list it is given, never from these pre-computed full-tree totals.
+  bedCount: 99,
+  occupiedBedCount: 99,
+  planCount: 99,
+});
+
+const field = (
+  id: number,
+  name: string,
+  locationId: number,
+): OccupancyHierarchyNode => ({
+  id: `field-${id}`,
+  parentId: `location-${locationId}`,
+  type: 'field',
+  name,
+  locationId,
+  fieldId: id,
+  tasks: [],
+  bedCount: 99,
+  occupiedBedCount: 99,
+  planCount: 99,
+});
+
+const bed = (
+  id: number,
+  name: string,
+  locationId: number,
+  fieldId: number,
+  occupied: boolean,
+): OccupancyHierarchyNode => ({
+  id: `bed-${id}`,
+  parentId: `field-${fieldId}`,
+  type: 'bed',
+  name,
+  locationId,
+  fieldId,
+  bedId: id,
+  tasks: [],
+  bedCount: 1,
+  occupiedBedCount: occupied ? 1 : 0,
+  planCount: occupied ? 1 : 0,
+});
+
+/** Standort "Hof" with two Parzellen, six Beete, five of them occupied. */
+const fullTree = (): OccupancyHierarchyNode[] => [
+  location(1, 'Hof'),
+  field(10, 'Nordfeld', 1),
+  bed(100, 'Beet 1', 1, 10, true),
+  bed(101, 'Beet 2', 1, 10, true),
+  bed(102, 'Beet 3', 1, 10, false),
+  field(11, 'Südfeld', 1),
+  bed(110, 'Beet 4', 1, 11, true),
+  bed(111, 'Beet 5', 1, 11, true),
+  bed(112, 'Beet 6', 1, 11, true),
+];
+
+describe('buildOccupancyStructureSummaries', () => {
+  it('counts Parzellen, Beete and occupied Beete per Standort and per Parzelle', () => {
+    const summaries = buildOccupancyStructureSummaries(fullTree());
+
+    expect(summaries.get('location-1')).toEqual({
+      fieldCount: 2,
+      bedCount: 6,
+      occupiedBedCount: 5,
+    });
+    expect(summaries.get('field-10')).toEqual({ bedCount: 3, occupiedBedCount: 2 });
+    expect(summaries.get('field-11')).toEqual({ bedCount: 3, occupiedBedCount: 3 });
+  });
+
+  it('emits no summary for Beet rows', () => {
+    const summaries = buildOccupancyStructureSummaries(fullTree());
+
+    expect(summaries.has('bed-100')).toBe(false);
+  });
+
+  it('derives the counts from the nodes it is given, not from the full-tree totals on them', () => {
+    // What "Nur belegte Beete" leaves behind: the empty Beet 3 is gone, so the
+    // Standort must report five beds, not the six the node still remembers.
+    const pruned = fullTree().filter((node) => node.id !== 'bed-102');
+
+    const summaries = buildOccupancyStructureSummaries(pruned);
+
+    expect(summaries.get('location-1')).toEqual({
+      fieldCount: 2,
+      bedCount: 5,
+      occupiedBedCount: 5,
+    });
+    expect(summaries.get('field-10')).toEqual({ bedCount: 2, occupiedBedCount: 2 });
+  });
+
+  it('reflects a search that leaves a single matching Beet in one branch', () => {
+    const filtered = [
+      location(1, 'Hof'),
+      field(10, 'Nordfeld', 1),
+      bed(100, 'Beet 1', 1, 10, true),
+    ];
+
+    const summaries = buildOccupancyStructureSummaries(filtered);
+
+    expect(summaries.get('location-1')).toEqual({
+      fieldCount: 1,
+      bedCount: 1,
+      occupiedBedCount: 1,
+    });
+  });
+
+  it('reports zeros for a Standort without Parzellen', () => {
+    const summaries = buildOccupancyStructureSummaries([location(2, 'Neuer Hof')]);
+
+    expect(summaries.get('location-2')).toEqual({
+      fieldCount: 0,
+      bedCount: 0,
+      occupiedBedCount: 0,
+    });
+  });
+
+  it('reports zeros for a Parzelle without Beete and still counts it for its Standort', () => {
+    const summaries = buildOccupancyStructureSummaries([
+      location(1, 'Hof'),
+      field(10, 'Leeres Feld', 1),
+    ]);
+
+    expect(summaries.get('field-10')).toEqual({ bedCount: 0, occupiedBedCount: 0 });
+    expect(summaries.get('location-1')).toEqual({
+      fieldCount: 1,
+      bedCount: 0,
+      occupiedBedCount: 0,
+    });
+  });
+
+  it('reports a partially occupied structure without dropping the empty Beete', () => {
+    const summaries = buildOccupancyStructureSummaries([
+      location(1, 'Hof'),
+      field(10, 'Nordfeld', 1),
+      bed(100, 'Beet 1', 1, 10, true),
+      bed(101, 'Beet 2', 1, 10, false),
+      bed(102, 'Beet 3', 1, 10, false),
+    ]);
+
+    expect(summaries.get('field-10')).toEqual({ bedCount: 3, occupiedBedCount: 1 });
+  });
+
+  it('ignores orphaned nodes whose parent is not part of the given list', () => {
+    const summaries = buildOccupancyStructureSummaries([
+      location(1, 'Hof'),
+      bed(100, 'Beet 1', 1, 99, true),
+    ]);
+
+    expect(summaries.get('location-1')).toEqual({
+      fieldCount: 0,
+      bedCount: 0,
+      occupiedBedCount: 0,
+    });
+  });
+});
+
+describe('formatOccupancyStructureSummary', () => {
+  const restoreGerman = async () => {
+    await i18n.changeLanguage('de');
+  };
+
+  it('formats a Standort summary in German with correct plurals', async () => {
+    await restoreGerman();
+    const summaries = buildOccupancyStructureSummaries(fullTree());
+
+    expect(formatOccupancyStructureSummary(summaries.get('location-1')!, i18n.t))
+      .toBe('2 Parzellen · 6 Beete · 5 belegt');
+  });
+
+  it('formats a Parzelle summary in German without a Parzellen count', async () => {
+    await restoreGerman();
+    const summaries = buildOccupancyStructureSummaries(fullTree());
+
+    expect(formatOccupancyStructureSummary(summaries.get('field-10')!, i18n.t))
+      .toBe('3 Beete · 2 belegt');
+  });
+
+  it('uses German singular forms for single Parzellen, Beete and occupied Beete', async () => {
+    await restoreGerman();
+    const summaries = buildOccupancyStructureSummaries([
+      location(1, 'Hof'),
+      field(10, 'Nordfeld', 1),
+      bed(100, 'Beet 1', 1, 10, true),
+    ]);
+
+    expect(formatOccupancyStructureSummary(summaries.get('location-1')!, i18n.t))
+      .toBe('1 Parzelle · 1 Beet · 1 belegt');
+  });
+
+  it('formats zero counts with the plural forms', async () => {
+    await restoreGerman();
+    const summaries = buildOccupancyStructureSummaries([location(1, 'Hof')]);
+
+    expect(formatOccupancyStructureSummary(summaries.get('location-1')!, i18n.t))
+      .toBe('0 Parzellen · 0 Beete · 0 belegt');
+  });
+
+  it('formats the same summaries in English', async () => {
+    await i18n.changeLanguage('en');
+    try {
+      const summaries = buildOccupancyStructureSummaries(fullTree());
+
+      expect(formatOccupancyStructureSummary(summaries.get('location-1')!, i18n.t))
+        .toBe('2 fields · 6 beds · 5 occupied');
+      expect(formatOccupancyStructureSummary(summaries.get('field-10')!, i18n.t))
+        .toBe('3 beds · 2 occupied');
+    } finally {
+      await restoreGerman();
+    }
+  });
+
+  it('uses English singular forms for single counts', async () => {
+    await i18n.changeLanguage('en');
+    try {
+      const summaries = buildOccupancyStructureSummaries([
+        location(1, 'Hof'),
+        field(10, 'Nordfeld', 1),
+        bed(100, 'Beet 1', 1, 10, true),
+      ]);
+
+      expect(formatOccupancyStructureSummary(summaries.get('location-1')!, i18n.t))
+        .toBe('1 field · 1 bed · 1 occupied');
+    } finally {
+      await restoreGerman();
+    }
+  });
+});

--- a/frontend/src/gantt-chart/src/components/task/TaskList.tsx
+++ b/frontend/src/gantt-chart/src/components/task/TaskList.tsx
@@ -6,6 +6,7 @@ import {
   getHierarchyLevels,
   normalizeLeftColumnWidth,
   TREE_INDENT_PX,
+  TREE_META_LABEL_OFFSET_PX,
 } from "../../utils";
 import { ContextMenuIndicator } from "../../../../components/contextMenu/ContextMenuIndicator";
 import { OverflowTooltip } from "../../../../components/OverflowTooltip";
@@ -142,6 +143,7 @@ const TaskList: React.FC<TaskListProps> = ({
           const depth = taskGroup.depth ?? 0;
           const isExpanded = Boolean(taskGroup.isExpanded);
           const displayName = taskGroup.name || "Unnamed";
+          const metaLabel = taskGroup.metaLabel?.trim() || undefined;
 
           return (
             <div
@@ -191,8 +193,8 @@ const TaskList: React.FC<TaskListProps> = ({
                 )}
 
                 <OverflowTooltip
-                  title={taskGroup.emptyRowLabel
-                    ? `${displayName} — ${taskGroup.emptyRowLabel}`
+                  title={metaLabel
+                    ? `${displayName} — ${metaLabel}`
                     : displayName}
                 >
                   <span
@@ -203,6 +205,20 @@ const TaskList: React.FC<TaskListProps> = ({
                   </span>
                 </OverflowTooltip>
               </div>
+
+              {/* Compact structural summary beneath the name. Indented to
+                  line up with the name itself (tree indent + the fixed
+                  chevron column) so it reads as that row's subtitle rather
+                  than as another tree level. */}
+              {metaLabel && (
+                <div
+                  className="rmg-task-group-tree-meta"
+                  data-rmg-component="task-group-meta"
+                  style={{ paddingLeft: `${depth * TREE_INDENT_PX + TREE_META_LABEL_OFFSET_PX}px` }}
+                >
+                  {metaLabel}
+                </div>
+              )}
 
               {showTaskCount && taskGroup.tasks && taskGroup.tasks.length > 0 && (
                 <div

--- a/frontend/src/gantt-chart/src/styles/gantt.css
+++ b/frontend/src/gantt-chart/src/styles/gantt.css
@@ -425,6 +425,31 @@
   color: var(--rmg-gray-200);
 }
 
+/* Structural summary line under a tree row's name (Standort/Parzelle:
+   "2 Parzellen · 6 Beete · 5 belegt"). Deliberately quiet — small,
+   secondary colour, tight line-height — so it reads as metadata and never
+   competes with the row name or the timeline bars next to it. */
+.rmg-task-group-tree-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  font-weight: 400;
+  color: var(--rmg-gray-500);
+}
+
+.rmg-dark .rmg-task-group-tree-meta {
+  color: var(--rmg-gray-400);
+}
+
+/* The name's per-depth weight/colour ramp must not bleed into the meta
+   line — it stays uniformly secondary at every depth. */
+.rmg-task-group-tree-row[data-depth="0"] .rmg-task-group-tree-meta,
+.rmg-task-group-tree-row[data-depth="1"] .rmg-task-group-tree-meta {
+  font-weight: 400;
+}
+
 .rmg-task-row-empty-label {
   display: flex;
   align-items: center;

--- a/frontend/src/gantt-chart/src/types/core.ts
+++ b/frontend/src/gantt-chart/src/types/core.ts
@@ -41,6 +41,15 @@ export interface TaskGroup {
    */
   emptyRowLabel?: string;
   /**
+   * Compact secondary line rendered in the left column directly beneath the
+   * group's name — e.g. a structural summary of a tree parent row
+   * ("2 fields · 6 beds · 5 occupied"). Purely a caller-provided string;
+   * this library has no opinion on its content. Tree rows only; callers that
+   * set it should also size the row (see `rowHeightOverride`) so the extra
+   * line fits, otherwise the left column and the timeline drift apart.
+   */
+  metaLabel?: string;
+  /**
    * Overrides the computed row height for this group only (e.g. a compact
    * height for a tree parent row that has no bars of its own). Falls back
    * to the normal task-row-count-based height when unset.

--- a/frontend/src/gantt-chart/src/utils/hierarchyLabel.ts
+++ b/frontend/src/gantt-chart/src/utils/hierarchyLabel.ts
@@ -153,6 +153,11 @@ export function getLabelLinesSource(
  * eats into the space a wrapped label actually has to render in. */
 export const TREE_INDENT_PX = 20;
 
+/** Extra left offset for a tree row's `metaLabel` line so it starts under the
+ * name rather than under the chevron: the fixed 16px chevron column plus the
+ * 2px gap `.rmg-task-group-tree-content` puts after it. */
+export const TREE_META_LABEL_OFFSET_PX = 18;
+
 /**
  * Estimates a task group's row height contribution from its label alone
  * (before factoring in how many task bars need to stack). Used by both
@@ -169,7 +174,7 @@ export function estimateTaskGroupLabelHeight(
   const isTreeRow = taskGroup.depth !== undefined;
   const hierarchyLevels = isTreeRow ? null : getHierarchyLevels(taskGroup);
   const labelLinesSource = isTreeRow
-    ? [taskGroup.name || "Unnamed"]
+    ? [taskGroup.name || "Unnamed", taskGroup.metaLabel ?? ""].filter(Boolean)
     : getLabelLinesSource(taskGroup, hierarchyLevels, options.includeDescription ?? true);
   const effectiveWidth = leftColumnWidth - (isTreeRow ? (taskGroup.depth ?? 0) * TREE_INDENT_PX : 0);
   return estimateLabelHeight(labelLinesSource, effectiveWidth);

--- a/frontend/src/i18n/locales/de/ganttChart.json
+++ b/frontend/src/i18n/locales/de/ganttChart.json
@@ -163,6 +163,14 @@
   "sidebar": {
     "resizeHandle": "Seitenleiste verbreitern oder verkleinern"
   },
+  "structureSummary": {
+    "fields_one": "{{count}} Parzelle",
+    "fields_other": "{{count}} Parzellen",
+    "beds_one": "{{count}} Beet",
+    "beds_other": "{{count}} Beete",
+    "occupiedBeds_one": "{{count}} belegt",
+    "occupiedBeds_other": "{{count}} belegt"
+  },
   "treeFilters": {
     "searchPlaceholder": "Suche nach Kultur, Beet, Parzelle oder Standort…",
     "searchPlaceholderSeedlings": "Suche nach Kultur…",

--- a/frontend/src/i18n/locales/en/ganttChart.json
+++ b/frontend/src/i18n/locales/en/ganttChart.json
@@ -163,6 +163,14 @@
   "sidebar": {
     "resizeHandle": "Widen or narrow the sidebar"
   },
+  "structureSummary": {
+    "fields_one": "{{count}} field",
+    "fields_other": "{{count}} fields",
+    "beds_one": "{{count}} bed",
+    "beds_other": "{{count}} beds",
+    "occupiedBeds_one": "{{count}} occupied",
+    "occupiedBeds_other": "{{count}} occupied"
+  },
   "treeFilters": {
     "searchPlaceholder": "Search by culture, bed, field, or location…",
     "searchPlaceholderSeedlings": "Search by culture…",

--- a/frontend/src/pages/GanttChart.tsx
+++ b/frontend/src/pages/GanttChart.tsx
@@ -109,6 +109,10 @@ import {
   type GanttTaskGroup,
   type OccupancyHierarchyNode,
 } from './ganttChartUtils';
+import {
+  buildOccupancyStructureSummaries,
+  formatOccupancyStructureSummary,
+} from './occupancyStructureSummary';
 import { useGanttContextMenu } from './useGanttContextMenu';
 import { useGanttTaskActions } from './useGanttTaskActions';
 import { useOccupancyHierarchyFilter } from './useOccupancyHierarchyFilter';
@@ -843,6 +847,16 @@ function GanttChartPage() {
       visibleIds = collectVisibleIdsWithAncestors(prunedNodes, matchedBedIds);
     }
 
+    // Summaries come from the filtered node set (structural "nur belegte
+    // Beete" pruning plus the location/field/search match), so the grey meta
+    // line can never claim more beds than the view actually lists. Expansion
+    // state is intentionally not folded in — collapsing a row hides it, it
+    // does not remove it from the structure.
+    const summarizedNodes = visibleIds
+      ? prunedNodes.filter((node) => visibleIds.has(node.id))
+      : prunedNodes;
+    const structureSummaries = buildOccupancyStructureSummaries(summarizedNodes);
+
     const flatRows = flattenTreeRows(prunedNodes, {
       expandedIds: expandedHierarchyIds,
       visibleIds,
@@ -852,15 +866,10 @@ function GanttChartPage() {
       const isExpandable = node.type !== 'bed' && hasChildren;
       const isExpanded = expandedHierarchyIds.has(node.id);
 
-      let emptyRowLabel: string | undefined;
-      if (node.type === 'field') {
-        emptyRowLabel = `${node.bedCount} Beet${node.bedCount === 1 ? '' : 'e'} · ${node.occupiedBedCount} belegt`;
-      } else if (node.type === 'location') {
-        const fieldCount = prunedNodes.filter(
-          (candidate) => candidate.type === 'field' && candidate.parentId === node.id,
-        ).length;
-        emptyRowLabel = `${fieldCount} Parzelle${fieldCount === 1 ? '' : 'n'} · ${node.bedCount} Beet${node.bedCount === 1 ? '' : 'e'} · ${node.occupiedBedCount} belegt`;
-      }
+      const structureSummary = structureSummaries.get(node.id);
+      const metaLabel = structureSummary
+        ? formatOccupancyStructureSummary(structureSummary, t)
+        : undefined;
 
       const group: GanttTaskGroup = {
         id: node.id,
@@ -869,10 +878,11 @@ function GanttChartPage() {
         depth,
         isExpandable,
         isExpanded,
-        emptyRowLabel,
+        metaLabel,
         // Standort/Parzelle rows have no bars of their own, so they don't
-        // need a full task-row height — Beet rows keep the normal,
-        // task-count-based height (rowHeightOverride left unset).
+        // need a full task-row height — just enough for the name plus the
+        // meta line. Beet rows keep the normal, task-count-based height
+        // (rowHeightOverride left unset).
         rowHeightOverride: node.type === 'bed' ? undefined : OCCUPANCY_COMPACT_ROW_HEIGHT,
         locationId: node.locationId,
         fieldId: node.fieldId,
@@ -888,6 +898,7 @@ function GanttChartPage() {
     occupancyLocationFilter,
     occupancySearchText,
     onlyOccupiedBeds,
+    t,
   ]);
 
   const handleToggleGroupExpand = useCallback((groupId: string) => {

--- a/frontend/src/pages/ganttChartState.ts
+++ b/frontend/src/pages/ganttChartState.ts
@@ -36,16 +36,15 @@ export const GANTT_VIEWPORT_MIN_HEIGHT_PX = 320;
 // Above this many combined location+field+bed nodes, default to
 // locations-expanded/fields-collapsed instead of fully expanding the tree.
 export const OCCUPANCY_TREE_AUTO_EXPAND_ALL_THRESHOLD = 30;
-// Compact row height for Standort/Parzelle rows, which show a meta-text
-// summary (as a title tooltip, not a second visible line — see
-// TaskList.tsx) instead of bars. Beet rows keep the normal, task-count-
-// based height computed by the Gantt library itself. Must be tall enough
-// to fit the sidebar's single content line (chevron + name, ~17px) plus
-// its ~8px vertical padding without TaskList's minHeight being exceeded
-// by actual content — otherwise the sidebar row silently renders taller
-// than TaskRow's timeline row and the two columns drift out of sync row
-// by row.
-export const OCCUPANCY_COMPACT_ROW_HEIGHT = 32;
+// Compact row height for Standort/Parzelle rows, which show a structural
+// meta-text summary ("2 Parzellen · 6 Beete · 5 belegt") instead of bars.
+// Beet rows keep the normal, task-count-based height computed by the Gantt
+// library itself. Must be tall enough to fit the sidebar's two content
+// lines (chevron + name at ~17px, meta line at ~14px) plus its ~8px
+// vertical padding without TaskList's minHeight being exceeded by actual
+// content — otherwise the sidebar row silently renders taller than
+// TaskRow's timeline row and the two columns drift out of sync row by row.
+export const OCCUPANCY_COMPACT_ROW_HEIGHT = 40;
 export const GANTT_HEADER_VIEW_MODES = [
   ViewMode.DAY,
   ViewMode.WEEK,

--- a/frontend/src/pages/ganttChartUtils.ts
+++ b/frontend/src/pages/ganttChartUtils.ts
@@ -48,6 +48,8 @@ export interface GanttTaskGroup {
   isExpandable?: boolean;
   isExpanded?: boolean;
   emptyRowLabel?: string;
+  /** Compact grey summary line under the row name in the left column. */
+  metaLabel?: string;
   rowHeightOverride?: number;
 }
 

--- a/frontend/src/pages/occupancyStructureSummary.ts
+++ b/frontend/src/pages/occupancyStructureSummary.ts
@@ -1,0 +1,105 @@
+import type { OccupancyHierarchyNode } from './ganttChartUtils';
+
+/**
+ * Structural counts shown as the grey meta line under a Standort/Parzelle
+ * row of the occupancy calendar ("2 Parzellen · 6 Beete · 5 belegt").
+ *
+ * `fieldCount` is only meaningful for Standort rows — a Parzelle has no
+ * Parzellen of its own, so it stays undefined there and drops out of the
+ * formatted label.
+ */
+export interface OccupancyStructureSummary {
+  fieldCount?: number;
+  bedCount: number;
+  occupiedBedCount: number;
+}
+
+/** Separator between the summary's parts. Punctuation, not translatable copy. */
+const SUMMARY_SEPARATOR = ' · ';
+
+type SummaryTranslator = (key: string, options: { count: number }) => string;
+
+/**
+ * Aggregates the structural counts for every Standort/Parzelle row of an
+ * occupancy tree, keyed by node id.
+ *
+ * The counts are derived from exactly the nodes handed in, never from the
+ * pre-computed `bedCount`/`occupiedBedCount` on the nodes themselves: those
+ * always describe the *full* tree, so reusing them would make a filtered
+ * view claim more beds than it shows ("6 Beete" above three visible rows
+ * once "Nur belegte Beete" or a search has pruned the rest). Callers pass
+ * the already-filtered node list and get numbers that match what is on
+ * screen.
+ *
+ * Expand/collapse state is deliberately *not* part of that filtering:
+ * collapsing a Parzelle hides its rows but does not remove its beds from the
+ * structure, so the summary must not change when a row is folded away.
+ */
+export function buildOccupancyStructureSummaries(
+  nodes: OccupancyHierarchyNode[],
+): Map<string, OccupancyStructureSummary> {
+  const parentById = new Map<string, string | null>(
+    nodes.map((node) => [node.id, node.parentId]),
+  );
+  const summaries = new Map<string, OccupancyStructureSummary>();
+
+  nodes.forEach((node) => {
+    if (node.type === 'location') {
+      summaries.set(node.id, { fieldCount: 0, bedCount: 0, occupiedBedCount: 0 });
+    } else if (node.type === 'field') {
+      summaries.set(node.id, { bedCount: 0, occupiedBedCount: 0 });
+    }
+  });
+
+  nodes.forEach((node) => {
+    if (node.type === 'field' && node.parentId) {
+      const locationSummary = summaries.get(node.parentId);
+      if (locationSummary?.fieldCount !== undefined) {
+        locationSummary.fieldCount += 1;
+      }
+      return;
+    }
+
+    if (node.type !== 'bed') {
+      return;
+    }
+
+    // Walk the ancestor chain instead of assuming a fixed Standort ->
+    // Parzelle -> Beet depth, so a bed still counts towards its Standort if
+    // the tree ever grows another level.
+    const occupied = node.occupiedBedCount > 0 ? 1 : 0;
+    const seen = new Set<string>();
+    let ancestorId = node.parentId;
+    while (ancestorId && !seen.has(ancestorId)) {
+      seen.add(ancestorId);
+      const summary = summaries.get(ancestorId);
+      if (summary) {
+        summary.bedCount += 1;
+        summary.occupiedBedCount += occupied;
+      }
+      ancestorId = parentById.get(ancestorId) ?? null;
+    }
+  });
+
+  return summaries;
+}
+
+/**
+ * Renders a summary as the localized meta line. Singular/plural comes from
+ * i18next's own plural resolution (`_one`/`_other`), so languages that count
+ * differently than German stay correct.
+ */
+export function formatOccupancyStructureSummary(
+  summary: OccupancyStructureSummary,
+  t: SummaryTranslator,
+): string {
+  const parts: string[] = [];
+
+  if (summary.fieldCount !== undefined) {
+    parts.push(t('ganttChart:structureSummary.fields', { count: summary.fieldCount }));
+  }
+  parts.push(t('ganttChart:structureSummary.beds', { count: summary.bedCount }));
+  parts.push(t('ganttChart:structureSummary.occupiedBeds', { count: summary.occupiedBedCount }));
+
+  return parts.join(SUMMARY_SEPARATOR);
+}


### PR DESCRIPTION
## What

Standort and Parzelle rows of the Anbaukalender's occupancy view show their structural summary again as a quiet grey line directly under the row name, instead of only as a hover tooltip:

- Standort: `2 Parzellen · 6 Beete · 5 belegt`
- Parzelle: `3 Beete · 2 belegt`

## Why it was missing

The summary was still being computed in `GanttChart.tsx`, but only fed into two places: the left column's `title` tooltip, and `TaskRow`'s empty-row label — which sits at the far left of the timeline area and is therefore scrolled off screen for most of the year. Nothing rendered it under the row name.

## How

- **New pure module `frontend/src/pages/occupancyStructureSummary.ts`** holds the counting (`buildOccupancyStructureSummaries`) and the localized formatting (`formatOccupancyStructureSummary`), so the page no longer inlines either.
- **Counts come from the filtered node set**, not from the hierarchy nodes' pre-computed full-tree `bedCount`/`occupiedBedCount`. Those describe the whole tree, so reusing them made a filtered view claim more beds than it listed (e.g. "6 Beete" above three visible rows once "Nur belegte Beete" pruned the rest). "Nur belegte Beete", the Standort/Parzelle filters and the search all now feed the same numbers the rows show.
- **Expand/collapse is deliberately excluded** from that filtering: folding a row hides it, it does not remove its beds from the structure, so the counts stay stable while collapsing.
- **New `metaLabel` field on the Gantt library's `TaskGroup`** renders the line in `TaskList`, indented to line up with the name (tree indent + the fixed chevron column). `emptyRowLabel` keeps its original library meaning; the page no longer sets it, so the summary appears exactly once.
- **Localization**: the hardcoded German string is replaced with `ganttChart:structureSummary.*` keys using i18next plural forms (`1 Parzelle` / `2 Parzellen`, `1 Beet` / `3 Beete`, `1 belegt` / `3 belegt`), plus English (`1 field` / `2 fields`, `1 bed` / `3 beds`, `1 occupied` / `3 occupied`).
- **Row height**: `OCCUPANCY_COMPACT_ROW_HEIGHT` goes 32px → 40px so the second line fits *inside* the override that both the sidebar and the timeline row use. Verified in a real browser that the rendered sidebar row is exactly 40px — content never exceeds the `minHeight`, so the two columns cannot drift apart. Beet rows keep their normal computed height.

Styling is intentionally quiet: 0.6875rem, `--rmg-gray-500` (`--rmg-gray-400` in dark mode), line-height 1.2, single line with ellipsis, no per-depth weight ramp. Bars, colours, hierarchy rows, chevrons, context menus and scrolling are untouched.

## Tests

- `occupancyStructureSummary.test.ts` (14): counting per Standort/Parzelle, deriving from the given nodes rather than the full-tree totals, pruned/searched subsets, Standort without Parzellen, Parzelle without Beete, partially occupied structures, orphaned nodes, and German/English singular/plural/zero formatting.
- `GanttChart.test.tsx` (7 new): meta line under Standort and Parzelle but not under Beet rows, counts changing with "Nur belegte Beete", narrowing with search, staying stable when a level is collapsed, restricted by the Standort filter, and localized in English.
- `TaskList.metaLabel.test.tsx` (7): renders as its own line inside the right row, per-depth indentation, absent without a `metaLabel`, blank labels ignored, and no meta line on flat (non-tree) groups.

Full frontend suite: 1750 passed / 182 files. Lint warning count unchanged (57, all pre-existing); `tsc -b` and `vite build` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKVMERSGWdwsjK3t8GCxeV)_