### PR TITLE
fix: simplify supplier deletion dialog UX

### DIFF
--- a/frontend/src/__tests__/SuppliersPage.test.tsx
+++ b/frontend/src/__tests__/SuppliersPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Suppliers from '../pages/Suppliers';
@@ -628,9 +628,15 @@ describe('Suppliers page empty and table states', () => {
     expect(await screen.findByRole('heading', { name: 'Lieferant wird noch verwendet' })).toBeInTheDocument();
     expect(screen.getByText('Dieser Lieferant wird noch von 12 Kulturen verwendet.')).toBeInTheDocument();
     expect(screen.getByText('12 Kulturen nutzen diesen Lieferanten direkt.')).toBeInTheDocument();
-    expect(screen.getByText('Beim Fortfahren bleiben alle Kulturen erhalten. Lediglich die Lieferantenzuordnung wird entfernt.')).toBeInTheDocument();
+    expect(screen.getByText('Kulturen werden nicht gelöscht. Vor dem Löschen des Lieferanten wird nur die Lieferantenzuordnung entfernt.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Zu betroffenen Kulturen' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Lieferant aus allen Kulturen entfernen und löschen' })).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    const footer = dialog.querySelector('.MuiDialogActions-root');
+    expect(footer).not.toBeNull();
+    expect(within(footer as HTMLElement).getAllByRole('button').map((button) => button.textContent)).toEqual([
+      'Abbrechen',
+      'Lieferant löschen',
+    ]);
     expect(mocks.delete).not.toHaveBeenCalled();
     expect(screen.getAllByText('Reinsaat').length).toBeGreaterThan(0);
   });
@@ -686,7 +692,7 @@ describe('Suppliers page empty and table states', () => {
 
     await screen.findByText('Reinsaat');
     fireEvent.click(screen.getByRole('button', { name: 'Löschen' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Lieferant aus allen Kulturen entfernen und löschen' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Lieferant löschen' }));
 
     await waitFor(() => expect(mocks.unlinkAndDelete).toHaveBeenCalledWith(1));
     expect(screen.queryByText('Reinsaat')).not.toBeInTheDocument();

--- a/frontend/src/components/suppliers/SupplierDeleteUsageDialog.tsx
+++ b/frontend/src/components/suppliers/SupplierDeleteUsageDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
   Typography,
 } from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 import { useTranslation } from '../../i18n';
 import type { Supplier, SupplierDeleteUsage } from '../../api/types';
@@ -91,12 +92,21 @@ export function SupplierDeleteUsageDialog({
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
               {t('deleteUsageDialog.unlinkExplanation')}
             </Typography>
+            <Button
+              onClick={onOpenAffectedCultures}
+              variant="text"
+              size="small"
+              endIcon={<ArrowForwardIcon />}
+              sx={{ mt: 1, px: 0 }}
+            >
+              {t('deleteUsageDialog.openAffectedCultures')}
+            </Button>
           </Box>
         ) : null}
       </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1, gap: 1, flexWrap: 'wrap' }}>
-        <Button onClick={onOpenAffectedCultures} variant="outlined">
-          {t('deleteUsageDialog.openAffectedCultures')}
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
+        <Button onClick={onClose} variant="outlined">
+          {t('common:actions.cancel')}
         </Button>
         <Button
           onClick={onUnlinkAndDelete}
@@ -105,9 +115,6 @@ export function SupplierDeleteUsageDialog({
           disabled={unlinkDeletingSupplierId === dialog?.supplier.id}
         >
           {t('deleteUsageDialog.unlinkAndDelete')}
-        </Button>
-        <Button onClick={onClose}>
-          {t('common:actions.cancel')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/i18n/locales/de/suppliers.json
+++ b/frontend/src/i18n/locales/de/suppliers.json
@@ -33,9 +33,9 @@
     "supplierDataUsage": "{{cultureCount}} Kulturen haben Saatgut- oder Lieferantendaten mit {{rowCount}} Einträgen.",
     "seedDemandUsage_one": "{{count}} Kultur nutzt diesen Lieferanten in der Saatgutplanung.",
     "seedDemandUsage_other": "{{count}} Kulturen nutzen diesen Lieferanten in der Saatgutplanung.",
-    "unlinkExplanation": "Beim Fortfahren bleiben alle Kulturen erhalten. Lediglich die Lieferantenzuordnung wird entfernt.",
+    "unlinkExplanation": "Kulturen werden nicht gelöscht. Vor dem Löschen des Lieferanten wird nur die Lieferantenzuordnung entfernt.",
     "openAffectedCultures": "Zu betroffenen Kulturen",
-    "unlinkAndDelete": "Lieferant aus allen Kulturen entfernen und löschen"
+    "unlinkAndDelete": "Lieferant löschen"
   },
   "invalidDomain": "Ungültige Domain: {{domain}}. Domains müssen gültige Hostnamen ohne Schema oder Pfad sein (z.B. example.com).",
   "domainValidationError": "Einige Domains sind ungültig. Bitte korrigieren Sie die Eingabe.",

--- a/frontend/src/i18n/locales/en/suppliers.json
+++ b/frontend/src/i18n/locales/en/suppliers.json
@@ -33,9 +33,9 @@
     "supplierDataUsage": "{{cultureCount}} cultures have seed or supplier data with {{rowCount}} entries.",
     "seedDemandUsage_one": "{{count}} culture uses this supplier in seed demand planning.",
     "seedDemandUsage_other": "{{count}} cultures use this supplier in seed demand planning.",
-    "unlinkExplanation": "If you continue, all cultures are kept. Only the supplier link is removed.",
+    "unlinkExplanation": "Cultures are not deleted. Only their supplier relationship is removed before the supplier is deleted.",
     "openAffectedCultures": "Go to affected cultures",
-    "unlinkAndDelete": "Remove supplier from all cultures and delete"
+    "unlinkAndDelete": "Delete supplier"
   },
   "invalidDomain": "Invalid domain: {{domain}}. Domains must be valid hostnames without a scheme or path (e.g. example.com).",
   "domainValidationError": "Some domains are invalid. Please correct the input.",


### PR DESCRIPTION
### Motivation

- Make the "Supplier is still in use" dialog follow common destructive-action patterns so the confirmation is clear and visually balanced.
- Reduce clutter by moving navigation actions into the information area and keeping only final actions in the footer.

### Description

- Move the "View affected cultures" navigation into the info card as a compact text button with an arrow icon inside `SupplierDeleteUsageDialog` (`frontend/src/components/suppliers/SupplierDeleteUsageDialog.tsx`).
- Limit the dialog footer to two actions: an outlined `Cancel` and a destructive red `Delete supplier` button, and ensure the footer uses the app's standard DialogActions layout in the same component.
- Shorten and clarify the destructive label from "Remove supplier from all cultures and delete" to `Delete supplier` in the i18n resources (`frontend/src/i18n/locales/en/suppliers.json` and `frontend/src/i18n/locales/de/suppliers.json`).
- Make the explanatory copy explicit that cultures are not deleted and only the supplier relationship is removed in the i18n files.
- Update the supplier page unit test to assert the new copy, the footer-only action layout and order, and the shortened destructive label (`frontend/src/__tests__/SuppliersPage.test.tsx`).

### Testing

- Ran the targeted unit test with `cd frontend && npm run test -- --run src/__tests__/SuppliersPage.test.tsx` and observed the test file passed (19 tests passed).
- Ran a focused ESLint check for the changed files with `npx eslint src/components/suppliers/SupplierDeleteUsageDialog.tsx src/__tests__/SuppliersPage.test.tsx` which passed for the modified files.
- Built the frontend with `cd frontend && npm run build` which completed successfully for the app bundle.
- Performed a visual inspection using a temporary Vite harness plus Playwright screenshot to confirm the dialog renders correctly at desktop breakpoint and the footer contains only the `Cancel` and `Delete supplier` actions.
- Note: a repository-wide lint run reports pre-existing React lint issues outside the changed files and did not affect the targeted tests or the modified dialog component.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a701a5984b08322aadff0579d466f24)