### PR TITLE
fix: center landing header logo across the viewport

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -110,6 +110,11 @@ the current value through `aria-checked` rather than colour alone, has an
 accessible name that states what the control does, and uses 44px minimum touch
 targets.
 
+On phones the compact (`dense`) variant used in the public headers drops its
+decorative globe and chevron icons and keeps the language name alone — never
+an icon-only control — so the header rows it shares with the centred logo stay
+readable on narrow screens.
+
 ---
 
 ## 2. Translating the UI

--- a/frontend/e2e/landing-header-centering.spec.ts
+++ b/frontend/e2e/landing-header-centering.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+// Functional assertions rather than a screenshot baseline: what matters here is
+// a geometric relation (the logo's centre matches the viewport's centre, and it
+// does not move when the language changes), which a pixel diff would only cover
+// indirectly and would have to be re-baselined for every unrelated landing-page
+// tweak.
+const viewports = [
+  { key: 'mobile', width: 375, height: 800 },
+  { key: 'tablet', width: 768, height: 900 },
+  { key: 'desktop', width: 1440, height: 900 },
+];
+
+async function boundingBox(locator: Locator): Promise<{ x: number; y: number; width: number; height: number }> {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  return box!;
+}
+
+function header(page: Page): Locator {
+  return page.locator('header');
+}
+
+function logo(page: Page): Locator {
+  // The logo row is the icon plus the "OpenFarmPlanner" heading.
+  return header(page).locator('h1').locator('..');
+}
+
+function languageButton(page: Page): Locator {
+  return header(page).getByRole('button', { name: /Sprache|language/i });
+}
+
+test.describe('landing page header', () => {
+  for (const viewport of viewports) {
+    test(`centers the logo across the viewport at ${viewport.key}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto('/');
+      await expect(page.locator('header h1')).toHaveText('OpenFarmPlanner');
+
+      const logoBox = await boundingBox(logo(page));
+      const languageBox = await boundingBox(languageButton(page));
+
+      // Centred on the viewport, not merely inside the space the language
+      // selector leaves over. One pixel of slack for sub-pixel rounding.
+      expect(Math.abs(logoBox.x + logoBox.width / 2 - viewport.width / 2)).toBeLessThanOrEqual(1);
+
+      // Same row, selector on the right, and the two never touch.
+      expect(languageBox.x).toBeGreaterThan(logoBox.x + logoBox.width);
+      expect(languageBox.y).toBeLessThan(logoBox.y + logoBox.height);
+      expect(logoBox.y).toBeLessThan(languageBox.y + languageBox.height);
+
+      const headerBox = await boundingBox(header(page));
+      expect(headerBox.x + headerBox.width - (languageBox.x + languageBox.width)).toBeLessThanOrEqual(2);
+      // A single row, not a header that grew a second one.
+      expect(headerBox.height).toBeLessThanOrEqual(64);
+    });
+  }
+
+  test('keeps the logo in place when the language changes', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto('/');
+    await expect(page.locator('header h1')).toHaveText('OpenFarmPlanner');
+
+    const before = await boundingBox(logo(page));
+
+    await languageButton(page).click();
+    await page.getByRole('menuitemradio', { name: 'English' }).click();
+    await expect(languageButton(page)).toHaveText(/English/);
+
+    const after = await boundingBox(logo(page));
+    expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(after.width - before.width)).toBeLessThanOrEqual(1);
+
+    // Still reachable and still opening its menu after the switch.
+    await languageButton(page).click();
+    await expect(page.getByRole('menuitemradio', { name: 'Deutsch' })).toBeVisible();
+  });
+});

--- a/frontend/src/__tests__/HomePageHeader.test.tsx
+++ b/frontend/src/__tests__/HomePageHeader.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import HomePage from '../pages/public/HomePage';
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ startGuestDemo: vi.fn() }),
+}));
+
+function renderHomePage() {
+  render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>,
+  );
+}
+
+describe('HomePage header', () => {
+  it('keeps the logo and the language selector in one row, logo first', () => {
+    renderHomePage();
+
+    const logo = screen.getByRole('heading', { level: 1 });
+    const languageButton = screen.getByRole('button', { name: /Sprache/ });
+    const header = logo.closest('header');
+
+    expect(header).not.toBeNull();
+    expect(header?.contains(languageButton)).toBe(true);
+    // One row means one grid row: the header holds exactly the logo group and
+    // the language selector.
+    expect(header?.children.length).toBe(2);
+    expect(logo.compareDocumentPosition(languageButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('centers the logo with two mirrored side columns so the selector cannot shift it', () => {
+    renderHomePage();
+
+    const logo = screen.getByRole('heading', { level: 1 });
+    const languageButton = screen.getByRole('button', { name: /Sprache/ });
+    const header = logo.closest('header') as HTMLElement;
+    const headerStyle = window.getComputedStyle(header);
+
+    expect(headerStyle.display).toBe('grid');
+    // The empty first column and the selector's column share the same track
+    // size, so the middle column stays centred whatever the language label is.
+    const columns = headerStyle.gridTemplateColumns.split(' auto ');
+    expect(columns).toHaveLength(2);
+    expect(columns[0]).toBe(columns[1]);
+
+    // The logo sits in the centre column, the selector in the trailing one.
+    const logoGroup = logo.parentElement as HTMLElement;
+    expect(window.getComputedStyle(logoGroup).gridColumn).toBe('2');
+    const selectorCell = languageButton.parentElement as HTMLElement;
+    expect(window.getComputedStyle(selectorCell).gridColumn).toBe('3');
+  });
+});

--- a/frontend/src/i18n/LanguageSwitcher.tsx
+++ b/frontend/src/i18n/LanguageSwitcher.tsx
@@ -75,11 +75,15 @@ export function PublicLanguageSwitcher({ dense = false }: { dense?: boolean }) {
           textTransform: 'none',
           fontWeight: 500,
           whiteSpace: 'nowrap',
+          // On phones the switcher shares its row with the page's centred logo,
+          // so the dense variant drops both decorative icons and keeps only the
+          // language name - the part that carries the meaning.
           '& .MuiButton-startIcon': {
             display: { xs: 'none', sm: 'inherit' },
             mr: 0.75,
           },
           '& .MuiButton-endIcon': {
+            display: dense ? { xs: 'none', sm: 'inherit' } : undefined,
             ml: 0.35,
           },
         }}

--- a/frontend/src/pages/public/HomePage.tsx
+++ b/frontend/src/pages/public/HomePage.tsx
@@ -91,6 +91,37 @@ const HERO_CARD_SX = {
   boxShadow: '0 12px 40px rgba(0,0,0,0.28)',
 };
 
+// Three-column grid so the logo stays centred in the header: the empty first
+// column and the language-selector column are both `1fr`, so they always claim
+// the same width and the middle column stays centred no matter how long the
+// current language label is ("Deutsch", "English", future languages). The side
+// columns use `minmax(0, ...)` so a wide selector never pushes the row past the
+// container width on small screens.
+const HEADER_SX = {
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)',
+  alignItems: 'center',
+  columnGap: { xs: 0.5, sm: 1 },
+  minHeight: 48,
+};
+
+// Centring costs the wordmark the width of the language selector twice (once
+// for the selector itself, once for the mirroring spacer column), so the title
+// only has room for its full size once the viewport is wide enough. The clamps
+// keep the regular size from ~360px (phones) and ~690px (tablets) upwards and
+// scale the heading down below that, so it can never run into the selector.
+const TITLE_SX = {
+  minWidth: 0,
+  fontSize: {
+    xs: 'clamp(0.75rem, calc(11.5vw - 25px), 1rem)',
+    sm: 'clamp(1.6rem, 4.4vw, 1.9rem)',
+    md: '2.5rem',
+  },
+  fontWeight: 600,
+  lineHeight: 1.1,
+  overflowWrap: 'normal',
+};
+
 /**
  * Public landing page with refined spacing and modern visual hierarchy.
  *
@@ -119,39 +150,22 @@ export default function HomePage() {
     <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', bgcolor: 'background.default' }}>
       <Box component="main" sx={{ flex: 1 }}>
         <Container maxWidth="lg" sx={{ width: '100%', pt: { xs: 1.5, md: 2 }, pb: { xs: 2.5, md: 3 } }}>
-          <Stack
-            component="header"
-            direction="row"
-            spacing={{ xs: 0.75, sm: 2 }}
-            alignItems="center"
-            justifyContent="space-between"
-            sx={{ minHeight: 48 }}
-          >
+          <Box component="header" sx={HEADER_SX}>
             <Stack
               direction="row"
               spacing={{ xs: 0.75, sm: 1.4 }}
               alignItems="center"
-              sx={{ minWidth: 0, flex: '1 1 auto' }}
+              sx={{ gridColumn: 2, minWidth: 0 }}
             >
               <AppIcon decorative size={{ xs: 32, sm: 40, md: 48 }} sx={{ opacity: 0.95 }} />
-              <Typography
-                variant="h2"
-                component="h1"
-                sx={{
-                  minWidth: 0,
-                  fontSize: { xs: '1.1rem', sm: '1.9rem', md: '2.5rem' },
-                  fontWeight: 600,
-                  lineHeight: 1.1,
-                  overflowWrap: 'normal',
-                }}
-              >
+              <Typography variant="h2" component="h1" sx={TITLE_SX}>
                 {t('landing.title')}
               </Typography>
             </Stack>
-            <Box sx={{ flex: '0 0 auto' }}>
+            <Box sx={{ gridColumn: 3, justifySelf: 'end' }}>
               <PublicLanguageSwitcher dense />
             </Box>
-          </Stack>
+          </Box>
         </Container>
 
         <Box


### PR DESCRIPTION
## What changed

The landing header laid the logo and the language selector out as a
`space-between` flex row, so the wordmark sat left of centre and moved whenever
the selector's label changed width ("Deutsch" vs "English").

It now uses a three-column grid, `minmax(0, 1fr) auto minmax(0, 1fr)`:

- the empty leading column mirrors the selector's column, so the logo column is
  centred on the viewport **independent of the selector's width** — no shift
  when the language changes, and none for future, longer language names;
- the selector keeps `justifySelf: end`, so it stays right-aligned;
- still one row, still `minHeight: 48` — the header height is unchanged;
- `minmax(0, ...)` on the side columns keeps a wide selector from pushing the
  row past the container, so there is no horizontal overflow on phones.

Centring reserves the selector's width twice (once for it, once for the
mirroring column), which only gets tight on small screens. Two changes keep the
row collision-free there:

- the heading scales down below ~360px (phones) and ~690px (tablets) via
  `clamp()`, keeping its regular size everywhere above that;
- the dense language switcher drops its chevron on phones, the same way it
  already drops its globe icon — it stays a labelled text control, never
  icon-only (`docs/i18n.md` updated).

## Verification

- Measured in Chromium from 300px to 1920px, in German and English: the logo's
  centre matches the viewport centre at every width (≤0.1px), the logo's box is
  identical in both languages (no shift on switch), no overlap between logo and
  selector, no horizontal overflow, header height 48px throughout.
- New `frontend/e2e/landing-header-centering.spec.ts` asserts centring at
  mobile/tablet/desktop, right alignment, single row, and that switching to
  English leaves the logo in place while the selector stays operable.
- New `frontend/src/__tests__/HomePageHeader.test.tsx` guards the structure:
  one row, logo before selector, mirrored side columns.
- `npx tsc -b` and `npm run lint` clean; `npm run test:ci` green apart from one
  unrelated `PublicCropLibraryPage` timing flake that passes when run on its
  own.

## Breakpoints checked

Desktop (1440/1920), small desktop (1024), tablet (768, 600–700), and mobile
(300–420) — all with both languages. Mobile is intentionally changed here,
since the task asks for the logo to be centred on narrow screens too: the
wordmark is slightly smaller below ~360px and the phone selector loses its
chevron. The auth pages and the imprint/privacy language bar share the dense
switcher and inherit that chevron change; their layouts are otherwise
untouched (checked at 375 and 1440).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vDWQN8T2wnZnmyLKWRfLX


---
_Generated by [Claude Code](https://claude.ai/code/session_013vDWQN8T2wnZnmyLKWRfLX)_