### PR TITLE
Refactor legal document pages with shared LegalDocumentLayout

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -93,7 +93,10 @@ clobbered by a leftover value in a shared browser.
 ### Where the switcher lives
 
 - **Public pages** — landing page header, all auth pages (via `AuthPageShell`),
-  imprint / privacy / terms (via `PublicPageLanguageBar`).
+  imprint / privacy / terms (via `PublicPageLanguageBar`). On the legal
+  documents the bar is pinned to the top-right corner of the document container
+  by `LegalDocumentLayout`, i.e. positioned absolutely: it costs no vertical
+  space and cannot shift the centred document title.
 - **Signed-in app** — the account menu (desktop and mobile) under a "Language"
   section, and Account settings → *Language*.
 

--- a/frontend/src/__tests__/LegalDocumentLayout.test.tsx
+++ b/frontend/src/__tests__/LegalDocumentLayout.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import ImprintPage from '../pages/public/ImprintPage';
+import PrivacyPolicyPage from '../pages/public/PrivacyPolicyPage';
+import TermsOfServicePage from '../pages/public/TermsOfServicePage';
+
+const legalPages = [
+  ['Imprint', ImprintPage],
+  ['Privacy policy', PrivacyPolicyPage],
+  ['Terms of service', TermsOfServicePage],
+] as const;
+
+function renderPage(Page: (typeof legalPages)[number][1]): void {
+  render(
+    <MemoryRouter>
+      <Page />
+    </MemoryRouter>,
+  );
+}
+
+function getLanguageSwitcher(): HTMLElement {
+  return screen.getByRole('button', { name: /Sprache/ });
+}
+
+function getDocumentContainer(): HTMLElement {
+  return screen.getByRole('heading', { level: 1 }).closest('.MuiContainer-root') as HTMLElement;
+}
+
+describe.each(legalPages)('%s layout', (_name, Page) => {
+  it('pins the language switcher to the top-right corner of the document container', () => {
+    renderPage(Page);
+
+    const container = getDocumentContainer();
+    const switcherRow = getLanguageSwitcher().parentElement as HTMLElement;
+
+    expect(container).toBeInTheDocument();
+    expect(getComputedStyle(container).position).toBe('relative');
+    expect(getComputedStyle(switcherRow).position).toBe('absolute');
+    expect(switcherRow.parentElement).toBe(container);
+  });
+
+  it('keeps the switcher out of the document flow instead of giving it its own row', () => {
+    renderPage(Page);
+
+    const heading = screen.getByRole('heading', { level: 1 });
+    const flowRoot = heading.parentElement?.parentElement as HTMLElement;
+
+    // The heading's Stack is the first element in the flow: nothing (least of
+    // all the switcher) may sit above it and push the document down.
+    expect(flowRoot.firstElementChild).toBe(heading.parentElement);
+    expect(within(heading.parentElement as HTMLElement).queryByRole('button', { name: /Sprache/ })).toBeNull();
+  });
+
+  it('centres the document title', () => {
+    renderPage(Page);
+
+    expect(getComputedStyle(screen.getByRole('heading', { level: 1 })).textAlign).toBe('center');
+  });
+});

--- a/frontend/src/components/legal/LegalDocumentLayout.tsx
+++ b/frontend/src/components/legal/LegalDocumentLayout.tsx
@@ -1,0 +1,69 @@
+/**
+ * Shared shell for the legal documents (imprint, privacy policy, terms).
+ *
+ * The language switcher is pinned to the top-right corner of the document
+ * container instead of sitting in a row of its own: it is taken out of the
+ * document flow, so it costs no vertical space and cannot push or shift the
+ * centred title. The container's top padding is only large enough to clear the
+ * pinned switcher, which keeps the document starting as high as the switcher
+ * allows without ever overlapping the title on narrow screens.
+ */
+
+import type { ReactNode } from 'react';
+import { Container, Stack, Typography } from '@mui/material';
+
+import PublicPageLanguageBar from '../../i18n/PublicPageLanguageBar';
+
+/**
+ * Distance in px from the container's top/right edge to the switcher (`top` and
+ * `right` are not spacing-aware in `sx`). Together with the switcher's 44px
+ * touch target this defines how far down the title can start.
+ */
+const languageSwitcherSx = {
+  position: 'absolute',
+  top: { xs: 8, sm: 12, md: 16 },
+  right: { xs: 8, sm: 12, md: 16 },
+  zIndex: 1,
+  '@media print': { display: 'none' },
+} as const;
+
+/** Clears the pinned switcher (top offset + its 44px height) with a little air. */
+const documentSx = {
+  position: 'relative',
+  pt: { xs: 7, sm: 7.5, md: 8 },
+  pb: { xs: 6, md: 9 },
+} as const;
+
+/**
+ * The German titles are single long words ("Nutzungsbedingungen"), so the
+ * heading scales down on phones instead of overflowing the viewport.
+ */
+const titleSx = {
+  textAlign: 'center',
+  fontSize: { xs: '1.75rem', sm: '2.5rem', md: '3rem' },
+  overflowWrap: 'anywhere',
+} as const;
+
+interface LegalDocumentLayoutProps {
+  title: string;
+  /** Centred under the title, e.g. the print action or a cross-reference link. */
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+export default function LegalDocumentLayout({ title, actions, children }: LegalDocumentLayoutProps) {
+  return (
+    <Container maxWidth="md" sx={documentSx}>
+      <PublicPageLanguageBar sx={languageSwitcherSx} />
+      <Stack spacing={3}>
+        <Stack spacing={2} alignItems="center">
+          <Typography variant="h3" component="h1" sx={titleSx}>
+            {title}
+          </Typography>
+          {actions}
+        </Stack>
+        {children}
+      </Stack>
+    </Container>
+  );
+}

--- a/frontend/src/pages/public/ImprintPage.tsx
+++ b/frontend/src/pages/public/ImprintPage.tsx
@@ -1,6 +1,6 @@
-import { Container, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { useTranslation } from '../../i18n';
-import PublicPageLanguageBar from '../../i18n/PublicPageLanguageBar';
+import LegalDocumentLayout from '../../components/legal/LegalDocumentLayout';
 
 const imprintSections = [
   'provider',
@@ -12,22 +12,15 @@ export default function ImprintPage() {
   const { t } = useTranslation('home');
 
   return (
-    <Container maxWidth="md" sx={{ py: { xs: 6, md: 9 } }}>
-      <Stack spacing={3}>
-        <PublicPageLanguageBar />
-        <Typography variant="h3" component="h1">
-          {t('legal.imprint.title')}
-        </Typography>
-
-        {imprintSections.map((sectionKey) => (
-          <Stack key={sectionKey} spacing={0.5}>
-            <Typography variant="h6">{t(`legal.imprint.sections.${sectionKey}.title`)}</Typography>
-            <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
-              {t(`legal.imprint.sections.${sectionKey}.content`)}
-            </Typography>
-          </Stack>
-        ))}
-      </Stack>
-    </Container>
+    <LegalDocumentLayout title={t('legal.imprint.title')}>
+      {imprintSections.map((sectionKey) => (
+        <Stack key={sectionKey} spacing={0.5}>
+          <Typography variant="h6">{t(`legal.imprint.sections.${sectionKey}.title`)}</Typography>
+          <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
+            {t(`legal.imprint.sections.${sectionKey}.content`)}
+          </Typography>
+        </Stack>
+      ))}
+    </LegalDocumentLayout>
   );
 }

--- a/frontend/src/pages/public/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/public/PrivacyPolicyPage.tsx
@@ -1,7 +1,7 @@
-import { Box, Container, Link, Stack, Typography } from '@mui/material';
+import { Box, Link, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router';
 import { useTranslation } from '../../i18n';
-import PublicPageLanguageBar from '../../i18n/PublicPageLanguageBar';
+import LegalDocumentLayout from '../../components/legal/LegalDocumentLayout';
 
 const privacySections = [
   'controller',
@@ -35,46 +35,42 @@ export default function PrivacyPolicyPage() {
   const { t, i18n } = useTranslation('home');
 
   return (
-    <Container maxWidth="md" sx={{ py: { xs: 6, md: 9 } }}>
-      <Stack spacing={3}>
-        <PublicPageLanguageBar />
-        <Typography variant="h3" component="h1">
-          {t('legal.privacy.title')}
-        </Typography>
-
+    <LegalDocumentLayout
+      title={t('legal.privacy.title')}
+      actions={
         <Link component={RouterLink} to="/nutzungsbedingungen" underline="hover">
           {t('legal.terms.title')}
         </Link>
-
-        {privacySections.map((sectionKey, index) => {
-          const bulletKeys = privacySectionBulletKeys[sectionKey];
-          return (
-            <Stack key={sectionKey} spacing={1}>
-              <Typography variant="h6">{`${index + 1}. ${t(`legal.privacy.sections.${sectionKey}.title`)}`}</Typography>
-              <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
-                {t(`legal.privacy.sections.${sectionKey}.content`)}
+      }
+    >
+      {privacySections.map((sectionKey, index) => {
+        const bulletKeys = privacySectionBulletKeys[sectionKey];
+        return (
+          <Stack key={sectionKey} spacing={1}>
+            <Typography variant="h6">{`${index + 1}. ${t(`legal.privacy.sections.${sectionKey}.title`)}`}</Typography>
+            <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
+              {t(`legal.privacy.sections.${sectionKey}.content`)}
+            </Typography>
+            {bulletKeys ? (
+              <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
+                {bulletKeys.map((bulletKey) => (
+                  <li key={bulletKey}>{t(`legal.privacy.sections.${sectionKey}.bullets.${bulletKey}`)}</li>
+                ))}
+              </Box>
+            ) : null}
+            {i18n.exists(`home:legal.privacy.sections.${sectionKey}.legalBasis`) ? (
+              <Typography color="text.secondary" sx={{ fontWeight: 500 }}>
+                {t(`legal.privacy.sections.${sectionKey}.legalBasis`)}
               </Typography>
-              {bulletKeys ? (
-                <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
-                  {bulletKeys.map((bulletKey) => (
-                    <li key={bulletKey}>{t(`legal.privacy.sections.${sectionKey}.bullets.${bulletKey}`)}</li>
-                  ))}
-                </Box>
-              ) : null}
-              {i18n.exists(`home:legal.privacy.sections.${sectionKey}.legalBasis`) ? (
-                <Typography color="text.secondary" sx={{ fontWeight: 500 }}>
-                  {t(`legal.privacy.sections.${sectionKey}.legalBasis`)}
-                </Typography>
-              ) : null}
-              {i18n.exists(`home:legal.privacy.sections.${sectionKey}.contact`) ? (
-                <Typography color="text.secondary">{t(`legal.privacy.sections.${sectionKey}.contact`)}</Typography>
-              ) : null}
-            </Stack>
-          );
-        })}
+            ) : null}
+            {i18n.exists(`home:legal.privacy.sections.${sectionKey}.contact`) ? (
+              <Typography color="text.secondary">{t(`legal.privacy.sections.${sectionKey}.contact`)}</Typography>
+            ) : null}
+          </Stack>
+        );
+      })}
 
-        <Typography color="text.secondary">{t('legal.privacy.version')}</Typography>
-      </Stack>
-    </Container>
+      <Typography color="text.secondary">{t('legal.privacy.version')}</Typography>
+    </LegalDocumentLayout>
   );
 }

--- a/frontend/src/pages/public/TermsOfServicePage.tsx
+++ b/frontend/src/pages/public/TermsOfServicePage.tsx
@@ -1,7 +1,7 @@
 import PrintIcon from '@mui/icons-material/Print';
-import { Box, Button, Container, Stack, Typography } from '@mui/material';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import { useTranslation } from '../../i18n';
-import PublicPageLanguageBar from '../../i18n/PublicPageLanguageBar';
+import LegalDocumentLayout from '../../components/legal/LegalDocumentLayout';
 
 const termsSections = [
   'provider',
@@ -30,45 +30,40 @@ export default function TermsOfServicePage() {
   const { t } = useTranslation('home');
 
   return (
-    <Container maxWidth="md" sx={{ py: { xs: 6, md: 9 } }}>
-      <Stack spacing={3}>
-        <PublicPageLanguageBar />
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }} justifyContent="space-between">
-          <Typography variant="h3" component="h1">
-            {t('legal.terms.title')}
-          </Typography>
-          <Button
-            type="button"
-            variant="outlined"
-            startIcon={<PrintIcon />}
-            onClick={() => window.print()}
-            sx={{ '@media print': { display: 'none' } }}
-          >
-            {t('legal.terms.print')}
-          </Button>
-        </Stack>
+    <LegalDocumentLayout
+      title={t('legal.terms.title')}
+      actions={
+        <Button
+          type="button"
+          variant="outlined"
+          startIcon={<PrintIcon />}
+          onClick={() => window.print()}
+          sx={{ '@media print': { display: 'none' } }}
+        >
+          {t('legal.terms.print')}
+        </Button>
+      }
+    >
+      {termsSections.map((sectionKey, index) => {
+        const bulletKeys = termsSectionBulletKeys[sectionKey];
+        return (
+          <Stack key={sectionKey} spacing={1}>
+            <Typography variant="h6">{`${index + 1}. ${t(`legal.terms.sections.${sectionKey}.title`)}`}</Typography>
+            <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
+              {t(`legal.terms.sections.${sectionKey}.content`)}
+            </Typography>
+            {bulletKeys ? (
+              <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
+                {bulletKeys.map((bulletKey) => (
+                  <li key={bulletKey}>{t(`legal.terms.sections.${sectionKey}.bullets.${bulletKey}`)}</li>
+                ))}
+              </Box>
+            ) : null}
+          </Stack>
+        );
+      })}
 
-        {termsSections.map((sectionKey, index) => {
-          const bulletKeys = termsSectionBulletKeys[sectionKey];
-          return (
-            <Stack key={sectionKey} spacing={1}>
-              <Typography variant="h6">{`${index + 1}. ${t(`legal.terms.sections.${sectionKey}.title`)}`}</Typography>
-              <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
-                {t(`legal.terms.sections.${sectionKey}.content`)}
-              </Typography>
-              {bulletKeys ? (
-                <Box component="ul" sx={{ mt: 0, mb: 0, pl: 3, color: 'text.secondary' }}>
-                  {bulletKeys.map((bulletKey) => (
-                    <li key={bulletKey}>{t(`legal.terms.sections.${sectionKey}.bullets.${bulletKey}`)}</li>
-                  ))}
-                </Box>
-              ) : null}
-            </Stack>
-          );
-        })}
-
-        <Typography color="text.secondary">{t('legal.terms.version')}</Typography>
-      </Stack>
-    </Container>
+      <Typography color="text.secondary">{t('legal.terms.version')}</Typography>
+    </LegalDocumentLayout>
   );
 }


### PR DESCRIPTION
## Summary
Consolidates the layout logic for legal document pages (Imprint, Privacy Policy, Terms of Service) into a new reusable `LegalDocumentLayout` component, eliminating code duplication and improving the positioning of the language switcher.

## Key Changes
- **New component**: Created `LegalDocumentLayout` that provides a consistent shell for all legal documents with:
  - Centered title rendering
  - Support for optional action elements (e.g., print button, cross-reference links)
  - Language switcher pinned to the top-right corner using absolute positioning
  - Proper spacing that accounts for the pinned switcher without pushing content down

- **Refactored pages**: Updated `ImprintPage`, `PrivacyPolicyPage`, and `TermsOfServicePage` to use the new layout component, removing duplicate Container/Stack/PublicPageLanguageBar boilerplate

- **Added tests**: Created comprehensive test suite (`LegalDocumentLayout.test.tsx`) verifying:
  - Language switcher is pinned to the top-right corner
  - Switcher is positioned absolutely and doesn't affect document flow
  - Document title is centered

## Notable Implementation Details
- The language switcher is positioned absolutely within the document container, taking it out of the normal document flow so it doesn't consume vertical space or shift the centered title
- Container top padding is sized to clear the pinned switcher (44px height + configurable offset) while keeping the document as high as possible
- German legal document titles (e.g., "Nutzungsbedingungen") scale responsively on mobile to prevent overflow
- The layout supports flexible action elements passed as children, accommodating different needs across the three legal pages
- Print styles hide the language switcher via `@media print`

https://claude.ai/code/session_01NZbbUxF5NjCLPR2o2uwr7M