### PR TITLE
Unify public culture removal into single action

### DIFF
--- a/backend/farm/cultures/serializers/cultures.py
+++ b/backend/farm/cultures/serializers/cultures.py
@@ -31,6 +31,7 @@ from farm.seed_units import (
     SEED_RATE_UNITS,
 )
 from farm.services.culture_display import resolve_culture_display_name
+from farm.services.public_cultures import is_public_culture_contributor
 
 from .seed_packages import SeedPackageSerializer
 from .seed_rates import (
@@ -46,6 +47,9 @@ from .suppliers import (
     _supplier_data_payload_has_information,
     _supplier_data_payload_has_supplier,
 )
+
+# Sentinel so a resolved `None` is cached instead of re-queried per field.
+_UNRESOLVED = object()
 
 
 class CultureSerializer(serializers.ModelSerializer):
@@ -165,7 +169,8 @@ class CultureSerializer(serializers.ModelSerializer):
         help_text='Calculated plants per square meter based on spacing (read-only)'
     )
     owned_public_culture_id = serializers.SerializerMethodField()
-    
+    owned_public_culture_role = serializers.SerializerMethodField()
+
     def get_image_file(self, obj):
         if not obj.image_file_id:
             return None
@@ -213,37 +218,66 @@ class CultureSerializer(serializers.ModelSerializer):
             return {}
         return species.translations_by_language()
     
-    def get_owned_public_culture_id(self, obj: Culture) -> int | None:
+    def _resolve_owned_public_culture(self, obj: Culture) -> PublicCulture | None:
+        """The published public-library entry the requesting user may act on for this culture."""
+        cached = getattr(obj, '_resolved_owned_public_culture', _UNRESOLVED)
+        if cached is not _UNRESOLVED:
+            return cached
+
+        resolved = self._query_owned_public_culture(obj)
+        obj._resolved_owned_public_culture = resolved
+        return resolved
+
+    def _query_owned_public_culture(self, obj: Culture) -> PublicCulture | None:
         request = self.context.get('request')
         user = getattr(request, 'user', None)
         if not user or not user.is_authenticated:
             return None
 
         if obj.source_public_culture_id:
+            source_public = obj.source_public_culture
             if (
-                obj.source_public_culture
-                and obj.source_public_culture.status == PublicCulture.STATUS_PUBLISHED
+                source_public
+                and source_public.status == PublicCulture.STATUS_PUBLISHED
                 and (
-                    obj.source_public_culture.created_by_id == user.id
+                    source_public.created_by_id == user.id
                     or self._can_moderate_public_cultures(user)
                 )
             ):
-                return obj.source_public_culture_id
+                return source_public
             return None
 
         prefetched = getattr(obj, '_prefetched_owned_public_cultures', None)
         if prefetched is not None:
-            if prefetched:
-                return prefetched[0].id
-            return None
+            return prefetched[0] if prefetched else None
 
         linked_public = PublicCulture.objects.filter(
             source_project_culture=obj,
             status=PublicCulture.STATUS_PUBLISHED,
         )
-        if prefetched is None and not self._can_moderate_public_cultures(user):
+        if not self._can_moderate_public_cultures(user):
             linked_public = linked_public.filter(created_by=user)
-        return linked_public.order_by('-updated_at', '-id').values_list('id', flat=True).first()
+        return linked_public.order_by('-updated_at', '-id').first()
+
+    def get_owned_public_culture_id(self, obj: Culture) -> int | None:
+        public_culture = self._resolve_owned_public_culture(obj)
+        return public_culture.id if public_culture else None
+
+    def get_owned_public_culture_role(self, obj: Culture) -> str | None:
+        """How the requesting user relates to the linked public entry.
+
+        `contributor` means they published it themselves and can withdraw it
+        without a reason; `moderator` means removing it is a moderation action
+        that requires a structured reason.
+        """
+        public_culture = self._resolve_owned_public_culture(obj)
+        if public_culture is None:
+            return None
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+        if is_public_culture_contributor(public_culture=public_culture, user=user):
+            return 'contributor'
+        return 'moderator'
 
     def _can_moderate_public_cultures(self, user) -> bool:
         request = self.context.get('request')

--- a/backend/farm/cultures/views/public.py
+++ b/backend/farm/cultures/views/public.py
@@ -32,7 +32,6 @@ from farm.services.public_cultures import (
     replace_public_culture_translations,
     restore_public_culture_version,
     update_public_culture_directly,
-    withdraw_public_culture,
 )
 
 from ..serializers import (
@@ -465,21 +464,9 @@ class PublicCultureViewSet(viewsets.ModelViewSet):
         proposal.save(update_fields=['status', 'reviewed_by', 'reviewed_at', 'review_note', 'updated_at'])
         return Response(PublicCultureChangeProposalSerializer(proposal).data)
 
-    @action(detail=True, methods=['post'], url_path='withdraw')
-    def withdraw(self, request, pk=None):
-        if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
-            return forbidden
-        public_culture = self._get_public_culture_for_status_action()
-        try:
-            updated = withdraw_public_culture(public_culture=public_culture, user=request.user)
-        except PublicCulturePermissionError as error:
-            return self._transition_error_response(error, status.HTTP_403_FORBIDDEN)
-        except PublicCultureStatusTransitionError as error:
-            return self._transition_error_response(error, status.HTTP_400_BAD_REQUEST)
-        return Response(PublicCultureSerializer(updated, context=self.get_serializer_context()).data)
-
     @action(detail=True, methods=['post'], url_path='remove')
     def remove(self, request, pk=None):
+        """Remove an entry from the public library (contributor withdrawal or moderator removal)."""
         if (forbidden := self._guest_demo_write_forbidden(request)) is not None:
             return forbidden
         public_culture = self._get_public_culture_for_status_action()

--- a/backend/farm/services/public_cultures.py
+++ b/backend/farm/services/public_cultures.py
@@ -777,21 +777,42 @@ def publish_culture_to_public_library(
     return public_culture, duplicates, 'created'
 
 
-def withdraw_public_culture(*, public_culture: PublicCulture, user: User | None) -> PublicCulture:
-    if not user or not user.is_authenticated or public_culture.created_by_id != user.id:
-        raise PublicCulturePermissionError('Only the contributor may withdraw this public culture.')
-    if public_culture.status != PublicCulture.STATUS_PUBLISHED:
-        raise PublicCultureStatusTransitionError('Only published public cultures can be withdrawn.')
-    return _set_public_culture_status(
-        public_culture=public_culture,
-        status=PublicCulture.STATUS_WITHDRAWN,
-        user=user,
-    )
+def is_public_culture_contributor(*, public_culture: PublicCulture, user: User | None) -> bool:
+    """Whether `user` is the contributor who published this public culture."""
+    return bool(user and user.is_authenticated and public_culture.created_by_id == user.id)
 
 
-def remove_public_culture(*, public_culture: PublicCulture, user: User | None, reason: str) -> PublicCulture:
+def remove_public_culture(
+    *,
+    public_culture: PublicCulture,
+    user: User | None,
+    reason: str = '',
+) -> PublicCulture:
+    """Remove a public culture from the public library.
+
+    This is the single entry point for both removal paths, so the UI only has
+    to offer one "remove from library" action:
+
+    - the contributor withdraws their own entry (`withdrawn`), which stays
+      reversible: publishing the project culture again republishes it;
+    - a moderator removes somebody else's entry (`removed`) and must supply a
+      structured moderation reason.
+    """
+    if is_public_culture_contributor(public_culture=public_culture, user=user):
+        if public_culture.status != PublicCulture.STATUS_PUBLISHED:
+            raise PublicCultureStatusTransitionError(
+                'Only published public cultures can be removed from the library.',
+            )
+        return _set_public_culture_status(
+            public_culture=public_culture,
+            status=PublicCulture.STATUS_WITHDRAWN,
+            user=user,
+        )
+
     if not _is_public_library_moderator(user):
-        raise PublicCulturePermissionError('Only moderators may remove public cultures.')
+        raise PublicCulturePermissionError(
+            'Only the contributor or a moderator may remove this public culture.',
+        )
     if reason not in {item[0] for item in PublicCulture.REMOVAL_REASON_CHOICES}:
         raise PublicCultureStatusTransitionError('A valid removal reason is required.', code='removal_reason_required')
     if public_culture.status == PublicCulture.STATUS_REMOVED:

--- a/backend/farm/tests/test_public_cultures_api.py
+++ b/backend/farm/tests/test_public_cultures_api.py
@@ -1076,7 +1076,7 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_owner_can_withdraw_public_culture_without_changing_imported_project_copy(self):
+    def test_contributor_can_remove_own_public_culture_without_changing_imported_project_copy(self):
         public_culture = PublicCulture.objects.create(
             name='Bean',
             variety='Canadian Wonder',
@@ -1088,7 +1088,7 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
         import_response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/import/', {}, format='json')
         imported = Culture.objects.get(id=import_response.data['id'])
 
-        response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/withdraw/', {}, format='json')
+        response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/remove/', {}, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         public_culture.refresh_from_db()
@@ -1107,8 +1107,13 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
         self.assertEqual(list_response.status_code, status.HTTP_200_OK)
         self.assertEqual(list_response.data['results'], [])
 
-    def test_non_owner_cannot_withdraw_public_culture(self):
-        other_user = User.objects.create_user(username='other-withdrawer', email='withdrawer@example.com', password='testpass', is_active=True)
+    def test_non_contributor_without_moderation_rights_cannot_remove_public_culture(self):
+        other_user = User.objects.create_user(
+            username='other-contributor',
+            email='other-contributor@example.com',
+            password='testpass',
+            is_active=True,
+        )
         public_culture = PublicCulture.objects.create(
             name='Bean',
             variety='Canadian Wonder',
@@ -1116,13 +1121,13 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
             created_by=other_user,
         )
 
-        response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/withdraw/', {}, format='json')
+        response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/remove/', {}, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         public_culture.refresh_from_db()
         self.assertEqual(public_culture.status, PublicCulture.STATUS_PUBLISHED)
 
-    def test_owner_can_republish_withdrawn_public_culture(self):
+    def test_contributor_can_republish_a_culture_removed_from_the_library(self):
         public_culture = PublicCulture.objects.create(
             name='Lettuce',
             variety='Bijella',
@@ -1133,8 +1138,8 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
             source_project=self.project,
             source_project_culture=self.culture,
         )
-        withdraw_response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/withdraw/', {}, format='json')
-        self.assertEqual(withdraw_response.status_code, status.HTTP_200_OK)
+        remove_response = self.client.post(f'/openfarmplanner/api/public-cultures/{public_culture.id}/remove/', {}, format='json')
+        self.assertEqual(remove_response.status_code, status.HTTP_200_OK)
 
         response = self.publish_current_culture()
 
@@ -1204,21 +1209,65 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['results'][0]['owned_public_culture_id'], public_culture.id)
+        self.assertEqual(response.data['results'][0]['owned_public_culture_role'], 'moderator')
 
-    def test_remove_requires_admin_and_reason(self):
+    def test_contributor_culture_list_reports_the_contributor_role_for_their_public_entry(self):
+        public_culture = PublicCulture.objects.create(
+            name='Lettuce',
+            variety='Bijella',
+            status=PublicCulture.STATUS_PUBLISHED,
+            created_by=self.user,
+            source_project=self.project,
+            source_project_culture=self.culture,
+        )
+
+        response = self.client.get('/openfarmplanner/api/cultures/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['results'][0]['owned_public_culture_id'], public_culture.id)
+        self.assertEqual(response.data['results'][0]['owned_public_culture_role'], 'contributor')
+
+    def test_culture_list_reports_no_public_library_role_without_a_linked_entry(self):
+        response = self.client.get('/openfarmplanner/api/cultures/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data['results'][0]['owned_public_culture_id'])
+        self.assertIsNone(response.data['results'][0]['owned_public_culture_role'])
+
+    def test_moderator_removing_their_own_public_culture_withdraws_it_without_a_reason(self):
+        moderator = User.objects.create_user(
+            username='self-moderator',
+            email='self-moderator@example.com',
+            password='testpass',
+            is_active=True,
+        )
+        grant_public_library_moderator_access(moderator)
+        self.client.force_authenticate(user=moderator)
+        public_culture = PublicCulture.objects.create(
+            name='Tomato',
+            variety='Roma',
+            status=PublicCulture.STATUS_PUBLISHED,
+            created_by=moderator,
+        )
+
+        response = self.client.post(
+            f'/openfarmplanner/api/public-cultures/{public_culture.id}/remove/',
+            {},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        public_culture.refresh_from_db()
+        self.assertEqual(public_culture.status, PublicCulture.STATUS_WITHDRAWN)
+        self.assertEqual(public_culture.removal_reason, '')
+
+    def test_moderator_removing_a_foreign_public_culture_requires_a_reason(self):
         public_culture = PublicCulture.objects.create(
             name='Tomato',
             variety='Roma',
             status=PublicCulture.STATUS_PUBLISHED,
             created_by=self.user,
         )
-
-        forbidden_response = self.client.post(
-            f'/openfarmplanner/api/public-cultures/{public_culture.id}/remove/',
-            {'reason': PublicCulture.REMOVAL_REASON_DUPLICATE},
-            format='json',
-        )
-        self.assertEqual(forbidden_response.status_code, status.HTTP_403_FORBIDDEN)
 
         moderator = User.objects.create_user(
             username='moderator-missing-reason',

--- a/docs/crop-library-architecture.md
+++ b/docs/crop-library-architecture.md
@@ -18,10 +18,11 @@ The public Crop Library follows an open-data model:
 
 - Published crop data becomes part of a shared knowledge base intended to
   persist beyond the contributing user's project or account.
-- Contributors may withdraw their own publications when a publication was
-  accidental or needs correction. Withdrawal is non-destructive: the entry
-  disappears from discovery, but attribution, license evidence, import
-  lineage, and already-imported project copies remain intact.
+- Contributors may take their own publications back out of the library when a
+  publication was accidental or needs correction. Withdrawal is
+  non-destructive: the entry disappears from discovery, but attribution,
+  license evidence, import lineage, and already-imported project copies remain
+  intact. The UI offers this as a single "Aus Bibliothek entfernen" action.
 - Moderator removal is reserved for exceptional cases such as test data,
   duplicates, unlawful content, personal data in a published record, spam,
   obvious abuse, or another moderation decision. It is also non-destructive.
@@ -330,10 +331,19 @@ multilingual species library.
 
 The status-change API lives on `/api/public-cultures/<id>/`:
 
-- `withdraw/` lets the contributor withdraw their own published entry.
-- `remove/` lets staff remove an entry with a structured reason
-  (`accidental_publication`, `test_data`, `duplicate`, `wrong_mapping`,
-  `unlawful_content`, `other`).
+- `remove/` is the single entry point for taking an entry out of the library,
+  so the culture overflow menu only needs one "Aus Bibliothek entfernen"
+  action. The actor decides the transition: the contributor of the entry
+  withdraws it (`withdrawn`, no reason required, reversible by publishing the
+  project culture again), while a moderator removing somebody else's entry
+  must pass a structured reason (`accidental_publication`, `test_data`,
+  `duplicate`, `wrong_mapping`, `unlawful_content`, `other`) and produces
+  `removed`. Contributor intent wins for moderators acting on their own
+  entries — a moderator who wants the stronger `removed` state for their own
+  publication uses the admin surface.
+  `CultureSerializer.owned_public_culture_role` (`contributor` / `moderator` /
+  `null`) tells the UI which of the two paths applies, so the confirmation
+  dialog only asks for a moderation reason when one is actually required.
 - `hard-delete/` is staff-only and intentionally narrow. It is blocked when
   the public entry has imported project copies or source-project provenance;
   ordinary cleanup and moderation should use `removed` instead.

--- a/frontend/src/__tests__/CultureDetail.test.tsx
+++ b/frontend/src/__tests__/CultureDetail.test.tsx
@@ -724,7 +724,7 @@ describe('CultureDetail Component', () => {
     expect(screen.queryByRole('menuitem', { name: 'Bearbeiten' })).not.toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Versionen' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Veröffentlichen' })).toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: 'Projektkultur löschen' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Löschen' })).toBeInTheDocument();
   });
 
   it('keeps the portrait mobile culture UI in short-height phone landscape', () => {

--- a/frontend/src/__tests__/CultureHeaderActionsMenu.test.tsx
+++ b/frontend/src/__tests__/CultureHeaderActionsMenu.test.tsx
@@ -6,46 +6,58 @@ import { CultureHeaderActionsMenu } from '../cultures/CultureHeaderActionsMenu';
 const labels: Record<string, string> = {
   'buttons.edit': 'Bearbeiten',
   'buttons.versions': 'Versionen',
-  'buttons.deleteProjectCulture': 'Projektkultur löschen',
+  'buttons.delete': 'Löschen',
   'library.updateButton': 'Öffentliche Kulturbibliothek aktualisieren',
-  'library.withdrawAction': 'Veröffentlichung zurückziehen',
   'library.removeAction': 'Aus Bibliothek entfernen',
 };
 
 const t = ((key: string) => labels[key] ?? key) as TFunction<'cultures'>;
 
-describe('CultureHeaderActionsMenu', () => {
-  it('keeps secondary project actions separate from moderation actions', () => {
-    const anchor = document.createElement('button');
-    document.body.appendChild(anchor);
+const renderMenu = (props: { canRemovePublicCulture: boolean }) => {
+  const anchor = document.createElement('button');
+  document.body.appendChild(anchor);
 
-    render(
-      <CultureHeaderActionsMenu
-        anchorEl={anchor}
-        onClose={vi.fn()}
-        onEdit={vi.fn()}
-        onOpenHistory={vi.fn()}
-        onPublish={vi.fn()}
-        isPublishing={false}
-        publishLabel={labels['library.updateButton']}
-        onDelete={vi.fn()}
-        onWithdrawPublicCulture={vi.fn()}
-        onRemovePublicCulture={vi.fn()}
-        canWithdrawPublicCulture
-        canModeratePublicCulture
-        t={t}
-      />,
-    );
+  render(
+    <CultureHeaderActionsMenu
+      anchorEl={anchor}
+      onClose={vi.fn()}
+      onOpenHistory={vi.fn()}
+      onPublish={vi.fn()}
+      isPublishing={false}
+      publishLabel={labels['library.updateButton']}
+      onDelete={vi.fn()}
+      onRemovePublicCulture={vi.fn()}
+      canRemovePublicCulture={props.canRemovePublicCulture}
+      t={t}
+    />,
+  );
+};
+
+describe('CultureHeaderActionsMenu', () => {
+  it('offers a single short entry per action for published cultures', () => {
+    renderMenu({ canRemovePublicCulture: true });
 
     const menuItems = screen.getAllByRole('menuitem').map((item) => item.textContent);
 
     expect(menuItems).toEqual([
       'Versionen',
       'Öffentliche Kulturbibliothek aktualisieren',
-      'Veröffentlichung zurückziehen',
       'Aus Bibliothek entfernen',
-      'Projektkultur löschen',
+      'Löschen',
     ]);
+    expect(screen.queryByRole('menuitem', { name: 'Veröffentlichung zurückziehen' })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Endgültig löschen' })).not.toBeInTheDocument();
+  });
+
+  it('hides the library action for cultures that are not published', () => {
+    renderMenu({ canRemovePublicCulture: false });
+
+    const menuItems = screen.getAllByRole('menuitem').map((item) => item.textContent);
+
+    expect(menuItems).toEqual([
+      'Versionen',
+      'Öffentliche Kulturbibliothek aktualisieren',
+      'Löschen',
+    ]);
   });
 });

--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -15,7 +15,6 @@ const {
   cropSpeciesListMock,
   publishPreviewMock,
   publicCultureListMock,
-  publicCultureWithdrawMock,
   publicCultureRemoveMock,
   publishPublicMock,
   deleteMock,
@@ -30,7 +29,6 @@ const {
   cropSpeciesListMock: vi.fn(),
   publishPreviewMock: vi.fn(),
   publicCultureListMock: vi.fn(),
-  publicCultureWithdrawMock: vi.fn(),
   publicCultureRemoveMock: vi.fn(),
   publishPublicMock: vi.fn(),
   deleteMock: vi.fn(),
@@ -78,11 +76,19 @@ vi.mock('../api/api', async () => {
     publicCultureAPI: {
       ...actual.publicCultureAPI,
       list: publicCultureListMock,
-      withdraw: publicCultureWithdrawMock,
       remove: publicCultureRemoveMock,
     },
   };
 });
+
+interface CultureDetailMockCulture {
+  id?: number;
+  name: string;
+  variety?: string;
+  cultivation_type?: string;
+  owned_public_culture_id?: number | null;
+  owned_public_culture_role?: 'contributor' | 'moderator' | null;
+}
 
 vi.mock('../cultures/CultureDetail', () => ({
   CultureDetail: ({
@@ -91,7 +97,6 @@ vi.mock('../cultures/CultureDetail', () => ({
     onCreateCulture,
     onCreatePlan,
     onPublishCulture,
-    onWithdrawPublicCulture,
     onRemovePublicCulture,
     onEditCulture,
     onDeleteCulture,
@@ -99,13 +104,12 @@ vi.mock('../cultures/CultureDetail', () => ({
     publishActionLabel,
     selectedCultureId,
   }: {
-    cultures: Array<{ id?: number; name: string; variety?: string; cultivation_type?: string; owned_public_culture_id?: number | null }>;
+    cultures: Array<CultureDetailMockCulture>;
     onCultureSelect: (culture: { id?: number; name: string } | null) => void;
     onCreateCulture?: () => void;
     onCreatePlan?: () => void;
     onPublishCulture?: () => void;
-    onWithdrawPublicCulture?: (culture: { id?: number; name: string; owned_public_culture_id?: number | null }) => void;
-    onRemovePublicCulture?: (culture: { id?: number; name: string; owned_public_culture_id?: number | null }) => void;
+    onRemovePublicCulture?: (culture: CultureDetailMockCulture) => void;
     onEditCulture?: (culture: { id?: number; name: string }) => void;
     onDeleteCulture?: (culture: { id?: number; name: string; variety?: string; cultivation_type?: string }) => void;
     canCreatePlan?: boolean;
@@ -119,7 +123,6 @@ vi.mock('../cultures/CultureDetail', () => ({
       ))}
       <button type="button" onClick={() => onCreateCulture?.()}>Kultur hinzufügen</button>
       <button type="button" onClick={() => onPublishCulture?.()}>{publishActionLabel ?? 'Veröffentlichen'}</button>
-      <button type="button" onClick={() => onWithdrawPublicCulture?.(cultures[0])}>Veröffentlichung zurückziehen</button>
       <button type="button" onClick={() => onRemovePublicCulture?.(cultures[0])}>Aus Bibliothek entfernen</button>
       <button type="button" onClick={() => onCreatePlan?.()} disabled={!canCreatePlan}>Anbauplan erstellen</button>
       <button type="button" onClick={() => onEditCulture?.(cultures[0])}>Kultur bearbeiten</button>
@@ -160,7 +163,7 @@ function renderCultures(initialPath = '/cultures'): ReturnType<typeof render> {
 
 const waitForDeleteDialogToClose = async (): Promise<void> => {
   await waitFor(() => {
-    expect(screen.queryByRole('dialog', { name: 'Kultur löschen?' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Projektkultur löschen?' })).not.toBeInTheDocument();
   });
 };
 
@@ -221,7 +224,6 @@ describe('Cultures action area', () => {
         duplicates: [],
       },
     });
-    publicCultureWithdrawMock.mockResolvedValue({ data: { id: 77, name: 'Tomate', version: 1, status: 'withdrawn' } });
     publicCultureRemoveMock.mockResolvedValue({ data: { id: 77, name: 'Tomate', version: 1, status: 'removed' } });
   });
 
@@ -431,29 +433,38 @@ describe('Cultures action area', () => {
     expect(screen.queryByRole('button', { name: 'Veröffentlichen' })).not.toBeInTheDocument();
   });
 
-  it('withdraws an owned public culture after confirmation', async () => {
+  it('removes an owned public culture from the library without asking for a reason', async () => {
     listMock.mockResolvedValue({
       data: {
         count: 1,
         next: null,
         previous: null,
         results: [
-          { id: 1, name: 'Tomate', growth_duration_days: 1, harvest_duration_days: 1, owned_public_culture_id: 77 },
+          {
+            id: 1,
+            name: 'Tomate',
+            growth_duration_days: 1,
+            harvest_duration_days: 1,
+            owned_public_culture_id: 77,
+            owned_public_culture_role: 'contributor',
+          },
         ],
       },
     });
 
     renderCultures('/cultures?cultureId=1');
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Veröffentlichung zurückziehen' })).toBeInTheDocument());
-    fireEvent.click(screen.getByRole('button', { name: 'Veröffentlichung zurückziehen' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Aus Bibliothek entfernen' })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Aus Bibliothek entfernen' }));
 
-    const dialog = await screen.findByRole('dialog', { name: 'Veröffentlichung zurückziehen?' });
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('Aus Bibliothek entfernen?');
     expect(dialog).toHaveTextContent('Bereits importierte Kulturen in Projekten bleiben vollständig erhalten.');
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Veröffentlichung zurückziehen' }));
+    expect(within(dialog).queryByLabelText('Grund')).not.toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Aus Bibliothek entfernen' }));
 
     await waitFor(() => {
-      expect(publicCultureWithdrawMock).toHaveBeenCalledWith(77);
+      expect(publicCultureRemoveMock).toHaveBeenCalledWith(77, undefined);
     });
     expect(listMock).toHaveBeenCalledTimes(2);
   });
@@ -466,7 +477,14 @@ describe('Cultures action area', () => {
         next: null,
         previous: null,
         results: [
-          { id: 1, name: 'Tomate', growth_duration_days: 1, harvest_duration_days: 1, owned_public_culture_id: 77 },
+          {
+            id: 1,
+            name: 'Tomate',
+            growth_duration_days: 1,
+            harvest_duration_days: 1,
+            owned_public_culture_id: 77,
+            owned_public_culture_role: 'moderator',
+          },
         ],
       },
     });
@@ -476,7 +494,8 @@ describe('Cultures action area', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'Aus Bibliothek entfernen' })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'Aus Bibliothek entfernen' }));
 
-    const dialog = await screen.findByRole('dialog', { name: 'Aus Bibliothek entfernen?' });
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('Bitte wähle den Moderationsgrund.');
     expect(within(dialog).getByRole('button', { name: 'Aus Bibliothek entfernen' })).toBeDisabled();
     fireEvent.mouseDown(within(dialog).getByLabelText('Grund'));
     fireEvent.click(await screen.findByRole('option', { name: 'Duplikat' }));
@@ -515,8 +534,8 @@ describe('Cultures action area', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Kultur löschen' }));
 
     const dialog = await screen.findByRole('dialog');
-    expect(dialog).toHaveTextContent('Kultur löschen?');
-    expect(dialog).toHaveTextContent('„Tomate“ löschen?');
+    expect(dialog).toHaveTextContent('Projektkultur löschen?');
+    expect(dialog).toHaveTextContent('Möchtest du die Projektkultur „Tomate“ wirklich löschen?');
     expect(dialog).not.toHaveTextContent('Roma');
     expect(dialog).not.toHaveTextContent('Pflanzung');
     expect(dialog).not.toHaveTextContent('8 Sekunden');

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -162,9 +162,10 @@ export const publicCultureAPI = {
   match: (params: { name: string; variety: string }, signal?: AbortSignal) =>
     http.get<PublicCultureMatchResponse>('/public-cultures/match/', { params, signal }),
   importToProject: (id: number) => http.post<Culture>(`/public-cultures/${id}/import/`, {}),
-  withdraw: (id: number) => http.post<PublicCulture>(`/public-cultures/${id}/withdraw/`, {}),
-  remove: (id: number, reason: PublicCultureRemovalReason) =>
-    http.post<PublicCulture>(`/public-cultures/${id}/remove/`, { reason }),
+  // Contributors remove their own entry without a reason; moderators removing
+  // somebody else's entry must supply a structured moderation reason.
+  remove: (id: number, reason?: PublicCultureRemovalReason) =>
+    http.post<PublicCulture>(`/public-cultures/${id}/remove/`, reason ? { reason } : {}),
   hardDelete: (id: number) => http.post<void>(`/public-cultures/${id}/hard-delete/`, {}),
   discussionTopics: (id: number) => http.get<PublicCultureDiscussionTopic[]>(`/public-cultures/${id}/discussion-topics/`),
   createDiscussionTopic: (id: number, data: { title: string; body: string; revision?: number }) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,6 +80,7 @@ export interface Culture {
   source_public_version?: number | null;
   origin_type?: 'manual' | 'imported';
   owned_public_culture_id?: number | null;
+  owned_public_culture_role?: PublicCultureOwnershipRole | null;
   is_modified_from_source?: boolean;
   crop_species?: number | null;
   thousand_kernel_weight_g?: number;
@@ -311,6 +312,13 @@ export interface PublicCultureDiscussionTopic {
   last_activity_at?: string | null;
   last_comment_preview?: string | null;
 }
+
+/**
+ * How the current user relates to the public-library entry linked to a project
+ * culture. Contributors remove their own entry without a reason, moderators
+ * remove somebody else's entry and must pick a moderation reason.
+ */
+export type PublicCultureOwnershipRole = 'contributor' | 'moderator';
 
 export type PublicCultureRemovalReason =
   | 'accidental_publication'

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -60,10 +60,8 @@ interface CultureDetailProps {
   onCreatePlan?: () => void;
   onOpenHistory?: () => void;
   onPublishCulture?: () => void;
-  onWithdrawPublicCulture?: (culture: Culture) => void;
   onRemovePublicCulture?: (culture: Culture) => void;
   onDeleteCulture?: (culture: Culture) => void;
-  canModeratePublicCulture?: boolean;
   canCreatePlan?: boolean;
   isPublishingCulture?: boolean;
   publishActionLabel?: string;
@@ -93,10 +91,8 @@ export function CultureDetail({
   onCreatePlan,
   onOpenHistory,
   onPublishCulture,
-  onWithdrawPublicCulture,
   onRemovePublicCulture,
   onDeleteCulture,
-  canModeratePublicCulture = false,
   canCreatePlan = true,
   isPublishingCulture = false,
   publishActionLabel,
@@ -760,10 +756,8 @@ export function CultureDetail({
                 onPublish={() => onPublishCulture?.()}
                 isPublishing={isPublishingCulture}
                 publishLabel={publishActionLabel ?? t('library.publishButton')}
-                onWithdrawPublicCulture={() => onWithdrawPublicCulture?.(selectedCulture)}
                 onRemovePublicCulture={() => onRemovePublicCulture?.(selectedCulture)}
-                canWithdrawPublicCulture={Boolean(selectedCulture.owned_public_culture_id && onWithdrawPublicCulture)}
-                canModeratePublicCulture={Boolean(selectedCulture.owned_public_culture_id && canModeratePublicCulture)}
+                canRemovePublicCulture={Boolean(selectedCulture.owned_public_culture_id && onRemovePublicCulture)}
                 onDelete={() => onDeleteCulture?.(selectedCulture)}
                 t={t}
               />

--- a/frontend/src/cultures/CultureHeaderActionsMenu.tsx
+++ b/frontend/src/cultures/CultureHeaderActionsMenu.tsx
@@ -3,7 +3,6 @@ import HistoryIcon from '@mui/icons-material/History';
 import PublicIcon from '@mui/icons-material/Public';
 import DeleteIcon from '@mui/icons-material/Delete';
 import PublicOffIcon from '@mui/icons-material/PublicOff';
-import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import type { TFunction } from 'i18next';
 
 interface CultureHeaderActionsMenuProps {
@@ -14,18 +13,16 @@ interface CultureHeaderActionsMenuProps {
   isPublishing: boolean;
   publishLabel: string;
   onDelete: () => void;
-  onWithdrawPublicCulture?: () => void;
   onRemovePublicCulture?: () => void;
-  canWithdrawPublicCulture?: boolean;
-  canModeratePublicCulture?: boolean;
+  canRemovePublicCulture?: boolean;
   t: TFunction<'cultures'>;
 }
 
 /**
  * Presentational overflow menu for the culture detail header (versions,
- * publish to public library, delete). Anchor state lives in
- * CultureDetail.tsx; each item closes the menu before running its action,
- * matching the original inline behavior.
+ * publish to public library, remove from public library, delete). Anchor state
+ * lives in CultureDetail.tsx; each item closes the menu before running its
+ * action, matching the original inline behavior.
  */
 export function CultureHeaderActionsMenu({
   anchorEl,
@@ -35,10 +32,8 @@ export function CultureHeaderActionsMenu({
   isPublishing,
   publishLabel,
   onDelete,
-  onWithdrawPublicCulture,
   onRemovePublicCulture,
-  canWithdrawPublicCulture = false,
-  canModeratePublicCulture = false,
+  canRemovePublicCulture = false,
   t,
 }: CultureHeaderActionsMenuProps) {
   return (
@@ -59,24 +54,15 @@ export function CultureHeaderActionsMenu({
         <PublicIcon sx={{ fontSize: 18, mr: 1, color: 'rgba(37, 111, 42, 0.78)' }} />
         {publishLabel}
       </MenuItem>
-      {canWithdrawPublicCulture ? (
-        <MenuItem
-          onClick={() => { onClose(); onWithdrawPublicCulture?.(); }}
-          sx={{ color: 'warning.dark' }}
-        >
-          <PublicOffIcon sx={{ fontSize: 18, mr: 1, color: 'warning.dark' }} />
-          {t('library.withdrawAction')}
-        </MenuItem>
-      ) : null}
-      {canModeratePublicCulture ? (
+      {canRemovePublicCulture ? (
         [
-          <Divider key="moderation-divider" sx={{ my: 0.5 }} />,
+          <Divider key="public-library-divider" sx={{ my: 0.5 }} />,
           <MenuItem
             key="remove-public-culture"
             onClick={() => { onClose(); onRemovePublicCulture?.(); }}
-            sx={{ color: 'error.main' }}
+            sx={{ color: 'warning.dark' }}
           >
-            <RemoveCircleOutlineIcon sx={{ fontSize: 18, mr: 1, color: 'error.main' }} />
+            <PublicOffIcon sx={{ fontSize: 18, mr: 1, color: 'warning.dark' }} />
             {t('library.removeAction')}
           </MenuItem>,
         ]
@@ -84,7 +70,7 @@ export function CultureHeaderActionsMenu({
       <Divider sx={{ my: 0.5 }} />
       <MenuItem onClick={() => { onClose(); onDelete(); }} sx={{ color: 'error.main' }}>
         <DeleteIcon sx={{ fontSize: 18, mr: 1, color: 'error.main' }} />
-        {t('buttons.deleteProjectCulture')}
+        {t('buttons.delete')}
       </MenuItem>
     </Menu>
   );

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -275,8 +275,8 @@
     "restoreError": "Version konnte nicht wiederhergestellt werden"
   },
   "deleteDialog": {
-    "title": "Kultur löschen?",
-    "confirmation": "„{{name}}“ löschen?"
+    "title": "Projektkultur löschen?",
+    "confirmation": "Möchtest du die Projektkultur „{{name}}“ wirklich löschen?"
   },
   "seedDemand": {
     "title": "Saatgutbedarf",
@@ -474,7 +474,6 @@
     "versions": "Versionen",
     "delete": "Löschen",
     "moreActions": "Weitere Aktionen",
-    "deleteProjectCulture": "Projektkultur löschen",
     "deleteConfirm": "Möchten Sie diese Kultur wirklich löschen?",
     "createPlantingPlan": "Anbauplan hinzufügen",
     "goToFieldsBeds": "Zu Anbauflächen",
@@ -765,22 +764,16 @@
     "publishDuplicateError": "Diese Kultur ist bereits in der Kulturbibliothek vorhanden.",
     "publishDuplicateErrorWithCandidates": "Diese Kultur ist bereits öffentlich vorhanden: {{duplicates}}",
     "publishError": "Die Kultur konnte nicht veröffentlicht werden.",
-    "withdrawAction": "Veröffentlichung zurückziehen",
-    "withdrawSuccess": "Die Veröffentlichung von „{{name}}“ wurde zurückgezogen.",
-    "withdrawError": "Die Veröffentlichung konnte nicht zurückgezogen werden.",
     "removeAction": "Aus Bibliothek entfernen",
     "removeSuccess": "„{{name}}“ wurde aus der öffentlichen Kulturbibliothek entfernt.",
     "removeError": "Die Kultur konnte nicht aus der Bibliothek entfernt werden.",
     "hardDeleteAction": "Endgültig löschen",
     "hardDeleteSuccess": "„{{name}}“ wurde endgültig gelöscht.",
     "hardDeleteError": "Die Kultur konnte nicht endgültig gelöscht werden. Wahrscheinlich existieren noch Referenzen oder Herkunftsdaten.",
-    "withdrawDialog": {
-      "title": "Veröffentlichung zurückziehen?",
-      "message": "„{{name}}“ verschwindet aus der öffentlichen Kulturbibliothek. Bereits importierte Kulturen in Projekten bleiben vollständig erhalten. Du kannst die Kultur später erneut veröffentlichen."
-    },
     "removeDialog": {
       "title": "Aus Bibliothek entfernen?",
-      "message": "„{{name}}“ wird für alle Nutzer aus der öffentlichen Kulturbibliothek entfernt. Bereits importierte Projektkulturen bleiben unverändert. Bitte wähle den Moderationsgrund.",
+      "message": "„{{name}}“ verschwindet aus der öffentlichen Kulturbibliothek. Bereits importierte Kulturen in Projekten bleiben vollständig erhalten. Du kannst die Kultur später erneut veröffentlichen.",
+      "moderationMessage": "„{{name}}“ wird für alle Nutzer aus der öffentlichen Kulturbibliothek entfernt. Bereits importierte Projektkulturen bleiben unverändert. Bitte wähle den Moderationsgrund.",
       "reasonLabel": "Grund"
     },
     "hardDeleteDialog": {

--- a/frontend/src/i18n/locales/en/cultures.json
+++ b/frontend/src/i18n/locales/en/cultures.json
@@ -275,8 +275,8 @@
     "restoreError": "Version could not be restored"
   },
   "deleteDialog": {
-    "title": "Delete culture?",
-    "confirmation": "Delete “{{name}}”?"
+    "title": "Delete project culture?",
+    "confirmation": "Do you really want to delete the project culture “{{name}}”?"
   },
   "seedDemand": {
     "title": "Seed demand",
@@ -474,7 +474,6 @@
     "versions": "Versions",
     "delete": "Delete",
     "moreActions": "More actions",
-    "deleteProjectCulture": "Delete project culture",
     "deleteConfirm": "Do you really want to delete this crop?",
     "createPlantingPlan": "Add planting plan",
     "goToFieldsBeds": "Go to growing areas",
@@ -765,22 +764,16 @@
     "publishDuplicateError": "This crop already exists in the crop library.",
     "publishDuplicateErrorWithCandidates": "This crop already exists publicly: {{duplicates}}",
     "publishError": "The crop could not be published.",
-    "withdrawAction": "Withdraw publication",
-    "withdrawSuccess": "The publication of “{{name}}” was withdrawn.",
-    "withdrawError": "The publication could not be withdrawn.",
     "removeAction": "Remove from library",
     "removeSuccess": "“{{name}}” was removed from the public crop library.",
     "removeError": "The culture could not be removed from the library.",
     "hardDeleteAction": "Permanently delete",
     "hardDeleteSuccess": "“{{name}}” was permanently deleted.",
     "hardDeleteError": "The culture could not be permanently deleted. There are probably still references or provenance data.",
-    "withdrawDialog": {
-      "title": "Withdraw publication?",
-      "message": "“{{name}}” disappears from the public crop library. Cultures already imported into projects remain fully intact. You can publish the culture again later."
-    },
     "removeDialog": {
       "title": "Remove from library?",
-      "message": "“{{name}}” is removed from the public crop library for all users. Already imported project cultures remain unchanged. Please select the moderation reason.",
+      "message": "“{{name}}” disappears from the public crop library. Cultures already imported into projects remain fully intact. You can publish the culture again later.",
+      "moderationMessage": "“{{name}}” is removed from the public crop library for all users. Already imported project cultures remain unchanged. Please select the moderation reason.",
       "reasonLabel": "Reason"
     },
     "hardDeleteDialog": {

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -100,7 +100,6 @@ function Cultures() {
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<CultureHistoryEntry[]>([]);
   const [historyScope, setHistoryScope] = useState<HistoryScope>('culture');
-  const [withdrawDialogCulture, setWithdrawDialogCulture] = useState<Culture | null>(null);
   const [removeDialogCulture, setRemoveDialogCulture] = useState<Culture | null>(null);
   const [removeReason, setRemoveReason] = useState<PublicCultureRemovalReason | ''>('');
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -111,7 +110,6 @@ function Cultures() {
   const [hasFields, setHasFields] = useState(false);
   const [hasBeds, setHasBeds] = useState(false);
   const selectedCulture = cultures.find((culture) => culture.id === selectedCultureId);
-  const canModeratePublicCulture = Boolean(user?.is_staff || user?.is_superuser);
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'info') => {
     setSnackbar({ open: true, message, severity });
@@ -231,7 +229,6 @@ function Cultures() {
     handleViewPublicLibraryMatch,
     handleImportPublicCulture,
     handlePublishCurrentCulture,
-    handleWithdrawPublicCulture,
     handleRemovePublicCulture,
   } = usePublicCultureLibrary({
     shouldShowProjectRequiredState,
@@ -260,26 +257,27 @@ function Cultures() {
     });
   }, [handlePublishCurrentCulture]);
 
-  const handleConfirmWithdrawPublicCulture = useCallback(async () => {
-    if (!withdrawDialogCulture) {
-      return;
-    }
-    const success = await handleWithdrawPublicCulture(withdrawDialogCulture);
-    if (success) {
-      setWithdrawDialogCulture(null);
-    }
-  }, [handleWithdrawPublicCulture, withdrawDialogCulture]);
+  // Moderators removing an entry they did not publish must state a reason;
+  // contributors withdrawing their own entry do not.
+  const removeRequiresModerationReason = removeDialogCulture?.owned_public_culture_role === 'moderator';
+
+  const closeRemovePublicCultureDialog = useCallback(() => {
+    setRemoveDialogCulture(null);
+    setRemoveReason('');
+  }, []);
 
   const handleConfirmRemovePublicCulture = useCallback(async () => {
-    if (!removeDialogCulture || !removeReason) {
+    if (!removeDialogCulture || (removeRequiresModerationReason && !removeReason)) {
       return;
     }
-    const success = await handleRemovePublicCulture(removeDialogCulture, removeReason);
+    const success = await handleRemovePublicCulture(
+      removeDialogCulture,
+      removeRequiresModerationReason ? removeReason || undefined : undefined,
+    );
     if (success) {
-      setRemoveDialogCulture(null);
-      setRemoveReason('');
+      closeRemovePublicCultureDialog();
     }
-  }, [handleRemovePublicCulture, removeDialogCulture, removeReason]);
+  }, [closeRemovePublicCultureDialog, handleRemovePublicCulture, removeDialogCulture, removeReason, removeRequiresModerationReason]);
 
   // Fetch cultures on mount
   useEffect(() => {
@@ -596,13 +594,11 @@ function Cultures() {
           onCreatePlan={handleCreatePlantingPlan}
           onOpenHistory={handleOpenHistory}
           onPublishCulture={handleRequestPublishCulture}
-          onWithdrawPublicCulture={(culture) => setWithdrawDialogCulture(culture)}
           onRemovePublicCulture={(culture) => {
             setRemoveReason('');
             setRemoveDialogCulture(culture);
           }}
           onDeleteCulture={handleDelete}
-          canModeratePublicCulture={canModeratePublicCulture}
           canCreatePlan={canCreatePlantingPlan}
           isPublishingCulture={Boolean(selectedCulture && publishingCultureId === selectedCulture.id)}
           publishActionLabel={publishingCultureId === selectedCulture?.id
@@ -660,76 +656,55 @@ function Cultures() {
         confirmButtonProps={{ color: 'error', variant: 'contained' }}
       />
 
-      <ConfirmationDialog
-        open={Boolean(withdrawDialogCulture)}
-        fullWidth
-        title={t('library.withdrawDialog.title')}
-        message={t('library.withdrawDialog.message', { name: withdrawDialogCulture ? getCultureDisplayName(withdrawDialogCulture) : '' })}
-        cancelLabel={t('common:actions.cancel')}
-        confirmLabel={t('library.withdrawAction')}
-        onCancel={() => setWithdrawDialogCulture(null)}
-        onConfirm={handleConfirmWithdrawPublicCulture}
-        titleSx={{ pb: 1 }}
-        contentSx={{ pt: 1 }}
-        messageTypographyProps={{ variant: 'body1', color: 'text.secondary' }}
-        actionsSx={{ px: 3, pb: 2.5, pt: 1 }}
-        cancelButtonProps={{ variant: 'outlined' }}
-        confirmButtonProps={{ color: 'warning', variant: 'contained' }}
-      />
-
       <Dialog
         open={Boolean(removeDialogCulture)}
-        onClose={() => {
-          setRemoveDialogCulture(null);
-          setRemoveReason('');
-        }}
+        onClose={closeRemovePublicCultureDialog}
         maxWidth="sm"
         fullWidth
       >
         <DialogTitle>{t('library.removeDialog.title')}</DialogTitle>
         <DialogContent sx={{ pt: 1 }}>
           <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-            {t('library.removeDialog.message', { name: removeDialogCulture ? getCultureDisplayName(removeDialogCulture) : '' })}
+            {t(
+              removeRequiresModerationReason ? 'library.removeDialog.moderationMessage' : 'library.removeDialog.message',
+              { name: removeDialogCulture ? getCultureDisplayName(removeDialogCulture) : '' },
+            )}
           </Typography>
-          <FormControl fullWidth size="small">
-            <InputLabel id="public-culture-removal-reason-label">
-              {t('library.removeDialog.reasonLabel')}
-            </InputLabel>
-            <Select
-              labelId="public-culture-removal-reason-label"
-              value={removeReason}
-              label={t('library.removeDialog.reasonLabel')}
-              onChange={(event) => setRemoveReason(event.target.value as PublicCultureRemovalReason)}
-            >
-              {([
-                'accidental_publication',
-                'test_data',
-                'duplicate',
-                'wrong_mapping',
-                'unlawful_content',
-                'other',
-              ] as PublicCultureRemovalReason[]).map((reason) => (
-                <MenuItem key={reason} value={reason}>
-                  {t(`library.removeReasons.${reason}`)}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          {removeRequiresModerationReason ? (
+            <FormControl fullWidth size="small">
+              <InputLabel id="public-culture-removal-reason-label">
+                {t('library.removeDialog.reasonLabel')}
+              </InputLabel>
+              <Select
+                labelId="public-culture-removal-reason-label"
+                value={removeReason}
+                label={t('library.removeDialog.reasonLabel')}
+                onChange={(event) => setRemoveReason(event.target.value as PublicCultureRemovalReason)}
+              >
+                {([
+                  'accidental_publication',
+                  'test_data',
+                  'duplicate',
+                  'wrong_mapping',
+                  'unlawful_content',
+                  'other',
+                ] as PublicCultureRemovalReason[]).map((reason) => (
+                  <MenuItem key={reason} value={reason}>
+                    {t(`library.removeReasons.${reason}`)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          ) : null}
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
-          <Button
-            variant="outlined"
-            onClick={() => {
-              setRemoveDialogCulture(null);
-              setRemoveReason('');
-            }}
-          >
+          <Button variant="outlined" onClick={closeRemovePublicCultureDialog}>
             {t('common:actions.cancel')}
           </Button>
           <Button
-            color="error"
+            color={removeRequiresModerationReason ? 'error' : 'warning'}
             variant="contained"
-            disabled={!removeReason}
+            disabled={removeRequiresModerationReason && !removeReason}
             onClick={() => void handleConfirmRemovePublicCulture()}
           >
             {t('library.removeAction')}

--- a/frontend/src/pages/usePublicCultureLibrary.ts
+++ b/frontend/src/pages/usePublicCultureLibrary.ts
@@ -150,25 +150,13 @@ export function usePublicCultureLibrary({
     }
   };
 
-  const handleWithdrawPublicCulture = async (culture: Culture): Promise<boolean> => {
-    if (!culture.owned_public_culture_id) {
-      return false;
-    }
-    try {
-      await publicCultureAPI.withdraw(culture.owned_public_culture_id);
-      await refreshPublicCultureStatusContext();
-      showSnackbar(t('library.withdrawSuccess', { name: formatCultureDisplayName(culture) }), 'success');
-      return true;
-    } catch (error) {
-      console.error('Error withdrawing public culture:', error);
-      showSnackbar(extractApiErrorMessage(error, t, t('library.withdrawError')), 'error');
-      return false;
-    }
-  };
-
+  /**
+   * Removes the culture from the public library. Contributors withdraw their
+   * own entry (no reason needed), moderators pass a moderation reason.
+   */
   const handleRemovePublicCulture = async (
     culture: Culture,
-    reason: PublicCultureRemovalReason,
+    reason?: PublicCultureRemovalReason,
   ): Promise<boolean> => {
     if (!culture.owned_public_culture_id) {
       return false;
@@ -222,7 +210,6 @@ export function usePublicCultureLibrary({
     handleViewPublicLibraryMatch,
     handleImportPublicCulture,
     handlePublishCurrentCulture,
-    handleWithdrawPublicCulture,
     handleRemovePublicCulture,
   };
 }


### PR DESCRIPTION
## Summary
Consolidates the separate "withdraw" and "remove" actions for public cultures into a single "remove from library" action. Contributors can now remove their own published entries without providing a reason (withdrawal), while moderators removing others' entries must provide a structured moderation reason (removal). This simplifies the UI while maintaining the distinction between these two operational modes.

## Key Changes

### Backend
- **Unified removal endpoint**: Merged `withdraw_public_culture()` and `remove_public_culture()` into a single `remove_public_culture()` function that handles both paths based on user role and ownership
- **New helper function**: Added `is_public_culture_contributor()` to determine if a user published a specific public culture
- **Role tracking in serializer**: Extended `CultureSerializer` to include `owned_public_culture_role` field that returns either `'contributor'` or `'moderator'` to indicate the user's relationship to a linked public entry
- **Removed `/withdraw/` endpoint**: The separate withdraw endpoint is no longer needed; all removal goes through `/remove/`

### Frontend
- **Removed withdraw dialog**: Eliminated the separate withdrawal confirmation dialog
- **Unified remove dialog**: The remove dialog now conditionally shows the reason field only when `removeRequiresModerationReason` is true (i.e., when the user is a moderator removing someone else's entry)
- **Simplified menu**: `CultureHeaderActionsMenu` now has a single `canRemovePublicCulture` prop instead of separate `canWithdrawPublicCulture` and `canModeratePublicCulture` props
- **Updated hook**: `usePublicCultureLibrary` now exports only `handleRemovePublicCulture` with an optional reason parameter
- **Removed API method**: Deleted `publicCultureAPI.withdraw()` method

### UI/UX
- **Single action**: Users see one "Remove from library" action instead of two separate actions
- **Conditional reason field**: The moderation reason dropdown only appears when removing as a moderator
- **Consistent messaging**: Dialog messages adapt based on whether it's a contributor withdrawal or moderator removal
- **Updated labels**: Changed button colors and labels to reflect the unified action (warning color for both paths)

### Tests
- Updated test names and expectations to reflect the unified removal flow
- Added tests for role-based behavior (`owned_public_culture_role` field)
- Removed tests for the separate withdraw endpoint

## Implementation Details
- The `_resolve_owned_public_culture()` method in the serializer caches the resolved public culture to avoid redundant queries
- The removal reason is only passed to the API when it's a moderation action (moderator removing another user's entry)
- Contributors withdrawing their own entry can republish by publishing the project culture again (non-destructive withdrawal)
- Moderators removing entries produce a `removed` status with a structured reason; contributors produce a `withdrawn` status

https://claude.ai/code/session_01ShyU6iRMXuqBMMz2VNyFkP