### PR TITLE
test(e2e): cover Tab navigation past cells with hidden columns

### DIFF
--- a/frontend/e2e/planting-plans-tab-navigation.spec.ts
+++ b/frontend/e2e/planting-plans-tab-navigation.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test, type Page } from '@playwright/test';
+import { loginWithDeterministicProject } from './utils';
+
+// 1100px keeps the desktop grid but is narrow enough for the responsive column
+// visibility model to hide the two calculated harvest columns that sit right
+// after "Pflanzdatum" — the case where Tab used to die on the date cell
+// because the hidden columns shifted the index handed to MUI's scrollToIndexes.
+const NARROW_DESKTOP_WIDTH = 1100;
+
+const focusedField = async (page: Page): Promise<string | null> =>
+  page.evaluate(() =>
+    document.activeElement?.closest('[role="gridcell"]')?.getAttribute('data-field') ?? null);
+
+test.describe('planting plans tab navigation with hidden columns', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.setViewportSize({ width: NARROW_DESKTOP_WIDTH, height: 900 });
+    await loginWithDeterministicProject(page, request, 'planting-plans-tab-navigation', {
+      demoProject: true,
+      loginAsAdmin: true,
+    });
+    await page.goto('/app/planting-plans');
+    await expect(page.getByRole('heading', { name: 'Anbaupläne' })).toBeVisible();
+    await expect(page.locator('[role="row"][data-id]').first()).toBeVisible();
+  });
+
+  test('Tab and Shift+Tab keep moving between editable cells around the date cell', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    const firstRow = page.locator('[role="row"][data-id]').first();
+    await firstRow.locator('[data-field="planting_date"]').dblclick();
+    await expect(page.locator('.MuiDataGrid-row--editing')).toHaveCount(1);
+    await expect.poll(() => focusedField(page)).toBe('planting_date');
+
+    await page.keyboard.press('Tab');
+    await expect.poll(() => focusedField(page)).toBe('area_m2');
+
+    await page.keyboard.press('Tab');
+    await expect.poll(() => focusedField(page)).toBe('plants_count');
+
+    await page.keyboard.press('Shift+Tab');
+    await expect.poll(() => focusedField(page)).toBe('area_m2');
+
+    await page.keyboard.press('Shift+Tab');
+    await expect.poll(() => focusedField(page)).toBe('planting_date');
+
+    expect(pageErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds the missing browser-level regression test for the planting-plans Tab navigation bug.

## Scope change

This PR originally carried the production fix as well. While rebasing onto current `main` it turned out `main` already contains an equivalent fix — `scrollCellIntoView` / `getVisibleColumnIndex` in the data-grid keyboard navigation helper — reached independently under different names, wired up at every production call site. The earlier merge on this branch had already, and correctly, taken `main`'s version.

What was genuinely still missing is the regression test, so that is all this PR now contains. It also no longer carries the `PublicCropLibraryPage.test.tsx` change, which landed with #436.

## The bug it covers

Tab navigation died on the "Pflanzdatum" cell: focus moved to "Fläche" once, then stopped responding. The column index passed to `scrollToIndexes` came from MUI's `getColumnIndexRelativeToVisibleColumns`, which counts hidden columns too. Once the responsive visibility model hid the two calculated harvest columns sitting right behind the date column, every later index was shifted and the trailing ones overran `scrollToIndexes`' visible-column array — throwing on `undefined.computedWidth` out of the Tab handler, after `preventDefault()` had already run. So neither our focus move nor the browser's native tab happened.

## The test

Runs at a 1100px viewport, which keeps the desktop grid but is narrow enough that the two harvest columns are actually hidden — the condition the bug required. It walks Tab and Shift+Tab across that boundary in both directions and asserts no `pageerror` was raised, so a reintroduced throw fails the test instead of silently degrading navigation.