### PR TITLE
fix(crop-library): stop a stale list refresh from undoing a save

### DIFF
--- a/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
+++ b/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
@@ -1555,14 +1555,19 @@ describe('PublicCropLibraryPage', () => {
       });
     });
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Öffentliche Kultur bearbeiten' })).not.toBeInTheDocument());
-    // Both waits outlast RTL's 1s default: this test drives several chained
-    // requests, which on a loaded CI runner can take longer than that.
-    await waitFor(() => expect(screen.getByText('48 Tage')).toBeInTheDocument(), { timeout: 10000 });
+    // Deliberately no assertion on the saved values here. The search above
+    // refreshes the list on a debounce, so a request can still be in flight at
+    // this point, and while it is the page shows "Kulturen werden geladen…"
+    // with no detail pane at all. Whether that request has fired yet is a race,
+    // which is what made this spot flaky — raising the timeout could not fix
+    // it, because nothing arrives until the response below lands.
 
     await act(async () => {
       staleList.resolve({ data: { results: publicCultures } });
     });
 
+    // The actual subject: the stale response carries the pre-save culture, and
+    // must not roll the saved values back.
     await waitFor(() => expect(screen.getByText('48 Tage')).toBeInTheDocument(), { timeout: 10000 });
     expect(screen.queryByText('70 Tage')).not.toBeInTheDocument();
   }, 30000);

--- a/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
+++ b/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
@@ -910,7 +910,10 @@ describe('PublicCropLibraryPage', () => {
       created_at: '2026-07-28T10:00:00Z',
       comment_count: 1,
       last_activity_at: '2026-07-28T10:00:00Z',
-      last_comment_preview: 'Was ist hier gemeint?',
+      // Deliberately not the comment body: the overview list renders this
+      // preview, so reusing the body text let the assertion below pass by
+      // matching the overview instead of the opened discussion.
+      last_comment_preview: 'Vorschau des Kommentars',
     };
     const createdComment: PublicCultureDiscussionComment = {
       id: 21,

--- a/frontend/src/__tests__/applySavedCultures.test.ts
+++ b/frontend/src/__tests__/applySavedCultures.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { PublicCulture } from '../api/types';
+import { applySavedCultures } from '../crops/publicCultureListMerge';
+
+const culture = (id: number, version: number, growthDurationDays: number): PublicCulture => ({
+  id,
+  version,
+  growth_duration_days: growthDurationDays,
+} as PublicCulture);
+
+describe('applySavedCultures', () => {
+  it('returns the list untouched when nothing was saved locally', () => {
+    const results = [culture(1, 1, 70)];
+
+    expect(applySavedCultures(results, new Map())).toBe(results);
+  });
+
+  it('keeps a saved culture when the list response predates the save', () => {
+    const saved = new Map([[1, culture(1, 2, 48)]]);
+
+    const applied = applySavedCultures([culture(1, 1, 70), culture(2, 1, 30)], saved);
+
+    expect(applied.map((entry) => entry.growth_duration_days)).toEqual([48, 30]);
+  });
+
+  it('lets the server win once it returns the saved version', () => {
+    const saved = new Map([[1, culture(1, 2, 48)]]);
+
+    const applied = applySavedCultures([culture(1, 2, 48)], saved);
+
+    expect(applied[0].version).toBe(2);
+    // The override has served its purpose and must not outlive the response
+    // it was protecting against, or later server-side edits would be ignored.
+    expect(saved.has(1)).toBe(false);
+  });
+
+  it('lets a newer server version replace the saved one and drops the override', () => {
+    const saved = new Map([[1, culture(1, 2, 48)]]);
+
+    const applied = applySavedCultures([culture(1, 3, 55)], saved);
+
+    expect(applied[0].growth_duration_days).toBe(55);
+    expect(saved.has(1)).toBe(false);
+  });
+
+  it('leaves cultures that were never saved locally alone', () => {
+    const saved = new Map([[1, culture(1, 2, 48)]]);
+
+    const applied = applySavedCultures([culture(9, 1, 12)], saved);
+
+    expect(applied[0].growth_duration_days).toBe(12);
+    expect(saved.has(1)).toBe(true);
+  });
+});

--- a/frontend/src/crops/pages/PublicCropLibraryPage.tsx
+++ b/frontend/src/crops/pages/PublicCropLibraryPage.tsx
@@ -75,6 +75,7 @@ import {
   getPublicCultureName,
   getPublicCultureTitle,
 } from '../publicCultureDisplay';
+import { applySavedCultures } from '../publicCultureListMerge';
 import { MultilingualTextFieldSection } from '../components/MultilingualTextFieldSection';
 import { AppTooltip } from '../../components/AppTooltip';
 
@@ -1090,6 +1091,12 @@ export default function PublicCropLibraryPage() {
   const cultureListRef = useRef<HTMLUListElement>(null);
   const cultureListScrollTopRef = useRef<number>(storedViewState?.listScrollTop ?? 0);
   const cultureListRequestIdRef = useRef(0);
+  // Cultures this client has saved, kept until a list response catches up with
+  // them. Bumping cultureListRequestIdRef on save only discards list requests
+  // that are already in flight; one started right after the save (the search
+  // box refreshes on a debounce) still carries pre-save data and would
+  // otherwise write the old values straight back over the saved ones.
+  const savedCulturesRef = useRef<Map<number, PublicCulture>>(new Map());
   const newTopicButtonRef = useRef<HTMLButtonElement>(null);
   const newTopicTitleInputRef = useRef<HTMLInputElement>(null);
   const activeCommentFormInputRef = useRef<HTMLInputElement>(null);
@@ -1429,7 +1436,7 @@ export default function PublicCropLibraryPage() {
       if (requestId !== cultureListRequestIdRef.current) {
         return;
       }
-      setCultures(results);
+      setCultures(applySavedCultures(results, savedCulturesRef.current));
       setLoadStatus('success');
     } catch {
       if (requestId !== cultureListRequestIdRef.current) {
@@ -1640,6 +1647,7 @@ export default function PublicCropLibraryPage() {
 
   const upsertCultureInList = (updatedCulture: PublicCulture): void => {
     cultureListRequestIdRef.current += 1;
+    savedCulturesRef.current.set(updatedCulture.id, updatedCulture);
     setLoadError('');
     setLoadStatus('success');
     setCultures((current) => {

--- a/frontend/src/crops/publicCultureListMerge.ts
+++ b/frontend/src/crops/publicCultureListMerge.ts
@@ -1,0 +1,35 @@
+import type { PublicCulture } from '../api/types';
+
+/**
+ * Keeps locally saved cultures from being rolled back by a list response that
+ * predates the save.
+ *
+ * The page already discards list requests that were in flight when a save
+ * landed, but a request started *after* the save — the search box refreshes on
+ * a debounce — still carries pre-save data and would otherwise write the old
+ * values straight back over the saved ones.
+ *
+ * An entry is dropped from `saved` as soon as the server returns that culture
+ * at the saved version or newer, so an override never outlives the request it
+ * was protecting against and later server-side edits still win.
+ */
+export function applySavedCultures(
+  results: PublicCulture[],
+  saved: Map<number, PublicCulture>,
+): PublicCulture[] {
+  if (saved.size === 0) {
+    return results;
+  }
+
+  return results.map((culture) => {
+    const savedCulture = saved.get(culture.id);
+    if (!savedCulture) {
+      return culture;
+    }
+    if (culture.version >= savedCulture.version) {
+      saved.delete(culture.id);
+      return culture;
+    }
+    return savedCulture;
+  });
+}


### PR DESCRIPTION
Fixes the `frontend-tests` failure that has `main` — and every branch cut from it — red.

## The bug

Saving a public culture while the list is refreshing can roll the saved values straight back to their pre-save state. The detail pane shows the old growth duration again, with nothing indicating the save was discarded.

`upsertCultureInList` bumps `cultureListRequestIdRef` so a list request already in flight when the save landed gets dropped. That does not cover a request started *after* the save: the search box refreshes the list on a 250 ms debounce, so such a request still carries pre-save data, passes the request-id guard with a newer id, and overwrites the saved culture.

## The fix

Guard list results by `version`, in a new `src/crops/publicCultureListMerge.ts`. Cultures this client has saved are kept until a response returns them at the saved version or newer, at which point the override is dropped — so later server-side edits still win and the override never outlives the request it was protecting against.

## Why this was showing up as a flaky test

`keeps the saved public culture details when a stale list refresh resolves later` is the test that has been failing. It is not flaky — it correctly catches this bug, intermittently, because whether the debounced refresh lands before or after the save is a race.

This PR also drops that test's assertion sitting *between* the save and the stale response. The debounced refresh can still be in flight at that point, and while it is, the page renders `Kulturen werden geladen…` with no detail pane at all — so the values it looked for cannot be on screen. `main` tried to absorb this with `timeout: 10000`, which cannot help, because nothing arrives there until the stale response below lands. The assertions after it cover the test's actual subject.

## Verification

| | result |
|---|---|
| product fix + test change | **8/8 green** over repeated runs |
| test change only, product fix reverted | 1/6 green — the product fix is what makes it pass |
| `main` as-is | 2/6 green |

Plus five deterministic unit tests for the merge rule itself (`applySavedCultures.test.ts`), covering the stale-response case, the server catching up, a newer server version winning, and untouched cultures.

Full suite under CI settings: **188 files / 1850 tests green**. Typecheck clean. ESLint error count unchanged from `main` (7, all pre-existing `setState-in-effect` / `refs during render` findings in this file).

## Note on ordering

PR #434 is red on this same failure. Landing this first turns `main` green and lets #434 go green on a re-run, rather than merging a red PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011MNcv7jaWpCVW1YC7w7aGz)_