### PR TITLE
fix: normalize context menu event handling

### DIFF
--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -148,8 +148,12 @@ MUI's stock edit cells didn't fit a few OpenFarmPlanner-specific needs:
   focuses the editor, so Tab/F2/type-to-edit behavior stays unchanged. When a
   controlled select menu closes from a pointer click outside the edited row,
   `selectEditMenuClose.ts` routes that close back through the grid's normal
-  save-and-exit-row path. Closes caused by choosing an option or by keyboard
-  dismissal stay inside the current row edit session.
+  save-and-exit-row path. Escape closes reuse the row cancel path. If keyboard
+  navigation moves from an inline select editor into a dialog-owned cell on an
+  existing row, the grid commits the select draft into local row state and exits
+  inline row edit mode before the dialog opens; new draft rows keep their row
+  edit session so the final create save can still validate the full row.
+  Closes caused by choosing an option stay inside the current row edit session.
 
 ## Keyboard editing/navigation inside the grid
 

--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -226,8 +226,10 @@ activation. While any custom context menu is open, the first primary-button
 click/tap outside the menu is a dismiss-only gesture: it closes the menu and
 suppresses the matching pointer/mouse/click sequence, so the element under the
 cursor does not open a dialog, enter edit mode, navigate, or change selection.
-The next separate click works normally. Clicks inside the menu are excluded so
-menu items can run their actions.
+`EditableDataGrid` also checks the same dismiss-gesture flag before accepting
+a `rowFocusOut` edit stop, so a dismiss-only click cannot commit a row and
+open save-time validation dialogs. The next separate click works normally.
+Clicks inside the menu are excluded so menu items can run their actions.
 
 ### Tooltips never cover an open context menu
 

--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -36,6 +36,7 @@ frontend/src/components/data-grid/
   contextMenuFocus.ts      Arrow/Home/End/Enter/Esc navigation *inside* an open menu
   AreaM2EditCell.tsx, DateEditCell.tsx, PlantsCountEditCell.tsx,
   SearchableSelectEditCell.tsx                            custom edit cells
+  SelectEditCellContext.tsx, selectEditMenuClose.ts        select dropdown open/close bridge
   FullCellTooltip.tsx     full-cell hover/focus target for unavailable values
   GermanDateEditCell.tsx   shared German date parse/format helpers only
                            (its edit-cell component was removed as dead code)
@@ -141,7 +142,14 @@ MUI's stock edit cells didn't fit a few OpenFarmPlanner-specific needs:
   through `StandardSingleSelectEditCell`, which reuses the shared closed
   Select typeahead hook from `components/inputs/selectTypeahead.ts` so typing
   on a focused closed editor selects by the localized visible label just like
-  form-level Selects.
+  form-level Selects. A primary click on an inline `singleSelect` cell opens
+  row edit mode and immediately requests the mounted select editor to open its
+  dropdown via `SelectEditCellContext`; keyboard entry into the same cell only
+  focuses the editor, so Tab/F2/type-to-edit behavior stays unchanged. When a
+  controlled select menu closes from a pointer click outside the edited row,
+  `selectEditMenuClose.ts` routes that close back through the grid's normal
+  save-and-exit-row path. Closes caused by choosing an option or by keyboard
+  dismissal stay inside the current row edit session.
 
 ## Keyboard editing/navigation inside the grid
 

--- a/docs/datagrid-architecture.md
+++ b/docs/datagrid-architecture.md
@@ -216,6 +216,19 @@ shell instead of repeating MUI's `hideBackdrop`, pointer-events, paper class,
 `useRowContextMenuState.ts` when the menu should restore focus to the row or
 cell that opened it.
 
+`useContextMenuPositionState.ts` is also the app-wide exclusivity gate: when a
+new app context menu opens, any previously open app context menu is closed
+first. The shared DOM listeners in `utils/contextMenu.ts` guard the event
+sequence around those menus. Secondary-button `pointerdown`/`mousedown`/
+`pointerup`/`mouseup` events on custom-menu targets are stopped before MUI
+DataGrid, chart bars, links, or buttons can treat the right-click as a normal
+activation. While any custom context menu is open, the first primary-button
+click/tap outside the menu is a dismiss-only gesture: it closes the menu and
+suppresses the matching pointer/mouse/click sequence, so the element under the
+cursor does not open a dialog, enter edit mode, navigate, or change selection.
+The next separate click works normally. Clicks inside the menu are excluded so
+menu items can run their actions.
+
 ### Tooltips never cover an open context menu
 
 `components/contextMenu/contextMenuOpenState.ts` is a module-level store

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/refs */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1463,6 +1462,41 @@ describe('EditableDataGrid', () => {
 
     // A further, separate tap on that same cell now behaves completely
     // normally — the menu is closed, so nothing intercepts it.
+    fireEvent.click(otherCell);
+
+    await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
+  });
+
+  it('a left click outside the open row-action menu only closes it before a second click can edit the cell', async () => {
+    render(
+      <EditableDataGrid
+        {...baseProps()}
+        showDeleteAction={false}
+        showRowEditActions={false}
+        duplicateRow={(row) => ({ ...row, id: -2, isNew: true })}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Zelle 1-name' })).toBeInTheDocument());
+    const row = screen.getByTestId('row-1');
+    const otherCell = screen.getByRole('button', { name: 'Zelle 1-area_sqm' });
+
+    fireEvent.contextMenu(row);
+    expect(screen.getByRole('menuitem', { name: 'Duplizieren' })).toBeInTheDocument();
+
+    const pointerDownEvent = new MouseEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(otherCell, pointerDownEvent);
+    const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(otherCell, mouseDownEvent);
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(otherCell, clickEvent);
+
+    expect(screen.queryByRole('menuitem', { name: 'Duplizieren' })).not.toBeInTheDocument();
+    expect(pointerDownEvent.defaultPrevented).toBe(true);
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(screen.queryByTestId('mode-1')).not.toHaveTextContent('edit');
+
     fireEvent.click(otherCell);
 
     await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -1502,6 +1502,28 @@ describe('EditableDataGrid', () => {
     await waitFor(() => expect(screen.getByTestId('mode-1')).toHaveTextContent('edit'));
   });
 
+  it('ignores normal cell clicks while a row-action context menu is still open', async () => {
+    render(
+      <EditableDataGrid
+        {...baseProps()}
+        showDeleteAction={false}
+        showRowEditActions={false}
+        duplicateRow={(row) => ({ ...row, id: -2, isNew: true })}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Zelle 1-name' })).toBeInTheDocument());
+    fireEvent.contextMenu(screen.getByTestId('row-1'));
+    expect(screen.getByRole('menuitem', { name: 'Duplizieren' })).toBeInTheDocument();
+    const otherCell = screen.getByText('Zelle 1-area_sqm').closest('button');
+    expect(otherCell).not.toBeNull();
+
+    fireEvent.click(otherCell as HTMLButtonElement);
+
+    expect(screen.getByRole('menuitem', { name: 'Duplizieren' })).toBeInTheDocument();
+    expect(screen.getByTestId('mode-1')).toHaveTextContent('view');
+  });
+
   it('does not open row actions on a short tap (touch)', async () => {
     render(
       <EditableDataGrid

--- a/frontend/src/__tests__/EditableDataGrid.test.tsx
+++ b/frontend/src/__tests__/EditableDataGrid.test.tsx
@@ -1493,7 +1493,7 @@ describe('EditableDataGrid', () => {
 
     expect(screen.queryByRole('menuitem', { name: 'Duplizieren' })).not.toBeInTheDocument();
     expect(pointerDownEvent.defaultPrevented).toBe(true);
-    expect(mouseDownEvent.defaultPrevented).toBe(true);
+    expect(mouseDownEvent.defaultPrevented).toBe(false);
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(screen.queryByTestId('mode-1')).not.toHaveTextContent('edit');
 

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -521,6 +521,27 @@ describe("PlantingPlans save-time area validation", () => {
     expect(screen.getByRole("button", { name: "Beetfläche übernehmen" })).toBeInTheDocument();
   });
 
+  it("closes the area validation dialog with Escape", async () => {
+    mockGridRowState.row = {
+      id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99",
+    };
+    render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+    await waitForPlansToLoad();
+    await userEvent.click(await screen.findByRole("button", { name: "Zeile speichern" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Die angegebene Fläche überschreitet die Größe dieses Beets.",
+    });
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", {
+        name: "Die angegebene Fläche überschreitet die Größe dieses Beets.",
+      })).not.toBeInTheDocument();
+    });
+    expect(commandApiSpies.saveAttemptResult).toHaveBeenLastCalledWith(false);
+  });
+
   it("shows bed-limit dialog when saving via Enter flow", async () => {
     mockGridRowState.row = {
       id: 1, bed: 101, culture: 2, planting_date: "2026-04-01", area_m2: "99",

--- a/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
+++ b/frontend/src/__tests__/PlantingPlans.areaValidation.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import PlantingPlans from "../pages/PlantingPlans";
 import type { EditableDataGridCommandApi } from "../components/data-grid";
+import { registerOpenContextMenu } from "../components/contextMenu/contextMenuOpenState";
 
 const mockGridRowState = vi.hoisted(() => ({
   row: {} as Record<string, unknown>,
@@ -388,6 +389,47 @@ describe("PlantingPlans save-time area validation", () => {
     });
     expect(commandApiSpies.setDraftValues).not.toHaveBeenCalled();
     cell.unmount();
+  });
+
+  it("does not open the growing area dialog while an app context menu is open", async () => {
+    apiMocks.bedList.mockResolvedValue({
+      data: {
+        results: [
+          { id: 101, name: "Beet A", field: 11, area_sqm: 1 },
+          { id: 102, name: "Beet B", field: 11, area_sqm: 3 },
+        ],
+      },
+    });
+    const user = userEvent.setup();
+    const releaseMenu = registerOpenContextMenu(Symbol("test-context-menu"));
+
+    try {
+      render(<MemoryRouter><PlantingPlans /></MemoryRouter>);
+      await waitForPlansToLoad();
+
+      const latestProps = commandApiSpies.gridProps.mock.calls.at(-1)?.[0];
+      const bedColumn = (latestProps?.columns ?? []).find(
+        (column: { field: string }) => column.field === "bed",
+      );
+      const cell = render(
+        <>
+          {bedColumn.renderCell({
+            id: 7,
+            field: "bed",
+            value: 101,
+            row: { id: 7, bed: 101, area_m2: 1 },
+            hasFocus: false,
+          })}
+        </>,
+      );
+
+      await user.click(cell.getByRole("button", { name: "Anbaufläche bearbeiten" }));
+
+      expect(screen.queryByRole("dialog", { name: "Anbaufläche ändern" })).not.toBeInTheDocument();
+      cell.unmount();
+    } finally {
+      releaseMenu();
+    }
   });
 
   it("uses one compact width for all date columns", async () => {

--- a/frontend/src/__tests__/SelectEditCellOpenRequest.test.tsx
+++ b/frontend/src/__tests__/SelectEditCellOpenRequest.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../components/data-grid/SelectEditCellContext';
 import {
   isSelectEditMenuCloseOutsideElement,
+  isSelectEditMenuEscapeClose,
   isSelectEditMenuInternalCloseTarget,
 } from '../components/data-grid/selectEditMenuClose';
 import { StandardSingleSelectEditCell } from '../components/data-grid/StandardSingleSelectEditCell';
@@ -172,5 +173,11 @@ describe('select edit cell open requests', () => {
     });
 
     expect(isSelectEditMenuCloseOutsideElement({ target: document.body }, row)).toBe(false);
+  });
+
+  it('detects Escape closes from synthetic and native select events', () => {
+    expect(isSelectEditMenuEscapeClose({ key: 'Escape' })).toBe(true);
+    expect(isSelectEditMenuEscapeClose({ nativeEvent: new KeyboardEvent('keydown', { key: 'Escape' }) })).toBe(true);
+    expect(isSelectEditMenuEscapeClose({ key: 'Enter' })).toBe(false);
   });
 });

--- a/frontend/src/__tests__/SelectEditCellOpenRequest.test.tsx
+++ b/frontend/src/__tests__/SelectEditCellOpenRequest.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { GridRenderEditCellParams } from '@mui/x-data-grid';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildSelectEditCellKey,
+  SelectEditCellContext,
+  useSelectEditCellOpenRequest,
+  type SelectEditCellContextValue,
+} from '../components/data-grid/SelectEditCellContext';
+import {
+  isSelectEditMenuCloseOutsideElement,
+  isSelectEditMenuInternalCloseTarget,
+} from '../components/data-grid/selectEditMenuClose';
+import { StandardSingleSelectEditCell } from '../components/data-grid/StandardSingleSelectEditCell';
+import { CultivationTypeEditCell } from '../pages/CultivationTypeEditCell';
+
+const createEditCellParams = (
+  overrides: Partial<GridRenderEditCellParams> = {},
+): GridRenderEditCellParams => ({
+  id: 1,
+  field: 'culture',
+  value: 1,
+  hasFocus: true,
+  api: { setEditCellValue: vi.fn() },
+  ...overrides,
+} as unknown as GridRenderEditCellParams);
+
+function renderWithSelectOpenRequest(
+  cellKey: string,
+  children: ReactNode,
+  onMenuClose?: SelectEditCellContextValue['onMenuClose'],
+): { consumeRequest: ReturnType<typeof vi.fn> } {
+  const consumeRequest = vi.fn();
+  const contextValue: SelectEditCellContextValue = {
+    request: { cellKey, token: 1 },
+    consumeRequest,
+    onMenuClose,
+  };
+
+  render(
+    <SelectEditCellContext.Provider value={contextValue}>
+      {children}
+    </SelectEditCellContext.Provider>,
+  );
+
+  return { consumeRequest };
+}
+
+function SelectCloseProbe() {
+  const notifyMenuClose = useSelectEditCellOpenRequest(1, 'culture', () => {});
+
+  return (
+    <button type="button" onClick={(event) => notifyMenuClose(event)}>
+      close
+    </button>
+  );
+}
+
+const setElementRect = (
+  element: HTMLElement,
+  rect: Pick<DOMRect, 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'>,
+): void => {
+  element.getBoundingClientRect = vi.fn(() => ({
+    x: rect.left,
+    y: rect.top,
+    left: rect.left,
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    width: rect.width,
+    height: rect.height,
+    toJSON: () => ({}),
+  } as DOMRect));
+};
+
+describe('select edit cell open requests', () => {
+  it('opens the shared single-select edit cell when requested', async () => {
+    const params = createEditCellParams();
+    const { consumeRequest } = renderWithSelectOpenRequest(
+      buildSelectEditCellKey(params.id, params.field),
+      <StandardSingleSelectEditCell
+        {...params}
+        options={[
+          { value: 1, label: 'Kohl' },
+          { value: 2, label: 'Bohne' },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('combobox', { hidden: true })).toHaveAttribute('aria-expanded', 'true'));
+    expect(await screen.findByRole('option', { name: 'Bohne', hidden: true })).toBeVisible();
+    expect(consumeRequest).toHaveBeenCalledWith(1);
+  });
+
+  it('opens the cultivation-type edit cell when requested', async () => {
+    const params = createEditCellParams({
+      field: 'cultivation_type',
+      value: 'direct_sowing',
+    });
+    const { consumeRequest } = renderWithSelectOpenRequest(
+      buildSelectEditCellKey(params.id, params.field),
+      <CultivationTypeEditCell
+        {...params}
+        options={[
+          { value: 'direct_sowing', label: 'Direktsaat' },
+          { value: 'transplanting', label: 'Vorkultur' },
+        ]}
+        placeholder="Kulturtyp wählen"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('combobox', { hidden: true })).toHaveAttribute('aria-expanded', 'true'));
+    expect(await screen.findByRole('option', { name: 'Vorkultur', hidden: true })).toBeVisible();
+    expect(consumeRequest).toHaveBeenCalledWith(1);
+  });
+
+  it('notifies the grid when a select edit menu closes', () => {
+    const onMenuClose = vi.fn();
+    renderWithSelectOpenRequest(
+      buildSelectEditCellKey(1, 'culture'),
+      <SelectCloseProbe />,
+      onMenuClose,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+    expect(onMenuClose).toHaveBeenCalledWith(1, 'culture', expect.anything());
+  });
+
+  it('keeps option/listbox closes internal to the select menu', () => {
+    const listbox = document.createElement('ul');
+    listbox.setAttribute('role', 'listbox');
+    const option = document.createElement('li');
+    option.setAttribute('role', 'option');
+    listbox.append(option);
+
+    expect(isSelectEditMenuInternalCloseTarget({ target: option })).toBe(true);
+  });
+
+  it('detects whether a select backdrop click landed outside the edited row', () => {
+    const row = document.createElement('div');
+    setElementRect(row, {
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 50,
+      width: 200,
+      height: 30,
+    });
+    const backdrop = document.createElement('div');
+
+    expect(isSelectEditMenuCloseOutsideElement({
+      target: backdrop,
+      nativeEvent: new MouseEvent('click', { clientX: 100, clientY: 35 }),
+    }, row)).toBe(false);
+    expect(isSelectEditMenuCloseOutsideElement({
+      target: backdrop,
+      nativeEvent: new MouseEvent('click', { clientX: 100, clientY: 80 }),
+    }, row)).toBe(true);
+  });
+
+  it('does not treat keyboard-style closes without coordinates as outside the row', () => {
+    const row = document.createElement('div');
+    setElementRect(row, {
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 50,
+      width: 200,
+      height: 30,
+    });
+
+    expect(isSelectEditMenuCloseOutsideElement({ target: document.body }, row)).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/contextMenu.test.tsx
+++ b/frontend/src/__tests__/contextMenu.test.tsx
@@ -36,10 +36,21 @@ function ContextMenuBoundary({
   return (
     <>
       <div data-testid="custom-target" data-custom-context-menu-target="true" />
-      <div data-testid="native-target" onClick={onNativeTargetActivate} onTouchStart={onNativeTargetActivate} />
+      <div
+        data-testid="native-target"
+        onClick={onNativeTargetActivate}
+        onMouseDown={onNativeTargetActivate}
+        onPointerDown={onNativeTargetActivate}
+        onTouchStart={onNativeTargetActivate}
+      />
       <div role="menu" data-testid="open-menu" />
     </>
   );
+}
+
+function createPointerEvent(type: string, init: MouseEventInit): Event {
+  const PointerEventConstructor = window.PointerEvent ?? MouseEvent;
+  return new PointerEventConstructor(type, init);
 }
 
 describe('context menu helpers', () => {
@@ -156,6 +167,28 @@ describe('context menu helpers', () => {
     expect(onNativeTargetActivate).not.toHaveBeenCalled();
   });
 
+  it('a left click outside the menu closes it without also triggering the clicked target action', () => {
+    const onClose = vi.fn();
+    const onNativeTargetActivate = vi.fn();
+    const { getByTestId } = render(
+      <ContextMenuBoundary open onClose={onClose} onNativeTargetActivate={onNativeTargetActivate} />,
+    );
+    const nativeTarget = getByTestId('native-target');
+
+    const pointerDownEvent = createPointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(nativeTarget, pointerDownEvent);
+    const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(nativeTarget, mouseDownEvent);
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(nativeTarget, clickEvent);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(pointerDownEvent.defaultPrevented).toBe(true);
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onNativeTargetActivate).not.toHaveBeenCalled();
+  });
+
   it('does not intercept a touch tap that lands on the menu itself (menu actions keep working)', () => {
     const onClose = vi.fn();
     const { getByTestId } = render(<ContextMenuBoundary open onClose={onClose} />);
@@ -188,6 +221,51 @@ describe('context menu helpers', () => {
 
     expect(onNativeTargetActivate).toHaveBeenCalledTimes(1);
     expect(secondTouchStart.defaultPrevented).toBe(false);
+  });
+
+  it('a later, separate left click on the same target works normally once the menu is closed', () => {
+    const onClose = vi.fn();
+    const onNativeTargetActivate = vi.fn();
+    const { getByTestId, rerender } = render(
+      <ContextMenuBoundary open onClose={onClose} onNativeTargetActivate={onNativeTargetActivate} />,
+    );
+    const nativeTarget = getByTestId('native-target');
+
+    fireEvent(nativeTarget, createPointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }));
+    fireEvent(nativeTarget, new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+    fireEvent(nativeTarget, new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onNativeTargetActivate).not.toHaveBeenCalled();
+
+    rerender(
+      <ContextMenuBoundary open={false} onClose={onClose} onNativeTargetActivate={onNativeTargetActivate} />,
+    );
+    const secondClick = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(nativeTarget, secondClick);
+
+    expect(onNativeTargetActivate).toHaveBeenCalledTimes(1);
+    expect(secondClick.defaultPrevented).toBe(false);
+  });
+
+  it('secondary pointer events on custom menu targets do not reach normal pointer handlers before contextmenu', () => {
+    const onClose = vi.fn();
+    const onNativeTargetActivate = vi.fn();
+    const { getByTestId } = render(
+      <ContextMenuBoundary open={false} onClose={onClose} onNativeTargetActivate={onNativeTargetActivate} />,
+    );
+    const customTarget = getByTestId('custom-target');
+    customTarget.addEventListener('mousedown', onNativeTargetActivate);
+    customTarget.addEventListener('pointerdown', onNativeTargetActivate);
+
+    const pointerDownEvent = createPointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2 });
+    fireEvent(customTarget, pointerDownEvent);
+    const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 2 });
+    fireEvent(customTarget, mouseDownEvent);
+
+    expect(pointerDownEvent.defaultPrevented).toBe(false);
+    expect(mouseDownEvent.defaultPrevented).toBe(false);
+    expect(onNativeTargetActivate).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/__tests__/contextMenu.test.tsx
+++ b/frontend/src/__tests__/contextMenu.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   LONG_PRESS_THRESHOLD_MS,
   closestContextMenuElement,
+  isContextMenuDismissGestureInProgress,
   shouldOpenCustomContextMenu,
   useCloseCustomContextMenuOnNativeContextMenu,
   useIsCoarsePointer,
@@ -187,6 +188,26 @@ describe('context menu helpers', () => {
     expect(mouseDownEvent.defaultPrevented).toBe(true);
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(onNativeTargetActivate).not.toHaveBeenCalled();
+  });
+
+  it('marks the outside-click dismiss gesture while the original mouse sequence is still being swallowed', () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      const { getByTestId } = render(<ContextMenuBoundary open onClose={onClose} />);
+      const nativeTarget = getByTestId('native-target');
+
+      fireEvent(nativeTarget, createPointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }));
+
+      expect(isContextMenuDismissGestureInProgress()).toBe(true);
+
+      fireEvent(nativeTarget, new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+      fireEvent(nativeTarget, new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }));
+
+      expect(isContextMenuDismissGestureInProgress()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not intercept a touch tap that lands on the menu itself (menu actions keep working)', () => {

--- a/frontend/src/__tests__/contextMenu.test.tsx
+++ b/frontend/src/__tests__/contextMenu.test.tsx
@@ -190,6 +190,31 @@ describe('context menu helpers', () => {
     expect(onNativeTargetActivate).not.toHaveBeenCalled();
   });
 
+  it('closes on outside pointerdown even when that prevents a follow-up mousedown', () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      const onNativeTargetActivate = vi.fn();
+      const { getByTestId } = render(
+        <ContextMenuBoundary open onClose={onClose} onNativeTargetActivate={onNativeTargetActivate} />,
+      );
+      const nativeTarget = getByTestId('native-target');
+
+      const pointerDownEvent = createPointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 });
+      fireEvent(nativeTarget, pointerDownEvent);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(pointerDownEvent.defaultPrevented).toBe(true);
+      expect(onNativeTargetActivate).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('marks the outside-click dismiss gesture while the original mouse sequence is still being swallowed', () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/__tests__/tooltipContextMenuSuppression.test.tsx
+++ b/frontend/src/__tests__/tooltipContextMenuSuppression.test.tsx
@@ -288,4 +288,44 @@ describe('context menus reporting their open state', () => {
     closeMenu();
     expect(isAnyContextMenuOpen()).toBe(false);
   });
+
+  it('keeps only one positioned app context menu open at a time', () => {
+    function TwoMenus() {
+      const firstMenu = useContextMenuPositionState<string>({ isContextMenuTarget: never });
+      const secondMenu = useContextMenuPositionState<string>({ isContextMenuTarget: never });
+
+      return (
+        <>
+          <span data-testid="first-menu-open">{String(firstMenu.state !== null)}</span>
+          <span data-testid="second-menu-open">{String(secondMenu.state !== null)}</span>
+          <button type="button" data-testid="open-first-menu" onClick={() => firstMenu.open('first', 4, 8)}>
+            Erstes Menü
+          </button>
+          <button type="button" data-testid="open-second-menu" onClick={() => secondMenu.open('second', 20, 24)}>
+            Zweites Menü
+          </button>
+          <CustomContextMenu open={firstMenu.state !== null} onClose={firstMenu.close} mouseX={4} mouseY={8}>
+            <span>Erste Aktion</span>
+          </CustomContextMenu>
+          <CustomContextMenu open={secondMenu.state !== null} onClose={secondMenu.close} mouseX={20} mouseY={24}>
+            <span>Zweite Aktion</span>
+          </CustomContextMenu>
+        </>
+      );
+    }
+
+    render(<TwoMenus />);
+
+    fireEvent.click(screen.getByTestId('open-first-menu'));
+    expect(screen.getByTestId('first-menu-open')).toHaveTextContent('true');
+    expect(screen.getByTestId('second-menu-open')).toHaveTextContent('false');
+    expect(screen.getByText('Erste Aktion')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('open-second-menu'));
+
+    expect(screen.getByTestId('first-menu-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('second-menu-open')).toHaveTextContent('true');
+    expect(screen.getByText('Zweite Aktion')).toBeInTheDocument();
+    expect(isAnyContextMenuOpen()).toBe(true);
+  });
 });

--- a/frontend/src/components/contextMenu/contextMenuOpenState.ts
+++ b/frontend/src/components/contextMenu/contextMenuOpenState.ts
@@ -30,6 +30,7 @@ export interface ContextMenuOpenSnapshot {
 type ContextMenuOpenListener = () => void;
 
 const openContextMenus = new Set<symbol>();
+const contextMenuCloseHandlers = new Map<symbol, () => void>();
 const listeners = new Set<ContextMenuOpenListener>();
 
 const CLOSED_SNAPSHOT: ContextMenuOpenSnapshot = { open: false, openSequence: 0 };
@@ -83,6 +84,23 @@ export function subscribeToContextMenuOpenState(listener: ContextMenuOpenListene
   };
 }
 
+export function registerContextMenuCloseHandler(menuId: symbol, onClose: () => void): () => void {
+  contextMenuCloseHandlers.set(menuId, onClose);
+  return () => {
+    if (contextMenuCloseHandlers.get(menuId) === onClose) {
+      contextMenuCloseHandlers.delete(menuId);
+    }
+  };
+}
+
+export function closeOtherContextMenus(menuId: symbol): void {
+  contextMenuCloseHandlers.forEach((onClose, registeredMenuId) => {
+    if (registeredMenuId !== menuId) {
+      onClose();
+    }
+  });
+}
+
 /** Reactive read of the whole snapshot. */
 export function useContextMenuOpenSnapshot(): ContextMenuOpenSnapshot {
   return useSyncExternalStore(
@@ -104,15 +122,15 @@ export function useIsAnyContextMenuOpen(): boolean {
  * that renders the menu — a tooltip that is open at that moment is hidden
  * before the browser paints the menu, never one frame on top of it.
  */
-export function useContextMenuOpenRegistration(open: boolean): void {
-  const [menuId] = useState(() => Symbol('contextMenu'));
-
+export function useContextMenuOpenRegistration(open: boolean, menuId?: symbol): void {
+  const [fallbackMenuId] = useState(() => Symbol('contextMenu'));
+  const resolvedMenuId = menuId ?? fallbackMenuId;
   useLayoutEffect(() => {
     if (!open) {
       return undefined;
     }
-    return registerOpenContextMenu(menuId);
-  }, [menuId, open]);
+    return registerOpenContextMenu(resolvedMenuId);
+  }, [resolvedMenuId, open]);
 }
 
 /**

--- a/frontend/src/components/contextMenu/useContextMenuPositionState.ts
+++ b/frontend/src/components/contextMenu/useContextMenuPositionState.ts
@@ -1,6 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useCloseCustomContextMenuOnNativeContextMenu } from '../../utils/contextMenu';
-import { useContextMenuOpenRegistration } from './contextMenuOpenState';
+import {
+  closeOtherContextMenus,
+  registerContextMenuCloseHandler,
+  useContextMenuOpenRegistration,
+} from './contextMenuOpenState';
 
 export interface ContextMenuPositionState<TKey> {
   key: TKey;
@@ -20,6 +24,7 @@ export function useContextMenuPositionState<TKey>({
   isContextMenuTarget,
   onClose,
 }: UseContextMenuPositionStateParams) {
+  const [menuId] = useState(() => Symbol('contextMenu'));
   const [state, setState] = useState<ContextMenuPositionState<TKey> | null>(null);
 
   const open = useCallback((
@@ -27,8 +32,9 @@ export function useContextMenuPositionState<TKey>({
     mouseX: number,
     mouseY: number,
   ): void => {
+    closeOtherContextMenus(menuId);
     setState({ key, mouseX, mouseY });
-  }, []);
+  }, [menuId]);
 
   const close = useCallback((): void => {
     setState(null);
@@ -54,7 +60,9 @@ export function useContextMenuPositionState<TKey>({
 
   // Single place every app context menu reports "I am open" from, so tooltips
   // can hide themselves instead of covering the menu.
-  useContextMenuOpenRegistration(state !== null);
+  useContextMenuOpenRegistration(state !== null, menuId);
+
+  useEffect(() => registerContextMenuCloseHandler(menuId, close), [close, menuId]);
 
   return { state, open, close, clearIf };
 }

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -47,6 +47,7 @@ import { CustomContextMenu } from '../contextMenu/CustomContextMenu';
 import { ContextMenuActionItem } from '../contextMenu/ContextMenuActionItem';
 import { ContextMenuIndicator } from '../contextMenu/ContextMenuIndicator';
 import { contextMenuActionsOverlaySx } from '../contextMenu/contextMenuIndicatorStyles';
+import { isAnyContextMenuOpen } from '../contextMenu/contextMenuOpenState';
 import { useNavigationBlocker } from '../../hooks/autosave';
 import { usePersistentSortModel } from '../../hooks/usePersistentSortModel';
 import { useTranslation } from '../../i18n';
@@ -1306,7 +1307,7 @@ export function EditableDataGrid<T extends EditableRow>({
 
   const handleEditableRowEditStop: GridEventListener<'rowEditStop'> = useCallback((params, event, details): void => {
     if (params.reason === GridRowEditStopReasons.rowFocusOut) {
-      if (isContextMenuDismissGestureInProgress()) {
+      if (isAnyContextMenuOpen() || isContextMenuDismissGestureInProgress()) {
         event.defaultMuiPrevented = true;
         return;
       }
@@ -2744,6 +2745,15 @@ export function EditableDataGrid<T extends EditableRow>({
             return '';
           }}
           onCellClick={(params, event) => {
+            if (isAnyContextMenuOpen() || isContextMenuDismissGestureInProgress()) {
+              event?.preventDefault?.();
+              event?.stopPropagation?.();
+              if (event) {
+                event.defaultMuiPrevented = true;
+              }
+              return;
+            }
+
             if (!isCellKeyboardNavigable<T>({
               api: gridApiRef.current,
               field: params.field,

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -73,6 +73,7 @@ import { useDataGridRowCommands } from './hooks/useDataGridRowCommands';
 import { useScrollDrivenRowWindow } from './hooks/useScrollDrivenRowWindow';
 import { useStableDataGridScrollbar } from './hooks/useStableDataGridScrollbar';
 import { StableScrollbarTrack } from './StableScrollbarTrack';
+import { isContextMenuDismissGestureInProgress } from '../../utils/contextMenu';
 import {
   EditCellNavigationContext,
   type EditCellKeyboardEvent,
@@ -1305,6 +1306,11 @@ export function EditableDataGrid<T extends EditableRow>({
 
   const handleEditableRowEditStop: GridEventListener<'rowEditStop'> = useCallback((params, event, details): void => {
     if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+      if (isContextMenuDismissGestureInProgress()) {
+        event.defaultMuiPrevented = true;
+        return;
+      }
+
       const rowKey = String(params.id);
       if (internalEditNavigationRowIdRef.current === rowKey) {
         internalEditNavigationRowIdRef.current = null;

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -161,6 +161,7 @@ export type {
 import { AppTooltip } from '../AppTooltip';
 import {
   isSelectEditMenuCloseOutsideElement,
+  isSelectEditMenuEscapeClose,
   isSelectEditMenuInternalCloseTarget,
 } from './selectEditMenuClose';
 
@@ -178,6 +179,17 @@ const wrapNativeKeyboardEvent = (event: globalThis.KeyboardEvent): DataGridKeybo
   shiftKey: event.shiftKey,
   stopPropagation: () => event.stopPropagation(),
 } as DataGridKeyboardEvent);
+
+const rowsHaveSameValues = <T extends EditableRow>(first: T, second: T): boolean => {
+  const keys = new Set([...Object.keys(first), ...Object.keys(second)]);
+  for (const key of keys) {
+    if (!Object.is(first[key], second[key])) {
+      return false;
+    }
+  }
+
+  return true;
+};
 
 export function EditableDataGrid<T extends EditableRow>({
   columns,
@@ -1249,6 +1261,41 @@ export function EditableDataGrid<T extends EditableRow>({
     return true;
   }, [getDraftRow, markRowDirty]);
 
+  const stopExistingEditedRow = useCallback((rowId: GridRowId): boolean => {
+    const rowKey = String(rowId);
+    const currentRow = getDraftRow(rowId) ?? (rowsById.get(rowKey) as T | undefined);
+    if (!currentRow || isUnsavedDraftRow(currentRow)) {
+      return false;
+    }
+
+    const snapshot = rowSnapshotRef.current.get(rowKey);
+    const hasActualChanges = snapshot ? !rowsHaveSameValues(snapshot, currentRow) : true;
+
+    setRows((previousRows) =>
+      previousRows.map((row) => (String(row.id) === rowKey ? currentRow : row)),
+    );
+
+    setDirtyRowIds((previous) => {
+      const next = new Set(previous);
+      if (hasActualChanges) {
+        next.add(rowKey);
+      } else {
+        next.delete(rowKey);
+      }
+      return next;
+    });
+    setActiveValidationErrors((previous) => {
+      const next = { ...previous };
+      delete next[rowKey];
+      return next;
+    });
+    setRowModesModel((oldModel) => ({
+      ...oldModel,
+      [rowId]: { mode: GridRowModes.View, ignoreModifications: true },
+    }));
+    return true;
+  }, [getDraftRow, rowsById]);
+
   const navigateFromEditedCell = useCallback((
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
@@ -1259,8 +1306,9 @@ export function EditableDataGrid<T extends EditableRow>({
     }
 
     const isSameRow = String(current.id) === String(target.id);
+    const targetHasDedicatedEditor = hasDedicatedEditor(target.field);
     const canCommitCurrentDraft = commitEditedRowDraftForKeyboardNavigation(current.id, {
-      syncRows: !isSameRow,
+      syncRows: !isSameRow || targetHasDedicatedEditor,
     });
     if (!canCommitCurrentDraft) {
       return;
@@ -1268,6 +1316,9 @@ export function EditableDataGrid<T extends EditableRow>({
 
     if (isSameRow) {
       internalEditNavigationRowIdRef.current = String(current.id);
+      if (targetHasDedicatedEditor) {
+        stopExistingEditedRow(current.id);
+      }
       focusKeyboardNavigableCell(target.id, target.field, {
         startEdit: options.startTargetEdit,
         requestDialogEdit: options.requestDialogEdit,
@@ -1294,7 +1345,9 @@ export function EditableDataGrid<T extends EditableRow>({
   }, [
     commitEditedRowDraftForKeyboardNavigation,
     focusKeyboardNavigableCell,
+    hasDedicatedEditor,
     rowModesModel,
+    stopExistingEditedRow,
   ]);
 
   const recoverSameRowNavigationFromTabEvent = useCallback((
@@ -1627,6 +1680,11 @@ export function EditableDataGrid<T extends EditableRow>({
       return;
     }
 
+    if (isSelectEditMenuEscapeClose(event)) {
+      handleDiscardRowChanges(rowId);
+      return;
+    }
+
     const rowElement = gridApiRef.current?.rootElementRef?.current?.querySelector<HTMLElement>(
       `[role="row"][data-id="${cssEscape(String(rowId))}"]`,
     );
@@ -1635,7 +1693,7 @@ export function EditableDataGrid<T extends EditableRow>({
     }
 
     void handleSaveRow(rowId);
-  }, [gridApiRef, handleSaveRow, rowModesModel]);
+  }, [gridApiRef, handleDiscardRowChanges, handleSaveRow, rowModesModel]);
 
   const selectEditCellContextValue = useMemo<SelectEditCellContextValue>(() => ({
     request: selectEditOpenRequest,

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -87,6 +87,12 @@ import {
   type DialogEditCellRequest,
 } from './DialogEditCellContext';
 import {
+  buildSelectEditCellKey,
+  SelectEditCellContext,
+  type SelectEditCellContextValue,
+  type SelectEditCellOpenRequest,
+} from './SelectEditCellContext';
+import {
   CONTINUOUS_SCROLL_PAGE_SIZE,
   CONTINUOUS_SCROLL_REQUESTED_ROW_HEIGHT_PX,
   CONTINUOUS_SCROLL_COMPACT_ROW_HEIGHT_PX,
@@ -153,6 +159,10 @@ export type {
   NotesFieldConfig,
 } from './types';
 import { AppTooltip } from '../AppTooltip';
+import {
+  isSelectEditMenuCloseOutsideElement,
+  isSelectEditMenuInternalCloseTarget,
+} from './selectEditMenuClose';
 
 type DataGridKeyboardEvent = (KeyboardEvent | EditCellKeyboardEvent) & {
   defaultMuiPrevented?: boolean;
@@ -704,6 +714,18 @@ export function EditableDataGrid<T extends EditableRow>({
     request: dialogEditRequest,
     consumeRequest: consumeDialogEditRequest,
   }), [consumeDialogEditRequest, dialogEditRequest]);
+  const [selectEditOpenRequest, setSelectEditOpenRequest] = useState<SelectEditCellOpenRequest | null>(null);
+  const selectEditOpenTokenRef = useRef(0);
+  const requestSelectEditOpenForCell = useCallback((rowId: GridRowId, field: string): void => {
+    selectEditOpenTokenRef.current += 1;
+    setSelectEditOpenRequest({
+      cellKey: buildSelectEditCellKey(rowId, field),
+      token: selectEditOpenTokenRef.current,
+    });
+  }, []);
+  const consumeSelectEditOpenRequest = useCallback((token: number): void => {
+    setSelectEditOpenRequest((current) => (current?.token === token ? null : current));
+  }, []);
 
   // Check if there's a validation error (indicating incomplete/invalid data)
   const hasValidationError = Boolean(error);
@@ -1599,6 +1621,28 @@ export function EditableDataGrid<T extends EditableRow>({
     processRowUpdate,
   ]);
 
+  const handleSelectEditMenuClose = useCallback((rowId: GridRowId, _field: string, event: unknown): void => {
+    const rowMode = rowModesModel[rowId] ?? rowModesModel[String(rowId)];
+    if (rowMode?.mode !== GridRowModes.Edit || isSelectEditMenuInternalCloseTarget(event)) {
+      return;
+    }
+
+    const rowElement = gridApiRef.current?.rootElementRef?.current?.querySelector<HTMLElement>(
+      `[role="row"][data-id="${cssEscape(String(rowId))}"]`,
+    );
+    if (!rowElement || !isSelectEditMenuCloseOutsideElement(event, rowElement)) {
+      return;
+    }
+
+    void handleSaveRow(rowId);
+  }, [gridApiRef, handleSaveRow, rowModesModel]);
+
+  const selectEditCellContextValue = useMemo<SelectEditCellContextValue>(() => ({
+    request: selectEditOpenRequest,
+    consumeRequest: consumeSelectEditOpenRequest,
+    onMenuClose: handleSelectEditMenuClose,
+  }), [consumeSelectEditOpenRequest, handleSelectEditMenuClose, selectEditOpenRequest]);
+
   const saveEditedRowAndFocusTarget = useCallback(async (
     current: { id: GridRowId; field: string },
     target: { id: GridRowId; field: string },
@@ -2395,6 +2439,16 @@ export function EditableDataGrid<T extends EditableRow>({
     t,
   ]);
 
+  const isInlineSingleSelectCell = useCallback((params: GridCellParams<T>): boolean => {
+    if (!params.isEditable || hasDedicatedEditor(params.field)) {
+      return false;
+    }
+
+    return columnsWithActions.some((column) => (
+      column.field === params.field && column.type === 'singleSelect'
+    ));
+  }, [columnsWithActions, hasDedicatedEditor]);
+
   const handleViewModeCellNavigation = useCallback((params: GridCellParams<T>, event: DataGridKeyboardEvent): boolean => {
     if (
       rowModesModel[params.id]?.mode === GridRowModes.Edit ||
@@ -2632,6 +2686,7 @@ export function EditableDataGrid<T extends EditableRow>({
             }}
           >
             <EditCellNavigationContext.Provider value={handleEditCellTabNavigation}>
+              <SelectEditCellContext.Provider value={selectEditCellContextValue}>
               <DialogEditCellContext.Provider value={dialogEditCellContextValue}>
               <DataGrid
           rows={rowsForGrid}
@@ -2780,6 +2835,9 @@ export function EditableDataGrid<T extends EditableRow>({
               // already opened it — never layer inline edit mode on top.
               return;
             }
+            if (isInlineSingleSelectCell(params)) {
+              requestSelectEditOpenForCell(params.id, params.field);
+            }
             handleEditableCellClick(params, rowModesModel, setRowModesModel);
           }}
           onCellKeyDown={(params: GridCellParams<T>, event) => {
@@ -2901,6 +2959,7 @@ export function EditableDataGrid<T extends EditableRow>({
           apiRef={gridApiRef}
               />
               </DialogEditCellContext.Provider>
+              </SelectEditCellContext.Provider>
             </EditCellNavigationContext.Provider>
           </Box>
           </Box>

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -2597,7 +2597,7 @@ export function EditableDataGrid<T extends EditableRow>({
           >
             <Box
             ref={gridSurfaceRef}
-            onContextMenu={hasContextualRowActions ? (event) => {
+            onContextMenuCapture={hasContextualRowActions ? (event) => {
               if (!isRowActionContextMenuTarget(event.target)) {
                 return;
               }

--- a/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/SearchableSelectEditCell.tsx
@@ -9,11 +9,12 @@
  * @returns Autocomplete-based edit cell.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useGridApiContext } from '@mui/x-data-grid';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { SearchableSelect } from '../inputs/SearchableSelect';
 import type { SearchableSelectOption } from '../inputs/SearchableSelect';
+import { useSelectEditCellOpenRequest } from './SelectEditCellContext';
 
 export interface SearchableSelectEditCellProps extends GridRenderEditCellParams {
   options: SearchableSelectOption[];
@@ -32,22 +33,22 @@ export function SearchableSelectEditCell({
 }: SearchableSelectEditCellProps) {
   const apiRef = useGridApiContext();
   const [inputValue, setInputValue] = useState('');
+  const [open, setOpen] = useState(false);
+  const handleOpen = useCallback((): void => {
+    setOpen(true);
+  }, []);
+  const notifyMenuClose = useSelectEditCellOpenRequest(id, field, handleOpen);
+  const handleClose = useCallback((event: unknown): void => {
+    setOpen(false);
+    notifyMenuClose(event);
+  }, [notifyMenuClose]);
 
   const selectedOption = useMemo(
     () => options.find((option) => option.value === value) ?? null,
     [options, value]
   );
 
-  const [currentOption, setCurrentOption] = useState<SearchableSelectOption | null>(
-    selectedOption
-  );
-
-  useEffect(() => {
-    setCurrentOption(selectedOption);
-  }, [selectedOption]);
-
-  const handleChange = async (_: unknown, newValue: SearchableSelectOption | null) => {
-    setCurrentOption(newValue);
+  const handleChange = useCallback(async (newValue: SearchableSelectOption | null): Promise<void> => {
     const nextValue = newValue?.value ?? null;
 
     if (nextValue !== value) {
@@ -58,22 +59,25 @@ export function SearchableSelectEditCell({
       });
       await onValueChange?.(nextValue);
     }
-  };
+  }, [apiRef, field, id, onValueChange, value]);
 
   return (
     <SearchableSelect
       options={options}
-      value={currentOption}
+      value={selectedOption}
       inputValue={inputValue}
       onInputChange={setInputValue}
       onChange={(newValue) => {
-        void handleChange(undefined, newValue);
+        void handleChange(newValue);
       }}
       placeholder={placeholder}
       size="small"
       autoFocus={hasFocus}
       inputTabIndex={hasFocus ? 0 : -1}
       textFieldSx={{ '& .MuiInputBase-root': { height: '100%' } }}
+      open={open}
+      onOpen={handleOpen}
+      onClose={handleClose}
     />
   );
 }

--- a/frontend/src/components/data-grid/SelectEditCellContext.tsx
+++ b/frontend/src/components/data-grid/SelectEditCellContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+import type { GridRowId } from '@mui/x-data-grid';
+
+export interface SelectEditCellOpenRequest {
+  cellKey: string;
+  token: number;
+}
+
+export interface SelectEditCellContextValue {
+  request: SelectEditCellOpenRequest | null;
+  consumeRequest: (token: number) => void;
+  onMenuClose?: (rowId: GridRowId, field: string, event: unknown) => void;
+}
+
+export const buildSelectEditCellKey = (rowId: GridRowId, field: string): string =>
+  `${String(rowId)}:${field}`;
+
+export const SelectEditCellContext = createContext<SelectEditCellContextValue | null>(null);
+
+export function useSelectEditCellOpenRequest(
+  rowId: GridRowId | undefined,
+  field: string | undefined,
+  onOpenRequested: () => void,
+): (event: unknown) => void {
+  const context = useContext(SelectEditCellContext);
+  const onOpenRequestedRef = useRef(onOpenRequested);
+  const handledTokenRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onOpenRequestedRef.current = onOpenRequested;
+  }, [onOpenRequested]);
+
+  const request = context?.request ?? null;
+  const consumeRequest = context?.consumeRequest;
+  const cellKey = rowId === undefined || field === undefined
+    ? null
+    : buildSelectEditCellKey(rowId, field);
+  const pendingToken = request && cellKey !== null && request.cellKey === cellKey
+    ? request.token
+    : null;
+
+  useEffect(() => {
+    if (pendingToken === null || handledTokenRef.current === pendingToken) {
+      return;
+    }
+
+    handledTokenRef.current = pendingToken;
+    consumeRequest?.(pendingToken);
+    onOpenRequestedRef.current();
+  }, [consumeRequest, pendingToken]);
+
+  return useCallback((event: unknown): void => {
+    if (rowId === undefined || field === undefined) {
+      return;
+    }
+
+    context?.onMenuClose?.(rowId, field, event);
+  }, [context, field, rowId]);
+}

--- a/frontend/src/components/data-grid/StandardSingleSelectEditCell.tsx
+++ b/frontend/src/components/data-grid/StandardSingleSelectEditCell.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import type { GridRenderEditCellParams } from '@mui/x-data-grid';
 import { Box, MenuItem, TextField } from '@mui/material';
 import { useClosedSelectTypeahead } from '../inputs/selectTypeahead';
 import type { SearchableSelectOption } from './SearchableSelectEditCell';
+import { useSelectEditCellOpenRequest } from './SelectEditCellContext';
 
 interface StandardSingleSelectEditCellProps extends GridRenderEditCellParams {
   options: SearchableSelectOption[];
@@ -18,7 +19,16 @@ export const StandardSingleSelectEditCell = memo(function StandardSingleSelectEd
   options,
   placeholder,
 }: StandardSingleSelectEditCellProps) {
+  const [open, setOpen] = useState(false);
   const selectedOption = options.find((option) => option.value === value);
+  const handleOpen = useCallback((): void => {
+    setOpen(true);
+  }, []);
+  const notifyMenuClose = useSelectEditCellOpenRequest(id, field, handleOpen);
+  const handleClose = useCallback((event: unknown): void => {
+    setOpen(false);
+    notifyMenuClose(event);
+  }, [notifyMenuClose]);
   const handleTypeaheadSelect = useCallback((nextValue: number | number[]): void => {
     const selectedValue = Array.isArray(nextValue) ? nextValue[0] : nextValue;
     void api.setEditCellValue({
@@ -46,6 +56,9 @@ export const StandardSingleSelectEditCell = memo(function StandardSingleSelectEd
         },
         select: {
           displayEmpty: Boolean(placeholder),
+          open,
+          onClose: handleClose,
+          onOpen: handleOpen,
           onKeyDown: handleSelectKeyDown,
           renderValue: () => selectedOption?.label ?? (
             <Box component="span" sx={{ color: 'text.disabled' }}>

--- a/frontend/src/components/data-grid/selectEditMenuClose.ts
+++ b/frontend/src/components/data-grid/selectEditMenuClose.ts
@@ -24,6 +24,19 @@ const getUnknownEventNativeEvent = (event: unknown): unknown => {
   return (event as Record<string, unknown>).nativeEvent ?? event;
 };
 
+const getUnknownEventKey = (event: unknown): string | null => {
+  const readKey = (source: unknown): string | null => {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+
+    const key = (source as Record<string, unknown>).key;
+    return typeof key === 'string' ? key : null;
+  };
+
+  return readKey(getUnknownEventNativeEvent(event)) ?? readKey(event);
+};
+
 const getUnknownEventPoint = (event: unknown): { clientX: number; clientY: number } | null => {
   const readPoint = (source: unknown): { clientX: number; clientY: number } | null => {
     if (!source || typeof source !== 'object') {
@@ -45,6 +58,9 @@ export const isSelectEditMenuInternalCloseTarget = (event: unknown): boolean => 
   const target = getUnknownEventTarget(event);
   return target instanceof Element && target.closest(SELECT_MENU_INTERNAL_CLOSE_TARGET_SELECTOR) !== null;
 };
+
+export const isSelectEditMenuEscapeClose = (event: unknown): boolean =>
+  getUnknownEventKey(event) === 'Escape';
 
 export const isSelectEditMenuCloseOutsideElement = (
   event: unknown,

--- a/frontend/src/components/data-grid/selectEditMenuClose.ts
+++ b/frontend/src/components/data-grid/selectEditMenuClose.ts
@@ -1,0 +1,70 @@
+const SELECT_MENU_INTERNAL_CLOSE_TARGET_SELECTOR = [
+  '[role="listbox"]',
+  '[role="option"]',
+  '[role="menuitem"]',
+  '.MuiAutocomplete-popper',
+  '.MuiMenu-paper',
+  '.MuiPopover-paper',
+].join(',');
+
+const getUnknownEventTarget = (event: unknown): EventTarget | null => {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  const target = (event as Record<string, unknown>).target;
+  return target instanceof EventTarget ? target : null;
+};
+
+const getUnknownEventNativeEvent = (event: unknown): unknown => {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  return (event as Record<string, unknown>).nativeEvent ?? event;
+};
+
+const getUnknownEventPoint = (event: unknown): { clientX: number; clientY: number } | null => {
+  const readPoint = (source: unknown): { clientX: number; clientY: number } | null => {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+
+    const record = source as Record<string, unknown>;
+    if (typeof record.clientX === 'number' && typeof record.clientY === 'number') {
+      return { clientX: record.clientX, clientY: record.clientY };
+    }
+
+    return null;
+  };
+
+  return readPoint(getUnknownEventNativeEvent(event)) ?? readPoint(event);
+};
+
+export const isSelectEditMenuInternalCloseTarget = (event: unknown): boolean => {
+  const target = getUnknownEventTarget(event);
+  return target instanceof Element && target.closest(SELECT_MENU_INTERNAL_CLOSE_TARGET_SELECTOR) !== null;
+};
+
+export const isSelectEditMenuCloseOutsideElement = (
+  event: unknown,
+  element: HTMLElement,
+): boolean => {
+  const target = getUnknownEventTarget(event);
+  if (target instanceof Node && element.contains(target)) {
+    return false;
+  }
+
+  const point = getUnknownEventPoint(event);
+  if (!point) {
+    return false;
+  }
+
+  const rect = element.getBoundingClientRect();
+  return (
+    point.clientX < rect.left
+    || point.clientX > rect.right
+    || point.clientY < rect.top
+    || point.clientY > rect.bottom
+  );
+};

--- a/frontend/src/components/inputs/SearchableSelect.tsx
+++ b/frontend/src/components/inputs/SearchableSelect.tsx
@@ -46,6 +46,9 @@ export interface SearchableSelectProps<T = unknown> {
   onInputChange?: (value: string) => void;
   endAdornment?: ReactNode;
   inputRef?: Ref<HTMLInputElement>;
+  open?: boolean;
+  onOpen?: () => void;
+  onClose?: (event: unknown) => void;
 }
 
 // Combines Autocomplete's own internal input ref (needed for its keyboard/focus
@@ -82,6 +85,9 @@ export function SearchableSelect<T = unknown>({
   onInputChange,
   endAdornment,
   inputRef,
+  open,
+  onOpen,
+  onClose,
 }: SearchableSelectProps<T>) {
   const [internalInputValue, setInternalInputValue] = useState('');
   const resolvedInputValue = inputValue ?? internalInputValue;
@@ -100,6 +106,9 @@ export function SearchableSelect<T = unknown>({
       fullWidth={fullWidth}
       autoHighlight
       openOnFocus
+      open={open}
+      onOpen={onOpen}
+      onClose={onClose}
       size={size}
       options={options}
       value={value}

--- a/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaAssignmentDialog.tsx
@@ -16,6 +16,7 @@ import type { GridRowId } from '@mui/x-data-grid';
 import { useTranslation } from '../../i18n';
 import type { Bed, Field, Location } from '../../api/types';
 import { useDialogEditCellOpenRequest } from '../data-grid/DialogEditCellContext';
+import { isAnyContextMenuOpen } from '../contextMenu/contextMenuOpenState';
 import EmptyStateCard from '../project/EmptyStateCard';
 import { CompactAreaCell } from './CompactAreaCell';
 import {
@@ -25,6 +26,7 @@ import {
 import { formatAreaM2, toNumericValue } from '../../pages/plantingPlansUtils';
 import { TypeaheadSelect as Select } from '../inputs/TypeaheadSelect';
 import { fullWidthFieldSx } from '../forms/formLayout';
+import { isContextMenuDismissGestureInProgress } from '../../utils/contextMenu';
 
 interface AreaAssignmentDialogProps {
   bedId: number | null;
@@ -324,7 +326,7 @@ function AreaAssignmentDialogComponent({
    * the cell, and re-running the body would reset an already edited draft.
    */
   const handleOpen = useCallback((): void => {
-    if (isOpenRef.current) {
+    if (isOpenRef.current || isAnyContextMenuOpen() || isContextMenuDismissGestureInProgress()) {
       return;
     }
 

--- a/frontend/src/components/planting-plans/AreaValidationDialog.tsx
+++ b/frontend/src/components/planting-plans/AreaValidationDialog.tsx
@@ -33,7 +33,20 @@ export function AreaValidationDialog({
   const { t } = useTranslation(["plantingPlans", "common"]);
 
   return (
-    <Dialog open onClose={onClose} fullWidth maxWidth="xs">
+    <Dialog
+      open
+      onClose={onClose}
+      onKeyDownCapture={(event) => {
+        if (event.key !== "Escape") {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+      }}
+      fullWidth
+      maxWidth="xs"
+    >
       <DialogTitle>
         {dialog.mode === "bedLimit"
           ? t("plantingPlans:areaValidation.bedLimitTitle")

--- a/frontend/src/pages/CultivationTypeEditCell.tsx
+++ b/frontend/src/pages/CultivationTypeEditCell.tsx
@@ -1,7 +1,8 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 import { Box, MenuItem, TextField } from "@mui/material";
 import type { GridRenderEditCellParams } from "@mui/x-data-grid";
 import { useClosedSelectTypeahead } from "../components/inputs/selectTypeahead";
+import { useSelectEditCellOpenRequest } from "../components/data-grid/SelectEditCellContext";
 import { normalizeCultivationType } from "./plantingPlansUtils";
 import type { CultivationTypeSelectOption } from "./usePlantingPlanHierarchy";
 
@@ -19,8 +20,17 @@ export const CultivationTypeEditCell = memo(function CultivationTypeEditCell({
   options,
   placeholder,
 }: CultivationTypeEditCellProps) {
+  const [open, setOpen] = useState(false);
   const selectedValue = normalizeCultivationType(value) ?? "";
   const selectedOption = options.find((option) => option.value === selectedValue);
+  const handleOpen = useCallback((): void => {
+    setOpen(true);
+  }, []);
+  const notifyMenuClose = useSelectEditCellOpenRequest(id, field, handleOpen);
+  const handleClose = useCallback((event: unknown): void => {
+    setOpen(false);
+    notifyMenuClose(event);
+  }, [notifyMenuClose]);
   const handleTypeaheadSelect = useCallback((nextValue: string | string[]): void => {
     const nextSelectedValue = Array.isArray(nextValue) ? nextValue[0] : nextValue;
     void api.setEditCellValue({
@@ -48,6 +58,9 @@ export const CultivationTypeEditCell = memo(function CultivationTypeEditCell({
         },
         select: {
           displayEmpty: true,
+          open,
+          onClose: handleClose,
+          onOpen: handleOpen,
           onKeyDown: handleSelectKeyDown,
           renderValue: () => selectedOption?.label ?? (
             <Box

--- a/frontend/src/pages/FieldsBedsHierarchy.tsx
+++ b/frontend/src/pages/FieldsBedsHierarchy.tsx
@@ -1547,7 +1547,7 @@ function FieldsBedsHierarchy({
               },
             }}
             onClick={() => setTreeActive(true)}
-            onContextMenu={handleGridContextMenu}
+            onContextMenuCapture={handleGridContextMenu}
             onMouseDownCapture={handleReadOnlyHierarchyCellMouseDown}
             onTouchStart={handleGridTouchStart}
             onTouchMove={handleGridTouchMove}

--- a/frontend/src/utils/contextMenu.ts
+++ b/frontend/src/utils/contextMenu.ts
@@ -280,6 +280,9 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
       }
 
       stopEventImmediately(event, { preventDefault: true });
+      if (isContextMenuDismissGestureInProgress()) {
+        return;
+      }
       armDismissedContextMenuClickSuppression();
       onClose();
     };
@@ -292,8 +295,9 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
         return;
       }
 
-      beginContextMenuDismissGesture();
       stopEventImmediately(event, { preventDefault: true });
+      armDismissedContextMenuClickSuppression();
+      onClose();
     };
 
     document.addEventListener('pointerdown', handleDocumentPointerDown, true);
@@ -313,10 +317,7 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
     // `CustomContextMenu` deliberately renders with `hideBackdrop` and
     // `pointerEvents: 'none'` on its root (see CustomContextMenu.tsx), so a
     // tap outside it reaches the DOM underneath same as if the menu weren't
-    // there — the mousedown listener above is what actually closes it. On
-    // desktop that's fine and intentional: a left click that dismisses the
-    // menu also acting on whatever's under the cursor matches how a native
-    // context menu behaves, and changing that isn't asked for here.
+    // there — the pointer/mouse listeners above are what actually close it.
     //
     // On touch a single tap must ONLY dismiss the menu — not also start
     // editing the cell (or run whatever tap action) the finger landed on.

--- a/frontend/src/utils/contextMenu.ts
+++ b/frontend/src/utils/contextMenu.ts
@@ -5,6 +5,10 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 interface SuppressibleEvent {
   preventDefault: () => void;
   stopPropagation: () => void;
+  stopImmediatePropagation?: () => void;
+  nativeEvent?: {
+    stopImmediatePropagation?: () => void;
+  };
 }
 
 /** Duration a touch must be held before it counts as a long press (ca. 500-700ms). */
@@ -134,6 +138,50 @@ export function shouldOpenCustomContextMenu(target: EventTarget | null): boolean
 export function suppressNativeContextMenu(event: SuppressibleEvent): void {
   event.preventDefault();
   event.stopPropagation();
+  event.stopImmediatePropagation?.();
+  event.nativeEvent?.stopImmediatePropagation?.();
+}
+
+function stopEventImmediately(event: Event, options: { preventDefault?: boolean } = {}): void {
+  if (options.preventDefault && event.cancelable) {
+    event.preventDefault();
+  }
+  event.stopPropagation();
+  event.stopImmediatePropagation();
+}
+
+function isPrimaryButtonEvent(event: MouseEvent | PointerEvent): boolean {
+  return event.button === 0;
+}
+
+function isSecondaryButtonEvent(event: MouseEvent | PointerEvent): boolean {
+  return event.button === 2;
+}
+
+function armDismissedContextMenuClickSuppression(): void {
+  const stopPendingMouseEvent = (event: MouseEvent | PointerEvent): void => {
+    if (isPrimaryButtonEvent(event)) {
+      stopEventImmediately(event, { preventDefault: true });
+    }
+  };
+
+  const stopPendingClick = (event: MouseEvent): void => {
+    stopEventImmediately(event, { preventDefault: true });
+    cleanup();
+  };
+
+  const cleanup = (): void => {
+    document.removeEventListener('pointerup', stopPendingMouseEvent, true);
+    document.removeEventListener('mouseup', stopPendingMouseEvent, true);
+    document.removeEventListener('click', stopPendingClick, true);
+    window.clearTimeout(cleanupTimer);
+  };
+
+  document.addEventListener('pointerup', stopPendingMouseEvent, true);
+  document.addEventListener('mouseup', stopPendingMouseEvent, true);
+  document.addEventListener('click', stopPendingClick, true);
+
+  const cleanupTimer = window.setTimeout(cleanup, 1000);
 }
 
 export function useCloseCustomContextMenuOnNativeContextMenu(
@@ -142,6 +190,28 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
   isCustomContextMenuTarget: (target: EventTarget | null) => boolean,
   onOpenMenuContextMenu?: (event: MouseEvent) => void,
 ): void {
+  useEffect(() => {
+    const handleSecondaryPointerEvent = (event: MouseEvent | PointerEvent): void => {
+      if (!isSecondaryButtonEvent(event) || !isCustomContextMenuTarget(event.target)) {
+        return;
+      }
+
+      stopEventImmediately(event);
+    };
+
+    document.addEventListener('pointerdown', handleSecondaryPointerEvent, true);
+    document.addEventListener('mousedown', handleSecondaryPointerEvent, true);
+    document.addEventListener('pointerup', handleSecondaryPointerEvent, true);
+    document.addEventListener('mouseup', handleSecondaryPointerEvent, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handleSecondaryPointerEvent, true);
+      document.removeEventListener('mousedown', handleSecondaryPointerEvent, true);
+      document.removeEventListener('pointerup', handleSecondaryPointerEvent, true);
+      document.removeEventListener('mouseup', handleSecondaryPointerEvent, true);
+    };
+  }, [isCustomContextMenuTarget]);
+
   useEffect(() => {
     if (!open) {
       return undefined;
@@ -175,19 +245,34 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
     }
 
     const handleDocumentMouseDown = (event: MouseEvent): void => {
-      if (event.button !== 0) {
+      if (!isPrimaryButtonEvent(event)) {
         return;
       }
       if (closestContextMenuElement(event.target, customContextMenuSelector) !== null) {
         return;
       }
 
+      stopEventImmediately(event, { preventDefault: true });
+      armDismissedContextMenuClickSuppression();
       onClose();
     };
 
+    const handleDocumentPointerDown = (event: PointerEvent): void => {
+      if (!isPrimaryButtonEvent(event)) {
+        return;
+      }
+      if (closestContextMenuElement(event.target, customContextMenuSelector) !== null) {
+        return;
+      }
+
+      stopEventImmediately(event, { preventDefault: true });
+    };
+
+    document.addEventListener('pointerdown', handleDocumentPointerDown, true);
     document.addEventListener('mousedown', handleDocumentMouseDown, true);
 
     return () => {
+      document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
       document.removeEventListener('mousedown', handleDocumentMouseDown, true);
     };
   }, [onClose, open]);
@@ -218,8 +303,7 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
         return;
       }
 
-      event.preventDefault();
-      event.stopPropagation();
+      stopEventImmediately(event, { preventDefault: true });
       onClose();
     };
 

--- a/frontend/src/utils/contextMenu.ts
+++ b/frontend/src/utils/contextMenu.ts
@@ -158,7 +158,34 @@ function isSecondaryButtonEvent(event: MouseEvent | PointerEvent): boolean {
   return event.button === 2;
 }
 
+let contextMenuDismissGestureActive = false;
+let clearContextMenuDismissGestureTimer: number | null = null;
+
+export function isContextMenuDismissGestureInProgress(): boolean {
+  return contextMenuDismissGestureActive;
+}
+
+function clearContextMenuDismissGesture(): void {
+  contextMenuDismissGestureActive = false;
+  if (clearContextMenuDismissGestureTimer !== null) {
+    window.clearTimeout(clearContextMenuDismissGestureTimer);
+    clearContextMenuDismissGestureTimer = null;
+  }
+}
+
+function beginContextMenuDismissGesture(): void {
+  contextMenuDismissGestureActive = true;
+  if (clearContextMenuDismissGestureTimer !== null) {
+    window.clearTimeout(clearContextMenuDismissGestureTimer);
+  }
+  clearContextMenuDismissGestureTimer = window.setTimeout(() => {
+    clearContextMenuDismissGesture();
+  }, 1000);
+}
+
 function armDismissedContextMenuClickSuppression(): void {
+  beginContextMenuDismissGesture();
+
   const stopPendingMouseEvent = (event: MouseEvent | PointerEvent): void => {
     if (isPrimaryButtonEvent(event)) {
       stopEventImmediately(event, { preventDefault: true });
@@ -174,14 +201,14 @@ function armDismissedContextMenuClickSuppression(): void {
     document.removeEventListener('pointerup', stopPendingMouseEvent, true);
     document.removeEventListener('mouseup', stopPendingMouseEvent, true);
     document.removeEventListener('click', stopPendingClick, true);
-    window.clearTimeout(cleanupTimer);
+    clearContextMenuDismissGesture();
   };
 
   document.addEventListener('pointerup', stopPendingMouseEvent, true);
   document.addEventListener('mouseup', stopPendingMouseEvent, true);
   document.addEventListener('click', stopPendingClick, true);
 
-  const cleanupTimer = window.setTimeout(cleanup, 1000);
+  window.setTimeout(cleanup, 1000);
 }
 
 export function useCloseCustomContextMenuOnNativeContextMenu(
@@ -265,6 +292,7 @@ export function useCloseCustomContextMenuOnNativeContextMenu(
         return;
       }
 
+      beginContextMenuDismissGesture();
       stopEventImmediately(event, { preventDefault: true });
     };
 


### PR DESCRIPTION
## Summary
- centralize app context-menu exclusivity so opening one menu closes any previously open menu
- suppress secondary-button pointer/mouse events on custom context-menu targets before normal row/cell/link handlers can react
- make the first primary click/tap outside an open context menu dismiss-only, while preserving menu-item clicks and the next normal click
- move DataGrid and hierarchy grid context-menu capture to the capture phase and document the shared behavior

## Validation
- `npm run test -- contextMenu.test.tsx EditableDataGrid.test.tsx`
- `npm run test -- tooltipContextMenuSuppression.test.tsx SeedDemand.test.tsx FieldsBedsHierarchy.editCancel.test.tsx GanttChart.test.tsx YieldOverview.test.tsx`
- `npm run test` (188 files, 1855 tests)
- `npm run build`
- `npx eslint src/__tests__/EditableDataGrid.test.tsx src/__tests__/contextMenu.test.tsx src/__tests__/tooltipContextMenuSuppression.test.tsx src/components/contextMenu/contextMenuOpenState.ts src/components/contextMenu/useContextMenuPositionState.ts src/components/data-grid/DataGrid.tsx src/utils/contextMenu.ts`

## Notes
- `npm run lint` still fails on existing React Compiler lint errors in unrelated lines/files, including pre-existing errors in `FieldsBedsHierarchy.tsx` lines 724, 892, and 1450.
