### PR TITLE
Add keyboard navigation support for dialog-edited cells

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -272,6 +272,38 @@ grid then treats them exactly like notes cells:
   the trigger element itself, which stops propagation so the grid does not
   also react; after the dialog closes, focus returns to that trigger and
   ordinary navigation continues.
+- **Tab/Shift+Tab onto the cell opens the dialog** — that is what "entering
+  edit mode" means for a cell whose dialog *is* its edit session. Arrow keys
+  deliberately stay pure movement, so the cell can still be passed by without
+  a modal opening.
+
+That last point is what `DialogEditCellContext.tsx` exists for. The grid has
+no inline edit session to hang the dialog off, so `EditableDataGrid` publishes
+a *request* — `{ cellKey, token }` — every time keyboard navigation enters a
+`dialogEditFields` cell, and the cell's renderer opens on it via
+`useDialogEditCellOpenRequest(rowId, field, open)`. Two properties make
+repeated entries work where a "did I already open?" flag would not:
+
+- the token is bumped per entry, and a cell opens for a given token **exactly
+  once**, so a focus event, a click and the request all landing on the same
+  entry cannot stack up two dialogs (`AreaAssignmentDialog`'s `handleOpen` is
+  additionally idempotent while open, so a duplicate impulse can't reset a
+  draft the user is mid-way through);
+- the cell **consumes** the request as it opens, so nothing is left behind for
+  a later re-render or a re-mount (grid virtualization) to replay.
+
+Requests are issued from the Tab paths only — `handleViewModeCellNavigation`
+for a row in view mode, and `handleEditedCellTabNavigation` (via
+`navigateFromEditedCell` / `saveEditedRowAndFocusTarget` /
+`focusKeyboardNavigableCell`'s `requestDialogEdit` option) for a row in inline
+edit mode. Don't reintroduce a "the dialog was already opened once" flag or a
+timeout-based reopen: both are what made the cell open on the first Tab and
+never again.
+
+For this to hold, a cell renderer that focuses itself on `hasFocus` must
+cancel that pending frame on cleanup (see `CompactAreaCell`) — otherwise the
+frame scheduled by the focus that *caused* the request fires after the dialog
+mounted and pulls focus straight back out of it.
 
 The dialog writes its result back through the command API's
 `applyDialogEditValues(rowId, values)`, **not** `setEditCellValue` (there is

--- a/frontend/e2e/planting-plans-area-assignment-dialog.spec.ts
+++ b/frontend/e2e/planting-plans-area-assignment-dialog.spec.ts
@@ -7,6 +7,8 @@ const apiBase = `http://127.0.0.1:${backendPort}/api`;
 type AreaDialogFixtureOptions = {
   languageCode?: 'de' | 'en';
   longNames?: boolean;
+  /** Number of planting plans to create; defaults to a single row. */
+  planCount?: number;
 };
 
 async function createAreaDialogFixture(
@@ -76,13 +78,15 @@ async function createAreaDialogFixture(
     cultivation_types: ['pre_cultivation'],
     plants_per_m2: 4,
   });
-  await api<{ id: number }>('/planting-plans/', {
-    bed: bed.id,
-    culture: culture.id,
-    cultivation_type: 'pre_cultivation',
-    planting_date: '2026-04-10',
-    area_usage_sqm: 2,
-  });
+  for (let index = 0; index < (options.planCount ?? 1); index += 1) {
+    await api<{ id: number }>('/planting-plans/', {
+      bed: bed.id,
+      culture: culture.id,
+      cultivation_type: 'pre_cultivation',
+      planting_date: `2026-04-${String(10 + index).padStart(2, '0')}`,
+      area_usage_sqm: 2,
+    });
+  }
 }
 
 async function openAreaAssignmentDialog(page: Page, title: string, editLabel: string) {
@@ -155,6 +159,69 @@ test.describe('planting plans area assignment dialog', () => {
     await expect(
       page.locator('[role="gridcell"][data-field="cultivation_type"]').first(),
     ).toHaveAttribute('tabindex', '0');
+  });
+
+  test('reopens on every keyboard entry into the cell, forwards and backwards', async ({ page, request }) => {
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await createAreaDialogFixture(page, request, 'planting-plans-area-dialog-keyboard', { planCount: 3 });
+
+    await page.goto('/app/planting-plans');
+    await expect(page.getByRole('heading', { name: 'Anbaupläne' })).toBeVisible();
+
+    const dialog = page.getByRole('dialog', { name: 'Anbaufläche ändern' });
+    const cellAt = (field: string, rowIndex: number) =>
+      page.locator(`[role="gridcell"][data-field="${field}"]`).nth(rowIndex);
+    const bedCell = cellAt('bed', 0);
+    const previousCell = cellAt('cultivation_type', 0);
+    await expect(bedCell).toBeVisible();
+
+    // Tab onto the cell opens the dialog …
+    await previousCell.click();
+    await page.keyboard.press('Escape');
+    await previousCell.focus();
+    await page.keyboard.press('Tab');
+    await expect(dialog).toBeVisible();
+
+    // … cancelling leaves focus on the cell, and re-entering opens it again.
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+    await expect(dialog).toBeHidden();
+    await page.keyboard.press('Shift+Tab');
+    await expect(previousCell).toHaveAttribute('tabindex', '0');
+    await expect(dialog).toBeHidden();
+    await page.keyboard.press('Tab');
+    await expect(dialog).toBeVisible();
+
+    // Escape must not save, and must not stop the next entry from opening.
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('Tab');
+    await expect(dialog).toBeVisible();
+
+    // Backwards navigation from the following cell opens it too.
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await cellAt('planting_date', 0).focus();
+    await page.keyboard.press('Shift+Tab');
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+
+    // Every other row behaves the same, in both directions.
+    for (const rowIndex of [1, 2]) {
+      await cellAt('cultivation_type', rowIndex).focus();
+      await page.keyboard.press('Tab');
+      await expect(dialog).toBeVisible();
+      await page.getByRole('button', { name: 'Abbrechen' }).click();
+      await expect(dialog).toBeHidden();
+      await expect(cellAt('bed', rowIndex)).toHaveAttribute('tabindex', '0');
+
+      await cellAt('planting_date', rowIndex).focus();
+      await page.keyboard.press('Shift+Tab');
+      await expect(dialog).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden();
+    }
   });
 
   test('keeps the desktop field hierarchy editor compact without internal scrolling', async ({ page, request }) => {

--- a/frontend/src/__tests__/DialogEditCellContext.test.tsx
+++ b/frontend/src/__tests__/DialogEditCellContext.test.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildDialogEditCellKey,
+  DialogEditCellContext,
+  useDialogEditCellOpenRequest,
+  type DialogEditCellRequest,
+} from '../components/data-grid/DialogEditCellContext';
+
+function Probe({ rowId, field, onOpen }: { rowId?: string | number; field?: string; onOpen: () => void }) {
+  const [renderCount, setRenderCount] = useState(0);
+  useDialogEditCellOpenRequest(rowId, field, onOpen);
+
+  return (
+    <button type="button" onClick={() => setRenderCount((count) => count + 1)}>
+      rerender {renderCount}
+    </button>
+  );
+}
+
+const renderProbe = (
+  request: DialogEditCellRequest | null,
+  cell: { rowId?: string | number; field?: string } = { rowId: 7, field: 'bed' },
+) => {
+  const onOpen = vi.fn();
+  const consumeRequest = vi.fn();
+  const view = render(
+    <DialogEditCellContext.Provider value={{ request, consumeRequest }}>
+      <Probe rowId={cell.rowId} field={cell.field} onOpen={onOpen} />
+    </DialogEditCellContext.Provider>,
+  );
+
+  const rerenderWith = (
+    nextRequest: DialogEditCellRequest | null,
+    nextConsumeRequest: (token: number) => void = consumeRequest,
+  ): void => {
+    view.rerender(
+      <DialogEditCellContext.Provider value={{ request: nextRequest, consumeRequest: nextConsumeRequest }}>
+        <Probe rowId={cell.rowId} field={cell.field} onOpen={onOpen} />
+      </DialogEditCellContext.Provider>,
+    );
+  };
+
+  return { consumeRequest, onOpen, rerenderWith };
+};
+
+describe('useDialogEditCellOpenRequest', () => {
+  it('builds a stable key from the cell identity', () => {
+    expect(buildDialogEditCellKey(7, 'bed')).toBe('7:bed');
+    expect(buildDialogEditCellKey('7', 'bed')).toBe('7:bed');
+  });
+
+  it('opens once per request token and consumes the request', () => {
+    const { consumeRequest, onOpen } = renderProbe({ cellKey: '7:bed', token: 1 });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(consumeRequest).toHaveBeenCalledWith(1);
+  });
+
+  it('does not open again while the same token is still pending', async () => {
+    const user = userEvent.setup();
+    const { onOpen, rerenderWith } = renderProbe({ cellKey: '7:bed', token: 1 });
+
+    // Re-renders of the cell and of the provider must not replay the entry —
+    // a second open would reset a draft the user is already editing.
+    await user.click(screen.getByRole('button'));
+    act(() => rerenderWith({ cellKey: '7:bed', token: 1 }));
+    // Even a fresh consumer identity re-running the effect must not reopen.
+    act(() => rerenderWith({ cellKey: '7:bed', token: 1 }, vi.fn()));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens again for a new token on the same cell', () => {
+    const { onOpen, rerenderWith } = renderProbe({ cellKey: '7:bed', token: 1 });
+
+    act(() => rerenderWith(null));
+    act(() => rerenderWith({ cellKey: '7:bed', token: 2 }));
+
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores requests aimed at another cell', () => {
+    const { consumeRequest, onOpen } = renderProbe({ cellKey: '8:bed', token: 1 });
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(consumeRequest).not.toHaveBeenCalled();
+  });
+
+  it('ignores requests when the cell has no identity', () => {
+    const { onOpen } = renderProbe({ cellKey: 'undefined:undefined', token: 1 }, {});
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/PlantingPlans.areaDialogKeyboard.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaDialogKeyboard.test.tsx
@@ -1,0 +1,275 @@
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PlantingPlans from "../pages/PlantingPlans";
+
+const apiMocks = vi.hoisted(() => ({
+  cultureList: vi.fn(),
+  locationList: vi.fn(),
+  fieldList: vi.fn(),
+  bedList: vi.fn(),
+  planList: vi.fn(),
+  planUpdate: vi.fn(),
+}));
+
+vi.mock("../hooks/useProjectRequirement", () => ({
+  useProjectRequirement: () => ({
+    shouldShowProjectRequiredState: false,
+    missingProjectReason: null,
+  }),
+}));
+
+vi.mock("../commands/useCommandContext", () => ({
+  useCommandContextTag: vi.fn(),
+  useRegisterCommands: vi.fn(),
+  useRegisterCreateActions: vi.fn(),
+}));
+
+vi.mock("../hooks/useNavigationBlocker", () => ({
+  useNavigationBlocker: () => ({
+    isBlocked: false,
+    proceed: vi.fn(),
+    reset: vi.fn(),
+    destination: null,
+  }),
+}));
+
+vi.mock("../api/api", async () => {
+  const actual = await vi.importActual<typeof import("../api/api")>("../api/api");
+  return {
+    ...actual,
+    cultureAPI: { ...actual.cultureAPI, list: apiMocks.cultureList, listAll: async () => (await apiMocks.cultureList()).data },
+    locationAPI: { ...actual.locationAPI, list: apiMocks.locationList, listAll: async () => (await apiMocks.locationList()).data },
+    fieldAPI: { ...actual.fieldAPI, list: apiMocks.fieldList, listAll: async () => (await apiMocks.fieldList()).data },
+    bedAPI: { ...actual.bedAPI, list: apiMocks.bedList, listAll: async () => (await apiMocks.bedList()).data },
+    plantingPlanAPI: {
+      ...actual.plantingPlanAPI,
+      list: apiMocks.planList,
+      listAll: async () => (await apiMocks.planList()).data,
+      update: apiMocks.planUpdate,
+    },
+  };
+});
+
+// The real DataGrid.tsx keyboard/edit logic and the real AreaAssignmentDialog,
+// with only MUI's <DataGrid> swapped for a mock that renders focusable cells —
+// see helpers/muiDataGridKeyboardCellsMock.
+vi.mock("@mui/x-data-grid", async () => {
+  const { createMuiDataGridKeyboardCellsMock } = await import("./helpers/muiDataGridKeyboardCellsMock");
+  return createMuiDataGridKeyboardCellsMock({ renderCellFields: ["bed"] });
+});
+
+const DIALOG_NAME = "Anbaufläche ändern";
+
+const bedCell = (planId: number): HTMLElement => screen.getByTestId(`cell-${planId}-bed`);
+const cultivationTypeCell = (planId: number): HTMLElement =>
+  screen.getByTestId(`cell-${planId}-cultivation_type`);
+
+const queryDialogs = (): HTMLElement[] => screen.queryAllByRole("dialog", { name: DIALOG_NAME });
+
+const findDialog = async (): Promise<HTMLElement> =>
+  screen.findByRole("dialog", { name: DIALOG_NAME });
+
+const expectNoDialog = async (): Promise<void> => {
+  await waitFor(() => {
+    expect(queryDialogs()).toHaveLength(0);
+  });
+};
+
+const focusCell = async (cell: HTMLElement): Promise<void> => {
+  await act(async () => {
+    cell.focus();
+  });
+};
+
+const renderPlantingPlans = async (): Promise<ReturnType<typeof userEvent.setup>> => {
+  const user = userEvent.setup();
+  render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+  await waitFor(() => expect(apiMocks.planList).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByTestId("row-10")).toBeInTheDocument());
+  return user;
+};
+
+describe("PlantingPlans growing-area cell keyboard editing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.cultureList.mockResolvedValue({ data: { results: [{ id: 5, name: "Salat" }] } });
+    apiMocks.locationList.mockResolvedValue({ data: { results: [{ id: 1, name: "Hof" }] } });
+    apiMocks.fieldList.mockResolvedValue({ data: { results: [{ id: 11, name: "Feld 1", location: 1 }] } });
+    apiMocks.bedList.mockResolvedValue({
+      data: {
+        results: [
+          { id: 101, name: "Beet 1", field: 11, area_sqm: 10 },
+          { id: 102, name: "Beet 2", field: 11, area_sqm: 12 },
+        ],
+      },
+    });
+    apiMocks.planList.mockResolvedValue({
+      data: {
+        results: [
+          { id: 10, bed: 101, culture: 5, planting_date: "2026-04-01", harvest_date: "2026-05-01", area_usage_sqm: 3 },
+          { id: 20, bed: 101, culture: 5, planting_date: "2026-04-02", harvest_date: "2026-05-02", area_usage_sqm: 3 },
+        ],
+      },
+    });
+    apiMocks.planUpdate.mockImplementation(async (id: number, data: Record<string, unknown>) => ({
+      data: { id, ...data },
+    }));
+  });
+
+  it("opens the dialog when Tab moves onto the growing-area cell", async () => {
+    const user = await renderPlantingPlans();
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+
+    expect(await findDialog()).toBeInTheDocument();
+    expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-bed");
+  });
+
+  it("reopens the dialog after Cancel when Shift+Tab leaves and Tab re-enters the cell", async () => {
+    const user = await renderPlantingPlans();
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    await findDialog();
+
+    await user.click(screen.getByRole("button", { name: "Abbrechen" }));
+    await expectNoDialog();
+
+    // Focus is back on the cell, so Shift+Tab leaves it the normal way …
+    await user.tab({ shift: true });
+    await waitFor(() => {
+      expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-cultivation_type");
+    });
+    await expectNoDialog();
+
+    // … and coming back must start a fresh edit cycle.
+    await user.tab();
+    expect(await findDialog()).toBeInTheDocument();
+  });
+
+  it("reopens the dialog when the cell is entered again after Apply", async () => {
+    const user = await renderPlantingPlans();
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    const dialog = await findDialog();
+
+    await user.click(within(dialog).getByRole("combobox", { name: "Beet" }));
+    await user.click(await screen.findByRole("option", { name: /^Beet 2/ }));
+    await user.click(within(dialog).getByRole("button", { name: "Übernehmen" }));
+
+    await waitFor(() => {
+      expect(apiMocks.planUpdate).toHaveBeenCalledWith(10, expect.objectContaining({ bed: 102 }));
+    });
+    await expectNoDialog();
+
+    await user.tab({ shift: true });
+    await waitFor(() => {
+      expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-cultivation_type");
+    });
+    await user.tab();
+
+    expect(await findDialog()).toBeInTheDocument();
+  });
+
+  it("reopens the dialog when the cell is entered again after Escape", async () => {
+    const user = await renderPlantingPlans();
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    await findDialog();
+
+    await user.keyboard("{Escape}");
+    await expectNoDialog();
+    expect(apiMocks.planUpdate).not.toHaveBeenCalled();
+
+    await user.tab({ shift: true });
+    await waitFor(() => {
+      expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-cultivation_type");
+    });
+    await user.tab();
+
+    expect(await findDialog()).toBeInTheDocument();
+  });
+
+  it("opens the dialog only once for a single Tab entry", async () => {
+    const user = await renderPlantingPlans();
+
+    const trigger = within(bedCell(10)).getByRole("button", { name: "Anbaufläche bearbeiten" });
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    const dialog = await findDialog();
+    expect(queryDialogs()).toHaveLength(1);
+
+    await user.click(within(dialog).getByRole("combobox", { name: "Beet" }));
+    await user.click(await screen.findByRole("option", { name: /^Beet 2/ }));
+
+    // The focus, click and edit-request paths can all fire around one entry.
+    // A second open would reset the draft the user is already editing.
+    fireEvent.click(trigger);
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(queryDialogs()).toHaveLength(1);
+    expect(within(dialog).getByRole("combobox", { name: "Beet" })).toHaveTextContent(/Beet 2/);
+  });
+
+  it("keeps focus and tab order intact after Cancel and after Apply", async () => {
+    const user = await renderPlantingPlans();
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    await findDialog();
+    await user.click(screen.getByRole("button", { name: "Abbrechen" }));
+    await expectNoDialog();
+
+    await waitFor(() => {
+      expect(bedCell(10).contains(document.activeElement)).toBe(true);
+    });
+    expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-bed");
+
+    // Tab keeps walking the row from the cell the dialog was opened from.
+    await user.tab();
+    await waitFor(() => {
+      expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-planting_date");
+    });
+
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    const dialog = await findDialog();
+    await user.click(within(dialog).getByRole("button", { name: "Übernehmen" }));
+    await expectNoDialog();
+
+    await waitFor(() => {
+      expect(bedCell(10).contains(document.activeElement)).toBe(true);
+    });
+    expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-bed");
+  });
+
+  it("opens the dialog for every row and in both navigation directions", async () => {
+    const user = await renderPlantingPlans();
+
+    // Second row, forwards.
+    await focusCell(cultivationTypeCell(20));
+    await user.tab();
+    await findDialog();
+    await user.click(screen.getByRole("button", { name: "Abbrechen" }));
+    await expectNoDialog();
+
+    // Second row, backwards from the following cell.
+    await focusCell(screen.getByTestId("cell-20-planting_date"));
+    await user.tab({ shift: true });
+    expect(await findDialog()).toBeInTheDocument();
+    expect(screen.getByTestId("focused-cell")).toHaveTextContent("20-bed");
+    await user.click(screen.getByRole("button", { name: "Abbrechen" }));
+    await expectNoDialog();
+
+    // First row again — an earlier row's dialog must not consume its request.
+    await focusCell(cultivationTypeCell(10));
+    await user.tab();
+    expect(await findDialog()).toBeInTheDocument();
+    expect(screen.getByTestId("focused-cell")).toHaveTextContent("10-bed");
+  });
+});

--- a/frontend/src/__tests__/helpers/muiDataGridKeyboardCellsMock.tsx
+++ b/frontend/src/__tests__/helpers/muiDataGridKeyboardCellsMock.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import type { GridColDef } from '@mui/x-data-grid';
+
+type MockRow = { id: string | number; [key: string]: unknown };
+type CellLocation = { id: string | number; field: string };
+
+/**
+ * A mock of `@mui/x-data-grid`'s `<DataGrid>` for keyboard tests: unlike
+ * `muiDataGridEscapeFocusMock` (buttons only) it renders each cell as a real
+ * focusable `[role="gridcell"][data-field]` element inside a
+ * `[role="row"][data-id]`, calls the column's `renderCell` with a live
+ * `hasFocus`, and routes keydown through `onCellKeyDown`.
+ *
+ * That is exactly what `DataGrid.tsx`'s Tab/Shift+Tab navigation and the
+ * dialog-edited cells need to be exercised for real: pressing Tab on a focused
+ * cell runs the grid's own navigation, which moves DOM focus to the next cell
+ * and — for `dialogEditFields` columns — asks that cell to open its editor.
+ *
+ * `renderCellFields` keeps the mock cheap: only those columns get their real
+ * `renderCell`, everything else falls back to plain text, so a page's heavier
+ * cell renderers don't have to survive jsdom for an unrelated test.
+ */
+export function createMuiDataGridKeyboardCellsMock(options: { renderCellFields?: string[] } = {}) {
+  const renderCellFields = options.renderCellFields ?? null;
+  const GridRowModes = { Edit: 'edit', View: 'view' };
+  const GridRowEditStopReasons = {
+    rowFocusOut: 'rowFocusOut',
+    enterKeyDown: 'enterKeyDown',
+    tabKeyDown: 'tabKeyDown',
+    escapeKeyDown: 'escapeKeyDown',
+  };
+  const getMockFilterOperators = () => [{ value: 'contains', getApplyFilterFn: () => () => true }];
+  const useGridApiRef = () => React.useRef<Record<string, unknown>>({});
+
+  const DataGrid = (props: {
+    apiRef?: { current: Record<string, unknown> | null };
+    rows: MockRow[];
+    columns: GridColDef[];
+    onCellClick?: (
+      params: { id: string | number; field: string; isEditable: boolean; row: MockRow },
+      event: unknown,
+    ) => void;
+    onCellKeyDown?: (
+      params: { id: string | number; field: string; isEditable: boolean; row: MockRow },
+      event: unknown,
+    ) => void;
+    onRowSelectionModelChange?: (model: { type: string; ids: Set<string | number> }) => void;
+    processRowUpdate?: (row: MockRow) => Promise<MockRow> | MockRow;
+    onProcessRowUpdateError?: (error: unknown) => void;
+    onRowEditStop?: (params: { id: string | number; reason: string }, event: { defaultMuiPrevented: boolean }) => void;
+    rowModesModel?: Record<string | number, { mode: string; fieldToFocus?: string }>;
+  }) => {
+    const {
+      apiRef,
+      rows,
+      columns,
+      onCellClick,
+      onCellKeyDown,
+      onRowSelectionModelChange,
+      rowModesModel,
+    } = props;
+    const [focusedCell, setFocusedCell] = React.useState<CellLocation | null>(null);
+    const cellRefs = React.useRef(new Map<string, HTMLDivElement>());
+    const appliedFocusRef = React.useRef<string | null>(null);
+    const cellKey = (id: string | number, field: string): string => `${String(id)}-${field}`;
+
+    const registerCell = (key: string) => (element: HTMLDivElement | null): void => {
+      if (element) {
+        cellRefs.current.set(key, element);
+      } else {
+        cellRefs.current.delete(key);
+      }
+    };
+
+    React.useLayoutEffect(() => {
+      if (!apiRef?.current) {
+        return;
+      }
+
+      const api = apiRef.current;
+      api.state = api.state ?? { focus: { cell: null } };
+      api.getVisibleColumns = () => columns;
+      api.getAllRowIds = () => rows.map((row) => row.id);
+      api.getRow = (id: string | number) => rows.find((row) => String(row.id) === String(id)) ?? null;
+      api.getRowWithUpdatedValues = (id: string | number) =>
+        rows.find((row) => String(row.id) === String(id)) ?? null;
+      api.getRowIndexRelativeToVisibleRows = (id: string | number) =>
+        rows.findIndex((row) => String(row.id) === String(id));
+      api.getColumnIndexRelativeToVisibleColumns = (field: string) =>
+        columns.findIndex((column) => column.field === field);
+      api.isCellEditable = (params: { field: string }) =>
+        columns.find((column) => column.field === params.field)?.editable !== false;
+      api.getCellParams = (id: string | number, field: string) => ({
+        id,
+        field,
+        row: rows.find((row) => String(row.id) === String(id)),
+      });
+      api.getCellElement = (id: string | number, field: string) =>
+        cellRefs.current.get(cellKey(id, field)) ?? null;
+      api.scrollToIndexes = () => {};
+      api.setEditCellValue = async () => true;
+      api.stopRowEditMode = () => {};
+      api.setCellFocus = (id: string | number, field: string) => {
+        (api.state as { focus: { cell: CellLocation | null } }).focus.cell = { id, field };
+        setFocusedCell({ id, field });
+      };
+    }, [apiRef, columns, rows]);
+
+    // Mirrors MUI: the grid's focus state owns DOM focus, and it is only
+    // pushed onto the DOM when the focused cell actually changes — otherwise
+    // re-renders would keep yanking focus back out of a cell's own dialog.
+    React.useLayoutEffect(() => {
+      if (!focusedCell) {
+        return;
+      }
+      const key = cellKey(focusedCell.id, focusedCell.field);
+      if (appliedFocusRef.current === key) {
+        return;
+      }
+      appliedFocusRef.current = key;
+      cellRefs.current.get(key)?.focus();
+    }, [focusedCell]);
+
+    return (
+      <div role="grid">
+        {rows.map((row) => (
+          <div key={row.id} role="row" data-id={String(row.id)} data-testid={`row-${row.id}`}>
+            <span data-testid={`mode-${row.id}`}>{rowModesModel?.[row.id]?.mode ?? GridRowModes.View}</span>
+            {columns.map((column) => {
+              const isFocused = focusedCell?.field === column.field
+                && String(focusedCell.id) === String(row.id);
+              const params = {
+                id: row.id,
+                field: column.field,
+                isEditable: column.editable !== false,
+                row,
+              };
+              const shouldRenderCell = typeof column.renderCell === 'function'
+                && (!renderCellFields || renderCellFields.includes(column.field));
+
+              return (
+                <div
+                  key={`${row.id}-${column.field}`}
+                  ref={registerCell(cellKey(row.id, column.field))}
+                  role="gridcell"
+                  data-field={column.field}
+                  data-testid={`cell-${row.id}-${column.field}`}
+                  tabIndex={isFocused ? 0 : -1}
+                  onFocus={() => {
+                    if (apiRef?.current) {
+                      (apiRef.current.state as { focus: { cell: CellLocation | null } }).focus.cell = {
+                        id: row.id,
+                        field: column.field,
+                      };
+                    }
+                    appliedFocusRef.current = cellKey(row.id, column.field);
+                    setFocusedCell({ id: row.id, field: column.field });
+                  }}
+                  onClick={() => {
+                    onRowSelectionModelChange?.({ type: 'include', ids: new Set([row.id]) });
+                    onCellClick?.(params, {
+                      preventDefault: () => {},
+                      stopPropagation: () => {},
+                      defaultMuiPrevented: false,
+                    });
+                  }}
+                  onKeyDown={(event) => {
+                    onCellKeyDown?.(params, event);
+                  }}
+                >
+                  {shouldRenderCell
+                    ? column.renderCell?.({
+                      ...params,
+                      value: row[column.field],
+                      hasFocus: isFocused,
+                    } as never)
+                    : String(row[column.field] ?? '')}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+        <span data-testid="focused-cell">
+          {focusedCell ? `${focusedCell.id}-${focusedCell.field}` : 'none'}
+        </span>
+      </div>
+    );
+  };
+
+  return {
+    DataGrid,
+    GridRowModes,
+    GridRowEditStopReasons,
+    getGridBooleanOperators: getMockFilterOperators,
+    getGridDateOperators: getMockFilterOperators,
+    getGridNumericOperators: getMockFilterOperators,
+    getGridSingleSelectOperators: getMockFilterOperators,
+    getGridStringOperators: getMockFilterOperators,
+    useGridApiRef,
+  };
+}

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -79,6 +79,12 @@ import {
   type EditCellTabNavigationHandler,
 } from './EditCellNavigationContext';
 import {
+  buildDialogEditCellKey,
+  DialogEditCellContext,
+  type DialogEditCellContextValue,
+  type DialogEditCellRequest,
+} from './DialogEditCellContext';
+import {
   CONTINUOUS_SCROLL_PAGE_SIZE,
   CONTINUOUS_SCROLL_REQUESTED_ROW_HEIGHT_PX,
   CONTINUOUS_SCROLL_COMPACT_ROW_HEIGHT_PX,
@@ -666,6 +672,34 @@ export function EditableDataGrid<T extends EditableRow>({
     (field: string): boolean => dedicatedEditorFieldNames.includes(field),
     [dedicatedEditorFieldNames],
   );
+  // A dialog-edited cell has no inline edit session the grid could start, so
+  // "the cell entered edit mode" is expressed as a request its own renderer
+  // reacts to. One request per keyboard entry, consumed by the cell when it
+  // opens — see DialogEditCellContext.
+  const isDialogEditField = useCallback(
+    (field: string): boolean => (dialogEditFields ?? []).includes(field),
+    [dialogEditFields],
+  );
+  const [dialogEditRequest, setDialogEditRequest] = useState<DialogEditCellRequest | null>(null);
+  const dialogEditTokenRef = useRef(0);
+  const requestDialogEditForCell = useCallback((rowId: GridRowId, field: string): void => {
+    if (!isDialogEditField(field)) {
+      return;
+    }
+
+    dialogEditTokenRef.current += 1;
+    setDialogEditRequest({
+      cellKey: buildDialogEditCellKey(rowId, field),
+      token: dialogEditTokenRef.current,
+    });
+  }, [isDialogEditField]);
+  const consumeDialogEditRequest = useCallback((token: number): void => {
+    setDialogEditRequest((current) => (current?.token === token ? null : current));
+  }, []);
+  const dialogEditCellContextValue = useMemo<DialogEditCellContextValue>(() => ({
+    request: dialogEditRequest,
+    consumeRequest: consumeDialogEditRequest,
+  }), [consumeDialogEditRequest, dialogEditRequest]);
 
   // Check if there's a validation error (indicating incomplete/invalid data)
   const hasValidationError = Boolean(error);
@@ -785,7 +819,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const focusKeyboardNavigableCell = useCallback((
     rowId: GridRowId,
     field: string,
-    options: { startEdit: boolean },
+    options: { startEdit: boolean; requestDialogEdit?: boolean },
   ): void => {
     const rowKey = String(rowId);
     const row = rowsById.get(rowKey);
@@ -809,6 +843,10 @@ export function EditableDataGrid<T extends EditableRow>({
           && (rowModesModel[rowId]?.mode === GridRowModes.Edit || options.startEdit),
       });
 
+      if (options.requestDialogEdit) {
+        requestDialogEditForCell(rowId, field);
+      }
+
       if (!options.startEdit || hasDedicatedEditor(field)) {
         return;
       }
@@ -826,7 +864,14 @@ export function EditableDataGrid<T extends EditableRow>({
         [rowId]: { mode: GridRowModes.Edit, fieldToFocus: field },
       }));
     });
-  }, [gridApiRef, hasDedicatedEditor, rowModesModel, rowsById, runAfterRowVisible]);
+  }, [
+    gridApiRef,
+    hasDedicatedEditor,
+    requestDialogEditForCell,
+    rowModesModel,
+    rowsById,
+    runAfterRowVisible,
+  ]);
 
   const getHorizontalNavigationTarget = useCallback((
     rowId: GridRowId,
@@ -1183,7 +1228,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const navigateFromEditedCell = useCallback((
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
-    options: { startTargetEdit: boolean },
+    options: { startTargetEdit: boolean; requestDialogEdit?: boolean },
   ): void => {
     if (current.id === target.id && current.field === target.field) {
       return;
@@ -1201,6 +1246,7 @@ export function EditableDataGrid<T extends EditableRow>({
       internalEditNavigationRowIdRef.current = String(current.id);
       focusKeyboardNavigableCell(target.id, target.field, {
         startEdit: options.startTargetEdit,
+        requestDialogEdit: options.requestDialogEdit,
       });
       window.requestAnimationFrame(() => {
         if (internalEditNavigationRowIdRef.current === String(current.id)) {
@@ -1217,7 +1263,10 @@ export function EditableDataGrid<T extends EditableRow>({
       }));
     }
 
-    focusKeyboardNavigableCell(target.id, target.field, { startEdit: options.startTargetEdit });
+    focusKeyboardNavigableCell(target.id, target.field, {
+      startEdit: options.startTargetEdit,
+      requestDialogEdit: options.requestDialogEdit,
+    });
   }, [
     commitEditedRowDraftForKeyboardNavigation,
     focusKeyboardNavigableCell,
@@ -1245,6 +1294,7 @@ export function EditableDataGrid<T extends EditableRow>({
 
     navigateFromEditedCell(current, sameRowTarget, {
       startTargetEdit: !hasDedicatedEditor(sameRowTarget.field),
+      requestDialogEdit: true,
     });
     return true;
   }, [
@@ -1545,7 +1595,7 @@ export function EditableDataGrid<T extends EditableRow>({
   const saveEditedRowAndFocusTarget = useCallback(async (
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
-    options: { startTargetEdit?: boolean } = {},
+    options: { startTargetEdit?: boolean; requestDialogEdit?: boolean } = {},
   ): Promise<void> => {
     const preparedRow = await prepareRowForSave(current.id);
     if (!preparedRow) {
@@ -1563,6 +1613,7 @@ export function EditableDataGrid<T extends EditableRow>({
       );
       focusKeyboardNavigableCell(target.id, target.field, {
         startEdit: options.startTargetEdit ?? !hasDedicatedEditor(target.field),
+        requestDialogEdit: options.requestDialogEdit,
       });
     } catch (error) {
       handleProcessRowUpdateError(error);
@@ -1638,11 +1689,12 @@ export function EditableDataGrid<T extends EditableRow>({
     if (String(target.id) === String(current.id)) {
       navigateFromEditedCell(current, target, {
         startTargetEdit: !hasDedicatedEditor(target.field),
+        requestDialogEdit: true,
       });
       return true;
     }
 
-    void saveEditedRowAndFocusTarget(current, target);
+    void saveEditedRowAndFocusTarget(current, target, { requestDialogEdit: true });
     return true;
   }, [
     columns,
@@ -2405,12 +2457,18 @@ export function EditableDataGrid<T extends EditableRow>({
         api: gridApiRef.current,
         cell: target,
       });
+      // Tab/Shift+Tab is the "enter the cell to edit it" gesture; arrow keys
+      // stay pure movement so a dialog cell can still be passed by.
+      if (event.key === 'Tab') {
+        requestDialogEditForCell(target.id, target.field);
+      }
     });
     return true;
   }, [
     columnsWithActions,
     gridApiRef,
     isActionCellKeyboardNavigable,
+    requestDialogEditForCell,
     rowModesModel,
     rowsForGrid,
     runAfterRowVisible,
@@ -2564,6 +2622,7 @@ export function EditableDataGrid<T extends EditableRow>({
             }}
           >
             <EditCellNavigationContext.Provider value={handleEditCellTabNavigation}>
+              <DialogEditCellContext.Provider value={dialogEditCellContextValue}>
               <DataGrid
           rows={rowsForGrid}
           columns={columnsWithActions}
@@ -2822,6 +2881,7 @@ export function EditableDataGrid<T extends EditableRow>({
           localeText={getDataGridLocaleText()}
           apiRef={gridApiRef}
               />
+              </DialogEditCellContext.Provider>
             </EditCellNavigationContext.Provider>
           </Box>
           </Box>

--- a/frontend/src/components/data-grid/DialogEditCellContext.tsx
+++ b/frontend/src/components/data-grid/DialogEditCellContext.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useRef } from 'react';
+import type { GridRowId } from '@mui/x-data-grid';
+
+/**
+ * `dialogEditFields` cells have no inline edit session — their dialog *is* the
+ * edit session. This context is how `EditableDataGrid` tells such a cell that
+ * keyboard navigation just entered it, so the cell can start that session by
+ * opening its dialog.
+ *
+ * The request carries a token that is bumped on every entry. A cell opens for a
+ * token exactly once and consumes the request while doing so, which is what
+ * makes repeated entries work: the grid can hand out a *new* token for the same
+ * cell any number of times, while a re-render, a re-mount (grid virtualization),
+ * or a simultaneous focus/click event can never replay an old one.
+ */
+export interface DialogEditCellRequest {
+  cellKey: string;
+  token: number;
+}
+
+export interface DialogEditCellContextValue {
+  request: DialogEditCellRequest | null;
+  consumeRequest: (token: number) => void;
+}
+
+export const buildDialogEditCellKey = (rowId: GridRowId, field: string): string =>
+  `${String(rowId)}:${field}`;
+
+export const DialogEditCellContext = createContext<DialogEditCellContextValue | null>(null);
+
+/**
+ * Runs `onOpenRequested` once per keyboard entry into the cell identified by
+ * `rowId`/`field`. Cells rendered outside an `EditableDataGrid` (or without a
+ * cell identity) simply never get a request.
+ */
+export function useDialogEditCellOpenRequest(
+  rowId: GridRowId | undefined,
+  field: string | undefined,
+  onOpenRequested: () => void,
+): void {
+  const context = useContext(DialogEditCellContext);
+  const onOpenRequestedRef = useRef(onOpenRequested);
+  const handledTokenRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onOpenRequestedRef.current = onOpenRequested;
+  }, [onOpenRequested]);
+
+  const request = context?.request ?? null;
+  const consumeRequest = context?.consumeRequest;
+  const cellKey = rowId === undefined || field === undefined
+    ? null
+    : buildDialogEditCellKey(rowId, field);
+  const pendingToken = request && cellKey !== null && request.cellKey === cellKey
+    ? request.token
+    : null;
+
+  useEffect(() => {
+    if (pendingToken === null || handledTokenRef.current === pendingToken) {
+      return;
+    }
+
+    handledTokenRef.current = pendingToken;
+    consumeRequest?.(pendingToken);
+    onOpenRequestedRef.current();
+  }, [consumeRequest, pendingToken]);
+}

--- a/frontend/src/components/data-grid/index.ts
+++ b/frontend/src/components/data-grid/index.ts
@@ -56,6 +56,13 @@ export {
 export { buildTsv, copyRowsToClipboard, copyTextToClipboard, copyTextToClipboardSilently, formatClipboardValue } from './tableClipboard';
 export type { TableClipboardRow } from './tableClipboard';
 
+export {
+  buildDialogEditCellKey,
+  DialogEditCellContext,
+  useDialogEditCellOpenRequest,
+} from './DialogEditCellContext';
+export type { DialogEditCellContextValue, DialogEditCellRequest } from './DialogEditCellContext';
+
 export { handleEditableCellClick, handleRowEditStop } from './handlers';
 
 export { StableScrollbarTrack } from './StableScrollbarTrack';

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -12,8 +12,10 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import type { GridRowId } from '@mui/x-data-grid';
 import { useTranslation } from '../../i18n';
 import type { Bed, Field, Location } from '../../api/types';
+import { useDialogEditCellOpenRequest } from '../data-grid/DialogEditCellContext';
 import EmptyStateCard from '../project/EmptyStateCard';
 import { CompactAreaCell } from './CompactAreaCell';
 import {
@@ -35,6 +37,13 @@ interface AreaAssignmentDialogProps {
   placeholder?: string;
   hasFocus?: boolean;
   memoKey?: string;
+  /**
+   * Grid cell identity. Passing both lets the cell pick up the grid's
+   * "keyboard navigation entered this cell" requests and open the dialog —
+   * see `DialogEditCellContext`.
+   */
+  rowId?: GridRowId;
+  field?: string;
 }
 
 interface AssignmentState {
@@ -138,9 +147,12 @@ function AreaAssignmentDialogComponent({
   compactLabel,
   placeholder,
   hasFocus = false,
+  rowId,
+  field,
 }: AreaAssignmentDialogProps) {
   const { t } = useTranslation('plantingPlans');
   const [isOpen, setIsOpen] = useState(false);
+  const isOpenRef = useRef(false);
   const [openSelect, setOpenSelect] = useState<'location' | 'field' | 'bed' | null>(null);
   const [draft, setDraft] = useState<AssignmentState>({ locationId: null, fieldId: null, bedId: bedId ?? null });
   const locationSelectRef = useRef<HTMLDivElement | null>(null);
@@ -303,6 +315,7 @@ function AreaAssignmentDialogComponent({
       return;
     }
     await onApply(activeDraft.bedId);
+    isOpenRef.current = false;
     setIsOpen(false);
   };
 
@@ -386,13 +399,26 @@ function AreaAssignmentDialogComponent({
 
   const handleCancel = (): void => {
     setOpenSelect(null);
+    isOpenRef.current = false;
     setIsOpen(false);
   };
 
-  const handleOpen = (): void => {
+  /**
+   * Idempotent per edit cycle: the click, the Enter/Space keydown and the
+   * grid's keyboard-entry request can all fire for one and the same entry into
+   * the cell, and re-running the body would reset an already edited draft.
+   */
+  const handleOpen = useCallback((): void => {
+    if (isOpenRef.current) {
+      return;
+    }
+
+    isOpenRef.current = true;
     setDraft(getOpeningDraft());
     setIsOpen(true);
-  };
+  }, [getOpeningDraft]);
+
+  useDialogEditCellOpenRequest(rowId, field, handleOpen);
 
   useEffect(() => {
     if (!isOpen) {
@@ -535,4 +561,6 @@ export const AreaAssignmentDialog = memo(AreaAssignmentDialogComponent, (previou
   && previous.placeholder === next.placeholder
   && previous.hasFocus === next.hasFocus
   && previous.memoKey === next.memoKey
+  && previous.rowId === next.rowId
+  && previous.field === next.field
 ));

--- a/frontend/src/components/planting-plans/CompactAreaCell.tsx
+++ b/frontend/src/components/planting-plans/CompactAreaCell.tsx
@@ -32,12 +32,18 @@ export function CompactAreaCell({
 
   useEffect(() => {
     if (!hasFocus || suppressFocus) {
-      return;
+      return undefined;
     }
 
-    requestAnimationFrame(() => {
+    // Cancelled on cleanup: when the cell's own dialog opens in the same commit
+    // that focused the cell, a still-pending frame would pull focus back out of
+    // the dialog right after it mounted.
+    const frame = requestAnimationFrame(() => {
       triggerRef.current?.focus();
     });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
   }, [hasFocus, suppressFocus]);
 
   return (

--- a/frontend/src/pages/PlantingPlans.tsx
+++ b/frontend/src/pages/PlantingPlans.tsx
@@ -578,6 +578,8 @@ function PlantingPlans() {
               compactLabel={label}
               placeholder={t("plantingPlans:placeholders.selectArea")}
               hasFocus={params.hasFocus}
+              rowId={params.id}
+              field={params.field}
               memoKey={`${String(params.id)}:${params.field}`}
               onApply={(nextBedId) => applyBedSelection(params.id, row, nextBedId)}
             />


### PR DESCRIPTION
## Summary

This PR adds support for opening dialog-edited cells via keyboard navigation (Tab/Shift+Tab), enabling users to enter edit mode for cells like the area assignment dialog by tabbing into them, rather than only via mouse click.

## Key Changes

- **New `DialogEditCellContext`**: Implements a request/token pattern for cells to respond to keyboard entry events. When the grid navigates into a `dialogEditFields` cell via Tab/Shift+Tab, it issues a request with a unique token. The cell opens its dialog exactly once per token and consumes the request, preventing duplicate opens from re-renders or simultaneous events.

- **Updated `EditableDataGrid`**: 
  - Tracks dialog edit requests and tokens
  - Passes `requestDialogEdit` option through keyboard navigation paths (`handleViewModeCellNavigation` and `handleEditedCellTabNavigation`)
  - Provides `DialogEditCellContext` to child cells via context provider

- **Enhanced `AreaAssignmentDialog`**: 
  - Accepts `rowId` and `field` props to identify its grid cell
  - Calls `useDialogEditCellOpenRequest()` to open when keyboard navigation enters the cell
  - Tracks open state to prevent duplicate opens during the same entry

- **Updated `CompactAreaCell`**: Cancels pending focus frames when the dialog opens in the same render cycle, preventing focus from being yanked out of the newly-opened dialog.

- **Documentation**: Updated `datagrid-architecture.md` to explain the dialog edit cell pattern and token-based request mechanism.

## Implementation Details

The token-based request pattern solves a key problem: without it, a cell couldn't distinguish between "the user just tabbed into me" and "I'm re-rendering while already open." The token is bumped on every entry, so:
- A cell opens for a given token **exactly once**
- Multiple simultaneous events (focus, click, request) on the same entry can't stack dialogs
- Re-renders and re-mounts (grid virtualization) can't replay old requests

Requests are only issued from Tab navigation paths, not arrow keys, so users can still navigate past the cell without opening its dialog.

## Testing

Comprehensive test coverage added:
- Unit tests for `DialogEditCellContext` and token consumption
- Integration tests for keyboard navigation in `PlantingPlans` with multiple rows
- E2E tests for forwards/backwards Tab navigation and repeated entries
- Mock DataGrid implementation for keyboard testing that renders real focusable cells

https://claude.ai/code/session_01HtDP1qEEzThuzsPdoPp48G