### PR TITLE
fix: remove loopback asset hints from prerendered HTML

### DIFF
--- a/docs/seo-and-indexing.md
+++ b/docs/seo-and-indexing.md
@@ -176,6 +176,7 @@ npm run build   # postbuild runs prerender.ts automatically
 grep -E '<title>|rel="canonical"|name="description"' dist/impressum/index.html
 grep -E '<title>|rel="canonical"|name="description"' dist/datenschutz/index.html
 grep -E '<title>|rel="canonical"|name="description"' dist/nutzungsbedingungen/index.html
+! grep -R -E 'https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)' dist --include='*.html'
 ```
 
 Or over HTTP against `vite preview` — note the trailing slash (see the caveat

--- a/frontend/build/prerender.ts
+++ b/frontend/build/prerender.ts
@@ -58,6 +58,7 @@ interface PrerenderSeoModule {
   PUBLIC_INDEXABLE_ROUTES: readonly PublicRoute[];
   SITE_LANGUAGE: string;
   applyHeadTags: (html: string, route: PublicRoute, env: NodeJS.ProcessEnv) => string;
+  assertNoLoopbackUrls: (html: string, routePath: string) => void;
 }
 
 interface PrerenderedPage {
@@ -141,7 +142,7 @@ async function main(): Promise<void> {
   await copyFile(indexHtmlPath, appShellPath);
   console.log(`prerender: index.html -> ${path.relative(distDir, appShellPath)} (SPA fallback shell)`);
 
-  const { PUBLIC_INDEXABLE_ROUTES, SITE_LANGUAGE, applyHeadTags } = await loadSeoHelpers();
+  const { PUBLIC_INDEXABLE_ROUTES, SITE_LANGUAGE, applyHeadTags, assertNoLoopbackUrls } = await loadSeoHelpers();
 
   const server = await preview({
     root: rootDir,
@@ -179,6 +180,7 @@ async function main(): Promise<void> {
         await serializeCssInJsRules(page);
         const html = await page.content();
         const finalHtml = applyHeadTags(html, route, process.env);
+        assertNoLoopbackUrls(finalHtml, route.path);
 
         prerenderedPages.push({
           routePath: route.path,

--- a/frontend/build/prerenderSeo.test.ts
+++ b/frontend/build/prerenderSeo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyHeadTags, PUBLIC_INDEXABLE_ROUTES } from './prerenderSeo';
+import { applyHeadTags, assertNoLoopbackUrls, PUBLIC_INDEXABLE_ROUTES } from './prerenderSeo';
 
 /**
  * Simulates what Playwright's `page.content()` actually captures: the base
@@ -71,6 +71,42 @@ describe('applyHeadTags', () => {
 
     expect(html).toContain('<title>OpenFarmPlanner</title>');
     expect(html).toContain('href="https://openfarmplanner.org/"');
+  });
+
+  it('removes local preview preload hints captured from Vite preview', () => {
+    const html = applyHeadTags(
+      [
+        '<!doctype html>',
+        '<html lang="de"><head>',
+        '  <title>OpenFarmPlanner</title>',
+        '  <link rel="modulepreload" href="/assets/react.js">',
+        '  <link rel="modulepreload" href="http://127.0.0.1:44797/assets/HomePage.js">',
+        '  <link rel="preload" href="http://localhost:44797/assets/HeroImage.js">',
+        '  <link rel="prefetch" href="http://[::1]:44797/assets/useGuestDemoStart.js">',
+        '  <link rel="stylesheet" href="http://127.0.0.1:44797/assets/index.css">',
+        '</head><body><div id="root"><h1>OpenFarmPlanner</h1></div></body></html>',
+      ].join('\n'),
+      PUBLIC_INDEXABLE_ROUTES.find((route) => route.path === '/')!,
+      env,
+    );
+
+    expect(html).toContain('href="/assets/react.js"');
+    expect(html).toContain('rel="stylesheet" href="http://127.0.0.1:44797/assets/index.css"');
+    expect(html).not.toContain('rel="modulepreload" href="http://127.0.0.1:44797');
+    expect(html).not.toContain('rel="preload" href="http://localhost:44797');
+    expect(html).not.toContain('rel="prefetch" href="http://[::1]:44797');
+  });
+});
+
+describe('assertNoLoopbackUrls', () => {
+  it('allows production-local relative asset URLs', () => {
+    expect(() => assertNoLoopbackUrls('<script src="/assets/index.js"></script>', '/')).not.toThrow();
+  });
+
+  it('fails when prerendered HTML still contains an absolute loopback URL', () => {
+    expect(() => assertNoLoopbackUrls('<link href="http://127.0.0.1:44797/assets/index.css">', '/')).toThrow(
+      /contains local preview URL/,
+    );
   });
 });
 

--- a/frontend/build/prerenderSeo.ts
+++ b/frontend/build/prerenderSeo.ts
@@ -23,6 +23,44 @@ import { buildHeadTags } from '../src/seo/seoAssets';
 export { PUBLIC_INDEXABLE_ROUTES, SITE_LANGUAGE };
 export type { PublicRoute };
 
+function isLoopbackHttpUrl(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      ['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'].includes(parsed.hostname.toLowerCase())
+    );
+  } catch {
+    return false;
+  }
+}
+
+function removeLocalPreviewPreloads(document: Document): void {
+  document.querySelectorAll('link[href]').forEach((element) => {
+    const rel = (element.getAttribute('rel') ?? '').toLowerCase();
+    if (!['modulepreload', 'preload', 'prefetch'].includes(rel)) {
+      return;
+    }
+    if (isLoopbackHttpUrl(element.getAttribute('href'))) {
+      element.remove();
+    }
+  });
+}
+
+export function assertNoLoopbackUrls(html: string, routePath: string): void {
+  const matches = html.match(/https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)(?::\d+)?[^\s"'<>)]*/g);
+  if (matches?.length) {
+    const uniqueMatches = [...new Set(matches)];
+    throw new Error(
+      `prerender: ${routePath} contains local preview URL(s): ${uniqueMatches.join(', ')}`
+    );
+  }
+}
+
 /**
  * Rewrite `<head>` in a captured, client-rendered document to the
  * route-specific canonical values. Strips whatever `seoPlugin` baked into
@@ -37,6 +75,8 @@ export function applyHeadTags(html: string, route: PublicRoute, env: SeoEnv): st
 
   const dom = new JSDOM(html);
   const { document } = dom.window;
+
+  removeLocalPreviewPreloads(document);
 
   document.title = route.title ?? 'OpenFarmPlanner';
 


### PR DESCRIPTION
## Summary
- remove loopback preview preload hints from prerendered public HTML
- fail prerendering if any absolute localhost/loopback URL remains in a generated HTML artifact
- document the local verification grep for generated public HTML

## Root Cause
Playwright captures the DOM from a local Vite preview server during prerendering. Vite can inject absolute modulepreload hints that point back to that preview server, such as `http://127.0.0.1:<port>/assets/...`. Those hints were written into the production HTML and caused Chrome to request local-device access permission.

## Validation
- `cd frontend && npm run test -- build/prerenderSeo.test.ts`
- `cd frontend && npm run build`
- `cd frontend && rg -n "https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)" dist --glob "*.html"` (no matches)
- `cd frontend && npx eslint build/prerender.ts build/prerenderSeo.ts build/prerenderSeo.test.ts`
- `git diff --check`

## Note
`npm run lint` currently fails on pre-existing React compiler lint findings outside this change.