### PR TITLE
feat(datagrid): open popover-edited cells with a single click

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -63,6 +63,7 @@ it on mount (`hooks/useDataGridCommandApi.ts`):
 interface EditableDataGridCommandApi {
   addRow, editSelectedRow, deleteSelectedRow, deleteRow(rowId),
   getSelectedRowId, setDraftValues(rowId, values), commitDraftValues(rowId, values),
+  applyDialogEditValues(rowId, values),
   reload, focusTable, openRowById(rowId, { startEdit? }),
 }
 ```
@@ -105,6 +106,8 @@ scroll out of view as the user scrolls the table horizontally.
 `setDraftValues`/`commitDraftValues` let external code push field values
 into a row that's already mid-edit (e.g. a calculated side-effect from
 another field), either staying in edit mode or committing immediately.
+`applyDialogEditValues` is the entry point for cells that have no edit
+session at all — see "Cells edited in a popover/dialog" below.
 
 ## Custom edit cells
 
@@ -176,9 +179,10 @@ that's still true. But cell-level Tab/Arrow/Enter/F2 navigation
   hierarchy's name and dimension editors disable MUI's default input debounce
   because row-level validation across rapidly edited fields can otherwise
   complete out of order and restore an older value after a focus change.
-- Notes cells (see below) are deliberately excluded from both spreadsheet
-  auto-edit-start and the F2 flow — Enter/Space on a notes cell opens the
-  notes drawer instead.
+- Notes cells and `dialogEditFields` cells (both below) are deliberately
+  excluded from spreadsheet auto-edit-start, the F2 flow, and click-to-edit —
+  Enter/Space opens their own editor instead. They remain Tab/arrow stops via
+  the `isActionCell` hook, since `editable: false` alone would skip them.
 
 ## Hover actions / row actions / context menu
 
@@ -244,6 +248,45 @@ downscale/re-encode to WebP (falling back to JPEG) client-side before
 upload. `noteAttachmentsCache.ts` caches attachment fetches per note id so
 re-hovering a row doesn't refetch; the drawer explicitly invalidates that
 cache after upload/delete.
+
+## Cells edited in a popover/dialog (`dialogEditFields`)
+
+Some values are never typed into a cell — they are picked in a dialog
+(today: the Anbaupläne "Anbaufläche" column, a Standort → Parzelle → Beet
+picker in `AreaAssignmentDialog.tsx`). Those columns are **`editable:
+false`** and listed in `EditableDataGrid`'s `dialogEditFields` prop. The
+grid then treats them exactly like notes cells:
+
+- **one left click opens the real editor.** The column's `renderCell` —
+  not `renderEditCell` — renders both the value and the dialog, so the
+  click lands directly on the dialog trigger. There is deliberately no
+  intermediate inline edit state and no pencil icon: an edit mode the user
+  can only click *through* is a wasted click, not an affordance.
+- **no inline edit mode is ever started for them**, from the click, from
+  F2, or from "just start typing" (`onCellClick` returns early and
+  `useSpreadsheetEditStarter` gets an `isCellEditable` that rejects them).
+- **they stay keyboard stops.** `editable: false` would normally drop a
+  cell out of Tab/arrow navigation, so `isCellKeyboardNavigable`'s
+  `isActionCell` hook covers notes *and* dialog fields
+  (`dedicatedEditorFieldNames` in `DataGrid.tsx`). Enter/Space is handled by
+  the trigger element itself, which stops propagation so the grid does not
+  also react; after the dialog closes, focus returns to that trigger and
+  ordinary navigation continues.
+
+The dialog writes its result back through the command API's
+`applyDialogEditValues(rowId, values)`, **not** `setEditCellValue` (there is
+no edit session to write into) and **not** a column `valueSetter` (which
+only runs in edit mode — any side effects it had must move into the caller;
+see `applyBedSelection` in `PlantingPlans.tsx`). It branches on the row's
+current mode: a row already in inline edit mode — typically a new draft row
+— only gets the values merged into its draft, so its own save cycle
+persists everything at once; a row in view mode is saved immediately
+through the normal `processRowUpdate` path, including the
+`onBeforeSaveRow` gate.
+
+`FieldsBedsHierarchy.tsx` needs no equivalent: its only
+non-inline-edited column is `notes`, whose cell already opens the drawer on
+a single click.
 
 ## Text overflow tooltips
 
@@ -359,3 +402,7 @@ grid," that's new work, not exposing something that already half-exists.
   `useColumnVisibility`/the native panel instead.
 - Notes columns must stay `editable: false` and excluded from the
   spreadsheet auto-edit-start/F2 flow — they have their own editor.
+- A new column whose value is only ever picked in a popover/dialog belongs
+  in `dialogEditFields`, not in a `renderEditCell`. Don't reintroduce a
+  cell-level edit mode whose only purpose is to reveal a button that opens
+  the real editor — that costs the user a click for nothing.

--- a/frontend/e2e/planting-plans-area-assignment-dialog.spec.ts
+++ b/frontend/e2e/planting-plans-area-assignment-dialog.spec.ts
@@ -88,10 +88,12 @@ async function createAreaDialogFixture(
 async function openAreaAssignmentDialog(page: Page, title: string, editLabel: string) {
   await page.goto('/app/planting-plans');
   await expect(page.getByRole('heading', { name: /Anbaupläne|Planting plans/ })).toBeVisible();
-  await expect(page.locator('[role="gridcell"][data-field="bed"]').first()).toBeVisible();
+  const bedCell = page.locator('[role="gridcell"][data-field="bed"]').first();
+  await expect(bedCell).toBeVisible();
 
-  await page.locator('[role="gridcell"][data-field="bed"]').first().click();
-  await page.getByLabel(editLabel).click();
+  // A single click must open the real editor — the bed cell has no inline edit
+  // mode to step through first.
+  await bedCell.getByLabel(editLabel).click();
 
   const dialog = page.getByRole('dialog', { name: title });
   await expect(dialog).toBeVisible();
@@ -128,6 +130,33 @@ async function readDialogMetrics(page: Page, title: string) {
 }
 
 test.describe('planting plans area assignment dialog', () => {
+  test('opens on a single click and keeps the grid keyboard-navigable afterwards', async ({ page, request }) => {
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await createAreaDialogFixture(page, request, 'planting-plans-area-dialog-single-click');
+
+    await page.goto('/app/planting-plans');
+    await expect(page.getByRole('heading', { name: 'Anbaupläne' })).toBeVisible();
+    const bedCell = page.locator('[role="gridcell"][data-field="bed"]').first();
+    await expect(bedCell).toBeVisible();
+
+    // No pencil button next to the value, and no inline edit cell in between.
+    await expect(bedCell.locator('[data-testid="EditIcon"]')).toHaveCount(0);
+
+    await bedCell.getByLabel('Anbaufläche bearbeiten').click();
+    await expect(page.getByRole('dialog', { name: 'Anbaufläche ändern' })).toBeVisible();
+    await expect(page.locator('.MuiDataGrid-row.ofp-row-editing')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+    await expect(page.getByRole('dialog', { name: 'Anbaufläche ändern' })).toBeHidden();
+
+    // Focus returns to the cell, so plain arrow navigation keeps working.
+    await expect(bedCell.getByLabel('Anbaufläche bearbeiten')).toBeFocused();
+    await page.keyboard.press('ArrowLeft');
+    await expect(
+      page.locator('[role="gridcell"][data-field="cultivation_type"]').first(),
+    ).toHaveAttribute('tabindex', '0');
+  });
+
   test('keeps the desktop field hierarchy editor compact without internal scrolling', async ({ page, request }) => {
     await page.setViewportSize({ width: 1400, height: 900 });
     await createAreaDialogFixture(page, request, 'planting-plans-area-dialog-compact');

--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -43,6 +43,49 @@ const expectFocusAfterTab = async (user: ReturnType<typeof userEvent.setup>, ele
 };
 
 describe('AreaAssignmentDialog', () => {
+  it('opens on a single click on the cell without a separate edit affordance', async () => {
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="Regenbogenland · 8 Karotte + Zwiebel · 5" onApply={vi.fn()} />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Anbaufläche bearbeiten' });
+    expect(screen.getAllByRole('button')).toEqual([trigger]);
+    expect(trigger).toHaveTextContent('Regenbogenland · 8 Karotte + Zwiebel · 5');
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole('dialog', { name: 'Anbaufläche ändern' })).toBeInTheDocument();
+  });
+
+  it('opens with Enter while the grid cell owns the focus', async () => {
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" hasFocus onApply={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Anbaufläche bearbeiten' })).toHaveFocus();
+    });
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('dialog', { name: 'Anbaufläche ändern' })).toBeInTheDocument();
+  });
+
+  it('returns focus to the cell trigger after the dialog closes', async () => {
+    const user = userEvent.setup();
+    render(
+      <AreaAssignmentDialog bedId={101} beds={beds} fields={fields} locations={locations} locale="de-DE" compactLabel="x" hasFocus onApply={vi.fn()} />,
+    );
+
+    await openDialog();
+    await user.click(screen.getByRole('button', { name: 'Abbrechen' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Anbaufläche bearbeiten' })).toHaveFocus();
+    });
+  });
+
   it('opens with current location/field/bed selection', async () => {
     render(
       <AreaAssignmentDialog

--- a/frontend/src/__tests__/CompactAreaCell.test.tsx
+++ b/frontend/src/__tests__/CompactAreaCell.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CompactAreaCell } from '../components/planting-plans/CompactAreaCell';
@@ -68,6 +68,62 @@ describe('CompactAreaCell', () => {
     await user.hover(screen.getByText(label));
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('opens its editor on a single click when it acts as the trigger', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+
+    render(<CompactAreaCell label="Beet 5" onOpen={onOpen} triggerLabel="Anbaufläche bearbeiten" />);
+
+    await user.click(screen.getByRole('button', { name: 'Anbaufläche bearbeiten' }));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens its editor from the keyboard without bubbling the key to the grid cell', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const onCellKeyDown = vi.fn();
+
+    render(
+      <div onKeyDown={onCellKeyDown}>
+        <CompactAreaCell label="Beet 5" hasFocus onOpen={onOpen} triggerLabel="Anbaufläche bearbeiten" />
+      </div>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Anbaufläche bearbeiten' });
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+
+    expect(onOpen).toHaveBeenCalledTimes(2);
+    expect(onCellKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('renders no separate edit affordance next to the value', () => {
+    render(<CompactAreaCell label="Beet 5" onOpen={vi.fn()} triggerLabel="Anbaufläche bearbeiten" />);
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(document.querySelector('svg[data-testid="EditIcon"]')).toBeNull();
+  });
+
+  it('falls back to the placeholder while no area is assigned', () => {
+    render(<CompactAreaCell label="" placeholder="Anbaufläche wählen" onOpen={vi.fn()} />);
+
+    expect(screen.getByText('Anbaufläche wählen')).toBeInTheDocument();
+  });
+
+  it('keeps focus inside the editor while it is open', async () => {
+    const { rerender } = render(<CompactAreaCell label="Beet 5" hasFocus suppressFocus onOpen={vi.fn()} />);
+
+    const trigger = screen.getByRole('button');
+    expect(trigger).not.toHaveFocus();
+
+    rerender(<CompactAreaCell label="Beet 5" hasFocus onOpen={vi.fn()} />);
+
+    await waitFor(() => expect(trigger).toHaveFocus());
   });
 
   it('uses compact ellipsis styles', () => {

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -66,6 +66,11 @@ vi.mock('@mui/x-data-grid', async () => {
     if (apiRef?.current) {
       apiRef.current.state = apiRef.current.state ?? { focus: { cell: null } };
       apiRef.current.setEditCellValue = (params: { id: string | number; field: string; value: unknown }) => {
+        // Mirrors MUI's own `throwIfNotEditable`: a field without an editor in
+        // the open edit session is a hard error, not a silent no-op.
+        if (columns.find((column: GridColDef) => column.field === params.field)?.editable === false) {
+          throw new Error(`MUI X: The cell with id=${String(params.id)} and field=${params.field} is not editable.`);
+        }
         setEditValues((currentValues) => ({
           ...currentValues,
           [`${String(params.id)}-${params.field}`]: params.value,
@@ -967,6 +972,100 @@ describe('EditableDataGrid', () => {
 
     await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-notes'));
     expect(screen.getByTestId('focused-cell')).not.toHaveTextContent('1-area_sqm');
+  });
+
+  describe('dialog-edited cells', () => {
+    const dialogColumns: GridColDef[] = [
+      { field: 'name', headerName: 'Name', editable: true },
+      { field: 'area_sqm', headerName: 'Anbaufläche', editable: false },
+      { field: 'notes', headerName: 'Notizen', editable: true },
+    ];
+
+    const renderWithDialogColumn = (
+      overrides: Partial<Parameters<typeof EditableDataGrid>[0]> = {},
+    ) => {
+      const props = baseProps(() => null);
+      render(
+        <EditableDataGrid
+          {...props}
+          columns={dialogColumns}
+          dialogEditFields={['area_sqm']}
+          showDeleteAction={false}
+          {...overrides}
+        />,
+      );
+      return props;
+    };
+
+    it('never opens the inline edit mode when the cell is clicked', async () => {
+      renderWithDialogColumn();
+
+      const cell = await screen.findByRole('button', { name: 'Zelle 1-area_sqm' });
+      fireEvent.click(cell);
+
+      expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+      expect(mockSetEditCellValue).not.toHaveBeenCalled();
+    });
+
+    it('ignores F2 and printable keys that would start the inline editor', async () => {
+      renderWithDialogColumn();
+
+      const cell = await screen.findByRole('button', { name: 'Zelle 1-area_sqm' });
+      fireEvent.keyDown(cell, { key: 'F2' });
+      fireEvent.keyDown(cell, { key: '5' });
+
+      expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+      expect(mockSetEditCellValue).not.toHaveBeenCalled();
+    });
+
+    it('stays a keyboard navigation stop even though the column is not editable', async () => {
+      renderWithDialogColumn();
+
+      const nameCell = await screen.findByRole('button', { name: 'Zelle 1-name' });
+      fireEvent.keyDown(nameCell, {
+        key: 'ArrowRight',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+      });
+
+      await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-area_sqm'));
+    });
+
+    it('saves the row right away when the dialog applies values in view mode', async () => {
+      const commandApiRef: { current: EditableDataGridCommandApi | null } = { current: null };
+      const props = renderWithDialogColumn({ commandApiRef });
+      const updateSpy = vi.spyOn(props.api, 'update');
+
+      await waitFor(() => expect(commandApiRef.current).not.toBeNull());
+      await act(async () => {
+        await commandApiRef.current?.applyDialogEditValues(1, { area_sqm: 42 });
+      });
+
+      await waitFor(() => expect(updateSpy).toHaveBeenCalledWith(1, expect.objectContaining({ area_sqm: 42 })));
+      expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+    });
+
+    it('only feeds the open draft when the row is already being edited', async () => {
+      const commandApiRef: { current: EditableDataGridCommandApi | null } = { current: null };
+      const props = renderWithDialogColumn({ commandApiRef });
+      const updateSpy = vi.spyOn(props.api, 'update');
+
+      await waitFor(() => expect(commandApiRef.current).not.toBeNull());
+      fireEvent.click(await screen.findByRole('button', { name: 'Zelle 1-name' }));
+      await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+
+      await act(async () => {
+        await commandApiRef.current?.applyDialogEditValues(1, { area_sqm: 42 });
+      });
+
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(screen.getByTestId('mode-1')).toHaveTextContent('edit');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Enter speichern 1' }));
+      await waitFor(() => expect(updateSpy).toHaveBeenCalledWith(1, expect.objectContaining({ area_sqm: 42 })));
+    });
   });
 
   it('focuses the next editable row cell once after Tab saves the edited row', async () => {

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -22,6 +22,7 @@ const commandApiSpies = vi.hoisted(() => ({
   addRow: vi.fn(),
   setDraftValues: vi.fn(),
   commitDraftValues: vi.fn(),
+  applyDialogEditValues: vi.fn(),
   saveAttemptResult: vi.fn(),
   apiPayload: vi.fn(),
   gridProps: vi.fn(),
@@ -124,6 +125,7 @@ vi.mock("../components/data-grid", async () => {
             });
             commandApiSpies.saveAttemptResult(true);
           },
+          applyDialogEditValues: commandApiSpies.applyDialogEditValues,
         };
       }
       const latestPropsRef = React.useRef({ api, mapToRow, onRowsStateChange, onLoadStateChange });
@@ -327,6 +329,65 @@ describe("PlantingPlans save-time area validation", () => {
     expect(inlineRowActions.map((action: { id: string }) => action.id)).toEqual(["delete"]);
     inlineRowActions[0].onClick({ id: -1, bed: 101 }, { delete: inlineDeleteHelper });
     expect(inlineDeleteHelper).toHaveBeenCalledWith(-1);
+  });
+
+  it("edits the growing area through its dialog instead of an inline edit cell", async () => {
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+
+    const latestProps = commandApiSpies.gridProps.mock.calls.at(-1)?.[0];
+    const bedColumn = (latestProps?.columns ?? []).find(
+      (column: { field: string }) => column.field === "bed",
+    );
+
+    expect(latestProps?.dialogEditFields).toContain("bed");
+    expect(bedColumn?.editable).toBe(false);
+    expect(bedColumn?.renderEditCell).toBeUndefined();
+    expect(bedColumn?.valueSetter).toBeUndefined();
+  });
+
+  it("opens the growing area dialog with a single click and saves the picked bed", async () => {
+    apiMocks.bedList.mockResolvedValue({
+      data: {
+        results: [
+          { id: 101, name: "Beet A", field: 11, area_sqm: 1 },
+          { id: 102, name: "Beet B", field: 11, area_sqm: 3 },
+        ],
+      },
+    });
+    const user = userEvent.setup();
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+
+    const latestProps = commandApiSpies.gridProps.mock.calls.at(-1)?.[0];
+    const bedColumn = (latestProps?.columns ?? []).find(
+      (column: { field: string }) => column.field === "bed",
+    );
+    const cell = render(
+      <>
+        {bedColumn.renderCell({
+          id: 7,
+          field: "bed",
+          value: 101,
+          row: { id: 7, bed: 101, area_m2: 1 },
+          hasFocus: false,
+        })}
+      </>,
+    );
+
+    await user.click(cell.getByRole("button", { name: "Anbaufläche bearbeiten" }));
+    await user.click(await screen.findByRole("combobox", { name: "Beet" }));
+    await user.click(await screen.findByRole("option", { name: /^Beet B/ }));
+    await user.click(screen.getByRole("button", { name: "Übernehmen" }));
+
+    await waitFor(() => {
+      expect(commandApiSpies.applyDialogEditValues).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ bed: 102 }),
+      );
+    });
+    expect(commandApiSpies.setDraftValues).not.toHaveBeenCalled();
+    cell.unmount();
   });
 
   it("uses one compact width for all date columns", async () => {

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -178,6 +178,7 @@ export function EditableDataGrid<T extends EditableRow>({
   defaultSortModel = [],
   persistSortInUrl = true,
   notes,
+  dialogEditFields,
   commandApiRef,
   onSelectedRowChange,
   getRowValidationErrors,
@@ -655,6 +656,16 @@ export function EditableDataGrid<T extends EditableRow>({
     () => notes?.fields.map((fieldConfig) => fieldConfig.field) ?? [],
     [notes],
   );
+  // Notes and dialog-edited cells share one rule: they own their editor, so the
+  // grid never starts inline edit mode for them, but they stay keyboard stops.
+  const dedicatedEditorFieldNames = useMemo(
+    () => [...notesFieldNames, ...(dialogEditFields ?? [])],
+    [dialogEditFields, notesFieldNames],
+  );
+  const hasDedicatedEditor = useCallback(
+    (field: string): boolean => dedicatedEditorFieldNames.includes(field),
+    [dedicatedEditorFieldNames],
+  );
 
   // Check if there's a validation error (indicating incomplete/invalid data)
   const hasValidationError = Boolean(error);
@@ -748,8 +759,8 @@ export function EditableDataGrid<T extends EditableRow>({
   ), [gridApiRef]);
 
   const isActionCellKeyboardNavigable = useCallback((params: GridCellParams<T>): boolean => (
-    notesFieldNames.includes(params.field)
-  ), [notesFieldNames]);
+    hasDedicatedEditor(params.field)
+  ), [hasDedicatedEditor]);
 
   const getKeyboardNavigableFieldsForRow = useCallback((rowId: GridRowId): string[] => {
     const api = gridApiRef.current;
@@ -794,11 +805,11 @@ export function EditableDataGrid<T extends EditableRow>({
       focusDataGridKeyboardNavigableCell<T>({
         api,
         cell: { id: rowId, field },
-        focusEditInput: rowModesModel[rowId]?.mode === GridRowModes.Edit
-          || (options.startEdit && !notesFieldNames.includes(field)),
+        focusEditInput: !hasDedicatedEditor(field)
+          && (rowModesModel[rowId]?.mode === GridRowModes.Edit || options.startEdit),
       });
 
-      if (!options.startEdit || notesFieldNames.includes(field)) {
+      if (!options.startEdit || hasDedicatedEditor(field)) {
         return;
       }
 
@@ -815,7 +826,7 @@ export function EditableDataGrid<T extends EditableRow>({
         [rowId]: { mode: GridRowModes.Edit, fieldToFocus: field },
       }));
     });
-  }, [gridApiRef, notesFieldNames, rowModesModel, rowsById, runAfterRowVisible]);
+  }, [gridApiRef, hasDedicatedEditor, rowModesModel, rowsById, runAfterRowVisible]);
 
   const getHorizontalNavigationTarget = useCallback((
     rowId: GridRowId,
@@ -1038,6 +1049,19 @@ export function EditableDataGrid<T extends EditableRow>({
     )
   ), [columns, gridApiRef]);
 
+  /** Whether the grid currently offers an inline editor for this cell. */
+  const isEditableCell = useCallback((rowId: GridRowId, field: string): boolean => {
+    if (!columns.find((column) => column.field === field)?.editable) {
+      return false;
+    }
+    const api = gridApiRef.current;
+    try {
+      return api?.isCellEditable(api.getCellParams(rowId, field)) ?? true;
+    } catch {
+      return true;
+    }
+  }, [columns, gridApiRef]);
+
   const applyDraftValues = useCallback(async (rowId: GridRowId, values: Partial<T>): Promise<void> => {
     const rowKey = String(rowId);
     const isEditing = rowModesModel[rowId]?.mode === GridRowModes.Edit;
@@ -1046,7 +1070,10 @@ export function EditableDataGrid<T extends EditableRow>({
 
     if (isEditing && api) {
       const editUpdates = Object.entries(values).flatMap(([fieldKey, fieldValue]) => {
-        if (fieldKey === 'id' || fieldKey === 'isNew') {
+        // MUI throws for a field that has no editor in the open edit session,
+        // so values for read-only or dialog-edited columns are carried by the
+        // `setRows` merge below instead.
+        if (fieldKey === 'id' || fieldKey === 'isNew' || !isEditableCell(rowId, fieldKey)) {
           return [];
         }
         return [
@@ -1074,7 +1101,7 @@ export function EditableDataGrid<T extends EditableRow>({
       }));
     }
     markRowDirty(rowKey);
-  }, [getRowValidationErrors, gridApiRef, markRowDirty, rowModesModel, rowsById]);
+  }, [getRowValidationErrors, gridApiRef, isEditableCell, markRowDirty, rowModesModel, rowsById]);
 
   const runBeforeSaveGate = useCallback(async (row: T): Promise<T | null> => {
     if (!onBeforeSaveRow) {
@@ -1217,13 +1244,13 @@ export function EditableDataGrid<T extends EditableRow>({
     }
 
     navigateFromEditedCell(current, sameRowTarget, {
-      startTargetEdit: !notesFieldNames.includes(sameRowTarget.field),
+      startTargetEdit: !hasDedicatedEditor(sameRowTarget.field),
     });
     return true;
   }, [
     getHorizontalNavigationTarget,
+    hasDedicatedEditor,
     navigateFromEditedCell,
-    notesFieldNames,
   ]);
 
   const handleEditableRowEditStop: GridEventListener<'rowEditStop'> = useCallback((params, event, details): void => {
@@ -1449,6 +1476,44 @@ export function EditableDataGrid<T extends EditableRow>({
     }
   }, [applyDraftValues, getDraftRow, gridApiRef, handleProcessRowUpdateError, rowsById, saveResolvedRow]);
 
+  const applyDialogEditValues = useCallback(async (
+    rowId: GridRowId,
+    values: Partial<T>,
+  ): Promise<void> => {
+    const rowKey = String(rowId);
+    await applyDraftValues(rowId, values);
+
+    if (rowModesModel[rowId]?.mode === GridRowModes.Edit) {
+      // The row already has an open edit session (typically a new draft row).
+      // Its own save cycle persists the dialog values together with the rest,
+      // so committing here would save a half-filled row.
+      return;
+    }
+
+    const baseRow = getDraftRow(rowId) ?? (rowsById.get(rowKey) as T | undefined);
+    if (!baseRow) {
+      return;
+    }
+
+    try {
+      const savedRow = await processRowUpdate({ ...baseRow, ...values } as T);
+      setRows((previousRows) =>
+        previousRows.map((currentRow) =>
+          String(currentRow.id) === rowKey ? savedRow : currentRow,
+        ),
+      );
+    } catch (error) {
+      handleProcessRowUpdateError(error);
+    }
+  }, [
+    applyDraftValues,
+    getDraftRow,
+    handleProcessRowUpdateError,
+    processRowUpdate,
+    rowModesModel,
+    rowsById,
+  ]);
+
   const handleSaveRow = useCallback(async (rowId: GridRowId): Promise<void> => {
     const preparedRow = await prepareRowForSave(rowId);
     if (!preparedRow) {
@@ -1497,7 +1562,7 @@ export function EditableDataGrid<T extends EditableRow>({
           : prevRows,
       );
       focusKeyboardNavigableCell(target.id, target.field, {
-        startEdit: options.startTargetEdit ?? !notesFieldNames.includes(target.field),
+        startEdit: options.startTargetEdit ?? !hasDedicatedEditor(target.field),
       });
     } catch (error) {
       handleProcessRowUpdateError(error);
@@ -1505,7 +1570,7 @@ export function EditableDataGrid<T extends EditableRow>({
   }, [
     focusKeyboardNavigableCell,
     handleProcessRowUpdateError,
-    notesFieldNames,
+    hasDedicatedEditor,
     prepareRowForSave,
     processRowUpdate,
   ]);
@@ -1572,7 +1637,7 @@ export function EditableDataGrid<T extends EditableRow>({
 
     if (String(target.id) === String(current.id)) {
       navigateFromEditedCell(current, target, {
-        startTargetEdit: !notesFieldNames.includes(target.field),
+        startTargetEdit: !hasDedicatedEditor(target.field),
       });
       return true;
     }
@@ -1584,9 +1649,9 @@ export function EditableDataGrid<T extends EditableRow>({
     getHorizontalNavigationTarget,
     gridApiRef,
     handleSaveRow,
+    hasDedicatedEditor,
     isActionCellKeyboardNavigable,
     navigateFromEditedCell,
-    notesFieldNames,
     rowsForGrid,
     saveEditedRowAndFocusTarget,
   ]);
@@ -1756,6 +1821,9 @@ export function EditableDataGrid<T extends EditableRow>({
     apiRef: gridApiRef,
     rowModesModel,
     setRowModesModel,
+    // Notes and dialog cells own their editor, so neither F2 nor "just start
+    // typing" may pull them into the inline edit mode they never leave through.
+    isCellEditable: (params) => !hasDedicatedEditor(params.field),
     onBeforeEdit: rememberRowSnapshotForCellEdit,
     onReplaceValue: (params) => markRowDirty(String(params.id)),
   });
@@ -1877,6 +1945,7 @@ export function EditableDataGrid<T extends EditableRow>({
     setRowModesModel,
     applyDraftValues,
     commitDraftValues,
+    applyDialogEditValues,
     reload: fetchData,
     focusTable,
     openRowById,
@@ -2628,6 +2697,11 @@ export function EditableDataGrid<T extends EditableRow>({
               }
             }
             markRowDirty(rowKey);
+            if (hasDedicatedEditor(params.field)) {
+              // The cell's own popover/dialog is the editor and the click has
+              // already opened it — never layer inline edit mode on top.
+              return;
+            }
             handleEditableCellClick(params, rowModesModel, setRowModesModel);
           }}
           onCellKeyDown={(params: GridCellParams<T>, event) => {

--- a/frontend/src/components/data-grid/hooks/useDataGridCommandApi.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridCommandApi.ts
@@ -14,6 +14,7 @@ interface UseDataGridCommandApiParams<T extends EditableRow> {
   setRowModesModel: Dispatch<SetStateAction<GridRowModesModel>>;
   applyDraftValues: (rowId: GridRowId, values: Partial<T>) => Promise<void>;
   commitDraftValues: (rowId: GridRowId, values: Partial<T>) => Promise<void>;
+  applyDialogEditValues: (rowId: GridRowId, values: Partial<T>) => Promise<void>;
   reload: () => Promise<void>;
   focusTable: () => void;
   openRowById: (rowId: GridRowId, options?: { startEdit?: boolean }) => void;
@@ -29,6 +30,7 @@ export function useDataGridCommandApi<T extends EditableRow>({
   setRowModesModel,
   applyDraftValues,
   commitDraftValues,
+  applyDialogEditValues,
   reload,
   focusTable,
   openRowById,
@@ -57,6 +59,9 @@ export function useDataGridCommandApi<T extends EditableRow>({
       commitDraftValues: async (rowId, values) => {
         await commitDraftValues(rowId, values as Partial<T>);
       },
+      applyDialogEditValues: async (rowId, values) => {
+        await applyDialogEditValues(rowId, values as Partial<T>);
+      },
       reload,
       focusTable,
       openRowById,
@@ -66,6 +71,7 @@ export function useDataGridCommandApi<T extends EditableRow>({
       commandApiRef.current = null;
     };
   }, [
+    applyDialogEditValues,
     applyDraftValues,
     commandApiRef,
     commitDraftValues,

--- a/frontend/src/components/data-grid/types.ts
+++ b/frontend/src/components/data-grid/types.ts
@@ -26,6 +26,13 @@ export interface EditableDataGridCommandApi {
   reload: () => Promise<void>;
   focusTable: () => void;
   openRowById: (rowId: GridRowId, options?: { startEdit?: boolean }) => void;
+  /**
+   * Writes values produced by a `dialogEditFields` cell's own popover/dialog.
+   * A row that already has an inline edit session open just receives the
+   * values into its draft; a row in view mode is saved right away, because a
+   * dialog cell never opens an edit session of its own.
+   */
+  applyDialogEditValues: (rowId: GridRowId, values: Partial<EditableRow>) => Promise<void>;
 }
 
 export interface EditableDataGridRowActionHelpers<T extends EditableRow> {
@@ -84,6 +91,16 @@ export interface EditableDataGridProps<T extends EditableRow> {
   notes?: {
     fields: NotesFieldConfig[];
   };
+  /**
+   * Fields whose value is only ever picked in a popover/dialog that the
+   * column's own `renderCell` owns (e.g. the Standort → Parzelle → Beet
+   * picker). Like notes cells these never open the inline row-edit mode: a
+   * single left click — or Enter/Space on the focused cell — opens the real
+   * editor, while Tab/arrow navigation still treats the cell as a stop.
+   * Columns listed here must stay `editable: false` and write their result
+   * back through `EditableDataGridCommandApi.applyDialogEditValues`.
+   */
+  dialogEditFields?: string[];
   commandApiRef?: MutableRefObject<EditableDataGridCommandApi | null>;
   onSelectedRowChange?: (row: T | null) => void;
   getRowValidationErrors?: (row: T) => Record<string, string>;

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -7,16 +7,15 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
-  IconButton,
   InputLabel,
   MenuItem,
   Stack,
   Typography,
 } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
 import { useTranslation } from '../../i18n';
 import type { Bed, Field, Location } from '../../api/types';
 import EmptyStateCard from '../project/EmptyStateCard';
+import { CompactAreaCell } from './CompactAreaCell';
 import {
   collectHierarchyAvailability,
   filterFieldOptionsByLocation,
@@ -147,19 +146,8 @@ function AreaAssignmentDialogComponent({
   const locationSelectRef = useRef<HTMLDivElement | null>(null);
   const fieldSelectRef = useRef<HTMLDivElement | null>(null);
   const bedSelectRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLDivElement | null>(null);
   const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
   const applyButtonRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    if (!hasFocus || isOpen) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      triggerRef.current?.focus();
-    });
-  }, [hasFocus, isOpen]);
 
   const fieldsById = useMemo(() => new Map(fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item])), [fields]);
 
@@ -419,50 +407,14 @@ function AreaAssignmentDialogComponent({
 
   return (
     <>
-      <Box
-        ref={triggerRef}
-        role="button"
-        tabIndex={hasFocus ? 0 : -1}
-        aria-label={t('areaAssignment.editButton')}
-        onClick={handleOpen}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            event.stopPropagation();
-            handleOpen();
-          }
-        }}
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 0.5,
-          width: '100%',
-          overflow: 'hidden',
-          cursor: 'pointer',
-          borderRadius: 0.5,
-          '&:focus-visible': {
-            outline: '2px solid',
-            outlineColor: 'primary.main',
-            outlineOffset: '1px',
-          },
-        }}
-      >
-        <Typography
-          variant="body2"
-          noWrap
-          sx={{ flexGrow: 1, color: compactLabel ? 'text.primary' : 'text.disabled' }}
-        >
-          {compactLabel || placeholder}
-        </Typography>
-        <IconButton
-          size="small"
-          tabIndex={-1}
-          aria-hidden
-          onClick={handleOpen}
-        >
-          <EditIcon fontSize="small" />
-        </IconButton>
-      </Box>
+      <CompactAreaCell
+        label={compactLabel}
+        placeholder={placeholder}
+        hasFocus={hasFocus}
+        suppressFocus={isOpen}
+        onOpen={handleOpen}
+        triggerLabel={t('areaAssignment.editButton')}
+      />
       <Dialog
         open={isOpen}
         onClose={handleCancel}

--- a/frontend/src/components/planting-plans/CompactAreaCell.tsx
+++ b/frontend/src/components/planting-plans/CompactAreaCell.tsx
@@ -5,34 +5,88 @@ import { OverflowTooltip } from '../OverflowTooltip';
 interface CompactAreaCellProps {
   label: string;
   hasFocus?: boolean;
+  /**
+   * Turns the cell into the trigger for its own editor. Passing this makes a
+   * single left click (and Enter/Space on the focused cell) open the editor
+   * directly, without the grid's inline edit mode in between.
+   */
+  onOpen?: () => void;
+  /** Shown instead of `label` while no area is assigned yet. */
+  placeholder?: string;
+  /** Accessible name for the trigger; only used together with `onOpen`. */
+  triggerLabel?: string;
+  /** Keeps focus where it is while the editor itself is open. */
+  suppressFocus?: boolean;
 }
 
-export function CompactAreaCell({ label, hasFocus = false }: CompactAreaCellProps) {
+export function CompactAreaCell({
+  label,
+  hasFocus = false,
+  onOpen,
+  placeholder,
+  triggerLabel,
+  suppressFocus = false,
+}: CompactAreaCellProps) {
   const triggerRef = useRef<HTMLDivElement | null>(null);
+  const displayText = label || placeholder || '';
 
   useEffect(() => {
-    if (!hasFocus) {
+    if (!hasFocus || suppressFocus) {
       return;
     }
 
     requestAnimationFrame(() => {
       triggerRef.current?.focus();
     });
-  }, [hasFocus]);
+  }, [hasFocus, suppressFocus]);
 
   return (
-    <OverflowTooltip title={label}>
+    <OverflowTooltip title={displayText}>
       <Box
         ref={triggerRef}
-        sx={{ width: '100%', minWidth: 0, overflow: 'hidden', display: 'flex', alignItems: 'center', height: '100%' }}
+        role={onOpen ? 'button' : undefined}
+        aria-label={onOpen ? triggerLabel : undefined}
+        aria-haspopup={onOpen ? 'dialog' : undefined}
+        onClick={onOpen}
+        onKeyDown={onOpen ? (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            onOpen();
+          }
+        } : undefined}
+        sx={{
+          width: '100%',
+          minWidth: 0,
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          height: '100%',
+          ...(onOpen
+            ? {
+              cursor: 'pointer',
+              borderRadius: 0.5,
+              '&:focus-visible': {
+                outline: '2px solid',
+                outlineColor: 'primary.main',
+                outlineOffset: '1px',
+              },
+            }
+            : {}),
+        }}
         tabIndex={hasFocus ? 0 : -1}
       >
         <Typography
           variant="body2"
           noWrap
-          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: label ? 'text.primary' : 'text.disabled',
+          }}
         >
-          {label}
+          {displayText}
         </Typography>
       </Box>
     </OverflowTooltip>

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -14,6 +14,7 @@ import type {
   GridCellParams,
   GridColDef,
   GridRenderCellParams,
+  GridRowId,
   GridValueOptionsParams,
 } from "@mui/x-data-grid";
 import {
@@ -92,7 +93,6 @@ import {
   getTranslatedProjectSetupActions,
 } from "./requirementFlow";
 import { AreaAssignmentDialog } from "../components/planting-plans/AreaAssignmentDialog";
-import { CompactAreaCell } from "../components/planting-plans/CompactAreaCell";
 import EmptyStateCard from "../components/project/EmptyStateCard";
 import { formatCultureDisplayName } from "../cultures/cultureDisplay";
 
@@ -124,6 +124,8 @@ const DATA_GRID_HEADER_LABEL_SX = { fontWeight: 600 };
 
 const CULTURE_COLUMN_MAX_WIDTH = 280;
 const BED_COLUMN_MAX_WIDTH = 220;
+/** Columns whose editor is a dialog the cell opens on a single click. */
+const PLANTING_PLAN_DIALOG_EDIT_FIELDS = ["bed"];
 
 function PlantingPlans() {
   const { t } = useTranslation(["plantingPlans", "common"]);
@@ -302,6 +304,28 @@ function PlantingPlans() {
     ],
   );
 
+  /**
+   * Writes a growing-area selection made in the AreaAssignmentDialog back into
+   * the grid. The bed cell has no inline edit mode, so the column's former
+   * `valueSetter` side effects (hierarchy sync, area autofill for new rows)
+   * live here instead.
+   */
+  const applyBedSelection = useCallback(
+    async (rowId: GridRowId, row: PlantingPlanRow, nextBedId: number): Promise<void> => {
+      const selectedBed = bedById.get(nextBedId);
+      const shouldAutofillArea = Boolean(row.isNew)
+        && (row.area_m2 === undefined || row.area_m2 === null);
+
+      await gridCommandApiRef.current?.applyDialogEditValues(rowId, {
+        bed: nextBedId,
+        ...normalizeSelectionAfterBedChange(row, nextBedId, fields, beds),
+        ...(shouldAutofillArea && selectedBed?.area_sqm !== undefined
+          ? { area_m2: selectedBed.area_sqm }
+          : {}),
+      });
+    },
+    [bedById, beds, fields],
+  );
 
   /**
    * Check for cultureId or bedId parameter in URL and set as initial values
@@ -521,11 +545,14 @@ function PlantingPlans() {
       },
       {
         field: "bed",
-          headerName: areaColumnLabel,
+        headerName: areaColumnLabel,
         flex: 0,
         minWidth: dynamicWidths.bed,
         maxWidth: BED_COLUMN_MAX_WIDTH,
-        editable: true,
+        // The growing area is only ever picked in AreaAssignmentDialog, so the
+        // cell skips inline edit mode entirely — see the grid's
+        // `dialogEditFields` prop below.
+        editable: false,
         type: "singleSelect",
         valueOptions: bedOptions,
         valueFormatter: (_value, row) => getBedLabelForRow(row as PlantingPlanRow),
@@ -539,13 +566,8 @@ function PlantingPlans() {
         },
         renderCell: (params) => {
           const row = params.row as PlantingPlanRow;
-          const label = getBedLabelForRow(row);
-          return <CompactAreaCell label={label} hasFocus={params.hasFocus} />;
-        },
-        renderEditCell: (params) => {
-          const row = params.row as PlantingPlanRow;
           const bedId = resolveBedCellValue(params.value, row);
-          const label = getBedLabelForRow({ ...row, bed: bedId });
+          const label = getBedLabelForRow(row);
           return (
             <AreaAssignmentDialog
               bedId={bedId || null}
@@ -557,32 +579,9 @@ function PlantingPlans() {
               placeholder={t("plantingPlans:placeholders.selectArea")}
               hasFocus={params.hasFocus}
               memoKey={`${String(params.id)}:${params.field}`}
-              onApply={async (nextBedId) => {
-                await params.api.setEditCellValue({
-                  id: params.id,
-                  field: "bed",
-                  value: nextBedId,
-                });
-              }}
+              onApply={(nextBedId) => applyBedSelection(params.id, row, nextBedId)}
             />
           );
-        },
-        valueSetter: (value, row) => {
-          const nextRow = row as PlantingPlanRow;
-          const numericValue = resolveBedCellValue(value, nextRow);
-          const selectedBed = bedById.get(numericValue);
-          const isNewRow = Boolean(nextRow.isNew);
-          const currentArea = nextRow.area_m2;
-          const shouldAutofill = isNewRow && (currentArea === undefined || currentArea === null);
-
-          return {
-            ...nextRow,
-            ...normalizeSelectionAfterBedChange(nextRow, numericValue, fields, beds),
-            area_m2:
-              shouldAutofill && selectedBed?.area_sqm !== undefined
-                ? selectedBed.area_sqm
-                : currentArea,
-          } as PlantingPlanRow;
         },
       },
       {
@@ -757,7 +756,7 @@ function PlantingPlans() {
       },
     ],
     [
-      bedById,
+      applyBedSelection,
       bedLabelById,
       bedOptions,
       beds,
@@ -1559,6 +1558,7 @@ function PlantingPlans() {
             scrollMode="continuous"
             columns={columns}
             api={plantingPlanGridAPI}
+            dialogEditFields={PLANTING_PLAN_DIALOG_EDIT_FIELDS}
             commandApiRef={gridCommandApiRef}
             onSelectedRowChange={setSelectedPlan}
             onRowsStateChange={(rows) => {


### PR DESCRIPTION
## Problem

Cells whose value is only ever picked in a dialog needed **two** clicks: the first entered the grid's inline edit mode, which did nothing but reveal a pencil button; the second clicked that button to open the actual editor. The intermediate edit state carried no information, so the first click was pure overhead.

Only one such cell exists today — the Anbaupläne **Anbaufläche** column (Standort → Parzelle → Beet picker, `AreaAssignmentDialog`). Both grid pages were checked: `FieldsBedsHierarchy.tsx`'s only non-inline-edited column is `notes`, which already opens its drawer on a single click, and the remaining tables (Lieferanten, Saatgutbedarf) are plain read-only MUI `<Table>`s. Dropdown columns (Kultur, Anbauart) were deliberately left alone — they are inline editors with typeahead, not popover-only pickers, and converting them would break the documented "just start typing" behaviour.

## Change

A shared `dialogEditFields` concept on `EditableDataGrid`, modelled on how notes cells already work rather than as a page-specific special case:

- such columns are `editable: false` and render **both** the value and the dialog from `renderCell` (not `renderEditCell`), so a single left click lands directly on the dialog trigger
- no inline edit mode is started for them — from a click, from `F2`, or from "just start typing"
- the pencil icon is gone; the cell text itself is the trigger
- they stay Tab/Shift+Tab/arrow stops via the existing `isActionCell` hook (`editable: false` alone would drop them out of navigation), `Enter`/`Space` opens the editor, and focus returns to the cell after the dialog closes

The dialog writes its result back through a new command-API method, `applyDialogEditValues(rowId, values)`, instead of `setEditCellValue` (no edit session exists) or a column `valueSetter` (only runs in edit mode). It branches on the row's state: a row already in inline edit mode — typically a new draft row — only gets the values merged into its draft so its own save cycle persists everything at once; a row in view mode is saved immediately through the normal `processRowUpdate` path, including the `onBeforeSaveRow` area-validation gate. The bed column's former `valueSetter` side effects (hierarchy sync, area autofill for new rows) moved into `applyBedSelection` in `PlantingPlans.tsx`.

`CompactAreaCell` and `AreaAssignmentDialog` were merged into one trigger + dialog pair rather than duplicating the label rendering.

### Bug found and fixed along the way

`applyDraftValues` threw when values targeted a column with no editor in the open edit session — MUI's `setEditCellValue` rejects that outright. This surfaced as the dialog refusing to close when picking a bed on a new draft row. It now routes those fields through the `setRows` merge instead. The grid test mock was tightened to throw like MUI does, so the case is guarded.

## Verification

- `npm run lint` (0 errors, 57 warnings — unchanged baseline), `tsc -b`, `lint:circular` unchanged
- `npm run test`: 1737 passing (180 files), including new coverage for the click/keyboard/navigation rules, the command-API branching, and the `applyDraftValues` regression
- Playwright, driven against a real backend on the production build, manually verified: one click opens the dialog and the picked bed persists across a reload; a new draft row keeps its bed + autofilled area and saves as one unit; arrow/Tab navigation crosses the cell without opening it; right-click still opens the row context menu; normal cells keep click-to-edit + Escape; the hierarchy notes drawer is unaffected. The permanent e2e spec gained an equivalent single-click + keyboard case.

## Docs

`docs/datagrid-architecture.md` gains a "Cells edited in a popover/dialog" section, plus updates to the imperative-API list, the keyboard-editing notes, and the pre-change checklist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyaBtQwRhutP38aJU2zHfE)_