### PR TITLE
Refactor supplier data section layout and conditional field rendering

### DIFF
--- a/frontend/src/__tests__/CultureForm.test.tsx
+++ b/frontend/src/__tests__/CultureForm.test.tsx
@@ -445,6 +445,66 @@ describe('CultureForm', () => {
     });
   });
 
+  it('shows only a compact hint instead of supplier fields while no supplier is selected', async () => {
+    supplierListMock.mockResolvedValueOnce({ data: { results: [{ id: 10, name: 'Bingenheimer' }] } });
+
+    render(
+      <CultureForm
+        culture={{ ...CULTURE_A, supplier_data: [{ packaging_sizes: [] }] }}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onCancel={() => {}}
+      />,
+    );
+
+    expect(await screen.findByTestId('culture-supplier-data-hint')).toHaveTextContent('form.supplierDataSelectSupplierHint');
+    expect(screen.queryByLabelText('form.supplierProductNameLabel')).not.toBeInTheDocument();
+    expect(screen.queryByText('form.seedPackagesLabel')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'form.addSeedPackage' })).not.toBeInTheDocument();
+    // The row stays removable even without a selected supplier.
+    expect(screen.getByRole('button', { name: 'form.removeSupplierData' })).toBeInTheDocument();
+  });
+
+  it('reveals the supplier fields once a supplier is selected', async () => {
+    supplierListMock.mockResolvedValueOnce({ data: { results: [{ id: 10, name: 'Bingenheimer' }] } });
+
+    render(
+      <CultureForm
+        culture={{ ...CULTURE_A, supplier_data: [{ packaging_sizes: [] }] }}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onCancel={() => {}}
+      />,
+    );
+
+    const supplierSelect = await screen.findByRole('combobox');
+    fireEvent.mouseDown(supplierSelect);
+    fireEvent.click(screen.getByRole('option', { name: 'Bingenheimer' }));
+
+    expect(await screen.findByLabelText('form.supplierProductNameLabel')).toBeInTheDocument();
+    expect(screen.getByText('form.seedPackagesLabel')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'form.addSeedPackage' })).toBeInTheDocument();
+    expect(screen.queryByTestId('culture-supplier-data-hint')).not.toBeInTheDocument();
+  });
+
+  it('lays out the supplier section vertically without reserving extra height', async () => {
+    supplierListMock.mockResolvedValueOnce({ data: { results: [{ id: 10, name: 'Bingenheimer' }] } });
+
+    render(
+      <CultureForm
+        culture={{ ...CULTURE_A, supplier_data: [{ supplier_id: 10, supplier_name: 'Bingenheimer', packaging_sizes: [] }] }}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onCancel={() => {}}
+      />,
+    );
+
+    const section = await screen.findByTestId('culture-supplier-data-section');
+    expect(section).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '14px',
+    });
+    expect(section).not.toHaveStyle({ height: '100%' });
+  });
+
   it('shows duplicate culture validation and blocks saving', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     cultureDuplicateCheckMock.mockResolvedValueOnce({ data: { exists: true } });

--- a/frontend/src/__tests__/formLayout.test.ts
+++ b/frontend/src/__tests__/formLayout.test.ts
@@ -4,8 +4,11 @@ import {
   formRowSx,
   fullWidthFieldSx,
   mediumFieldSx,
+  mediumStackedFieldSx,
   smallFieldSx,
   wideFieldSx,
+  wideSingleColumnFieldSx,
+  wideStackedFieldSx,
 } from '../components/forms/formLayout';
 
 describe('form layout widths', () => {
@@ -18,6 +21,17 @@ describe('form layout widths', () => {
     expect(sx.width).toEqual({ xs: '100%', sm: desktopWidth });
     expect(sx.maxWidth).toEqual({ xs: '100%', sm: desktopWidth });
     expect(sx.flex).toEqual({ xs: '1 1 100%', sm: `0 1 ${desktopWidth}px` });
+  });
+
+  it.each([
+    ['mediumStacked', mediumStackedFieldSx],
+    ['wideSingleColumn', wideSingleColumnFieldSx],
+    ['wideStacked', wideStackedFieldSx],
+  ])('keeps %s fields free of a flex-basis that would become a height in a column', (_name, sx) => {
+    expect(sx).not.toHaveProperty('flex');
+    expect(sx).not.toHaveProperty('flexBasis');
+    expect(sx).not.toHaveProperty('height');
+    expect(sx).not.toHaveProperty('minHeight');
   });
 
   it('keeps prose fields full width and allows compact rows to wrap', () => {

--- a/frontend/src/cultures/CultureForm.tsx
+++ b/frontend/src/cultures/CultureForm.tsx
@@ -55,9 +55,9 @@ import { SupplierFormDialog } from '../components/suppliers/SupplierFormDialog';
 import {
   compactFieldSx,
   formRowSx,
-  mediumFieldSx,
+  mediumStackedFieldSx,
   smallFieldSx,
-  wideFieldSx,
+  wideSingleColumnFieldSx,
 } from '../components/forms/formLayout';
 
 interface CultureFormProps {
@@ -73,6 +73,8 @@ interface CultureFormProps {
 
 // Default color for display color picker
 const DEFAULT_DISPLAY_COLOR = '#3498db';
+// Vertical rhythm of the supplier data section (MUI spacing unit = 8px -> 14px).
+const SUPPLIER_SECTION_GAP = 1.75;
 const FOCUSABLE_DIALOG_ELEMENT_SELECTOR = [
   'a[href]',
   'button:not([disabled])',
@@ -800,8 +802,16 @@ export function CultureForm({
             ) : null}
             {extraSections}
             {showSupplierDataSection ? (
-              <>
-                <Typography variant="h6" sx={{ mt: 1 }}>{t('form.supplierDataSectionTitle')}</Typography>
+              <Box
+                data-testid="culture-supplier-data-section"
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: SUPPLIER_SECTION_GAP,
+                  mt: 1,
+                }}
+              >
+                <Typography variant="h6">{t('form.supplierDataSectionTitle')}</Typography>
                 <Typography variant="body2" color="text.secondary">
                   {t('form.supplierDataSectionDescription')}
                 </Typography>
@@ -810,147 +820,171 @@ export function CultureForm({
                     {t('form.noSupplierDataRows')}
                   </Typography>
                 ) : null}
-                {supplierRows.map((row, supplierIndex) => (
-                  <Box
-                    key={`supplier-row-${supplierIndex}`}
-                    data-testid="culture-supplier-data-row"
-                    sx={{
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      borderRadius: 1,
-                      p: 1,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-start',
-                      gap: 1,
-                      minHeight: 0,
-                      flexGrow: 0,
-                    }}
-                  >
-                {(() => {
+                {supplierRows.map((row, supplierIndex) => {
                   const selectedSupplierId = row.supplier_id ?? row.supplier?.id ?? null;
                   const availableSupplierIds = new Set(supplierOptions.map((supplier) => supplier.id));
                   const hasSelectedSupplier = typeof selectedSupplierId === 'number';
                   const isSelectedSupplierAvailable = hasSelectedSupplier && availableSupplierIds.has(selectedSupplierId);
                   const selectValue = isSelectedSupplierAvailable ? String(selectedSupplierId) : '';
-                  if (supplierOptions.length === 0) {
-                    return (
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: { xs: 'stretch', sm: 'center' },
-                          justifyContent: 'space-between',
-                          gap: 1,
-                          flexDirection: { xs: 'column', sm: 'row' },
-                          border: '1px solid',
-                          borderColor: 'surface.surfaceSoftBorder',
-                          borderRadius: 1,
-                          bgcolor: 'surface.surfaceSubtleBackground',
-                          px: 1.5,
-                          py: 1.25,
-                        }}
-                      >
-                        <Typography variant="body2" color="text.secondary">
-                          {t('form.noSuppliers')}
-                        </Typography>
-                        <Button
-                          ref={(element) => {
-                            createSupplierButtonRefs.current[supplierIndex] = element;
-                          }}
-                          variant="outlined"
-                          size="small"
-                          onClick={() => handleCreateSupplierClick(supplierIndex)}
-                        >
-                          {t('form.createSuppliers')}
-                        </Button>
-                      </Box>
-                    );
-                  }
+                  const hasSupplierOptions = supplierOptions.length > 0;
+                  // Supplier-specific inputs stay unmounted until a supplier is picked so the
+                  // section never reserves height for fields that cannot be filled in yet.
+                  const showSupplierFields = hasSupplierOptions && isSelectedSupplierAvailable;
 
                   return (
-                    <FormControl size="small" sx={mediumFieldSx}>
-                      <InputLabel shrink>{t('form.supplier')}</InputLabel>
-                      <Select
-                        fullWidth
-                        value={selectValue}
-                        label={t('form.supplier')}
-                        renderValue={(selected) => {
-                          if (!selected) {
-                            return (
-                              <Typography component="span" color="text.secondary">
-                                {t('form.supplierPlaceholder')}
-                              </Typography>
-                            );
-                          }
-                          const selectedSupplier = supplierOptions.find((supplier) => String(supplier.id) === String(selected));
-                          return selectedSupplier?.name ?? '';
-                        }}
-                        onChange={(event) => {
-                          const selectedValue = String(event.target.value ?? '');
+                    <Box
+                      key={`supplier-row-${supplierIndex}`}
+                      data-testid="culture-supplier-data-row"
+                      sx={{
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                        p: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                        gap: SUPPLIER_SECTION_GAP,
+                        minHeight: 0,
+                        flexGrow: 0,
+                      }}
+                    >
+                      {hasSupplierOptions ? (
+                        <FormControl size="small" sx={mediumStackedFieldSx}>
+                          <InputLabel shrink>{t('form.supplier')}</InputLabel>
+                          <Select
+                            fullWidth
+                            value={selectValue}
+                            label={t('form.supplier')}
+                            renderValue={(selected) => {
+                              if (!selected) {
+                                return (
+                                  <Typography component="span" color="text.secondary">
+                                    {t('form.supplierPlaceholder')}
+                                  </Typography>
+                                );
+                              }
+                              const selectedSupplier = supplierOptions.find((supplier) => String(supplier.id) === String(selected));
+                              return selectedSupplier?.name ?? '';
+                            }}
+                            onChange={(event) => {
+                              const selectedValue = String(event.target.value ?? '');
 
-                          const parsedSupplierId = Number(selectedValue);
-                          const selectedSupplier = supplierOptions.find((supplier) => supplier.id === parsedSupplierId);
-                          updateSupplierRow(supplierIndex, {
-                            supplier_id: parsedSupplierId,
-                            supplier: selectedSupplier,
-                            supplier_name_input: selectedSupplier ? undefined : row.supplier_name_input,
-                            supplier_name: selectedSupplier?.name ?? row.supplier_name,
-                          });
-                        }}
-                        displayEmpty
-                      >
-                        {supplierOptions.map((supplier) => (
-                          <MenuItem key={supplier.id} value={String(supplier.id)}>{supplier.name}</MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
+                              const parsedSupplierId = Number(selectedValue);
+                              const selectedSupplier = supplierOptions.find((supplier) => supplier.id === parsedSupplierId);
+                              updateSupplierRow(supplierIndex, {
+                                supplier_id: parsedSupplierId,
+                                supplier: selectedSupplier,
+                                supplier_name_input: selectedSupplier ? undefined : row.supplier_name_input,
+                                supplier_name: selectedSupplier?.name ?? row.supplier_name,
+                              });
+                            }}
+                            displayEmpty
+                          >
+                            {supplierOptions.map((supplier) => (
+                              <MenuItem key={supplier.id} value={String(supplier.id)}>{supplier.name}</MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      ) : (
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: { xs: 'stretch', sm: 'center' },
+                            justifyContent: 'space-between',
+                            gap: 1,
+                            flexDirection: { xs: 'column', sm: 'row' },
+                            border: '1px solid',
+                            borderColor: 'surface.surfaceSoftBorder',
+                            borderRadius: 1,
+                            bgcolor: 'surface.surfaceSubtleBackground',
+                            px: 1.5,
+                            py: 1.25,
+                          }}
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            {t('form.noSuppliers')}
+                          </Typography>
+                          <Button
+                            ref={(element) => {
+                              createSupplierButtonRefs.current[supplierIndex] = element;
+                            }}
+                            variant="outlined"
+                            size="small"
+                            onClick={() => handleCreateSupplierClick(supplierIndex)}
+                          >
+                            {t('form.createSuppliers')}
+                          </Button>
+                        </Box>
+                      )}
+                      {hasSupplierOptions && !showSupplierFields ? (
+                        <Box
+                          data-testid="culture-supplier-data-hint"
+                          sx={{
+                            border: '1px solid',
+                            borderColor: 'surface.surfaceSoftBorder',
+                            borderRadius: 1,
+                            bgcolor: 'surface.surfaceSubtleBackground',
+                            px: 1.5,
+                            py: 1,
+                          }}
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            {t('form.supplierDataSelectSupplierHint')}
+                          </Typography>
+                        </Box>
+                      ) : null}
+                      {showSupplierFields ? (
+                        <>
+                          <TextField
+                            label={t('form.supplierProductNameLabel')}
+                            value={row.supplier_product_name ?? ''}
+                            onChange={(event) => updateSupplierRow(supplierIndex, { supplier_product_name: event.target.value })}
+                            sx={wideSingleColumnFieldSx}
+                          />
+                          <Typography variant="subtitle2">{t('form.seedPackagesLabel')}</Typography>
+                          {(row.packaging_sizes ?? []).map((pkg, packageIndex) => (
+                            <Box
+                              key={`pkg-${supplierIndex}-${packageIndex}`}
+                              sx={{ ...formRowSx, gap: 1, alignItems: 'center' }}
+                            >
+                              <TextField
+                                label={t('form.seedAmountLabel')}
+                                type="number"
+                                value={pkg.size_value}
+                                onChange={(event) => updatePackageRow(supplierIndex, packageIndex, { size_value: Number(event.target.value) || 0 })}
+                                sx={compactFieldSx}
+                              />
+                              <Select
+                                value={pkg.size_unit}
+                                onChange={(event) => updatePackageRow(supplierIndex, packageIndex, { size_unit: event.target.value })}
+                                size="small"
+                                sx={smallFieldSx}
+                              >
+                                <MenuItem value="g">{t('form.packageUnitGram')}</MenuItem>
+                                <MenuItem value="seeds">{t('form.packageUnitSeeds')}</MenuItem>
+                              </Select>
+                              <IconButton
+                                color="error"
+                                onClick={() => removePackageRow(supplierIndex, packageIndex)}
+                                aria-label={t('form.removeSeedPackageAriaLabel')}
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </Box>
+                          ))}
+                        </>
+                      ) : null}
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                        {showSupplierFields ? (
+                          <Button variant="outlined" onClick={() => addPackageRow(supplierIndex)}>{t('form.addSeedPackage')}</Button>
+                        ) : null}
+                        <Button variant="outlined" color="error" onClick={() => removeSupplierRow(supplierIndex)}>{t('form.removeSupplierData')}</Button>
+                      </Box>
+                    </Box>
                   );
-                })()}
-                <TextField
-                  label={t('form.supplierProductNameLabel') }
-                  value={row.supplier_product_name ?? ''}
-                  onChange={(event) => updateSupplierRow(supplierIndex, { supplier_product_name: event.target.value })}
-                  sx={wideFieldSx}
-                />
-                <Typography variant="subtitle2">{t('form.seedPackagesLabel')}</Typography>
-                {(row.packaging_sizes ?? []).map((pkg, packageIndex) => (
-                  <Box
-                    key={`pkg-${supplierIndex}-${packageIndex}`}
-                    sx={{ ...formRowSx, gap: 1, alignItems: 'center' }}
-                  >
-                    <TextField
-                      label={t('form.seedAmountLabel')}
-                      type="number"
-                      value={pkg.size_value}
-                      onChange={(event) => updatePackageRow(supplierIndex, packageIndex, { size_value: Number(event.target.value) || 0 })}
-                      sx={compactFieldSx}
-                    />
-                    <Select
-                      value={pkg.size_unit}
-                      onChange={(event) => updatePackageRow(supplierIndex, packageIndex, { size_unit: event.target.value })}
-                      size="small"
-                      sx={smallFieldSx}
-                    >
-                      <MenuItem value="g">{t('form.packageUnitGram')}</MenuItem>
-                      <MenuItem value="seeds">{t('form.packageUnitSeeds')}</MenuItem>
-                    </Select>
-                    <IconButton
-                      color="error"
-                      onClick={() => removePackageRow(supplierIndex, packageIndex)}
-                      aria-label={t('form.removeSeedPackageAriaLabel')}
-                    >
-                      <DeleteIcon fontSize="small" />
-                    </IconButton>
-                  </Box>
-                ))}
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                  <Button variant="outlined" onClick={() => addPackageRow(supplierIndex)}>{t('form.addSeedPackage')}</Button>
-                  <Button variant="outlined" color="error" onClick={() => removeSupplierRow(supplierIndex)}>{t('form.removeSupplierData')}</Button>
-                </Box>
-                  </Box>
-                ))}
+                })}
                 <Button variant="outlined" onClick={addSupplierRow}>{t('form.addSupplierData')}</Button>
-              </>
+              </Box>
             ) : null}
           </div>
         </DialogContent>

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -161,6 +161,7 @@
     "supplierDataSectionTitle": "Kulturspezifische Lieferantendaten",
     "supplierDataSectionDescription": "Die folgenden Angaben gelten nur für den ausgewählten Lieferanten dieser Kultur.",
     "noSupplierDataRows": "Noch keine kulturspezifischen Lieferanteninformationen vorhanden.",
+    "supplierDataSelectSupplierHint": "Wähle einen Lieferanten aus, um kulturspezifische Daten zu bearbeiten.",
     "supplierProductNameLabel": "Artikelbezeichnung beim Lieferanten",
     "supplierDataMissingSupplier": "Bitte einen Lieferanten auswählen oder die Lieferantendaten entfernen.",
     "addSupplierData": "Lieferanteninformation hinzufügen",

--- a/frontend/src/i18n/locales/en/cultures.json
+++ b/frontend/src/i18n/locales/en/cultures.json
@@ -161,6 +161,7 @@
     "supplierDataSectionTitle": "Crop-specific supplier data",
     "supplierDataSectionDescription": "The following details apply only to the selected supplier of this crop.",
     "noSupplierDataRows": "No crop-specific supplier information yet.",
+    "supplierDataSelectSupplierHint": "Select a supplier to edit crop-specific data.",
     "supplierProductNameLabel": "Product name at the supplier",
     "supplierDataMissingSupplier": "Please select a supplier or remove the supplier data.",
     "addSupplierData": "Add supplier information",


### PR DESCRIPTION
## Summary
Restructured the supplier data section in the CultureForm to improve layout consistency and user experience by conditionally rendering supplier-specific fields only when a supplier is selected, preventing unnecessary height reservation in the form.

## Key Changes
- **Layout restructuring**: Wrapped the entire supplier data section in a flex column container with consistent vertical spacing (using new `SUPPLIER_SECTION_GAP` constant of 1.75 spacing units = 14px)
- **Conditional field rendering**: Supplier-specific fields (product name, seed packages, add package button) now only render when a supplier is selected, preventing the form from reserving height for unavailable fields
- **User guidance**: Added a hint message that displays when suppliers are available but none is selected yet, guiding users to select a supplier before filling in additional details
- **Refactored supplier row logic**: Simplified the nested IIFE pattern into a cleaner map function with early variable declarations for better readability
- **Updated form layout styles**: Renamed and introduced new form field style exports:
  - `mediumFieldSx` → `mediumStackedFieldSx` (for use in flex column contexts)
  - `wideFieldSx` → `wideSingleColumnFieldSx` (for full-width fields in columns)
  - Added `wideStackedFieldSx` for consistency
  - These new styles intentionally omit flex/height properties to prevent unintended height constraints in column layouts
- **Added test coverage**: Three new tests verify the conditional rendering behavior, field visibility, and layout structure
- **Internationalization**: Added new translation key `supplierDataSelectSupplierHint` for the guidance message

## Implementation Details
- The `showSupplierFields` variable determines visibility based on whether supplier options exist and a valid supplier is selected
- The hint box uses the same visual styling as the "no suppliers" state for consistency
- All supplier-specific inputs remain unmounted until needed, improving performance and preventing layout thrashing
- Test assertions verify both the presence/absence of fields and the correct CSS flex properties on the section container

https://claude.ai/code/session_014v3YDdmuzsCjofqAcPF8Ph