### PR TITLE
Make delete operations persist immediately with undo-restore

### DIFF
--- a/backend/farm/cultures/views/suppliers.py
+++ b/backend/farm/cultures/views/suppliers.py
@@ -65,6 +65,12 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
         return Response(build_delete_usage(supplier))
 
     def destroy(self, request: Request, *args: object, **kwargs: object) -> Response:
+        """Delete the supplier and return the payload needed to restore it.
+
+        The client offers an undo action after the delete, so the response
+        carries the same undo payload as `unlink-and-delete` instead of an
+        empty 204 body.
+        """
         instance = self.get_object()
         usage = build_delete_usage(instance)
         if not usage['can_delete']:
@@ -75,8 +81,9 @@ class SupplierViewSet(ProjectScopedMixin, ProjectRevisionMixin, viewsets.ModelVi
                 },
                 status=status.HTTP_409_CONFLICT,
             )
+        undo_payload = build_delete_undo_payload(instance)
         self.perform_destroy(instance)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response({'undo_payload': undo_payload}, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['post'], url_path='unlink-and-delete')
     def unlink_and_delete(self, request: Request, pk: int | None = None) -> Response:

--- a/backend/farm/tests/test_suppliers_api.py
+++ b/backend/farm/tests/test_suppliers_api.py
@@ -92,6 +92,45 @@ class SupplierApiTest(ProjectApiTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['homepage_url'], 'https://supplier.example/path')
 
+    def test_supplier_delete_removes_supplier_and_returns_undo_payload(self):
+        """Delete must persist immediately and hand back a restore payload for undo."""
+        response = self.client.delete(f'/openfarmplanner/api/suppliers/{self.supplier.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Supplier.objects.filter(pk=self.supplier.id).exists())
+        undo_payload = response.data['undo_payload']
+        self.assertEqual(undo_payload['supplier']['id'], self.supplier.id)
+        self.assertEqual(undo_payload['supplier']['name'], self.supplier.name)
+        self.assertEqual(undo_payload['culture_ids'], [])
+        self.assertEqual(undo_payload['supplier_data'], [])
+
+    def test_supplier_delete_undo_payload_restores_supplier(self):
+        """The undo payload from a delete restores the supplier under its old id."""
+        delete_response = self.client.delete(f'/openfarmplanner/api/suppliers/{self.supplier.id}/')
+        self.assertEqual(delete_response.status_code, status.HTTP_200_OK)
+
+        restore_response = self.client.post(
+            '/openfarmplanner/api/suppliers/restore-unlinked-delete/',
+            delete_response.data['undo_payload'],
+            format='json',
+        )
+
+        self.assertEqual(restore_response.status_code, status.HTTP_200_OK)
+        restored = Supplier.objects.get(pk=self.supplier.id)
+        self.assertEqual(restored.name, self.supplier.name)
+        self.assertEqual(restored.homepage_url, self.supplier.homepage_url)
+
+    def test_supplier_delete_rejects_supplier_still_in_use(self):
+        """A supplier referenced by a culture is kept and reported as a conflict."""
+        self.culture.supplier = self.supplier
+        self.culture.save(update_fields=['supplier'])
+
+        response = self.client.delete(f'/openfarmplanner/api/suppliers/{self.supplier.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertFalse(response.data['usage']['can_delete'])
+        self.assertTrue(Supplier.objects.filter(pk=self.supplier.id).exists())
+
     def test_supplier_update_not_limited_by_list_slice(self):
         """Supplier updates must work even if list endpoint shows only first 20 rows."""
         for idx in range(30):

--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -28,7 +28,7 @@ frontend/src/components/data-grid/
   hooks/
     useDataGridCommandApi.ts     builds the imperative EditableDataGridCommandApi
     useDataGridRowCommands.ts    addRow/editSelectedRow/openRowById/focusTable
-    useDataGridDelete.ts         delete + optional undo-snackbar flow
+    useDataGridDelete.ts         immediate delete + optional undo-snackbar flow
     useDataGridRowActionMenu.ts  right-click / long-press / keyboard row menu
   StableScrollbarTrack.tsx       shared track/thumb overlay for useStableDataGridScrollbar
   keyboardEditing.ts       "just start typing" / F2 spreadsheet-edit-start behavior
@@ -232,6 +232,41 @@ directly: saving notes for a new or still-editing Standort/Parzelle/Beet row
 first persists the current row draft with the note value, then closes the
 drawer. Users should never need to click outside the grid to make a new row
 exist before saving its notes.
+
+## Delete with undo — app-wide semantics
+
+Every "Löschen" flow that shows a `DeleteUndoSnackbar` follows the same
+contract, and new ones must too:
+
+1. **The delete hits the backend immediately.** The row disappears from the
+   list optimistically, but the DELETE request is sent in the same user
+   action — it is never deferred until the undo window has elapsed. A browser
+   reload right after deleting must never bring the record back.
+2. **"Rückgängig" restores, it never cancels.** By the time the snackbar is
+   visible the record is already gone server-side, so undo means calling a
+   restore/recreate endpoint.
+3. **A failed DELETE rolls the row back** into the list and reports the error;
+   no snackbar is shown, because there is nothing to undo.
+4. **Dismissing the snackbar does nothing** but drop the pending entry — it is
+   not a commit point.
+
+Where this lives:
+
+| Entity | Delete | Undo |
+| --- | --- | --- |
+| Anbaupläne (`useDataGridDelete.ts`, `deleteUndoOptions`) | `api.delete` | `api.create(mapToApiData(row))` + reload |
+| Kulturen (`pages/useCultureDelete.ts`) | `cultureAPI.delete` (soft delete) | `cultureAPI.undelete` |
+| Standorte/Parzellen/Beete (`hooks/useHierarchyDelete.ts`) | `locationAPI`/`fieldAPI`/`bedAPI.delete` | recreate location → field → bed, remapping parent ids |
+| Lieferanten (`pages/Suppliers.tsx`) | `supplierAPI.delete` (409 when still referenced) | `supplierAPI.restoreUnlinkedDelete` with the payload the delete/unlink response returned |
+| Projekte (`projects/projectDeletionFeedback.ts`) | `projectAPI.delete` (soft delete) | `projectAPI.restore` |
+
+Entities that are recreated rather than undeleted come back with a **new id**
+— the grid reloads from the backend after a restore instead of re-inserting
+the old row, so sorting decides the position, not the previous id.
+
+The supplier delete endpoint returns the same `undo_payload` shape as
+`unlink-and-delete` (instead of an empty `204`) so that both supplier delete
+paths share one restore endpoint.
 
 ## Notes / markdown cells
 

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -308,6 +308,27 @@ describe('EditableDataGrid', () => {
     }),
   });
 
+  /**
+   * Grid props whose api mock keeps its own row set, so an immediate delete and
+   * a following restore-by-recreate are visible in the next `list()` call.
+   */
+  const serverBackedProps = (initialRows: TestGridRow[]) => {
+    let serverRows = [...initialRows];
+    let nextCreatedId = 100;
+    const props = baseProps(() => null);
+    vi.spyOn(props.api, 'list').mockImplementation(async () => ({ data: { results: [...serverRows] } }));
+    vi.spyOn(props.api, 'delete').mockImplementation(async (id) => {
+      serverRows = serverRows.filter((row) => row.id !== Number(id));
+    });
+    vi.spyOn(props.api, 'create').mockImplementation(async (data) => {
+      const createdRow = createGridRow({ ...(data as Partial<TestGridRow>), id: nextCreatedId });
+      nextCreatedId += 1;
+      serverRows = [...serverRows, createdRow];
+      return { data: createdRow };
+    });
+    return props;
+  };
+
   const basePropsWithRows = (rows: TestGridRow[]) => {
     const props = baseProps(() => null);
     vi.spyOn(props.api, 'list').mockResolvedValue({ data: { results: rows } });
@@ -1596,13 +1617,9 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith(1));
   });
 
-  it('optimistically removes a row and restores it from the delete undo snackbar', async () => {
+  it('deletes a row in the backend right away and recreates it from the delete undo snackbar', async () => {
     const user = userEvent.setup();
-    const props = baseProps();
-    vi.spyOn(props.api, 'list').mockResolvedValue({
-      data: { results: [createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })] },
-    });
-    const deleteSpy = vi.spyOn(props.api, 'delete');
+    const props = serverBackedProps([createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })]);
     const confirmSpy = vi.spyOn(window, 'confirm');
 
     render(
@@ -1620,18 +1637,24 @@ describe('EditableDataGrid', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Löschen' }));
 
     expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
-    expect(screen.getByText('Anbauplan gelöscht')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' })).toBeInTheDocument();
-    expect(deleteSpy).not.toHaveBeenCalled();
+    // The delete is already persisted while undo is still offered — a reload
+    // at this point must not bring the row back.
+    await waitFor(() => expect(props.api.delete).toHaveBeenCalledWith(1));
     expect(confirmSpy).not.toHaveBeenCalled();
+    expect(await screen.findByText('Anbauplan gelöscht')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' }));
 
-    expect(screen.getByTestId('row-1')).toBeInTheDocument();
-    expect(deleteSpy).not.toHaveBeenCalled();
+    await waitFor(() => expect(props.api.create).toHaveBeenCalledWith({
+      name: 'Beet A',
+      area_sqm: 12,
+      notes: '',
+    }));
+    await waitFor(() => expect(screen.getByTestId('row-count')).toHaveTextContent('2'));
+    expect(screen.getByTestId('row-100')).toBeInTheDocument();
   });
 
-  it('finalizes optimistic delete after the 10000 ms undo window', async () => {
+  it('does not defer the backend delete until the undo window has passed', async () => {
     const props = baseProps();
     const deleteSpy = vi.spyOn(props.api, 'delete');
 
@@ -1647,16 +1670,41 @@ describe('EditableDataGrid', () => {
 
     await waitFor(() => expect(screen.getByTestId('row-1')).toBeInTheDocument());
     fireEvent.contextMenu(screen.getByTestId('row-1'));
-    vi.useFakeTimers();
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    });
 
-    vi.advanceTimersByTime(9999);
-    expect(deleteSpy).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(1);
-    await Promise.resolve();
     expect(deleteSpy).toHaveBeenCalledWith(1);
-    vi.useRealTimers();
+  });
+
+  it('puts the row back and reports the error when the immediate delete fails', async () => {
+    const props = baseProps();
+    vi.spyOn(props.api, 'list').mockResolvedValue({
+      data: { results: [createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })] },
+    });
+    vi.spyOn(props.api, 'delete').mockRejectedValue(new Error('boom'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <EditableDataGrid
+        {...props}
+        showDeleteAction={false}
+        showRowEditActions={false}
+        duplicateRow={(row) => ({ ...row, id: -2, isNew: true })}
+        deleteUndoOptions={{ message: 'Anbauplan gelöscht' }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('row-1')).toBeInTheDocument());
+    fireEvent.contextMenu(screen.getByTestId('row-1'));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    });
+
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+    expect(screen.queryByText('Anbauplan gelöscht')).not.toBeInTheDocument();
+    expect(screen.getByText('Löschen fehlgeschlagen')).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
   });
 
   it('discards an unsaved new row without backend delete or undo state', async () => {
@@ -1684,12 +1732,9 @@ describe('EditableDataGrid', () => {
     expect(confirmSpy).not.toHaveBeenCalled();
   });
 
-  it('handles multiple optimistic deletions independently', async () => {
-    const props = baseProps();
-    vi.spyOn(props.api, 'list').mockResolvedValue({
-      data: { results: [createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })] },
-    });
-    const deleteSpy = vi.spyOn(props.api, 'delete');
+  it('handles multiple immediate deletions independently', async () => {
+    const user = userEvent.setup();
+    const props = serverBackedProps([createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })]);
 
     render(
       <EditableDataGrid
@@ -1703,31 +1748,30 @@ describe('EditableDataGrid', () => {
 
     await waitFor(() => expect(screen.getByTestId('row-1')).toBeInTheDocument());
     fireEvent.contextMenu(screen.getByTestId('row-1'));
-    vi.useFakeTimers();
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Löschen' }));
     fireEvent.contextMenu(screen.getByTestId('row-2'));
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Löschen' }));
 
     expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('row-2')).not.toBeInTheDocument();
+    await waitFor(() => expect(props.api.delete).toHaveBeenCalledWith(1));
+    expect(props.api.delete).toHaveBeenCalledWith(2);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' })[0]);
-    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+    const undoButtons = await screen.findAllByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' });
+    expect(undoButtons).toHaveLength(2);
+    await user.click(undoButtons[0]);
+
+    // Only the undone row is recreated; the second deletion stays deleted and
+    // keeps its own snackbar.
+    await waitFor(() => expect(props.api.create).toHaveBeenCalledTimes(1));
+    expect(props.api.create).toHaveBeenCalledWith({ name: 'Beet A', area_sqm: 12, notes: '' });
+    await waitFor(() => expect(screen.getByTestId('row-100')).toBeInTheDocument());
     expect(screen.queryByTestId('row-2')).not.toBeInTheDocument();
-
-    vi.advanceTimersByTime(10000);
-    await Promise.resolve();
-    expect(deleteSpy).toHaveBeenCalledWith(2);
-    expect(deleteSpy).not.toHaveBeenCalledWith(1);
-    vi.useRealTimers();
   });
 
-  it('restores an optimistically deleted row to its previous sorted position', async () => {
+  it('reloads the restored row from the backend after undo', async () => {
     const user = userEvent.setup();
-    const props = baseProps();
-    vi.spyOn(props.api, 'list').mockResolvedValue({
-      data: { results: [createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })] },
-    });
+    const props = serverBackedProps([createGridRow({ id: 1 }), createGridRow({ id: 2, name: 'Beet B' })]);
 
     render(
       <EditableDataGrid
@@ -1742,12 +1786,15 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(screen.getByTestId('row-1')).toBeInTheDocument());
     fireEvent.contextMenu(screen.getByTestId('row-1'));
     await user.click(screen.getByRole('menuitem', { name: 'Löschen' }));
-    await user.click(screen.getByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' }));
+    await user.click(await screen.findByRole('button', { name: 'Rückgängig: Anbauplan gelöscht' }));
 
-    expect(screen.getAllByRole('row').map((row) => row.getAttribute('data-id'))).toEqual(['1', '2']);
+    // The restore recreates the record, so the row comes back with the id the
+    // backend assigned rather than the id it had before the delete.
+    await waitFor(() => expect(screen.getByTestId('row-100')).toBeInTheDocument());
+    expect(screen.getAllByRole('row').map((row) => row.getAttribute('data-id'))).toEqual(['2', '100']);
   });
 
-  it('cleans pending optimistic delete timers on unmount', async () => {
+  it('keeps the delete persisted when the grid unmounts right after deleting', async () => {
     const props = baseProps();
     const deleteSpy = vi.spyOn(props.api, 'delete');
     const { unmount } = render(
@@ -1762,12 +1809,13 @@ describe('EditableDataGrid', () => {
 
     await waitFor(() => expect(screen.getByTestId('row-1')).toBeInTheDocument());
     fireEvent.contextMenu(screen.getByTestId('row-1'));
-    vi.useFakeTimers();
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Löschen' }));
+    });
     unmount();
-    vi.advanceTimersByTime(8000);
 
-    expect(deleteSpy).not.toHaveBeenCalled();
+    // Leaving the page (or reloading it) must not undo the delete.
+    expect(deleteSpy).toHaveBeenCalledWith(1);
   });
 
   it('keeps inline editing available when contextual actions are enabled', async () => {

--- a/frontend/src/__tests__/SuppliersPage.test.tsx
+++ b/frontend/src/__tests__/SuppliersPage.test.tsx
@@ -468,10 +468,10 @@ describe('Suppliers page empty and table states', () => {
     expect(screen.getByRole('menuitem', { name: 'Löschen' })).toBeInTheDocument();
   });
 
-  it('deletes an unused supplier with undo feedback without a native browser confirm', async () => {
+  it('deletes an unused supplier immediately and offers undo without a native browser confirm', async () => {
     mocks.list.mockResolvedValue({
       data: {
-        results: [{ id: 1, name: 'Reinsaat', homepage_url: 'https://example.com' }],
+        results: [{ id: 1, name: 'Reinsaat', homepage_url: 'https://example.com', slug: 'reinsaat', allowed_domains: [] }],
       },
     });
     mocks.deleteUsage.mockResolvedValue({
@@ -485,6 +485,7 @@ describe('Suppliers page empty and table states', () => {
         culture_ids: [],
       },
     });
+    mocks.delete.mockResolvedValue({ data: { undo_payload: undefined } });
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
 
     render(
@@ -497,12 +498,104 @@ describe('Suppliers page empty and table states', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
 
     await waitFor(() => expect(mocks.deleteUsage).toHaveBeenCalledWith(1));
+    // The delete must already be persisted while undo is still offered, so a
+    // browser reload cannot bring the supplier back.
+    await waitFor(() => expect(mocks.delete).toHaveBeenCalledWith(1));
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(screen.queryByText('Reinsaat')).not.toBeInTheDocument();
-    expect(screen.getByText('Lieferant gelöscht.')).toBeInTheDocument();
+    expect(await screen.findByText('Lieferant gelöscht.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rückgängig: Lieferant gelöscht.' })).toBeInTheDocument();
 
     confirmSpy.mockRestore();
+  });
+
+  it('restores a deleted supplier through the restore endpoint when undo is used', async () => {
+    const serverUndoPayload = {
+      supplier: {
+        id: 1,
+        name: 'Reinsaat',
+        homepage_url: 'https://example.com',
+        slug: 'reinsaat',
+        allowed_domains: ['example.com'],
+      },
+      culture_ids: [],
+      seed_demand_culture_ids: [],
+      supplier_data: [],
+    };
+    mocks.list.mockResolvedValue({
+      data: {
+        results: [{ id: 1, name: 'Reinsaat', homepage_url: 'https://example.com', slug: 'reinsaat', allowed_domains: [] }],
+      },
+    });
+    mocks.deleteUsage.mockResolvedValue({
+      data: {
+        can_delete: true,
+        culture_count: 0,
+        seed_demand_culture_count: 0,
+        supplier_data_culture_count: 0,
+        supplier_data_count: 0,
+        total_culture_count: 0,
+        culture_ids: [],
+      },
+    });
+    mocks.delete.mockResolvedValue({ data: { undo_payload: serverUndoPayload } });
+    mocks.restoreUnlinkedDelete.mockResolvedValue({
+      data: {
+        supplier: { id: 1, name: 'Reinsaat', homepage_url: 'https://example.com', allowed_domains: [] },
+        restored_culture_count: 0,
+        restored_supplier_data_count: 0,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <Suppliers />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Reinsaat');
+    fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Rückgängig: Lieferant gelöscht.' }));
+
+    await waitFor(() => expect(mocks.restoreUnlinkedDelete).toHaveBeenCalledWith(serverUndoPayload));
+    await waitFor(() => expect(screen.getByText('Reinsaat')).toBeInTheDocument());
+  });
+
+  it('puts the supplier back and reports the error when the delete request fails', async () => {
+    mocks.list.mockResolvedValue({
+      data: {
+        results: [{ id: 1, name: 'Reinsaat', homepage_url: 'https://example.com', slug: 'reinsaat', allowed_domains: [] }],
+      },
+    });
+    mocks.deleteUsage.mockResolvedValue({
+      data: {
+        can_delete: true,
+        culture_count: 0,
+        seed_demand_culture_count: 0,
+        supplier_data_culture_count: 0,
+        supplier_data_count: 0,
+        total_culture_count: 0,
+        culture_ids: [],
+      },
+    });
+    mocks.delete.mockRejectedValue(new Error('network down'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter>
+        <Suppliers />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Reinsaat');
+    fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
+
+    await waitFor(() => expect(mocks.delete).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(screen.getByText('Reinsaat')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Rückgängig: Lieferant gelöscht.' })).not.toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('blocks supplier deletion when existing cultures still use it', async () => {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -32,6 +32,7 @@ import type {
   FieldLayoutEntry,
   LocationLayoutsResponse,
   CultureSupplierData,
+  SupplierDeleteResponse,
   SupplierDeleteUsage,
   SupplierDeleteUndoPayload,
   SupplierRestoreUnlinkedDeleteResponse,
@@ -205,7 +206,7 @@ export const supplierAPI = {
   unlinkAndDelete: (id: number) => http.post<SupplierUnlinkDeleteResponse>(`/suppliers/${id}/unlink-and-delete/`, {}),
   restoreUnlinkedDelete: (undoPayload: SupplierDeleteUndoPayload) =>
     http.post<SupplierRestoreUnlinkedDeleteResponse>('/suppliers/restore-unlinked-delete/', undoPayload),
-  delete: (id: number) => http.delete(`/suppliers/${id}/`),
+  delete: (id: number) => http.delete<SupplierDeleteResponse>(`/suppliers/${id}/`),
 };
 
 export const cultureSupplierDataAPI = {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -59,6 +59,10 @@ export interface SupplierUnlinkDeleteResponse {
   undo_payload: SupplierDeleteUndoPayload;
 }
 
+export interface SupplierDeleteResponse {
+  undo_payload: SupplierDeleteUndoPayload;
+}
+
 export interface SupplierRestoreUnlinkedDeleteResponse {
   supplier: Supplier;
   restored_culture_count: number;

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -1916,8 +1916,11 @@ export function EditableDataGrid<T extends EditableRow>({
     api,
     deleteConfirmMessage,
     deleteErrorMessage,
+    saveErrorMessage,
     deleteUndoOptions,
     t,
+    mapToApiData,
+    reloadRows: fetchData,
     setRows,
     setStableRowOrder,
     setRowModesModel,
@@ -2896,7 +2899,9 @@ export function EditableDataGrid<T extends EditableRow>({
           offsetIndex={index}
           testId={deleteUndoOptions.snackbarTestId ?? 'data-grid-delete-snackbar'}
           onClose={() => closeDeleteWithUndoSnackbar(deletion.id)}
-          onUndo={() => undoDeleteWithUndo(deletion.id)}
+          onUndo={() => {
+            void undoDeleteWithUndo(deletion.id);
+          }}
         />
       )) : null}
 

--- a/frontend/src/components/data-grid/hooks/useDataGridDelete.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridDelete.ts
@@ -3,7 +3,6 @@ import type { GridRowId, GridRowModesModel, GridRowsProp } from '@mui/x-data-gri
 import { extractApiErrorMessage } from '../../../api/errors';
 import { confirmAction } from '../../../utils/confirmAction';
 import { createTransientId } from '../../../utils/transientId';
-import { DELETE_UNDO_DURATION_MS } from '../DeleteUndoSnackbar';
 import { isUnsavedDraftRow } from '../dataGridUtils';
 import type { TFunction } from 'i18next';
 import type { DataGridAPI, DeleteUndoOptions, EditableRow } from '../types';
@@ -26,8 +25,11 @@ interface UseDataGridDeleteParams<T extends EditableRow> {
   api: DataGridAPI<T>;
   deleteConfirmMessage: string;
   deleteErrorMessage: string;
+  saveErrorMessage: string;
   deleteUndoOptions: DeleteUndoOptions | undefined;
   t: TFunction;
+  mapToApiData: (row: T) => Partial<T> | Promise<Partial<T>>;
+  reloadRows: () => Promise<void>;
   setRows: React.Dispatch<React.SetStateAction<GridRowsProp<T>>>;
   setStableRowOrder: React.Dispatch<React.SetStateAction<GridRowId[]>>;
   setRowModesModel: React.Dispatch<React.SetStateAction<GridRowModesModel>>;
@@ -44,8 +46,11 @@ export function useDataGridDelete<T extends EditableRow>({
   api,
   deleteConfirmMessage,
   deleteErrorMessage,
+  saveErrorMessage,
   deleteUndoOptions,
   t,
+  mapToApiData,
+  reloadRows,
   setRows,
   setStableRowOrder,
   setRowModesModel,
@@ -54,16 +59,7 @@ export function useDataGridDelete<T extends EditableRow>({
   moveFocusAwayFromRemovedRow,
 }: UseDataGridDeleteParams<T>) {
   const [pendingDeleteWithUndo, setPendingDeleteWithUndo] = useState<PendingDeleteWithUndo<T>[]>([]);
-  const pendingDeleteTimersRef = useRef<Map<string, number>>(new Map());
   const deleteRowCommandRef = useRef<(rowId: GridRowId) => void>(() => undefined);
-
-  useEffect(() => {
-    const pendingDeleteTimers = pendingDeleteTimersRef.current;
-    return () => {
-      pendingDeleteTimers.forEach((timerId) => window.clearTimeout(timerId));
-      pendingDeleteTimers.clear();
-    };
-  }, []);
 
   const removePendingDeleteWithUndo = useCallback((deletionId: string): void => {
     setPendingDeleteWithUndo((current) =>
@@ -106,48 +102,56 @@ export function useDataGridDelete<T extends EditableRow>({
     }
   }, [setRowModesModel, setRows, setStableRowOrder]);
 
-  const finalizeDeleteWithUndo = useCallback(async (deletion: PendingDeleteWithUndo<T>): Promise<void> => {
-    pendingDeleteTimersRef.current.delete(deletion.id);
-    removePendingDeleteWithUndo(deletion.id);
-
-    const numericId = Number(deletion.rowId);
-    if (numericId < 0) {
-      return;
-    }
-
+  /**
+   * Deletes the row in the backend right away and only then offers undo. The
+   * row is already gone from the grid at this point, so a failing request has
+   * to put it back; a successful one hands the snapshot to the undo snackbar,
+   * which recreates the record instead of cancelling a pending delete.
+   */
+  const deleteRowWithUndoSnackbar = useCallback(async (deletion: PendingDeleteWithUndo<T>): Promise<void> => {
     try {
-      await api.delete(numericId);
-      setError('');
+      await api.delete(Number(deletion.rowId));
     } catch (err) {
       restorePendingDeleteWithUndo(deletion);
       setError(extractApiErrorMessage(err, t, deleteErrorMessage));
       console.error('Error deleting data:', err);
+      return;
     }
-  }, [api, deleteErrorMessage, removePendingDeleteWithUndo, restorePendingDeleteWithUndo, setError, t]);
+
+    setError('');
+    setPendingDeleteWithUndo((current) => [...current, deletion]);
+  }, [api, deleteErrorMessage, restorePendingDeleteWithUndo, setError, t]);
 
   const closeDeleteWithUndoSnackbar = useCallback((deletionId: string): void => {
-    setPendingDeleteWithUndo((current) =>
-      current.map((deletion) =>
-        deletion.id === deletionId ? { ...deletion, visible: false } : deletion,
-      ),
-    );
-  }, []);
+    removePendingDeleteWithUndo(deletionId);
+  }, [removePendingDeleteWithUndo]);
 
-  const undoDeleteWithUndo = useCallback((deletionId: string): void => {
+  const undoDeleteWithUndo = useCallback(async (deletionId: string): Promise<void> => {
     const deletion = pendingDeleteWithUndo.find((d) => d.id === deletionId);
     if (!deletion) {
       return;
     }
 
-    const timerId = pendingDeleteTimersRef.current.get(deletionId);
-    if (timerId !== undefined) {
-      window.clearTimeout(timerId);
-      pendingDeleteTimersRef.current.delete(deletionId);
-    }
-
-    restorePendingDeleteWithUndo(deletion);
     removePendingDeleteWithUndo(deletionId);
-  }, [pendingDeleteWithUndo, removePendingDeleteWithUndo, restorePendingDeleteWithUndo]);
+    try {
+      await api.create(await mapToApiData(deletion.row));
+      await reloadRows();
+      setError('');
+    } catch (err) {
+      await reloadRows();
+      setError(extractApiErrorMessage(err, t, saveErrorMessage));
+      console.error('Error restoring deleted data:', err);
+    }
+  }, [
+    api,
+    mapToApiData,
+    pendingDeleteWithUndo,
+    reloadRows,
+    removePendingDeleteWithUndo,
+    saveErrorMessage,
+    setError,
+    t,
+  ]);
 
   const handleDeleteClick = useCallback((id: GridRowId) => (): void => {
     const rowKey = String(id);
@@ -184,12 +188,7 @@ export function useDataGridDelete<T extends EditableRow>({
       setStableRowOrder((previous) => previous.filter((orderedId) => String(orderedId) !== rowKey));
       clearRowInteractionState(id);
       setError('');
-      setPendingDeleteWithUndo((current) => [...current, pendingDeletion]);
-
-      const timerId = window.setTimeout(() => {
-        void finalizeDeleteWithUndo(pendingDeletion);
-      }, DELETE_UNDO_DURATION_MS);
-      pendingDeleteTimersRef.current.set(deletionId, timerId);
+      void deleteRowWithUndoSnackbar(pendingDeletion);
       return;
     }
 
@@ -223,8 +222,8 @@ export function useDataGridDelete<T extends EditableRow>({
     clearRowInteractionState,
     deleteConfirmMessage,
     deleteErrorMessage,
+    deleteRowWithUndoSnackbar,
     deleteUndoOptions,
-    finalizeDeleteWithUndo,
     moveFocusAwayFromRemovedRow,
     rowModesModel,
     rows,

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent, type TouchEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent, type MouseEvent, type TouchEvent } from 'react';
 import axios from 'axios';
 import {
   Alert,
@@ -26,7 +26,7 @@ import { ContextMenuIndicator } from '../components/contextMenu/ContextMenuIndic
 import { contextMenuActionsOverlaySx } from '../components/contextMenu/contextMenuIndicatorStyles';
 import { CustomContextMenu } from '../components/contextMenu/CustomContextMenu';
 import TableSurface from '../components/layout/TableSurface';
-import type { Supplier, SupplierDeleteUndoPayload } from '../api/types';
+import type { Supplier, SupplierDeleteUndoPayload, SupplierDeleteUsage } from '../api/types';
 import {
   SupplierDeleteUsageDialog,
   type SupplierDeleteUsageDialogState,
@@ -37,7 +37,7 @@ import { useProjectRequirement } from '../hooks/useProjectRequirement';
 import ProjectRequiredState from '../components/project/ProjectRequiredState';
 import EmptyStateCard from '../components/project/EmptyStateCard';
 import { useRegisterCreateActions } from '../commands/useCommandContext';
-import { ContextMenuHint, DELETE_UNDO_DURATION_MS, DeleteUndoSnackbar, TableCopyMenuItems, useContextMenuHint } from '../components/data-grid';
+import { ContextMenuHint, DeleteUndoSnackbar, TableCopyMenuItems, useContextMenuHint } from '../components/data-grid';
 import { handleContextMenuKeyboardNavigation } from '../components/data-grid/contextMenuFocus';
 import { useRowContextMenuState } from '../components/contextMenu/useRowContextMenuState';
 import { ROW_LONG_PRESS_MS, useLongPressTimer } from '../components/contextMenu/useLongPressTimer';
@@ -62,6 +62,37 @@ interface PendingSupplierDeletion {
   undoPayload?: SupplierDeleteUndoPayload;
 }
 
+/**
+ * Fallback restore payload for a supplier that was deleted without any
+ * remaining culture references — the delete endpoint returns the authoritative
+ * payload, this only covers a response without one.
+ */
+function buildSupplierRestorePayload(supplier: Supplier): SupplierDeleteUndoPayload | undefined {
+  if (typeof supplier.id !== 'number') {
+    return undefined;
+  }
+  return {
+    supplier: {
+      id: supplier.id,
+      name: supplier.name,
+      homepage_url: supplier.homepage_url ?? '',
+      slug: supplier.slug ?? '',
+      allowed_domains: supplier.allowed_domains ?? [],
+    },
+    culture_ids: [],
+    seed_demand_culture_ids: [],
+    supplier_data: [],
+  };
+}
+
+function extractDeleteConflictUsage(deleteError: unknown): SupplierDeleteUsage | undefined {
+  if (!axios.isAxiosError(deleteError) || deleteError.response?.status !== 409) {
+    return undefined;
+  }
+  const usage = (deleteError.response.data as { usage?: SupplierDeleteUsage } | undefined)?.usage;
+  return usage && typeof usage.can_delete === 'boolean' ? usage : undefined;
+}
+
 export default function Suppliers() {
   const { t } = useTranslation(['suppliers', 'common']);
   const location = useLocation();
@@ -79,7 +110,6 @@ export default function Suppliers() {
   const isMobileViewport = useMediaQuery('(max-width:900px)');
   const isTouchLikePointer = useMediaQuery('(pointer: coarse)');
   const shouldShowInlineSupplierActions = !(isMobileViewport || isTouchLikePointer);
-  const pendingSupplierDeleteTimersRef = useRef<Map<string, number>>(new Map());
   const {
     showContextMenuHint,
     closeContextMenuHint,
@@ -205,31 +235,11 @@ export default function Suppliers() {
     });
   }, []);
 
-  const finalizeSupplierDeletion = useCallback(async (deletion: PendingSupplierDeletion): Promise<void> => {
-    pendingSupplierDeleteTimersRef.current.delete(deletion.id);
-    removePendingSupplierDeletion(deletion.id);
-    try {
-      setError('');
-      const usageResponse = await supplierAPI.deleteUsage(deletion.supplierId);
-      if (!usageResponse.data.can_delete) {
-        restorePendingSupplierDeletion(deletion);
-        setDeleteUsageDialog({ supplier: deletion.supplier, usage: usageResponse.data });
-        return;
-      }
-      await supplierAPI.delete(deletion.supplierId);
-    } catch (deleteError) {
-      if (axios.isAxiosError(deleteError) && deleteError.response?.status === 404) {
-        await loadSuppliers();
-        return;
-      }
-      console.error('Error deleting supplier', deleteError);
-      restorePendingSupplierDeletion(deletion);
-      showDeleteError(extractApiErrorMessage(deleteError, t, t('deleteError')));
-    }
-  }, [loadSuppliers, removePendingSupplierDeletion, restorePendingSupplierDeletion, showDeleteError, t]);
-
-  const restoreUnlinkedSupplierDeletion = useCallback(async (deletion: PendingSupplierDeletion): Promise<void> => {
+  const restoreSupplierDeletion = useCallback(async (deletion: PendingSupplierDeletion): Promise<void> => {
     if (!deletion.undoPayload) {
+      removePendingSupplierDeletion(deletion.id);
+      showDeleteError(t('restoreDeleteError'));
+      await loadSuppliers();
       return;
     }
     try {
@@ -249,47 +259,24 @@ export default function Suppliers() {
       return;
     }
 
-    if (deletion.undoPayload) {
-      void restoreUnlinkedSupplierDeletion(deletion);
-      return;
-    }
-
-    const timerId = pendingSupplierDeleteTimersRef.current.get(deletionId);
-    if (timerId !== undefined) {
-      window.clearTimeout(timerId);
-      pendingSupplierDeleteTimersRef.current.delete(deletionId);
-    }
-
-    restorePendingSupplierDeletion(deletion);
-    removePendingSupplierDeletion(deletionId);
-  }, [pendingSupplierDeletions, removePendingSupplierDeletion, restorePendingSupplierDeletion, restoreUnlinkedSupplierDeletion]);
+    // The supplier is already deleted in the backend at this point, so undo
+    // always means recreating it — never cancelling a pending delete.
+    void restoreSupplierDeletion(deletion);
+  }, [pendingSupplierDeletions, restoreSupplierDeletion]);
 
   const closeSupplierDeletionSnackbar = useCallback((deletionId: string): void => {
-    setPendingSupplierDeletions((currentDeletions) =>
-      currentDeletions
-        .filter((deletion) => !(deletion.id === deletionId && deletion.undoPayload))
-        .map((deletion) =>
-          deletion.id === deletionId ? { ...deletion, visible: false } : deletion,
-        ),
-    );
-  }, []);
-
-  useEffect(() => {
-    const pendingSupplierDeleteTimers = pendingSupplierDeleteTimersRef.current;
-    return () => {
-      pendingSupplierDeleteTimers.forEach((timerId) => window.clearTimeout(timerId));
-      pendingSupplierDeleteTimers.clear();
-    };
-  }, []);
+    removePendingSupplierDeletion(deletionId);
+  }, [removePendingSupplierDeletion]);
 
   const deleteSupplier = useCallback(async (supplier: Supplier): Promise<void> => {
-    if (!supplier.id || pendingSupplierDeletions.some((deletion) => deletion.supplierId === supplier.id)) {
+    const supplierId = supplier.id;
+    if (!supplierId || pendingSupplierDeletions.some((deletion) => deletion.supplierId === supplierId)) {
       return;
     }
 
     try {
       setError('');
-      const usageResponse = await supplierAPI.deleteUsage(supplier.id);
+      const usageResponse = await supplierAPI.deleteUsage(supplierId);
       if (!usageResponse.data.can_delete) {
         setDeleteUsageDialog({ supplier, usage: usageResponse.data });
         return;
@@ -300,24 +287,40 @@ export default function Suppliers() {
       return;
     }
 
-    const deletionId = createTransientId('supplier', supplier.id);
     const pendingDeletion: PendingSupplierDeletion = {
-      id: deletionId,
-      supplierId: supplier.id,
+      id: createTransientId('supplier', supplierId),
+      supplierId,
       supplier,
       suppliersBeforeDelete: suppliers,
       visible: true,
       message: t('messages.deleted'),
+      undoPayload: buildSupplierRestorePayload(supplier),
     };
 
-    setSuppliers((currentSuppliers) => currentSuppliers.filter((currentSupplier) => currentSupplier.id !== supplier.id));
-    setPendingSupplierDeletions((currentDeletions) => [...currentDeletions, pendingDeletion]);
+    // The row disappears immediately, but the backend delete below runs right
+    // away too: the undo snackbar restores the supplier through the restore
+    // endpoint, so a page reload can never bring it back.
+    setSuppliers((currentSuppliers) => currentSuppliers.filter((currentSupplier) => currentSupplier.id !== supplierId));
 
-    const timerId = window.setTimeout(() => {
-      void finalizeSupplierDeletion(pendingDeletion);
-    }, DELETE_UNDO_DURATION_MS);
-    pendingSupplierDeleteTimersRef.current.set(deletionId, timerId);
-  }, [finalizeSupplierDeletion, pendingSupplierDeletions, showDeleteError, suppliers, t]);
+    try {
+      const deleteResponse = await supplierAPI.delete(supplierId);
+      const undoPayload = deleteResponse?.data?.undo_payload ?? pendingDeletion.undoPayload;
+      setPendingSupplierDeletions((currentDeletions) => [...currentDeletions, { ...pendingDeletion, undoPayload }]);
+    } catch (deleteError) {
+      if (axios.isAxiosError(deleteError) && deleteError.response?.status === 404) {
+        await loadSuppliers();
+        return;
+      }
+      restorePendingSupplierDeletion(pendingDeletion);
+      const conflictUsage = extractDeleteConflictUsage(deleteError);
+      if (conflictUsage) {
+        setDeleteUsageDialog({ supplier, usage: conflictUsage });
+        return;
+      }
+      console.error('Error deleting supplier', deleteError);
+      showDeleteError(extractApiErrorMessage(deleteError, t, t('deleteError')));
+    }
+  }, [loadSuppliers, pendingSupplierDeletions, restorePendingSupplierDeletion, showDeleteError, suppliers, t]);
 
   const openAffectedCultures = useCallback((): void => {
     if (!deleteUsageDialog) {


### PR DESCRIPTION
## Summary

This PR changes the delete-with-undo pattern across the application from "optimistic delete with deferred backend persistence" to "immediate backend delete with undo-restore". When a user deletes a record, the backend delete now happens right away, and the undo action restores/recreates the record instead of cancelling a pending delete.

## Key Changes

### Data Grid Delete Hook (`useDataGridDelete.ts`)
- Removed timer-based deferred deletion logic (`pendingDeleteTimersRef`, `DELETE_UNDO_DURATION_MS`)
- Changed `finalizeDeleteWithUndo` to `deleteRowWithUndoSnackbar` which executes the backend delete immediately
- If delete succeeds, the row snapshot is added to pending deletions for undo
- If delete fails, the row is restored to the grid and an error is shown
- Changed `undoDeleteWithUndo` to call `api.create()` with the row data instead of just restoring the UI state
- Undo now reloads rows from the backend after recreation, so restored records get new IDs

### Suppliers Page (`Suppliers.tsx`)
- Removed timer management for pending deletions
- Simplified delete flow: check usage → delete immediately → handle response/errors
- Added `buildSupplierRestorePayload()` to construct fallback undo payload when backend doesn't return one
- Added `extractDeleteConflictUsage()` to handle 409 conflict responses
- Changed `restoreUnlinkedSupplierDeletion` to `restoreSupplierDeletion` which always calls the restore endpoint
- Undo now calls `supplierAPI.restoreUnlinkedDelete()` with the payload from the delete response

### Backend Supplier Delete (`suppliers.py`)
- Modified `destroy()` endpoint to return `undo_payload` in a 200 response instead of empty 204
- Payload contains the supplier data and related culture/supplier_data IDs needed for restoration
- Returns 409 CONFLICT when supplier is still referenced, with usage details in response body

### Test Updates
- Updated `EditableDataGrid.test.tsx` tests to verify immediate backend deletion
- Added `serverBackedProps()` helper that simulates a real backend with persistent state
- Tests now verify that delete is persisted before undo snackbar appears
- Tests verify that undo calls `api.create()` to recreate the record
- Added test for failed delete that restores the row and shows error
- Updated `SuppliersPage.test.tsx` with new immediate-delete semantics
- Added backend tests verifying delete returns undo payload and rejects in-use suppliers

### Documentation
- Updated `datagrid-architecture.md` with new delete-with-undo contract:
  1. Delete hits backend immediately
  2. Undo restores/recreates, never cancels
  3. Failed delete rolls back the row
  4. Dismissing snackbar does nothing

## Notable Implementation Details

- The row disappears optimistically from the UI but the backend delete is not deferred
- Restored records get new IDs assigned by the backend (except for soft-delete entities like cultures)
- The undo snackbar now requires `mapToApiData` and `reloadRows` parameters to recreate records
- Supplier delete endpoint now returns the same payload shape as `unlink-and-delete` for consistency
- Error handling distinguishes between delete failures (restore row, show error) and restore failures (reload, show error)

https://claude.ai/code/session_011gdNyQrpQ1tL56EcA8EZnN