### PR TITLE
fix: compact legal document headers

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -94,9 +94,9 @@ clobbered by a leftover value in a shared browser.
 
 - **Public pages** — landing page header, all auth pages (via `AuthPageShell`),
   imprint / privacy / terms (via `PublicPageLanguageBar`). On the legal
-  documents the bar is pinned to the top-right corner of the document container
-  by `LegalDocumentLayout`, i.e. positioned absolutely: it costs no vertical
-  space and cannot shift the centred document title.
+  documents `LegalDocumentLayout` places the dense switcher beside the compact
+  print action in the title header on wider screens; on phones the controls
+  wrap below the centred document title.
 - **Signed-in app** — the account menu (desktop and mobile) under a "Language"
   section, and Account settings → *Language*.
 

--- a/frontend/src/__tests__/LegalDocumentLayout.test.tsx
+++ b/frontend/src/__tests__/LegalDocumentLayout.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, within } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router';
 import ImprintPage from '../pages/public/ImprintPage';
 import PrivacyPolicyPage from '../pages/public/PrivacyPolicyPage';
 import TermsOfServicePage from '../pages/public/TermsOfServicePage';
+import theme from '../theme';
 
 const legalPages = [
   ['Imprint', ImprintPage],
@@ -12,9 +14,11 @@ const legalPages = [
 
 function renderPage(Page: (typeof legalPages)[number][1]): void {
   render(
-    <MemoryRouter>
-      <Page />
-    </MemoryRouter>,
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <Page />
+      </MemoryRouter>
+    </ThemeProvider>,
   );
 }
 
@@ -22,38 +26,58 @@ function getLanguageSwitcher(): HTMLElement {
   return screen.getByRole('button', { name: /Sprache/ });
 }
 
-function getDocumentContainer(): HTMLElement {
-  return screen.getByRole('heading', { level: 1 }).closest('.MuiContainer-root') as HTMLElement;
+function getDocumentHeader(): HTMLElement {
+  return screen.getByRole('heading', { level: 1 }).closest('header') as HTMLElement;
 }
 
+const primaryGreen = 'rgb(37, 111, 42)';
+
 describe.each(legalPages)('%s layout', (_name, Page) => {
-  it('pins the language switcher to the top-right corner of the document container', () => {
+  it('keeps the title and compact controls in one shared header', () => {
     renderPage(Page);
 
-    const container = getDocumentContainer();
+    const header = getDocumentHeader();
+    const heading = screen.getByRole('heading', { level: 1 });
+    const printButton = screen.getByRole('button', { name: 'Drucken / als PDF speichern' });
     const switcherRow = getLanguageSwitcher().parentElement as HTMLElement;
 
-    expect(container).toBeInTheDocument();
-    expect(getComputedStyle(container).position).toBe('relative');
-    expect(getComputedStyle(switcherRow).position).toBe('absolute');
-    expect(switcherRow.parentElement).toBe(container);
+    expect(header).toBeInTheDocument();
+    expect(getComputedStyle(header).display).toBe('grid');
+    expect(heading.parentElement).toBe(header);
+    expect(printButton.parentElement).toBe(switcherRow.parentElement);
   });
 
-  it('keeps the switcher out of the document flow instead of giving it its own row', () => {
+  it('uses an icon-only print action next to the language switcher', () => {
     renderPage(Page);
 
-    const heading = screen.getByRole('heading', { level: 1 });
-    const flowRoot = heading.parentElement?.parentElement as HTMLElement;
+    const printButton = screen.getByRole('button', { name: 'Drucken / als PDF speichern' });
+    const switcher = getLanguageSwitcher();
+    const controls = printButton.parentElement as HTMLElement;
 
-    // The heading's Stack is the first element in the flow: nothing (least of
-    // all the switcher) may sit above it and push the document down.
-    expect(flowRoot.firstElementChild).toBe(heading.parentElement);
-    expect(within(heading.parentElement as HTMLElement).queryByRole('button', { name: /Sprache/ })).toBeNull();
+    expect(printButton).toHaveTextContent('');
+    expect(printButton).toHaveAttribute('aria-label', 'Drucken / als PDF speichern');
+    expect(within(controls).getByTestId('PrintIcon')).toBeInTheDocument();
+    expect(within(controls).getByRole('button', { name: /Sprache/ })).toBe(switcher);
   });
 
   it('centres the document title', () => {
     renderPage(Page);
 
-    expect(getComputedStyle(screen.getByRole('heading', { level: 1 })).textAlign).toBe('center');
+    const heading = screen.getByRole('heading', { level: 1 });
+
+    expect(getComputedStyle(heading).justifySelf).toBe('center');
+    expect(getComputedStyle(heading).textAlign).toBe('center');
+  });
+
+  it('uses the app accent colour for legal toolbar icons while keeping the title neutral', () => {
+    renderPage(Page);
+
+    const heading = screen.getByRole('heading', { level: 1 });
+    const printIcon = screen.getByTestId('PrintIcon');
+    const languageIcon = screen.getByTestId('LanguageIcon');
+
+    expect(getComputedStyle(printIcon).color).toBe(primaryGreen);
+    expect(getComputedStyle(languageIcon).color).toBe(primaryGreen);
+    expect(getComputedStyle(heading).color).not.toBe(primaryGreen);
   });
 });

--- a/frontend/src/components/legal/LegalDocumentLayout.tsx
+++ b/frontend/src/components/legal/LegalDocumentLayout.tsx
@@ -1,67 +1,135 @@
 /**
  * Shared shell for the legal documents (imprint, privacy policy, terms).
  *
- * The language switcher is pinned to the top-right corner of the document
- * container instead of sitting in a row of its own: it is taken out of the
- * document flow, so it costs no vertical space and cannot push or shift the
- * centred title. The container's top padding is only large enough to clear the
- * pinned switcher, which keeps the document starting as high as the switcher
- * allows without ever overlapping the title on narrow screens.
+ * The title remains the primary element while compact document controls share
+ * the same row on wider screens. The grid gives the title a balanced centre
+ * column and lets the controls stack underneath it on phones.
  */
 
 import type { ReactNode } from 'react';
-import { Container, Stack, Typography } from '@mui/material';
+import PrintIcon from '@mui/icons-material/Print';
+import { Box, Container, IconButton, Stack, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
 
+import { useTranslation } from '../../i18n';
 import PublicPageLanguageBar from '../../i18n/PublicPageLanguageBar';
+import { AppTooltip } from '../AppTooltip';
 
-/**
- * Distance in px from the container's top/right edge to the switcher (`top` and
- * `right` are not spacing-aware in `sx`). Together with the switcher's 44px
- * touch target this defines how far down the title can start.
- */
-const languageSwitcherSx = {
-  position: 'absolute',
-  top: { xs: 8, sm: 12, md: 16 },
-  right: { xs: 8, sm: 12, md: 16 },
-  zIndex: 1,
-  '@media print': { display: 'none' },
-} as const;
-
-/** Clears the pinned switcher (top offset + its 44px height) with a little air. */
 const documentSx = {
-  position: 'relative',
-  pt: { xs: 7, sm: 7.5, md: 8 },
+  pt: { xs: 2, sm: 2.5, md: 3 },
   pb: { xs: 6, md: 9 },
 } as const;
 
-/**
- * The German titles are single long words ("Nutzungsbedingungen"), so the
- * heading scales down on phones instead of overflowing the viewport.
- */
+const headerSx = {
+  display: 'grid',
+  gridTemplateColumns: { xs: '1fr', sm: 'minmax(7rem, 1fr) minmax(0, auto) minmax(7rem, 1fr)' },
+  alignItems: 'center',
+  columnGap: { sm: 1.5, md: 2 },
+  rowGap: 1,
+} as const;
+
 const titleSx = {
+  gridColumn: { xs: '1', sm: '2' },
+  justifySelf: 'center',
+  minWidth: 0,
+  maxWidth: '100%',
   textAlign: 'center',
-  fontSize: { xs: '1.75rem', sm: '2.5rem', md: '3rem' },
+  fontSize: { xs: '1.65rem', sm: '2.25rem', md: '2.75rem' },
   overflowWrap: 'anywhere',
 } as const;
 
+const headerControlsSx = {
+  gridColumn: { xs: '1', sm: '3' },
+  justifySelf: { xs: 'center', sm: 'end' },
+  display: 'flex',
+  alignItems: 'center',
+  gap: { xs: 0.5, sm: 0.75 },
+  '@media print': { display: 'none' },
+} as const;
+
+const getLegalToolbarInteractionSx = (theme: Theme) => ({
+  borderRadius: 1,
+  '&.Mui-focusVisible': {
+    outline: `2px solid ${theme.palette.primary.light}`,
+    outlineOffset: 2,
+  },
+});
+
+const printButtonSx = (theme: Theme) => ({
+  ...getLegalToolbarInteractionSx(theme),
+  flex: '0 0 auto',
+  width: 40,
+  height: 40,
+  color: theme.palette.primary.main,
+  '&:hover, &.Mui-focusVisible': {
+    color: theme.palette.primary.dark,
+    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+  },
+});
+
+const languageSwitcherButtonSx = (theme: Theme) => ({
+  ...getLegalToolbarInteractionSx(theme),
+  color: theme.palette.text.primary,
+  '& .MuiButton-startIcon, & .MuiButton-endIcon': {
+    color: theme.palette.primary.main,
+  },
+  '&:hover, &.Mui-focusVisible': {
+    color: theme.palette.text.primary,
+    backgroundColor: alpha(theme.palette.primary.main, 0.08),
+    '& .MuiButton-startIcon, & .MuiButton-endIcon': {
+      color: theme.palette.primary.dark,
+    },
+  },
+});
+
+const languageSwitcherSx = { flex: '0 1 auto' } as const;
+
 interface LegalDocumentLayoutProps {
   title: string;
-  /** Centred under the title, e.g. the print action or a cross-reference link. */
+  /** Optional secondary content below the title row, e.g. a cross-reference link. */
   actions?: ReactNode;
   children: ReactNode;
 }
 
 export default function LegalDocumentLayout({ title, actions, children }: LegalDocumentLayoutProps) {
+  const { t } = useTranslation('home');
+  const printLabel = t('legal.terms.print');
+
   return (
     <Container maxWidth="md" sx={documentSx}>
-      <PublicPageLanguageBar sx={languageSwitcherSx} />
       <Stack spacing={3}>
-        <Stack spacing={2} alignItems="center">
+        <Box component="header" sx={headerSx}>
           <Typography variant="h3" component="h1" sx={titleSx}>
             {title}
           </Typography>
-          {actions}
-        </Stack>
+          <Box sx={headerControlsSx}>
+            <AppTooltip title={printLabel}>
+              <IconButton
+                type="button"
+                aria-label={printLabel}
+                onClick={() => window.print()}
+                size="small"
+                sx={printButtonSx}
+              >
+                <PrintIcon fontSize="small" />
+              </IconButton>
+            </AppTooltip>
+            <PublicPageLanguageBar sx={languageSwitcherSx} buttonSx={languageSwitcherButtonSx} />
+          </Box>
+        </Box>
+        {actions ? (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              mt: -2,
+              '@media print': { display: 'none' },
+            }}
+          >
+            {actions}
+          </Box>
+        ) : null}
         {children}
       </Stack>
     </Container>

--- a/frontend/src/i18n/LanguageSwitcher.tsx
+++ b/frontend/src/i18n/LanguageSwitcher.tsx
@@ -22,6 +22,7 @@ import {
   Select,
   type SelectChangeEvent,
 } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import LanguageIcon from '@mui/icons-material/Language';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +41,7 @@ const MIN_TOUCH_TARGET_SX = { minHeight: 44 };
  * Compact switcher for the landing page header, auth pages and other public
  * pages: a labelled button that opens a menu of language names.
  */
-export function PublicLanguageSwitcher({ dense = false }: { dense?: boolean }) {
+export function PublicLanguageSwitcher({ dense = false, sx }: { dense?: boolean; sx?: SxProps<Theme> }) {
   const { t } = useTranslation('common');
   const { language, setPreference } = useLanguagePreference();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -68,25 +69,28 @@ export function PublicLanguageSwitcher({ dense = false }: { dense?: boolean }) {
         // The visible text is the current language; the accessible name adds
         // what the control does, so it is never just "Deutsch".
         aria-label={t('language.switcherLabel', { language: getLanguageLabel(language) })}
-        sx={{
-          minWidth: 0,
-          minHeight: 44,
-          px: dense ? { xs: 0.75, sm: 1 } : undefined,
-          textTransform: 'none',
-          fontWeight: 500,
-          whiteSpace: 'nowrap',
-          // On phones the switcher shares its row with the page's centred logo,
-          // so the dense variant drops both decorative icons and keeps only the
-          // language name - the part that carries the meaning.
-          '& .MuiButton-startIcon': {
-            display: { xs: 'none', sm: 'inherit' },
-            mr: 0.75,
+        sx={[
+          {
+            minWidth: 0,
+            minHeight: 44,
+            px: dense ? { xs: 0.75, sm: 1 } : undefined,
+            textTransform: 'none',
+            fontWeight: 500,
+            whiteSpace: 'nowrap',
+            // On phones the switcher shares its row with the page's centred logo,
+            // so the dense variant drops both decorative icons and keeps only the
+            // language name - the part that carries the meaning.
+            '& .MuiButton-startIcon': {
+              display: { xs: 'none', sm: 'inherit' },
+              mr: 0.75,
+            },
+            '& .MuiButton-endIcon': {
+              display: dense ? { xs: 'none', sm: 'inherit' } : undefined,
+              ml: 0.35,
+            },
           },
-          '& .MuiButton-endIcon': {
-            display: dense ? { xs: 'none', sm: 'inherit' } : undefined,
-            ml: 0.35,
-          },
-        }}
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
       >
         {getLanguageLabel(language)}
       </Button>

--- a/frontend/src/i18n/PublicPageLanguageBar.tsx
+++ b/frontend/src/i18n/PublicPageLanguageBar.tsx
@@ -1,8 +1,8 @@
 /**
- * Right-aligned language switcher row for public pages.
+ * Right-aligned language switcher for public pages.
  *
- * Present but not dominant: it sits above the page content, uses the page's
- * own text colour, and never competes with the primary call to action.
+ * Present but not dominant: it uses the page's own text colour and can sit
+ * either in a page header row or in a standalone row.
  */
 
 import { Box } from '@mui/material';
@@ -10,10 +10,15 @@ import type { SxProps, Theme } from '@mui/material';
 
 import { PublicLanguageSwitcher } from './LanguageSwitcher';
 
-export default function PublicPageLanguageBar({ sx }: { sx?: SxProps<Theme> }) {
+interface PublicPageLanguageBarProps {
+  sx?: SxProps<Theme>;
+  buttonSx?: SxProps<Theme>;
+}
+
+export default function PublicPageLanguageBar({ sx, buttonSx }: PublicPageLanguageBarProps) {
   return (
     <Box sx={[{ display: 'flex', justifyContent: 'flex-end' }, ...(Array.isArray(sx) ? sx : [sx])]}>
-      <PublicLanguageSwitcher dense />
+      <PublicLanguageSwitcher dense sx={buttonSx} />
     </Box>
   );
 }

--- a/frontend/src/i18n/locales/en/home.json
+++ b/frontend/src/i18n/locales/en/home.json
@@ -238,7 +238,7 @@
     },
     "terms": {
       "title": "Terms of Service",
-      "print": "Print / save as PDF",
+      "print": "Print / Save as PDF",
       "version": "Status: July 17, 2026",
       "sections": {
         "provider": {

--- a/frontend/src/pages/public/TermsOfServicePage.tsx
+++ b/frontend/src/pages/public/TermsOfServicePage.tsx
@@ -1,5 +1,4 @@
-import PrintIcon from '@mui/icons-material/Print';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { useTranslation } from '../../i18n';
 import LegalDocumentLayout from '../../components/legal/LegalDocumentLayout';
 
@@ -30,20 +29,7 @@ export default function TermsOfServicePage() {
   const { t } = useTranslation('home');
 
   return (
-    <LegalDocumentLayout
-      title={t('legal.terms.title')}
-      actions={
-        <Button
-          type="button"
-          variant="outlined"
-          startIcon={<PrintIcon />}
-          onClick={() => window.print()}
-          sx={{ '@media print': { display: 'none' } }}
-        >
-          {t('legal.terms.print')}
-        </Button>
-      }
-    >
+    <LegalDocumentLayout title={t('legal.terms.title')}>
       {termsSections.map((sectionKey, index) => {
         const bulletKeys = termsSectionBulletKeys[sectionKey];
         return (


### PR DESCRIPTION
## What changed

- Reworked the shared legal document header so the title stays centered while compact controls sit to the right on wider screens.
- Moved the print action into `LegalDocumentLayout` as an icon-only printer button with localized tooltip/aria label.
- Kept the dense public language selector next to the print icon and allowed the controls to wrap cleanly below the title on smaller screens.
- Aligned legal toolbar color usage with the app theme: print and language icons use the OpenFarmPlanner green accent, shared focus styling uses the green focus ring, and the document title/language text remain neutral.
- Added a scoped styling hook for `PublicLanguageSwitcher` so other public/auth headers keep their existing appearance.
- Updated legal layout tests and the i18n documentation note for the new header behavior.

## Why

The previous legal header used a heavier page-specific print button and an absolutely positioned language selector. The first compact version also mixed a muted print icon with inherited language styling. The shared layout now keeps imprint, privacy policy, and terms consistent with OpenFarmPlanner's green interactive accent without making the controls compete with the title.

## Validation

- `npm run test -- LegalDocumentLayout TermsOfServicePage PrivacyPolicyPage languageSwitcher AuthPageShell HomePageHeader --run`
- `npx eslint src/components/legal/LegalDocumentLayout.tsx src/i18n/PublicPageLanguageBar.tsx src/i18n/LanguageSwitcher.tsx src/__tests__/LegalDocumentLayout.test.tsx`
- `npm run test`
- Playwright layout/color inspection for `/nutzungsbedingungen`, `/datenschutz`, and `/impressum` at desktop, mobile portrait, and mobile landscape widths: no header overlaps or out-of-bounds controls; print/language icons resolve to the app green accent; title and language text remain neutral; focus ring resolves to the app green focus color.

## Notes

- Repo-wide `npm run lint` still fails on pre-existing React hook lint violations outside this change. The files touched here pass targeted ESLint.
- Reviewed similar toolbar color patterns across the app. Other low-emphasis or semantic toolbars are intentionally neutral/destructive/primary, so no broader color changes were made.
