### PR TITLE
fix: keep the page layout stable when menus and dialogs open

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -209,6 +209,20 @@ a new one.
 - **Deployment/infrastructure live in a separate repository**
   (`OpenFarmPlanner-ops`) — this repo intentionally has no Dockerfile,
   deploy scripts, or cron config for production use.
+- **`overflow-x: hidden` belongs on `<body>`/`#root`, never on `<html>`**
+  (`frontend/src/index.css`). The viewport takes its overflow from the root
+  element and only falls back to `<body>` when the root's own overflow is
+  `visible`. Setting it on `<html>` makes `<html>` the scrolling box, which
+  silently disables MUI's modal scroll lock — `Modal`/`Menu`/`Popover`/
+  `Dialog` set `overflow: hidden` on `<body>` and add the scrollbar width as
+  `padding-right` to compensate. With the compensation applied but the
+  scrollbar still there, every menu shrank the page sideways. Guarded by
+  `frontend/e2e/scrollbar-layout.spec.ts`.
+- **A viewport-fixed backdrop and its overlay must share one containing
+  block** (`components/HeroImage.tsx`'s `position` prop applies to the image
+  *and* the dimming overlay). Pinning the image to the viewport while the
+  overlay stays bound to a container lets the raw image show through
+  wherever the two disagree in width.
 
 ## Unclear / needs check
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -24,6 +24,12 @@ npm run test:e2e
   - `E2E_TEST_TOKEN` is set for the backend process started by Playwright
 - `FRONTEND_PORT` and `BACKEND_PORT` env vars override the default ports (4173 / 8000) if
   you need to run E2E tests alongside an already-running dev environment.
+- Two Playwright projects exist. `chromium` runs everything except
+  `scrollbar-layout.spec.ts`; `chromium-scrollbars` runs only that spec, with headless
+  Chrome's `--hide-scrollbars` flag dropped so the page actually renders a classic
+  scrollbar. That spec is about MUI's modal scroll lock compensating the scrollbar
+  width, which is unobservable without one. Keep the rest of the suite (and its
+  screenshot baselines) on the default, scrollbar-free rendering.
 
 See `frontend/playwright.config.ts` for exact runtime settings. In CI, the
 `E2E (production build)` workflow (`.github/workflows/e2e.yml`) runs this same build+test

--- a/frontend/e2e/scrollbar-layout.spec.ts
+++ b/frontend/e2e/scrollbar-layout.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Guards the interaction between MUI's modal scroll lock and the page's own
+ * overflow rules. When a `Menu`/`Popover`/`Dialog` opens, MUI hides the page
+ * scrollbar and compensates its width with `padding-right` on `<body>`. That
+ * only nets out when `<body>` really is the element whose overflow the viewport
+ * uses — an `overflow-x` on `<html>` silently breaks it, and the page then
+ * shrinks by the scrollbar width on every menu open.
+ *
+ * Functional/geometric assertions rather than screenshots: what matters is that
+ * boxes keep their exact coordinates, which a pixel diff would only cover
+ * indirectly while needing a re-baseline for every unrelated visual tweak.
+ *
+ * Runs in the `chromium-scrollbars` project, which keeps the classic scrollbar
+ * that the default headless run hides — without it there is no scrollbar to
+ * compensate and the regression is invisible. See playwright.config.ts.
+ */
+
+const AUTH_ROUTES = [
+  { key: 'login', path: '/login', heading: /Anmelden/i },
+  { key: 'register', path: '/register', heading: /Registrieren|Konto erstellen/i },
+];
+
+// Deliberately short: every page under test has to overflow vertically, or
+// there is no scrollbar for the scroll lock to compensate.
+const VIEWPORT = { width: 1280, height: 600 };
+
+function languageButton(page: Page): Locator {
+  return page.getByRole('button', { name: /Sprache|language/i }).first();
+}
+
+async function box(locator: Locator) {
+  const value = await locator.boundingBox();
+  expect(value).not.toBeNull();
+  return value!;
+}
+
+async function pageMetrics(page: Page) {
+  return page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    clientWidth: document.documentElement.clientWidth,
+    bodyPaddingRight: getComputedStyle(document.body).paddingRight,
+  }));
+}
+
+test.describe('scroll lock does not reshape the page', () => {
+  test('the test environment actually renders a classic scrollbar', async ({ page }) => {
+    await page.setViewportSize(VIEWPORT);
+    await page.goto('/register');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    const metrics = await pageMetrics(page);
+    // Without this the remaining assertions would pass vacuously.
+    expect(metrics.innerWidth - metrics.clientWidth).toBeGreaterThan(0);
+  });
+
+  for (const route of AUTH_ROUTES) {
+    test(`keeps the ${route.key} card and hero backdrop in place while the language menu is open`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(VIEWPORT);
+      await page.goto(route.path);
+      await expect(page.getByRole('heading', { level: 1, name: route.heading })).toBeVisible();
+
+      // CSS rather than a role query: an open Modal marks the whole app root
+      // `aria-hidden`, so role-based locators stop resolving inside it exactly
+      // when this test needs to measure.
+      const card = page.locator('.MuiPaper-root:has(h1)').first();
+      const before = await box(card);
+
+      await languageButton(page).click();
+      await expect(page.getByRole('menuitemradio', { name: 'English' })).toBeVisible();
+
+      // The scroll lock has to remove the scrollbar it compensates for,
+      // otherwise the compensation padding is pure loss and shifts the page.
+      const open = await pageMetrics(page);
+      expect(open.innerWidth - open.clientWidth).toBe(0);
+
+      // No layout shift: the card must not move by so much as a pixel.
+      const during = await box(card);
+      expect(Math.abs(during.x - before.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(during.width - before.width)).toBeLessThanOrEqual(1);
+
+      // No bare strip: the dimming overlay has to reach the viewport edges,
+      // exactly like the hero image it sits on.
+      const overlay = await box(page.getByTestId('hero-image-overlay'));
+      expect(overlay.x).toBeLessThanOrEqual(1);
+      expect(Math.abs(overlay.x + overlay.width - open.innerWidth)).toBeLessThanOrEqual(1);
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('menuitemradio', { name: 'English' })).toHaveCount(0);
+
+      const after = await box(card);
+      expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(after.width - before.width)).toBeLessThanOrEqual(1);
+    });
+  }
+
+  test('keeps the landing page header in place while the language menu is open', async ({ page }) => {
+    await page.setViewportSize(VIEWPORT);
+    await page.goto('/');
+    await expect(page.locator('header h1')).toHaveText('OpenFarmPlanner');
+
+    const logo = page.locator('header h1');
+    const before = await box(logo);
+
+    await languageButton(page).click();
+    await expect(page.getByRole('menuitemradio', { name: 'English' })).toBeVisible();
+
+    const during = await box(logo);
+    expect(Math.abs(during.x - before.x)).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -78,6 +78,21 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      testIgnore: /scrollbar-layout\.spec\.ts/,
+    },
+    {
+      // Headless Chrome is launched with `--hide-scrollbars`, so the page never
+      // gets the classic scrollbar that MUI's modal scroll lock compensates for
+      // - the very thing scrollbar-layout.spec.ts is about. Dropping that flag
+      // for this project only keeps the rest of the suite (and its screenshot
+      // baselines) on the default, scrollbar-free rendering.
+      name: 'chromium-scrollbars',
+      testMatch: /scrollbar-layout\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome',
+        launchOptions: { ignoreDefaultArgs: ['--hide-scrollbars'] },
+      },
     },
   ],
 });

--- a/frontend/src/__tests__/HeroImage.test.tsx
+++ b/frontend/src/__tests__/HeroImage.test.tsx
@@ -32,4 +32,20 @@ describe('HeroImage', () => {
     const overlay = container.querySelector('[aria-hidden="true"]');
     expect(overlay).not.toBeNull();
   });
+
+  // Regression: the auth pages used to pin the image to the viewport while the
+  // overlay stayed bound to the container. Whenever the two containing blocks
+  // disagreed in width - e.g. while MUI's modal scroll lock pads <body> - the
+  // undimmed image showed through as a strip along the right edge.
+  it('positions the overlay in the same containing block as the image', () => {
+    render(
+      <HeroImage alt="A field" position="fixed" overlaySx={{ backgroundColor: 'red' }} />,
+    );
+
+    const img = screen.getByRole('img', { name: 'A field' });
+    const overlay = screen.getByTestId('hero-image-overlay');
+
+    expect(img).toHaveStyle({ position: 'fixed' });
+    expect(overlay).toHaveStyle({ position: 'fixed' });
+  });
 });

--- a/frontend/src/components/HeroImage.tsx
+++ b/frontend/src/components/HeroImage.tsx
@@ -1,5 +1,6 @@
 import { Box, styled } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
+import type { ResponsiveStyleValue } from '@mui/system';
 import { useState } from 'react';
 import { publicAssetUrl } from '../utils/publicAssetUrl';
 
@@ -22,10 +23,20 @@ const HERO_IMAGE_SRC_SET = [
   `${HERO_IMAGE_SRC} 1920w`,
 ].join(', ');
 
+type HeroPosition = 'absolute' | 'fixed';
+
 interface HeroImageProps {
   /** Accessible description of the image. Pass "" for purely decorative use. */
   alt: string;
-  /** Additional/overriding sx merged onto the absolutely-positioned <img>. */
+  /**
+   * Positioning scheme for the backdrop. `absolute` (the default) anchors it
+   * to the nearest positioned ancestor, `fixed` pins it to the viewport.
+   * Applied to the image *and* its overlay together, so the two always share
+   * one containing block — mixing them would let the raw image show through
+   * wherever the container and the viewport disagree in size.
+   */
+  position?: ResponsiveStyleValue<HeroPosition>;
+  /** Additional/overriding sx merged onto the <img>. */
   sx?: SxProps<Theme>;
   /** Optional overlay (e.g. a readability gradient) rendered above the image. */
   overlaySx?: SxProps<Theme>;
@@ -37,7 +48,7 @@ interface HeroImageProps {
  * discover and prioritize it as early as possible, and fades it in once
  * loaded to avoid a jarring pop-in on slower connections.
  */
-export default function HeroImage({ alt, sx, overlaySx }: HeroImageProps) {
+export default function HeroImage({ alt, position = 'absolute', sx, overlaySx }: HeroImageProps) {
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -54,7 +65,7 @@ export default function HeroImage({ alt, sx, overlaySx }: HeroImageProps) {
         height={HERO_IMAGE_HEIGHT}
         onLoad={() => setLoaded(true)}
         sx={{
-          position: 'absolute',
+          position,
           inset: 0,
           width: '100%',
           height: '100%',
@@ -64,7 +75,9 @@ export default function HeroImage({ alt, sx, overlaySx }: HeroImageProps) {
           ...sx,
         }}
       />
-      {overlaySx ? <Box aria-hidden sx={{ position: 'absolute', inset: 0, ...overlaySx }} /> : null}
+      {overlaySx ? (
+        <Box aria-hidden data-testid="hero-image-overlay" sx={{ position, inset: 0, ...overlaySx }} />
+      ) : null}
     </>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,23 @@ body,
 #root {
   width: 100%;
   max-width: 100%;
+}
+
+/*
+ * Horizontal overflow is clamped on <body> and #root, deliberately NOT on
+ * <html>. The viewport takes its overflow from the root element and only falls
+ * back to <body> when the root's own overflow is `visible`. With `overflow-x`
+ * set on <html>, <html> becomes the scrolling box, so MUI's modal scroll lock
+ * — which sets `overflow: hidden` on <body> — can no longer remove the page
+ * scrollbar, while it still adds its scrollbar-width compensation padding to
+ * <body>. Every menu, popover and dialog then shrank the page by the scrollbar
+ * width and exposed a bare strip along the right edge.
+ * Leaving the clamp on <body> keeps the same "no horizontal page scrollbar"
+ * guarantee (the value propagates to the viewport) and restores the
+ * shift-free scroll lock MUI is built around.
+ */
+body,
+#root {
   overflow-x: hidden;
 }
 

--- a/frontend/src/pages/auth/AuthPageShell.tsx
+++ b/frontend/src/pages/auth/AuthPageShell.tsx
@@ -27,7 +27,7 @@ export default function AuthPageShell({ title, subtitle, children, legalLinksDen
     >
       <HeroImage
         alt=""
-        sx={{ position: { xs: 'absolute', md: 'fixed' } }}
+        position={{ xs: 'absolute', md: 'fixed' }}
         overlaySx={{
           backgroundImage:
             'linear-gradient(rgba(245, 247, 241, 0.88), rgba(245, 247, 241, 0.9))',


### PR DESCRIPTION
Opening the language menu on the login/registration pages exposed a narrow vertical strip of the **undimmed hero photo** along the right edge, and nudged the whole page sideways by the scrollbar width.

## Root cause

Two independent causes, both reproducible locally at 1280×600 in Chromium with classic scrollbars:

**1. The modal scroll lock was compensating for a scrollbar it never removed.**

`frontend/src/index.css` set `overflow-x: hidden` on `html`, `body` *and* `#root`. The viewport takes its overflow from the root element and only falls back to `<body>` when the root's own overflow is `visible` — so `<html>` was the scrolling box. MUI's scroll lock (`Modal`/`Menu`/`Popover`/`Dialog`) sets `overflow: hidden` on `<body>` and adds the scrollbar width as `padding-right` to compensate. With `<html>` owning the scroll, the `overflow: hidden` did nothing, the scrollbar stayed, and the padding was pure loss.

Measured on `/login` before the fix, at the moment the menu opens:

| | closed | open (before) | open (after) |
|---|---|---|---|
| `documentElement.clientWidth` | 1265 | 1265 (scrollbar still there) | 1280 (scrollbar gone) |
| `body` `padding-right` | 0px | 15px | 15px |
| page shell width | 1265 | **1250** | 1265 |

**2. The hero image and its dimming overlay lived in different containing blocks.**

`AuthPageShell` pinned the image to the viewport (`position: fixed` from `md` up) while `HeroImage` hard-coded `position: absolute` on the overlay, binding it to the shell. Any width disagreement between viewport and container — exactly what the compensation padding creates — let the raw photo show through. That was the visible strip.

## Fix

- `index.css`: the horizontal clamp moves to `body`/`#root` only. It still propagates to the viewport, so the "no horizontal page scrollbar" guarantee is unchanged (verified: an element wider than the viewport inside `#root` is still clipped, `scrollX` stays 0), but `<body>` is now the scrolling box the scroll lock expects. Zero shift, and it fixes every menu/popover/dialog in the app, not just the auth pages.
- `HeroImage`: new `position` prop applied to the image **and** the overlay together, so the two can never drift apart. `AuthPageShell` passes `{ xs: 'absolute', md: 'fixed' }` through it instead of overriding only the image via `sx`. The `xs`/`md` split is preserved deliberately — it is the translation of the earlier `backgroundAttachment: { xs: 'scroll', md: 'fixed' }`.

## Why this is robust

Neither change is auth-page specific. The CSS fix restores the invariant MUI's scroll lock is built around, so it holds for any current or future overlay component. The `HeroImage` fix makes the mismatch unrepresentable — the overlay can no longer be positioned differently from the image it dims.

## Tests

- `frontend/e2e/scrollbar-layout.spec.ts` (new): on `/login`, `/register` and `/`, asserts the scroll lock actually removes the scrollbar, the auth card does not move by even a pixel while the menu is open, and the overlay reaches both viewport edges. Verified to fail without each fix independently (reverting only the CSS → 3 failures incl. a 7.5px landing-page shift; reverting only the overlay position → the 2 auth failures at 15px).
- `frontend/playwright.config.ts`: new `chromium-scrollbars` project that drops headless Chrome's `--hide-scrollbars` for that spec only. Without a real scrollbar there is nothing to compensate and the regression is invisible. The rest of the suite — including the screenshot baselines — stays on the default rendering.
- `frontend/src/__tests__/HeroImage.test.tsx`: unit-level guard that the overlay shares the image's `position`.

## Breakpoints checked

Desktop (1280), tablet (800) and mobile (390), on `/login`, `/register`, `/` and `/demo`: no layout shift anywhere, scroll lock effective everywhere. **Mobile behaviour is unchanged by design** — below `md` the hero stays container-bound, so the reclaimed scrollbar column shows the document background (`#f7f6f1`) rather than the shell's (`#f5f7f1`); a 2/1/0 RGB difference, and on real touch devices there is no classic scrollbar to reclaim in the first place. This is the standard MUI scroll-lock appearance shared with every other page.

## Browser coverage

Verified in Chromium with classic scrollbars forced on. Firefox and WebKit could not be exercised — this sandbox's network policy blocks the Playwright browser CDN (403), so only the pre-installed Chromium was available. The behaviour relied on is the CSS overflow-propagation rule, which is spec'd and implemented identically in Blink, Gecko and WebKit; on macOS Firefox/Safari the overlay scrollbars mean MUI never adds the compensation padding at all, so the bug does not arise there. Worth a manual look in those two before merging.

## Docs

- `docs/architecture-overview.md`: both invariants recorded under "Notable architecture & UX decisions" so the `html` overflow rule is not reintroduced.
- `frontend/e2e/README.md`: notes the two Playwright projects and why they are split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ptqd9AMG47xc34fhCsdJe

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ptqd9AMG47xc34fhCsdJe)_