### PR TITLE
Refactor keyboard focus management in dialogs and Select dropdowns

### DIFF
--- a/docs/keyboard-architecture.md
+++ b/docs/keyboard-architecture.md
@@ -178,6 +178,40 @@ fields, and Autocomplete inputs remain owned by their native/MUI handlers.
 Autocomplete-based `SearchableSelect` stays separate because it is an editable
 combobox with its own input-value search behavior.
 
+### Tab out of an open Select dropdown
+
+MUI's `Menu` reacts to Tab by closing the dropdown and swallowing the browser's
+default focus move. That is what keeps focus inside a surrounding `Dialog` or
+`Popover`, but on its own it drops the highlighted option and parks focus back
+on the trigger, so Tab reads as "nothing happened".
+
+`components/inputs/selectDropdownTabNavigation.ts`
+(`useOpenSelectTabNavigation`, wired into `TypeaheadSelect` for every Select in
+the app) adds the two missing halves:
+
+1. **Take over the highlighted option.** The focused `[role="option"]` carries
+   MUI's `data-value`; it is matched back to the typed option list and applied
+   through the same synthesized `SelectChangeEvent` the closed-Select typeahead
+   uses. Multi-selects are skipped — their menu survives selections, and
+   toggling an option on the way out would be surprising.
+2. **Continue to the neighbouring field.** The focus scope is the Select's
+   nearest modal surface (`[role="dialog"]`, `[role="alertdialog"]`,
+   `.MuiPopover-paper`), where Tab wraps at the edges, or its `<form>`, where it
+   does not — a page form must stay leavable. Outside both, focus is left alone.
+
+The focus move deliberately runs from an effect: MUI restores focus to the
+trigger while committing the close, so anything scheduled earlier is overwritten
+again. Arrow keys, Enter, and Escape stay entirely with MUI.
+
+**Modal dialogs must not add a second focus trap.** MUI's `Dialog` already
+contains Tab, `aria-hidden`s the page behind it, and restores focus to the
+element that opened it. `AreaAssignmentDialog` and `CultureForm` used to run
+their own `document`-level Tab traps on top of that; both had to opt out while a
+dropdown was open — precisely the gap focus escaped through — and both fought
+MUI's restore with `requestAnimationFrame(() => …focus())` calls. They are gone;
+new dialogs should rely on MUI and, if a field needs special Tab handling, add
+it at the input level the way `TypeaheadSelect` does.
+
 ## 5. Adding this to a new page
 
 ```tsx

--- a/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
+++ b/frontend/src/__tests__/AreaAssignmentDialog.test.tsx
@@ -42,6 +42,37 @@ const expectFocusAfterTab = async (user: ReturnType<typeof userEvent.setup>, ele
   });
 };
 
+/** Renders the dialog between focusable page elements, so a Tab that escapes
+ * the modal overlay lands on one of them instead of silently passing. */
+const renderWithPageBackground = (
+  props: Partial<Parameters<typeof AreaAssignmentDialog>[0]> = {},
+): void => {
+  render(
+    <>
+      <button type="button">Navigation davor</button>
+      <AreaAssignmentDialog
+        bedId={101}
+        beds={beds}
+        fields={fields}
+        locations={locations}
+        locale="de-DE"
+        compactLabel="x"
+        onApply={vi.fn()}
+        {...props}
+      />
+      <button type="button">Tabellenzelle danach</button>
+    </>,
+  );
+};
+
+const getDialog = (): HTMLElement => screen.getByRole('dialog', { name: 'Anbaufläche ändern' });
+
+const expectFocusInsideDialog = (): void => {
+  const active = document.activeElement;
+  expect(active).not.toBeNull();
+  expect(getDialog().contains(active)).toBe(true);
+};
+
 describe('AreaAssignmentDialog', () => {
   it('opens on a single click on the cell without a separate edit affordance', async () => {
     const user = userEvent.setup();
@@ -316,6 +347,175 @@ describe('AreaAssignmentDialog', () => {
     await user.keyboard('{Shift>}{Tab}{/Shift}');
     await waitFor(() => {
       expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveFocus();
+    });
+  });
+
+  describe('keyboard focus control', () => {
+    it('keeps Tab inside the dialog instead of reaching the page behind it', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+
+      for (let step = 0; step < 8; step += 1) {
+        await user.tab();
+        expectFocusInsideDialog();
+      }
+    });
+
+    it('hides the page behind the dialog from keyboard and assistive technology', async () => {
+      renderWithPageBackground();
+
+      await openDialog();
+
+      // The page content is dropped from the accessibility tree entirely, so
+      // it can only be found with `hidden: true`.
+      expect(screen.queryByRole('button', { name: 'Tabellenzelle danach' })).not.toBeInTheDocument();
+      const backgroundButton = screen.getByRole('button', { name: 'Tabellenzelle danach', hidden: true });
+      expect(backgroundButton.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
+    it('keeps Shift+Tab inside the dialog instead of reaching the page behind it', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+
+      for (let step = 0; step < 8; step += 1) {
+        await user.keyboard('{Shift>}{Tab}{/Shift}');
+        expectFocusInsideDialog();
+      }
+    });
+
+    it('marks the dialog as modal and labels it through its title', async () => {
+      renderWithPageBackground();
+
+      await openDialog();
+
+      const dialog = getDialog();
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      const labelledBy = dialog.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      expect(document.getElementById(labelledBy as string)).toHaveTextContent('Anbaufläche ändern');
+    });
+
+    it('takes over the highlighted option and moves to the next field on Tab', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+      await user.click(screen.getByRole('combobox', { name: 'Standort' }));
+      await user.keyboard('{ArrowDown}');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('combobox', { name: 'Standort' })).toHaveTextContent('Sonnengarten');
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+      });
+    });
+
+    it('moves to the previous field on Shift+Tab out of an open dropdown', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+      await user.click(screen.getByRole('combobox', { name: 'Beet' }));
+      await user.keyboard('{Shift>}{Tab}{/Shift}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+      });
+    });
+
+    it('never lands behind the dialog when tabbing out of any of the three dropdowns', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+
+      for (const label of ['Standort', 'Parzelle', 'Beet']) {
+        await user.click(screen.getByRole('combobox', { name: label }));
+        expect(await screen.findByRole('listbox')).toBeInTheDocument();
+        await user.tab();
+        await waitFor(() => {
+          expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+        });
+        expectFocusInsideDialog();
+      }
+    });
+
+    it('keeps arrow keys and Enter working inside an open dropdown', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+      await user.click(screen.getByRole('combobox', { name: 'Parzelle' }));
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveTextContent('9 Pastinake');
+      expectFocusInsideDialog();
+    });
+
+    it('closes only the dropdown on the first Escape and the dialog on the second', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+      await user.click(screen.getByRole('combobox', { name: 'Standort' }));
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      expect(getDialog()).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: 'Anbaufläche ändern' })).not.toBeInTheDocument();
+      });
+    });
+
+    it('returns focus to the opening cell trigger after Escape', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground({ hasFocus: true });
+
+      await openDialog();
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Anbaufläche bearbeiten' })).toHaveFocus();
+      });
+    });
+
+    it('stays inside the dialog when a Tab commit resets the downstream fields', async () => {
+      const user = userEvent.setup();
+      renderWithPageBackground();
+
+      await openDialog();
+      // Switching the location clears parcel and bed, so the bed select and the
+      // apply button leave the tab order while focus is being moved.
+      await user.click(screen.getByRole('combobox', { name: 'Standort' }));
+      await user.keyboard('{ArrowDown}');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox', { name: 'Parzelle' })).toHaveFocus();
+      });
+      expect(screen.getByRole('combobox', { name: 'Beet' })).toHaveAttribute('aria-disabled', 'true');
+
+      await user.tab();
+      expectFocusInsideDialog();
+      expect(screen.getByRole('button', { name: 'Abbrechen' })).toHaveFocus();
     });
   });
 

--- a/frontend/src/__tests__/TypeaheadSelect.test.tsx
+++ b/frontend/src/__tests__/TypeaheadSelect.test.tsx
@@ -184,4 +184,81 @@ describe('TypeaheadSelect', () => {
     expect(screen.getByRole('combobox')).toHaveTextContent('Minze');
     expect(within(screen.getByRole('combobox')).queryByText('Mittel')).not.toBeInTheDocument();
   });
+
+  describe('Tab out of an open dropdown', () => {
+    it('takes over the highlighted option, closes the menu and moves on', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <form>
+          <SelectHarness initialValue="low" onChange={onChange} />
+          <button type="button">Weiter</button>
+        </form>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{ArrowDown}');
+      await user.tab();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledWith('corn');
+      expect(screen.getByRole('combobox')).toHaveTextContent('Mais');
+      expect(screen.getByRole('button', { name: 'Weiter' })).toHaveFocus();
+    });
+
+    it('moves to the previous field on Shift+Tab', async () => {
+      const user = userEvent.setup();
+      render(
+        <form>
+          <button type="button">Zurück</button>
+          <SelectHarness initialValue="low" />
+        </form>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Shift>}{Tab}{/Shift}');
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Zurück' })).toHaveFocus();
+    });
+
+    it('does not toggle the highlighted option of a multi-select', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <FormControl fullWidth>
+          <InputLabel id="crops-label">Kulturen</InputLabel>
+          <TypeaheadSelect<string[]>
+            multiple
+            labelId="crops-label"
+            label="Kulturen"
+            value={[]}
+            onChange={onChange}
+          >
+            <MenuItem value="low">Niedrig</MenuItem>
+            <MenuItem value="corn">Mais</MenuItem>
+          </TypeaheadSelect>
+        </FormControl>,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{ArrowDown}');
+      await user.tab();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('keeps focus on the trigger when there is no field to move to', async () => {
+      const user = userEvent.setup();
+      render(<SelectHarness initialValue="low" />);
+
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+      await user.tab();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(select).toHaveFocus();
+    });
+  });
 });

--- a/frontend/src/components/inputs/TypeaheadSelect.tsx
+++ b/frontend/src/components/inputs/TypeaheadSelect.tsx
@@ -7,11 +7,18 @@ import {
   useClosedSelectTypeahead,
 } from './selectTypeahead';
 import type { SelectTypeaheadOption } from './selectTypeahead';
+import { useOpenSelectTabNavigation } from './selectDropdownTabNavigation';
+import type { SelectMenuKeyboardEvent } from './selectDropdownTabNavigation';
 
 export type TypeaheadSelectProps<Value = unknown> = Omit<SelectProps<Value>, 'onKeyDown'> & {
   onKeyDown?: (event: KeyboardEvent<Element>) => void;
   typeaheadTimeoutMs?: number;
 };
+
+type SelectMenuProps<Value> = NonNullable<SelectProps<Value>['MenuProps']>;
+type MenuListSlotProps = {
+  onKeyDown?: (event: SelectMenuKeyboardEvent) => void;
+} & Record<string, unknown>;
 
 const createSelectChangeEvent = <Value,>(
   sourceEvent: KeyboardEvent<Element>,
@@ -26,6 +33,13 @@ const createSelectChangeEvent = <Value,>(
   } as unknown as SelectChangeEvent<Value>;
 };
 
+/** `slotProps.list` may be a callback that receives MUI's owner state; only the
+ * object form can be merged with the menu keyboard handling added here. */
+const readMenuListSlotProps = <Value,>(menuProps: SelectMenuProps<Value> | undefined): MenuListSlotProps => {
+  const listSlotProps = menuProps?.slotProps?.list;
+  return typeof listSlotProps === 'function' ? {} : (listSlotProps as MenuListSlotProps | undefined) ?? {};
+};
+
 function TypeaheadSelectInner<Value = unknown>(
   {
     children,
@@ -35,6 +49,7 @@ function TypeaheadSelectInner<Value = unknown>(
     typeaheadTimeoutMs,
     value,
     name,
+    MenuProps,
     ...props
   }: TypeaheadSelectProps<Value>,
   ref: Ref<HTMLDivElement>,
@@ -61,6 +76,22 @@ function TypeaheadSelectInner<Value = unknown>(
     onKeyDown,
   });
 
+  const listSlotProps = useMemo(() => readMenuListSlotProps<Value>(MenuProps), [MenuProps]);
+  const handleMenuKeyDown = useOpenSelectTabNavigation<Value>({
+    options,
+    multiple,
+    onSelect: handleSelect,
+    onKeyDown: listSlotProps.onKeyDown ?? MenuProps?.MenuListProps?.onKeyDown,
+  });
+
+  const menuProps = useMemo((): SelectMenuProps<Value> => ({
+    ...MenuProps,
+    slotProps: {
+      ...MenuProps?.slotProps,
+      list: { ...listSlotProps, onKeyDown: handleMenuKeyDown },
+    },
+  }), [MenuProps, handleMenuKeyDown, listSlotProps]);
+
   return (
     <MuiSelect<Value>
       {...props}
@@ -70,6 +101,7 @@ function TypeaheadSelectInner<Value = unknown>(
       value={value}
       onChange={onChange}
       onKeyDown={handleKeyDown}
+      MenuProps={menuProps}
     >
       {children}
     </MuiSelect>

--- a/frontend/src/components/inputs/selectDropdownTabNavigation.ts
+++ b/frontend/src/components/inputs/selectDropdownTabNavigation.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { getTabbableNeighbour } from '../../focus/focusableElements';
+import type { SelectTypeaheadOption } from './selectTypeahead';
+
+/** Surfaces that own their focus order: Tab cycles inside them, so handing
+ * focus from the last field back to the first one is the expected behaviour.
+ * A plain page form is not such a surface — Tab has to be able to leave it. */
+const MODAL_FOCUS_SCOPE_SELECTOR = '[role="dialog"], [role="alertdialog"], .MuiPopover-paper';
+
+interface FocusScope {
+  container: HTMLElement;
+  wrap: boolean;
+}
+
+const resolveFocusScope = (trigger: HTMLElement): FocusScope | null => {
+  const modalScope = trigger.closest<HTMLElement>(MODAL_FOCUS_SCOPE_SELECTOR);
+  if (modalScope) {
+    return { container: modalScope, wrap: true };
+  }
+
+  const form = trigger.closest('form');
+  return form ? { container: form, wrap: false } : null;
+};
+
+/** The Select trigger that opened `listboxId`. MUI links the two through
+ * `aria-controls`, which is the only connection available from the menu: the
+ * menu renders in its own portal, far away from the trigger. */
+const findTriggerForListbox = (listboxId: string): HTMLElement | null => (
+  Array.from(document.querySelectorAll<HTMLElement>('[role="combobox"][aria-expanded="true"]'))
+    .find((element) => element.getAttribute('aria-controls') === listboxId) ?? null
+);
+
+const getHighlightedOptionValue = (listbox: HTMLElement): string | null => {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || !listbox.contains(activeElement)) {
+    return null;
+  }
+
+  return activeElement.closest<HTMLElement>('[role="option"]')?.getAttribute('data-value') ?? null;
+};
+
+/** MUI renders a Select's option list as the `<ul>` of its floating menu. */
+export type SelectMenuKeyboardEvent = KeyboardEvent<HTMLUListElement>;
+
+interface UseOpenSelectTabNavigationProps<Value> {
+  options: SelectTypeaheadOption<Value>[];
+  multiple?: boolean;
+  onSelect: (value: Value, event: KeyboardEvent<Element>, option: SelectTypeaheadOption<Value>) => void;
+  onKeyDown?: (event: SelectMenuKeyboardEvent) => void;
+}
+
+interface PendingFocusAdvance {
+  trigger: HTMLElement;
+  direction: 1 | -1;
+}
+
+/**
+ * Tab / Shift+Tab while a Select's dropdown is open.
+ *
+ * MUI's `Menu` already closes the dropdown on Tab and swallows the browser's
+ * default focus move, which is what keeps focus inside a surrounding dialog or
+ * popover. What it does not do is take over the highlighted option or continue
+ * to the neighbouring field, so Tab reads as "nothing happened". This hook adds
+ * both, and runs the focus move from an effect on purpose: MUI restores focus
+ * to the Select trigger while committing the close, so a focus call made any
+ * earlier would be overwritten again.
+ *
+ * Multi-selects are left alone — their menu stays open across selections, and
+ * silently toggling the highlighted option on the way out would be surprising.
+ */
+export function useOpenSelectTabNavigation<Value = unknown>({
+  options,
+  multiple = false,
+  onSelect,
+  onKeyDown,
+}: UseOpenSelectTabNavigationProps<Value>): (event: SelectMenuKeyboardEvent) => void {
+  const pendingAdvanceRef = useRef<PendingFocusAdvance | null>(null);
+  const [advanceRequestCount, setAdvanceRequestCount] = useState(0);
+
+  useEffect(() => {
+    const pendingAdvance = pendingAdvanceRef.current;
+    if (!pendingAdvance) {
+      return;
+    }
+
+    pendingAdvanceRef.current = null;
+    const scope = resolveFocusScope(pendingAdvance.trigger);
+    if (!scope) {
+      return;
+    }
+
+    getTabbableNeighbour(
+      scope.container,
+      pendingAdvance.trigger,
+      pendingAdvance.direction,
+      { wrap: scope.wrap },
+    )?.focus();
+  }, [advanceRequestCount]);
+
+  return useCallback((event: SelectMenuKeyboardEvent): void => {
+    onKeyDown?.(event);
+    if (event.key !== 'Tab' || event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    const listbox = event.currentTarget;
+    const trigger = findTriggerForListbox(listbox.id);
+    const highlightedValue = multiple ? null : getHighlightedOptionValue(listbox);
+    const highlightedOption = highlightedValue === null
+      ? undefined
+      : options.find((option) => (
+        !option.disabled
+        && !option.hidden
+        && String(option.value) === highlightedValue
+      ));
+
+    if (highlightedOption) {
+      onSelect(highlightedOption.value, event, highlightedOption);
+    }
+    if (trigger) {
+      pendingAdvanceRef.current = { trigger, direction: event.shiftKey ? -1 : 1 };
+      setAdvanceRequestCount((count) => count + 1);
+    }
+  }, [multiple, onKeyDown, onSelect, options]);
+}

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { memo, useCallback, useMemo, useState, type FormEvent } from 'react';
 import {
   Box,
   Button,
@@ -44,11 +44,6 @@ interface AssignmentState {
 }
 
 type BedWithHierarchy = Bed & { id: number; fieldId: number; locationId: number };
-interface DialogKeyboardControl {
-  root: HTMLElement | null;
-  focusTarget: HTMLElement | null;
-  disabled: boolean;
-}
 
 const selectFieldSx = {
   ...fullWidthFieldSx,
@@ -141,13 +136,7 @@ function AreaAssignmentDialogComponent({
 }: AreaAssignmentDialogProps) {
   const { t } = useTranslation('plantingPlans');
   const [isOpen, setIsOpen] = useState(false);
-  const [openSelect, setOpenSelect] = useState<'location' | 'field' | 'bed' | null>(null);
   const [draft, setDraft] = useState<AssignmentState>({ locationId: null, fieldId: null, bedId: bedId ?? null });
-  const locationSelectRef = useRef<HTMLDivElement | null>(null);
-  const fieldSelectRef = useRef<HTMLDivElement | null>(null);
-  const bedSelectRef = useRef<HTMLDivElement | null>(null);
-  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
-  const applyButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const fieldsById = useMemo(() => new Map(fields.filter((item) => item.id !== undefined).map((item) => [item.id as number, item])), [fields]);
 
@@ -311,81 +300,7 @@ function AreaAssignmentDialogComponent({
     void handleApply();
   };
 
-  const getSelectFocusTarget = (root: HTMLDivElement | null): HTMLElement | null =>
-    root?.querySelector<HTMLElement>('[role="combobox"]') ?? root;
-
-  const getKeyboardControls = useCallback((): DialogKeyboardControl[] => [
-    {
-      root: locationSelectRef.current,
-      focusTarget: getSelectFocusTarget(locationSelectRef.current),
-      disabled: selectableLocations.length === 0,
-    },
-    {
-      root: fieldSelectRef.current,
-      focusTarget: getSelectFocusTarget(fieldSelectRef.current),
-      disabled: isFieldSelectDisabled,
-    },
-    {
-      root: bedSelectRef.current,
-      focusTarget: getSelectFocusTarget(bedSelectRef.current),
-      disabled: isBedSelectDisabled,
-    },
-    {
-      root: cancelButtonRef.current,
-      focusTarget: cancelButtonRef.current,
-      disabled: false,
-    },
-    {
-      root: applyButtonRef.current,
-      focusTarget: applyButtonRef.current,
-      disabled: isApplyDisabled,
-    },
-  ].filter((control) => control.root && control.focusTarget && !control.disabled), [
-    isApplyDisabled,
-    isBedSelectDisabled,
-    isFieldSelectDisabled,
-    selectableLocations.length,
-  ]);
-
-  const focusDialogControl = useCallback((control: DialogKeyboardControl | undefined): void => {
-    if (!control?.focusTarget) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      control.focusTarget?.focus();
-    });
-  }, []);
-
-  const handleNativeTabKeyDown = useCallback((event: globalThis.KeyboardEvent): void => {
-    if (!isOpen || openSelect !== null || event.key !== 'Tab') {
-      return;
-    }
-
-    const controls = getKeyboardControls();
-    if (controls.length === 0) {
-      return;
-    }
-
-    const activeElement = document.activeElement as HTMLElement | null;
-    const currentIndex = controls.findIndex((control) => (
-      Boolean(activeElement)
-      && (control.root === activeElement || control.focusTarget === activeElement || control.root?.contains(activeElement))
-    ));
-    const fallbackIndex = event.shiftKey ? controls.length : -1;
-    const normalizedIndex = currentIndex >= 0 ? currentIndex : fallbackIndex;
-    const nextIndex = event.shiftKey
-      ? (normalizedIndex - 1 + controls.length) % controls.length
-      : (normalizedIndex + 1) % controls.length;
-
-    event.preventDefault();
-    event.stopPropagation();
-    event.stopImmediatePropagation();
-    focusDialogControl(controls[nextIndex]);
-  }, [focusDialogControl, getKeyboardControls, isOpen, openSelect]);
-
   const handleCancel = (): void => {
-    setOpenSelect(null);
     setIsOpen(false);
   };
 
@@ -393,17 +308,6 @@ function AreaAssignmentDialogComponent({
     setDraft(getOpeningDraft());
     setIsOpen(true);
   };
-
-  useEffect(() => {
-    if (!isOpen) {
-      return undefined;
-    }
-
-    document.addEventListener('keydown', handleNativeTabKeyDown, true);
-    return () => {
-      document.removeEventListener('keydown', handleNativeTabKeyDown, true);
-    };
-  }, [handleNativeTabKeyDown, isOpen]);
 
   return (
     <>
@@ -440,19 +344,13 @@ function AreaAssignmentDialogComponent({
                   <InputLabel id="assignment-location-label">{t('columns.location')}</InputLabel>
                   <Select
                     fullWidth
-                    ref={locationSelectRef}
                     id="assignment-location"
                     labelId="assignment-location-label"
                     value={activeDraft.locationId ?? ''}
                     label={t('columns.location')}
                     disabled={selectableLocations.length === 0}
                     MenuProps={selectMenuProps}
-                    onOpen={() => setOpenSelect('location')}
-                    onClose={() => setOpenSelect(null)}
-                    onChange={(event) => {
-                      handleLocationChange(Number(event.target.value));
-                      requestAnimationFrame(() => locationSelectRef.current?.focus());
-                    }}
+                    onChange={(event) => handleLocationChange(Number(event.target.value))}
                   >
                     {selectableLocations.map((item) => (
                       <MenuItem key={item.id} value={item.id} title={item.name}>{item.name}</MenuItem>
@@ -464,19 +362,13 @@ function AreaAssignmentDialogComponent({
                   <InputLabel id="assignment-field-label">{t('columns.field')}</InputLabel>
                   <Select
                     fullWidth
-                    ref={fieldSelectRef}
                     id="assignment-field"
                     labelId="assignment-field-label"
                     value={activeDraft.fieldId ?? ''}
                     label={t('columns.field')}
                     disabled={isFieldSelectDisabled}
                     MenuProps={selectMenuProps}
-                    onOpen={() => setOpenSelect('field')}
-                    onClose={() => setOpenSelect(null)}
-                    onChange={(event) => {
-                      handleFieldChange(Number(event.target.value));
-                      requestAnimationFrame(() => fieldSelectRef.current?.focus());
-                    }}
+                    onChange={(event) => handleFieldChange(Number(event.target.value))}
                   >
                     {selectableFields.map((item) => (
                       <MenuItem key={item.id} value={item.id} title={item.name}>{item.name}</MenuItem>
@@ -488,21 +380,13 @@ function AreaAssignmentDialogComponent({
                   <InputLabel id="assignment-bed-label">{t('columns.bed')}</InputLabel>
                   <Select
                     fullWidth
-                    ref={bedSelectRef}
                     id="assignment-bed"
                     labelId="assignment-bed-label"
                     value={activeDraft.bedId ?? ''}
                     label={t('columns.bed')}
                     disabled={isBedSelectDisabled}
                     MenuProps={selectMenuProps}
-                    onOpen={() => setOpenSelect('bed')}
-                    onClose={() => setOpenSelect(null)}
-                    onChange={(event) => {
-                      handleBedChange(Number(event.target.value));
-                      requestAnimationFrame(() => {
-                        applyButtonRef.current?.focus();
-                      });
-                    }}
+                    onChange={(event) => handleBedChange(Number(event.target.value))}
                   >
                     {selectableBeds.map((item) => {
                       const label = renderBedLabel(item);
@@ -516,8 +400,8 @@ function AreaAssignmentDialogComponent({
             </Box>
           </DialogContent>
           <DialogActions>
-            <Button ref={cancelButtonRef} type="button" data-dialog-action="cancel" onClick={handleCancel}>{t('areaAssignment.cancel')}</Button>
-            <Button ref={applyButtonRef} type="submit" data-dialog-action="apply" variant="contained" disabled={isApplyDisabled}>{t('areaAssignment.apply')}</Button>
+            <Button type="button" data-dialog-action="cancel" onClick={handleCancel}>{t('areaAssignment.cancel')}</Button>
+            <Button type="submit" data-dialog-action="apply" variant="contained" disabled={isApplyDisabled}>{t('areaAssignment.apply')}</Button>
           </DialogActions>
         </Box>
       </Dialog>

--- a/frontend/src/cultures/CultureForm.tsx
+++ b/frontend/src/cultures/CultureForm.tsx
@@ -73,33 +73,6 @@ interface CultureFormProps {
 
 // Default color for display color picker
 const DEFAULT_DISPLAY_COLOR = '#3498db';
-const FOCUSABLE_DIALOG_ELEMENT_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled]):not([type="hidden"])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[role="button"]:not([aria-disabled="true"])',
-  '[role="combobox"]:not([aria-disabled="true"])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',');
-
-const isElementVisible = (element: HTMLElement): boolean => (
-  element.offsetParent !== null || element.getClientRects().length > 0
-);
-
-const getDialogFocusableElements = (dialogElement: HTMLElement): HTMLElement[] => (
-  Array.from(dialogElement.querySelectorAll<HTMLElement>(FOCUSABLE_DIALOG_ELEMENT_SELECTOR))
-    .filter((element) => (
-      isElementVisible(element)
-      && element.tabIndex >= 0
-      && element.getAttribute('aria-hidden') !== 'true'
-    ))
-);
-
-const isFloatingSelectMenuOpen = (): boolean => (
-  Boolean(document.querySelector('.MuiPopover-paper [role="listbox"], .MuiMenu-paper [role="listbox"]'))
-);
 
 // Empty culture template
 const EMPTY_CULTURE: Partial<Culture> = {
@@ -490,50 +463,9 @@ export function CultureForm({
     });
   };
 
-  useEffect(() => {
-    const handleDialogTabKeyDown = (event: globalThis.KeyboardEvent): void => {
-      if (
-        event.key !== 'Tab'
-        || event.altKey
-        || event.ctrlKey
-        || event.metaKey
-        || isFloatingSelectMenuOpen()
-      ) {
-        return;
-      }
-
-      const dialogElement = formRef.current?.closest('[role="dialog"]') as HTMLElement | null;
-      const activeElement = document.activeElement as HTMLElement | null;
-      if (!dialogElement || !activeElement || !dialogElement.contains(activeElement)) {
-        return;
-      }
-
-      const focusableElements = getDialogFocusableElements(dialogElement);
-      if (focusableElements.length === 0) {
-        return;
-      }
-
-      const currentIndex = focusableElements.findIndex((element) => (
-        element === activeElement || element.contains(activeElement)
-      ));
-      const nextIndex = currentIndex >= 0
-        ? event.shiftKey
-          ? (currentIndex - 1 + focusableElements.length) % focusableElements.length
-          : (currentIndex + 1) % focusableElements.length
-        : 0;
-
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-
-      requestAnimationFrame(() => {
-        focusableElements[nextIndex]?.focus();
-      });
-    };
-
-    document.addEventListener('keydown', handleDialogTabKeyDown, true);
-    return () => document.removeEventListener('keydown', handleDialogTabKeyDown, true);
-  }, []);
+  // Tab/Shift+Tab inside this dialog is MUI's `Dialog` focus trap's job; Tab
+  // out of an open Select dropdown belongs to `TypeaheadSelect`. Do not add a
+  // second trap here — see docs/keyboard-architecture.md.
 
   // Handle manual save (for Save button)
   const handleSubmit = async (e: React.FormEvent) => {

--- a/frontend/src/focus/focusableElements.ts
+++ b/frontend/src/focus/focusableElements.ts
@@ -16,13 +16,56 @@ const isVisible = (element: Element): boolean => {
   return style.display !== 'none' && style.visibility !== 'hidden';
 };
 
+/** Elements the browser skips even though they match the selector above: MUI
+ * renders a hidden `<input tabindex="-1" aria-hidden>` next to every Select,
+ * and roving-tabindex widgets park `tabindex="-1"` on their inactive items.
+ * Content-editable hosts are checked by attribute — jsdom does not implement
+ * contenteditable, so their `tabIndex` reads as -1 in tests. */
+const isTabbable = (element: HTMLElement): boolean => (
+  (element.tabIndex >= 0 || element.getAttribute('contenteditable') === 'true')
+  && element.getAttribute('aria-hidden') !== 'true'
+);
+
 /** Focusable descendants of `container`, in DOM (reading) order. Used both
  * to find the first element an `F6`-focused region should land on, and to
  * compute the Tab-wrap boundaries for that region. */
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(isVisible);
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => isVisible(element) && isTabbable(element));
 }
 
 export function getFirstFocusable(container: HTMLElement): HTMLElement | null {
   return getFocusableElements(container)[0] ?? null;
+}
+
+interface TabbableNeighbourOptions {
+  /** Close the cycle at the container's edges, the way a modal focus trap
+   * does. Off for containers Tab is allowed to leave (e.g. a page form). */
+  wrap?: boolean;
+}
+
+/** Where Tab (`direction: 1`) or Shift+Tab (`direction: -1`) would land when
+ * starting from `origin`, without leaving `container`. Returns `null` when the
+ * move would leave the container and `wrap` is off. */
+export function getTabbableNeighbour(
+  container: HTMLElement,
+  origin: HTMLElement,
+  direction: 1 | -1,
+  { wrap = false }: TabbableNeighbourOptions = {},
+): HTMLElement | null {
+  const tabbable = getFocusableElements(container);
+  const currentIndex = tabbable.indexOf(origin);
+  if (currentIndex === -1) {
+    return null;
+  }
+
+  const nextIndex = currentIndex + direction;
+  if (nextIndex >= 0 && nextIndex < tabbable.length) {
+    return tabbable[nextIndex];
+  }
+  if (!wrap) {
+    return null;
+  }
+
+  return direction === 1 ? tabbable[0] : tabbable[tabbable.length - 1];
 }


### PR DESCRIPTION
## Summary

This PR refactors keyboard focus management across the application by centralizing Tab navigation logic for Select dropdowns and removing redundant focus traps from modal dialogs. The changes improve focus handling consistency and eliminate conflicts between multiple focus management layers.

## Key Changes

- **New `selectDropdownTabNavigation.ts` hook**: Implements `useOpenSelectTabNavigation` to handle Tab/Shift+Tab while a Select dropdown is open. This hook:
  - Takes over the highlighted option when Tab is pressed (except for multi-selects)
  - Moves focus to the next/previous tabbable element in the focus scope
  - Respects modal boundaries (wraps at edges) vs. form boundaries (allows escape)
  - Runs focus moves from an effect to avoid being overwritten by MUI's focus restoration

- **Updated `TypeaheadSelect` component**: Integrated the new Tab navigation hook into all Select instances via `MenuProps.slotProps.list.onKeyDown`

- **Simplified `AreaAssignmentDialog`**: Removed custom Tab trap logic that manually tracked focus state and conflicted with MUI's Dialog focus management. The dialog now relies entirely on MUI's built-in focus trap.

- **Simplified `CultureForm`**: Removed redundant Tab trap that duplicated MUI Dialog's focus management

- **Enhanced `focusableElements.ts`**: 
  - Added `isTabbable()` filter to exclude hidden inputs and aria-hidden elements
  - New `getTabbableNeighbour()` function to find the next/previous focusable element with optional wrapping

- **Comprehensive test coverage**: Added 15+ new tests in `AreaAssignmentDialog.test.tsx` and `TypeaheadSelect.test.tsx` covering:
  - Tab/Shift+Tab containment within dialogs
  - Focus restoration after Escape
  - Dropdown option selection on Tab
  - Multi-select behavior (no auto-selection)
  - aria-hidden and aria-modal attributes

## Notable Implementation Details

- Focus moves are deliberately scheduled via `useEffect` to avoid being overwritten by MUI's focus restoration during dropdown close
- Modal focus scopes (dialogs, popovers) wrap Tab at edges; form scopes allow Tab to escape
- The trigger element is located via `aria-controls` attribute linking it to the listbox
- Multi-select dropdowns intentionally skip option selection on Tab to avoid surprising behavior
- Documentation added to `docs/keyboard-architecture.md` explaining the new approach and why dialogs should not add secondary focus traps

https://claude.ai/code/session_01JqcyXdmyXH3f8HibhLkoL8