### PR TITLE
Fix keyboard navigation with hidden columns in data grid

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -157,6 +157,18 @@ that's still true. But cell-level Tab/Arrow/Enter/F2 navigation
   focus helper focuses the target cell's actual editor input instead of only
   the DataGrid cell wrapper; otherwise the cell can look focused while
   printable keystrokes are ignored.
+- Scrolling a navigation target into view goes through
+  `keyboardNavigation.ts`'s `scrollCellIntoView` / `getVisibleColumnIndex`,
+  never through MUI's `getColumnIndexRelativeToVisibleColumns`. That API is
+  misnamed: it resolves the field against *all* columns, hidden ones
+  included, while `scrollToIndexes` indexes into the visible column
+  definitions. Mixing the two is off by however many columns are hidden to
+  the left and throws (`visibleColumns[colIndex].computedWidth` on
+  `undefined`) once the index passes the visible column count — and because
+  the throw escapes the Tab handler, keyboard navigation stops dead. That was
+  the planting plans bug below the `lg` breakpoint, where both harvest-date
+  columns are hidden by default: Tab out of "Pflanzdatum" reached "Fläche"
+  and never arrived at "Pflanzen".
 - While a row is in edit mode, `EditableDataGrid` owns Tab/Shift+Tab
   navigation even when focus is inside a custom editor input. MUI's own
   native capture handlers can otherwise move to the next row before React

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -54,6 +54,7 @@ vi.mock('@mui/x-data-grid', async () => {
     onRowSelectionModelChange,
     rowModesModel,
     rowSelectionModel,
+    columnVisibilityModel,
     slots,
     pagination,
     paginationModel,
@@ -62,6 +63,9 @@ vi.mock('@mui/x-data-grid', async () => {
   }: unknown) => {
     const [, forceFocusRender] = React.useState(0);
     const [editValues, setEditValues] = React.useState<Record<string, unknown>>({});
+    const visibleColumns = columns.filter(
+      (column: GridColDef) => columnVisibilityModel?.[column.field] !== false,
+    );
 
     if (apiRef?.current) {
       apiRef.current.state = apiRef.current.state ?? { focus: { cell: null } };
@@ -77,7 +81,7 @@ vi.mock('@mui/x-data-grid', async () => {
         }));
         return mockSetEditCellValue(params);
       };
-      apiRef.current.getVisibleColumns = () => columns;
+      apiRef.current.getVisibleColumns = () => visibleColumns;
       apiRef.current.getAllRowIds = () => rows.map((row: TestGridRow) => row.id);
       apiRef.current.getRowWithUpdatedValues = (id: string | number) => {
         const baseRow = rows.find((row: TestGridRow) => String(row.id) === String(id));
@@ -97,6 +101,8 @@ vi.mock('@mui/x-data-grid', async () => {
       };
       apiRef.current.getRowIndexRelativeToVisibleRows = (id: string | number) =>
         rows.findIndex((row: TestGridRow) => String(row.id) === String(id));
+      // Deliberately mirrors MUI's own (misnamed) implementation: it resolves
+      // the field against *all* columns, hidden ones included.
       apiRef.current.getColumnIndexRelativeToVisibleColumns = (field: string) =>
         columns.findIndex((column: GridColDef) => column.field === field);
       apiRef.current.getCellParams = (id: string | number, field: string) => {
@@ -105,7 +111,13 @@ vi.mock('@mui/x-data-grid', async () => {
       };
       apiRef.current.isCellEditable = (params: { field: string }) =>
         columns.find((column: GridColDef) => column.field === params.field)?.editable !== false;
-      apiRef.current.scrollToIndexes = vi.fn();
+      // MUI reads `visibleColumns[colIndex].computedWidth`, so an index that
+      // counted hidden columns too blows up here instead of scrolling.
+      apiRef.current.scrollToIndexes = (indexes: { rowIndex?: number; colIndex?: number }) => {
+        if (indexes.colIndex !== undefined && !visibleColumns[indexes.colIndex]) {
+          throw new TypeError("Cannot read properties of undefined (reading 'computedWidth')");
+        }
+      };
       apiRef.current.setCellFocus = (id: string | number, field: string) => {
         mockSetCellFocus(id, field);
         apiRef.current.state.focus.cell = { id, field };
@@ -149,7 +161,7 @@ vi.mock('@mui/x-data-grid', async () => {
             data-testid={`row-${row.id}`}
           >
             <span data-testid={`mode-${row.id}`}>{rowModesModel?.[row.id]?.mode ?? GridRowModes.View}</span>
-            {columns.map((col: GridColDef) => {
+            {visibleColumns.map((col: GridColDef) => {
               const isEditingCell =
                 rowModesModel?.[row.id]?.mode === GridRowModes.Edit &&
                 rowModesModel?.[row.id]?.fieldToFocus === col.field;
@@ -972,6 +984,49 @@ describe('EditableDataGrid', () => {
 
     await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-notes'));
     expect(screen.getByTestId('focused-cell')).not.toHaveTextContent('1-area_sqm');
+  });
+
+  it('keeps tabbing through an edited row when columns to the left are hidden', async () => {
+    // Regression: the planting plans grid hides both harvest-date columns
+    // below the `lg` breakpoint. Resolving the scroll target with MUI's
+    // `getColumnIndexRelativeToVisibleColumns` (which counts hidden columns)
+    // made `scrollToIndexes` throw, and the exception aborted the Tab
+    // handler — Tab out of "Pflanzdatum" reached "Fläche" and then went dead,
+    // never arriving at "Pflanzen".
+    const props = baseProps(() => null);
+    const plantingPlanColumns: GridColDef[] = [
+      { field: 'culture', headerName: 'Kultur', editable: true },
+      { field: 'planting_date', headerName: 'Pflanzdatum', editable: true },
+      { field: 'harvest_date', headerName: 'Erntebeginn', editable: false },
+      { field: 'harvest_end_date', headerName: 'Ernteende', editable: false },
+      { field: 'area_sqm', headerName: 'Fläche', editable: true },
+      { field: 'plants_count', headerName: 'Pflanzen', editable: true },
+    ];
+
+    render(
+      <EditableDataGrid
+        {...props}
+        columns={plantingPlanColumns}
+        columnVisibilityModel={{ harvest_date: false, harvest_end_date: false }}
+        showDeleteAction={false}
+      />,
+    );
+
+    const dateCell = await screen.findByRole('button', { name: 'Zelle 1-planting_date' });
+    fireEvent.click(dateCell);
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+
+    fireEvent.keyDown(dateCell, { key: 'Tab' });
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-area_sqm'));
+
+    fireEvent.keyDown(await screen.findByRole('button', { name: 'Zelle 1-area_sqm' }), { key: 'Tab' });
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-plants_count'));
+
+    fireEvent.keyDown(await screen.findByRole('button', { name: 'Zelle 1-plants_count' }), {
+      key: 'Tab',
+      shiftKey: true,
+    });
+    await waitFor(() => expect(screen.getByTestId('focused-cell')).toHaveTextContent('1-area_sqm'));
   });
 
   describe('dialog-edited cells', () => {

--- a/frontend/src/__tests__/keyboardNavigation.test.ts
+++ b/frontend/src/__tests__/keyboardNavigation.test.ts
@@ -4,8 +4,10 @@ import {
   getCellLocationFromDomTarget,
   getHorizontalKeyboardNavigationTarget,
   getKeyboardNavigationTarget,
+  getVisibleColumnIndex,
   isCellKeyboardNavigable,
   resolveFocusedCellFromEvent,
+  scrollCellIntoView,
 } from '../components/data-grid/keyboardNavigation';
 
 function buildGridCell(rowId: string, field: string): HTMLElement {
@@ -28,7 +30,7 @@ describe('keyboardNavigation', () => {
 
     const api = {
       getCellElement: vi.fn(() => cellElement),
-      getColumnIndexRelativeToVisibleColumns: vi.fn(() => 1),
+      getVisibleColumns: vi.fn(() => [{ field: 'name' }, { field: 'width_m' }]),
       getRowIndexRelativeToVisibleRows: vi.fn(() => 0),
       scrollToIndexes: vi.fn(),
       setCellFocus: vi.fn(),
@@ -125,6 +127,86 @@ describe('getHorizontalKeyboardNavigationTarget', () => {
 
   it('returns null when the current field is not navigable', () => {
     expect(getHorizontalKeyboardNavigationTarget(fields, 5, 'unknown', 1)).toBeNull();
+  });
+});
+
+describe('scrollCellIntoView', () => {
+  // Mirrors MUI's own `scrollToIndexes`, which indexes into the *visible*
+  // column definitions: an index that counts hidden columns too silently
+  // scrolls to the wrong column and throws once it runs past the visible
+  // count. Passing that index used to abort Tab navigation for good (below
+  // the `lg` breakpoint the planting plans grid hides both harvest-date
+  // columns, so Tab out of "Pflanzdatum" reached "Fläche" and then stopped
+  // short of "Pflanzen").
+  const createApiWithHiddenColumns = () => {
+    const visibleColumns = [
+      { field: 'culture' },
+      { field: 'planting_date' },
+      { field: 'area_m2' },
+      { field: 'plants_count' },
+    ];
+    return {
+      visibleColumns,
+      getVisibleColumns: vi.fn(() => visibleColumns),
+      getRowIndexRelativeToVisibleRows: vi.fn(() => 3),
+      scrollToIndexes: vi.fn((indexes: { rowIndex?: number; colIndex?: number }) => {
+        if (indexes.colIndex !== undefined) {
+          // Throws exactly like MUI does on `visibleColumns[colIndex].computedWidth`.
+          expect(visibleColumns[indexes.colIndex]).toBeDefined();
+        }
+      }),
+      setCellFocus: vi.fn(),
+    };
+  };
+
+  it('resolves the column index against the visible columns, not the hidden ones', () => {
+    const api = createApiWithHiddenColumns();
+
+    scrollCellIntoView(api, { id: 10, field: 'plants_count' });
+
+    expect(api.scrollToIndexes).toHaveBeenCalledWith({ rowIndex: 3, colIndex: 3 });
+  });
+
+  it('skips the column axis for a hidden field instead of scrolling out of range', () => {
+    const api = createApiWithHiddenColumns();
+
+    scrollCellIntoView(api, { id: 10, field: 'harvest_end_date' });
+
+    expect(api.scrollToIndexes).toHaveBeenCalledWith({ rowIndex: 3 });
+  });
+
+  it('does not scroll at all when neither axis resolves', () => {
+    const api = createApiWithHiddenColumns();
+    api.getRowIndexRelativeToVisibleRows.mockReturnValue(-1);
+
+    scrollCellIntoView(api, { id: 999, field: 'harvest_end_date' });
+
+    expect(api.scrollToIndexes).not.toHaveBeenCalled();
+  });
+
+  it('keeps focusing a cell behind hidden columns instead of throwing', () => {
+    const api = createApiWithHiddenColumns();
+
+    expect(() =>
+      focusKeyboardNavigableCell({ api, cell: { id: 10, field: 'plants_count' } }),
+    ).not.toThrow();
+    expect(api.setCellFocus).toHaveBeenCalledWith(10, 'plants_count');
+  });
+});
+
+describe('getVisibleColumnIndex', () => {
+  const api = {
+    getVisibleColumns: vi.fn(() => [{ field: 'name' }, { field: 'area_m2' }]),
+  };
+
+  it('returns the index within the visible columns', () => {
+    expect(getVisibleColumnIndex(api, 'area_m2')).toBe(1);
+  });
+
+  it('returns undefined for a hidden field and for a missing grid API', () => {
+    expect(getVisibleColumnIndex(api, 'harvest_date')).toBeUndefined();
+    expect(getVisibleColumnIndex(null, 'name')).toBeUndefined();
+    expect(getVisibleColumnIndex({}, 'name')).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -122,6 +122,7 @@ import {
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
   resolveFocusedCellFromEvent,
+  scrollCellIntoView,
 } from './keyboardNavigation';
 import { useSpreadsheetEditStarter } from './keyboardEditing';
 import type {
@@ -799,9 +800,7 @@ export function EditableDataGrid<T extends EditableRow>({
         return;
       }
 
-      const rowIndex = api.getRowIndexRelativeToVisibleRows(rowId);
-      const colIndex = api.getColumnIndexRelativeToVisibleColumns(field);
-      api.scrollToIndexes({ rowIndex, colIndex });
+      scrollCellIntoView<T>(api, { id: rowId, field });
       focusDataGridKeyboardNavigableCell<T>({
         api,
         cell: { id: rowId, field },

--- a/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
+++ b/frontend/src/components/data-grid/hooks/useDataGridRowCommands.ts
@@ -3,11 +3,11 @@ import { GridRowModes } from '@mui/x-data-grid';
 import type { GridApi, GridColDef, GridRowId, GridRowModesModel } from '@mui/x-data-grid';
 import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from 'react';
 import type { EditableRow } from '../types';
+import { scrollCellIntoView } from '../keyboardNavigation';
 
 interface ScrollFocusGridApi {
   getVisibleColumns: () => { field: string }[];
   getRowIndexRelativeToVisibleRows: (id: GridRowId) => number;
-  getColumnIndexRelativeToVisibleColumns: (field: string) => number;
   scrollToIndexes: (params: { rowIndex?: number; colIndex?: number }) => void;
   setCellFocus: (id: GridRowId, field: string) => void;
 }
@@ -32,12 +32,14 @@ function scrollAndFocusRow(
         return;
       }
 
-      api.scrollToIndexes(firstField
-        ? {
-            rowIndex: api.getRowIndexRelativeToVisibleRows(rowId),
-            colIndex: api.getColumnIndexRelativeToVisibleColumns(firstField),
-          }
-        : { rowIndex: api.getRowIndexRelativeToVisibleRows(rowId) });
+      if (firstField) {
+        // Resolves the column index against the visible columns (see
+        // scrollCellIntoView) — MUI's own getColumnIndexRelativeToVisibleColumns
+        // counts hidden columns too and makes scrollToIndexes throw.
+        scrollCellIntoView(api, { id: rowId, field: firstField });
+      } else {
+        api.scrollToIndexes({ rowIndex: api.getRowIndexRelativeToVisibleRows(rowId) });
+      }
       if (options.focus !== false && firstField) {
         api.setCellFocus(rowId, firstField);
       }

--- a/frontend/src/components/data-grid/keyboardNavigation.ts
+++ b/frontend/src/components/data-grid/keyboardNavigation.ts
@@ -17,7 +17,6 @@ interface DataGridNavigationApi<Row extends GridValidRowModel> {
   getAllRowIds?: () => GridRowId[];
   getCellElement?: (id: GridRowId, field: string) => HTMLElement | null;
   getCellParams?: (id: GridRowId, field: string) => GridCellParams<Row>;
-  getColumnIndexRelativeToVisibleColumns?: (field: string) => number;
   getRowIndexRelativeToVisibleRows?: (id: GridRowId) => number;
   getVisibleColumns?: () => GridColDef<Row>[];
   scrollToIndexes?: (indexes: { rowIndex?: number; colIndex?: number }) => void;
@@ -294,6 +293,64 @@ export function getHorizontalKeyboardNavigationTarget(
   return nextField ? { id: rowId, field: nextField } : null;
 }
 
+/**
+ * Resolves a field's index among the grid's *currently visible* columns, or
+ * undefined when the field is hidden (or the grid API isn't available yet).
+ *
+ * Deliberately not MUI's `getColumnIndexRelativeToVisibleColumns`: despite its
+ * name that one looks the field up in the *full* column list, hidden columns
+ * included, while `scrollToIndexes` indexes into the visible column
+ * definitions. Feeding one into the other is off by however many columns are
+ * hidden to the left, and once the index runs past the visible column count
+ * `scrollToIndexes` throws on `visibleColumns[colIndex].computedWidth`. That
+ * throw propagated out of the Tab handler and aborted keyboard navigation
+ * outright — e.g. on the planting plans grid below the `lg` breakpoint, where
+ * both harvest-date columns are hidden by default, Tab out of "Pflanzdatum"
+ * reached "Fläche" and then stopped short of "Pflanzen".
+ */
+export function getVisibleColumnIndex<Row extends GridValidRowModel>(
+  api: DataGridNavigationApi<Row> | null | undefined,
+  field: string,
+): number | undefined {
+  const visibleColumns = api?.getVisibleColumns?.();
+  if (!visibleColumns) {
+    return undefined;
+  }
+
+  const columnIndex = visibleColumns.findIndex((column) => column.field === field);
+  return columnIndex < 0 ? undefined : columnIndex;
+}
+
+/**
+ * Scrolls a cell into the grid's viewport. Each axis is only passed on when its
+ * index actually resolves, so a hidden column or an unknown row id simply skips
+ * that axis instead of handing `scrollToIndexes` an out-of-range index.
+ */
+export function scrollCellIntoView<Row extends GridValidRowModel>(
+  api: DataGridNavigationApi<Row> | null | undefined,
+  cell: CellLocation,
+): void {
+  if (!api?.scrollToIndexes) {
+    return;
+  }
+
+  const rowIndex = api.getRowIndexRelativeToVisibleRows?.(cell.id);
+  const colIndex = getVisibleColumnIndex(api, cell.field);
+  const indexes: { rowIndex?: number; colIndex?: number } = {};
+  if (typeof rowIndex === 'number' && rowIndex >= 0) {
+    indexes.rowIndex = rowIndex;
+  }
+  if (colIndex !== undefined) {
+    indexes.colIndex = colIndex;
+  }
+
+  if (indexes.rowIndex === undefined && indexes.colIndex === undefined) {
+    return;
+  }
+
+  api.scrollToIndexes(indexes);
+}
+
 export function focusKeyboardNavigableCell<Row extends GridValidRowModel>({
   api,
   cell,
@@ -303,9 +360,7 @@ export function focusKeyboardNavigableCell<Row extends GridValidRowModel>({
     return;
   }
 
-  const rowIndex = api.getRowIndexRelativeToVisibleRows?.(cell.id);
-  const colIndex = api.getColumnIndexRelativeToVisibleColumns?.(cell.field);
-  api.scrollToIndexes?.({ rowIndex, colIndex });
+  scrollCellIntoView(api, cell);
   api.setCellFocus(cell.id, cell.field);
 
   if (!focusEditInput) {

--- a/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
+++ b/frontend/src/components/hierarchy/hooks/useHierarchyGridKeyboard.ts
@@ -22,7 +22,6 @@ interface HierarchyGridKeyboardApi {
   getAllRowIds?: () => GridRowId[];
   getCellElement?: (id: GridRowId, field: string) => HTMLElement | null;
   getCellParams?: (id: GridRowId, field: string) => GridCellParams<HierarchyRow>;
-  getColumnIndexRelativeToVisibleColumns?: (field: string) => number;
   getRowIndexRelativeToVisibleRows?: (id: GridRowId) => number;
   getVisibleColumns?: () => GridColDef<HierarchyRow>[];
   isCellEditable?: (params: GridCellParams<HierarchyRow>) => boolean;


### PR DESCRIPTION
## Summary
Fixes a critical bug where keyboard navigation (Tab/Shift+Tab) would stop working when columns to the left were hidden in the data grid. The issue occurred because the code was mixing two incompatible column indexing systems: MUI's `getColumnIndexRelativeToVisibleColumns` (which counts hidden columns) with `scrollToIndexes` (which indexes only visible columns), causing an out-of-range error that aborted navigation.

## Key Changes

- **New `getVisibleColumnIndex` function**: Properly resolves a field's index among only the *visible* columns, replacing reliance on MUI's misnamed `getColumnIndexRelativeToVisibleColumns` API
- **New `scrollCellIntoView` function**: Safely scrolls a cell into view by:
  - Using `getVisibleColumnIndex` to get the correct column index
  - Only passing row/column indexes to `scrollToIndexes` when they actually resolve
  - Gracefully skipping axes for hidden columns instead of throwing errors
- **Removed `getColumnIndexRelativeToVisibleColumns` from API interface**: This method is no longer used in keyboard navigation logic
- **Updated all callers**: Modified `focusKeyboardNavigableCell`, `useDataGridRowCommands`, and `DataGrid` to use the new `scrollCellIntoView` function
- **Enhanced test mocks**: Updated `EditableDataGrid.test.tsx` mock to properly filter visible columns and simulate MUI's `scrollToIndexes` error behavior
- **Added comprehensive test coverage**: New tests verify correct behavior with hidden columns, including a regression test for the planting plans grid scenario

## Notable Implementation Details

- The root cause was that MUI's `getColumnIndexRelativeToVisibleColumns` resolves against *all* columns (including hidden ones), while `scrollToIndexes` expects an index into the visible columns array only
- When the index exceeded the visible column count, `scrollToIndexes` would throw on `visibleColumns[colIndex].computedWidth`, and this exception escaped the Tab handler, stopping keyboard navigation entirely
- The fix ensures each axis (row/column) is only passed to `scrollToIndexes` when it successfully resolves, allowing partial scrolling and preventing errors
- Documentation updated to explain the distinction and why this approach is necessary

https://claude.ai/code/session_01AUk3h2ALmxrP5nsYDiv3jK