### PR TITLE
Publish a variety immediately against a freshly-proposed crop species

### DIFF
--- a/backend/farm/services/public_cultures.py
+++ b/backend/farm/services/public_cultures.py
@@ -511,10 +511,28 @@ def get_public_required_field_gaps(culture: Culture, *, require_variety: bool = 
     return gaps
 
 
+PUBLISHABLE_CROP_SPECIES_STATUSES = (CropSpecies.STATUS_PUBLISHED, CropSpecies.STATUS_PROPOSED)
+
+
 def resolve_publishing_crop_species(*, culture: Culture, crop_species_id: int | None) -> CropSpecies | None:
+    """A species usable as the publish target: published, or still pending moderation.
+
+    A `proposed` species is intentionally allowed here so a user who just
+    suggested a missing species inline doesn't have to wait for moderator
+    approval before publishing their variety under it — the variety publishes
+    right away and becomes fully official once the species is approved (the
+    `CropSpecies` row is updated in place, so nothing needs to be relinked).
+    `rejected` species are excluded.
+    """
     if crop_species_id:
-        return CropSpecies.objects.filter(id=crop_species_id, status=CropSpecies.STATUS_PUBLISHED).first()
-    return culture.crop_species if culture.crop_species and culture.crop_species.status == CropSpecies.STATUS_PUBLISHED else None
+        return CropSpecies.objects.filter(
+            id=crop_species_id, status__in=PUBLISHABLE_CROP_SPECIES_STATUSES,
+        ).first()
+    return (
+        culture.crop_species
+        if culture.crop_species and culture.crop_species.status in PUBLISHABLE_CROP_SPECIES_STATUSES
+        else None
+    )
 
 
 def build_project_culture_payload(public_culture: PublicCulture) -> dict[str, Any]:

--- a/backend/farm/tests/test_public_cultures_api.py
+++ b/backend/farm/tests/test_public_cultures_api.py
@@ -119,6 +119,62 @@ class PublicCultureLibraryApiTest(DRFAPITestCase):
         self.assertEqual(response.data['original_language_code'], 'en')
         self.assertEqual(response.data['missing_required_fields'], [])
 
+    def test_publish_allows_a_freshly_proposed_crop_species(self):
+        proposed_species = CropSpecies.objects.create(
+            name='Zzz Testonly Kohlrabusch', status=CropSpecies.STATUS_PROPOSED, proposed_by=self.user,
+        )
+
+        preview = self.client.get(
+            f'/openfarmplanner/api/cultures/{self.culture.id}/publish-public/preview/',
+            {'crop_species_id': proposed_species.id, 'original_language_code': 'en'},
+        )
+        self.assertEqual(preview.status_code, status.HTTP_200_OK)
+        self.assertTrue(preview.data['can_publish'])
+        self.assertEqual(preview.data['crop_species']['name'], 'Zzz Testonly Kohlrabusch')
+
+        response = self.client.post(
+            f'/openfarmplanner/api/cultures/{self.culture.id}/publish-public/',
+            {
+                'accepted_public_library_terms': True,
+                'crop_species_id': proposed_species.id,
+                'original_language_code': 'en',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        public_culture = PublicCulture.objects.get(variety='Bijella')
+        self.assertEqual(public_culture.crop_species_id, proposed_species.id)
+        proposed_species.refresh_from_db()
+        self.assertEqual(proposed_species.status, CropSpecies.STATUS_PROPOSED)
+
+    def test_publish_still_rejects_a_rejected_crop_species(self):
+        rejected_species = CropSpecies.objects.create(
+            name='Zzz Testonly Rutabusch', status=CropSpecies.STATUS_REJECTED, proposed_by=self.user,
+        )
+
+        preview = self.client.get(
+            f'/openfarmplanner/api/cultures/{self.culture.id}/publish-public/preview/',
+            {'crop_species_id': rejected_species.id, 'original_language_code': 'en'},
+        )
+        self.assertEqual(preview.status_code, status.HTTP_200_OK)
+        self.assertFalse(preview.data['can_publish'])
+        self.assertIsNone(preview.data['crop_species'])
+
+        response = self.client.post(
+            f'/openfarmplanner/api/cultures/{self.culture.id}/publish-public/',
+            {
+                'accepted_public_library_terms': True,
+                'crop_species_id': rejected_species.id,
+                'original_language_code': 'en',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['code'], 'public_culture_publishing_checks_failed')
+        self.assertEqual(PublicCulture.objects.count(), 0)
+
     def test_publish_preview_blocks_missing_required_public_fields(self):
         self.culture.variety = ''
         self.culture.save()

--- a/docs/crop-library-architecture.md
+++ b/docs/crop-library-architecture.md
@@ -354,6 +354,30 @@ separate always-visible link — clicking it calls
 `crops.services`' `CropSpecies.propose()` endpoint directly from the
 dropdown.
 
+A user does not have to wait for moderation to publish once they've proposed
+a species: `resolve_publishing_crop_species()` (`farm.services.public_cultures`)
+accepts a `CropSpecies` in either `PUBLISHED` or `PROPOSED` status as a
+publish target (`PUBLISHABLE_CROP_SPECIES_STATUSES`) — `REJECTED` species
+remain excluded. `PROPOSED` already is the "pending moderation" state
+(`CropSpecies.STATUS_PROPOSED`); no separate status was introduced for this.
+On the frontend, a successful proposal immediately appends the new species to
+the wizard's local options and selects it, so "Publish now" becomes usable
+right away instead of staying blocked; a dismissible success `Alert`
+(`library.publishWizard.proposedSpeciesNotice`) explains that the variety
+will appear provisionally under the not-yet-approved species name. This is
+safe because `CropSpeciesViewSet.approve()`/`reject()`
+(`backend/crops/views.py`) mutate the same `CropSpecies` row in place — the
+id never changes — so once a moderator approves the species, everything
+already published under it (including the general entry auto-created below)
+keeps working with no relinking; nothing else in the publish path
+(`detect_public_culture_duplicates()`, `ensure_general_public_culture()`,
+`PublicCultureViewSet`'s list queryset) filters on `crop_species.status` at
+all, so this was already the only gate. `CropSpeciesViewSet.get_queryset()`
+still hides non-`PUBLISHED` species from every other user/surface (including
+the wizard's own initial species list) until a moderator approves or rejects
+them, so a pending species is not otherwise discoverable/searchable in the
+meantime.
+
 When publishing a variety and the species has no species-level ("general",
 empty-`variety`) published entry yet, the backend
 (`ensure_general_public_culture()` in `farm.services.public_cultures`)

--- a/frontend/src/__tests__/CulturesPublishingWizardDialog.test.tsx
+++ b/frontend/src/__tests__/CulturesPublishingWizardDialog.test.tsx
@@ -92,7 +92,7 @@ describe('CulturesPublishingWizardDialog', () => {
     expect(screen.queryByRole('radio')).not.toBeInTheDocument();
   });
 
-  it('offers an inline crop species proposal when the search has no matches', async () => {
+  it('offers an inline crop species proposal when the search has no matches, and lets the variety publish right away', async () => {
     cropSpeciesListMock.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } });
 
     renderWizard();
@@ -105,7 +105,21 @@ describe('CulturesPublishingWizardDialog', () => {
     fireEvent.click(proposeButton);
 
     await waitFor(() => expect(cropSpeciesProposeMock).toHaveBeenCalledWith('Kürbis'));
-    expect(await screen.findByText('Der Vorschlag wurde gespeichert und kann später geprüft werden.')).toBeInTheDocument();
+
+    // The freshly proposed (pending) species is immediately usable: it
+    // becomes the selected value, a notice explains the provisional state,
+    // and "Publish now" is enabled rather than staying blocked on moderation.
+    expect(await screen.findByDisplayValue('Kürbis')).toBeInTheDocument();
+    expect(screen.getByText(/Dein Vorschlag für die neue Kulturart „Kürbis“ wurde zur Prüfung eingereicht/)).toBeInTheDocument();
+
+    const publishButton = screen.getByRole('button', { name: 'Jetzt veröffentlichen' });
+    expect(publishButton).toBeEnabled();
+    fireEvent.click(publishButton);
+
+    await waitFor(() => expect(publishPreviewMock).toHaveBeenCalledWith(
+      CULTURE.id,
+      expect.objectContaining({ crop_species_id: 2 }),
+    ));
   });
 
   it('matches an existing species by its localized display name, not just the canonical name', async () => {
@@ -155,7 +169,7 @@ describe('CulturesPublishingWizardDialog', () => {
 
     await waitFor(() => expect(cropSpeciesProposeMock).toHaveBeenCalledWith('Kürbis'));
     expect(await screen.findByText(/existiert bereits oder wurde schon vorgeschlagen/)).toBeInTheDocument();
-    expect(screen.queryByText('Der Vorschlag wurde gespeichert und kann später geprüft werden.')).not.toBeInTheDocument();
+    expect(screen.queryByText(/wurde zur Prüfung eingereicht/)).not.toBeInTheDocument();
   });
 
   it('shows a link to view foreign duplicates instead of blocking on plain text', async () => {

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -965,7 +965,7 @@
       "speciesNoOptions": "Keine passende offizielle Kulturart gefunden.",
       "proposeSpeciesInline": "„{{name}}“ als neue Kulturart vorschlagen",
       "proposeSpeciesButton": "Vorschlagen",
-      "proposalSent": "Der Vorschlag wurde gespeichert und kann später geprüft werden.",
+      "proposedSpeciesNotice": "Dein Vorschlag für die neue Kulturart „{{name}}“ wurde zur Prüfung eingereicht. Du kannst deine Sorte jetzt trotzdem veröffentlichen — sie erscheint vorläufig unter „{{name}}“, bis der Vorschlag bestätigt ist.",
       "proposeSpeciesError": "Der Vorschlag konnte nicht gespeichert werden. Bitte versuche es erneut.",
       "speciesAlreadyExists": "Diese Kulturart existiert bereits oder wurde schon vorgeschlagen — möglicherweise unter einem anderen Namen. Bitte in der Liste danach suchen.",
       "originalLanguageLabel": "Originalsprache",

--- a/frontend/src/i18n/locales/en/cultures.json
+++ b/frontend/src/i18n/locales/en/cultures.json
@@ -965,7 +965,7 @@
       "speciesNoOptions": "No matching official crop species found.",
       "proposeSpeciesInline": "Suggest \"{{name}}\" as a new crop species",
       "proposeSpeciesButton": "Suggest",
-      "proposalSent": "The suggestion was saved and can be reviewed later.",
+      "proposedSpeciesNotice": "Your suggestion for the new crop species \"{{name}}\" has been submitted for review. You can go ahead and publish your variety now — it will appear provisionally under \"{{name}}\" until it's approved.",
       "proposeSpeciesError": "The suggestion could not be saved. Please try again.",
       "speciesAlreadyExists": "This crop species already exists or has already been suggested — possibly under a different name. Please search for it in the list.",
       "originalLanguageLabel": "Original language",

--- a/frontend/src/pages/CulturesPublishingWizardDialog.tsx
+++ b/frontend/src/pages/CulturesPublishingWizardDialog.tsx
@@ -98,7 +98,7 @@ export function CulturesPublishingWizardDialog({
   const [validationLoading, setValidationLoading] = useState(false);
   const [showLicenseConfirmation, setShowLicenseConfirmation] = useState(false);
   const [speciesInputValue, setSpeciesInputValue] = useState('');
-  const [proposalSent, setProposalSent] = useState(false);
+  const [proposedSpeciesName, setProposedSpeciesName] = useState<string | null>(null);
   const [proposingSpecies, setProposingSpecies] = useState(false);
   const [proposeSpeciesError, setProposeSpeciesError] = useState('');
   const [generalNoticeDismissed, setGeneralNoticeDismissed] = useState(false);
@@ -113,7 +113,7 @@ export function CulturesPublishingWizardDialog({
       setAcceptedLicense(false);
       setShowLicenseConfirmation(false);
       setSpeciesInputValue('');
-      setProposalSent(false);
+      setProposedSpeciesName(null);
       setProposeSpeciesError('');
       setGeneralNoticeDismissed(false);
       setValidationResult(null);
@@ -225,24 +225,35 @@ export function CulturesPublishingWizardDialog({
     && !validationResult.can_publish;
   const existingVarietyOptions = publicCultureOptions.filter((option) => (option.variety || '').trim());
 
+  const resetValidationResult = useCallback(() => {
+    setValidationResult(null);
+  }, []);
+
   const handleProposeSpecies = useCallback(async (name: string) => {
     const trimmedName = name.trim();
     if (!trimmedName) return;
     setProposingSpecies(true);
     setProposeSpeciesError('');
     try {
-      await cropSpeciesAPI.propose(trimmedName);
-      setProposalSent(true);
+      const response = await cropSpeciesAPI.propose(trimmedName);
+      const created = response.data;
+      // Make the pending species immediately usable for this publish attempt
+      // instead of leaving the user stuck until a moderator reviews it — the
+      // backend accepts `proposed` species as a publish target (see
+      // resolve_publishing_crop_species), and the variety becomes fully
+      // official automatically once the species is approved.
+      setSpecies((prev) => [...prev, created]);
+      setSelectedSpecies(created);
+      setSpeciesInputValue(getCropSpeciesOptionLabel(created));
+      setSelectedPublicCulture(null);
+      resetValidationResult();
+      setProposedSpeciesName(getCropSpeciesOptionLabel(created));
     } catch (error) {
       setProposeSpeciesError(extractApiErrorMessage(error, t, t('library.publishWizard.proposeSpeciesError')));
     } finally {
       setProposingSpecies(false);
     }
-  }, [t]);
-
-  const resetValidationResult = useCallback(() => {
-    setValidationResult(null);
-  }, []);
+  }, [resetValidationResult, t]);
 
   const handlePublish = useCallback(async () => {
     if (!culture?.id) return;
@@ -343,37 +354,33 @@ export function CulturesPublishingWizardDialog({
                   onChange={(_, value) => {
                     setSelectedSpecies(value);
                     setSelectedPublicCulture(null);
+                    setProposedSpeciesName(null);
                     resetValidationResult();
                   }}
                   onInputChange={(_, value) => {
                     setSpeciesInputValue(value);
-                    setProposalSent(false);
                     setProposeSpeciesError('');
                   }}
                   noOptionsText={speciesLoading ? (
                     <Typography variant="body2" color="text.secondary">{t('common:loading')}</Typography>
                   ) : speciesInputValue.trim() ? (
-                    proposalSent ? (
-                      <Typography variant="body2" color="success.main">{t('library.publishWizard.proposalSent')}</Typography>
-                    ) : (
-                      <Stack spacing={0.5} alignItems="flex-start">
-                        <Button
-                          size="small"
-                          onMouseDown={(event) => event.preventDefault()}
-                          onClick={() => void handleProposeSpecies(speciesInputValue)}
-                          disabled={proposingSpecies}
-                        >
-                          {proposingSpecies
-                            ? t('library.publishWizard.proposeSpeciesButton')
-                            : t('library.publishWizard.proposeSpeciesInline', { name: speciesInputValue.trim() })}
-                        </Button>
-                        {proposeSpeciesError ? (
-                          <Typography variant="body2" color="error.main" sx={{ px: 1 }}>
-                            {proposeSpeciesError}
-                          </Typography>
-                        ) : null}
-                      </Stack>
-                    )
+                    <Stack spacing={0.5} alignItems="flex-start">
+                      <Button
+                        size="small"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => void handleProposeSpecies(speciesInputValue)}
+                        disabled={proposingSpecies}
+                      >
+                        {proposingSpecies
+                          ? t('library.publishWizard.proposeSpeciesButton')
+                          : t('library.publishWizard.proposeSpeciesInline', { name: speciesInputValue.trim() })}
+                      </Button>
+                      {proposeSpeciesError ? (
+                        <Typography variant="body2" color="error.main" sx={{ px: 1 }}>
+                          {proposeSpeciesError}
+                        </Typography>
+                      ) : null}
+                    </Stack>
                   ) : (
                     t('library.publishWizard.speciesNoOptions')
                   )}
@@ -506,6 +513,12 @@ export function CulturesPublishingWizardDialog({
               </>
             ) : null}
           </Stack>
+
+          {proposedSpeciesName ? (
+            <Alert severity="success" onClose={() => setProposedSpeciesName(null)}>
+              {t('library.publishWizard.proposedSpeciesNotice', { name: proposedSpeciesName })}
+            </Alert>
+          ) : null}
 
           {validationResult?.general_crop_notice && !generalNoticeDismissed ? (
             <Alert severity="info" onClose={() => setGeneralNoticeDismissed(true)}>


### PR DESCRIPTION
## Summary

Stacked on #444 (`feat/crop-library-publish-flow-improvements`, still open) — extends the inline "propose a new crop species" flow in the publish wizard so proposing no longer dead-ends the current publish attempt.

## Analysis (before implementing)

A "pending review" status already exists: `CropSpecies.STATUS_PROPOSED` ('proposed'). Proposing a species already creates it with this status (`CropSpeciesViewSet.create()`). Today:
- `CropSpeciesViewSet.get_queryset()` hides non-`published` species from every non-moderator surface — a proposed species is not discoverable/searchable by anyone but a moderator.
- `resolve_publishing_crop_species()` only resolved `crop_species_id` when `status == PUBLISHED`, so publishing against the species the user *just* proposed was rejected — the only actual gate blocking this flow.
- Nothing else in the publish path (`detect_public_culture_duplicates()`, `ensure_general_public_culture()`, `PublicCultureViewSet`'s queryset) filters on `crop_species.status` at all — a `PublicCulture` linked to a `proposed` species already renders normally in the public library today.
- `CropSpeciesViewSet.approve()`/`reject()` mutate the same `CropSpecies` row in place (id unchanged), so once approved, everything already published under it keeps working with zero relinking.

No new status or model/migration changes were needed.

## Changes

- **Backend** (`backend/farm/services/public_cultures.py`): `resolve_publishing_crop_species()` now accepts `status in {PUBLISHED, PROPOSED}` (was `PUBLISHED` only); `rejected` species remain excluded. New tests cover both the allowed-proposed and still-rejected-rejected cases.
- **Frontend** (`CulturesPublishingWizardDialog.tsx`): after a successful species proposal, the new species is appended to the wizard's local options and auto-selected — "Publish now" becomes usable immediately instead of staying blocked on moderation. The old static "suggestion saved" text is replaced with a dismissible success `Alert` explaining the variety will appear provisionally under the not-yet-approved species name until it's approved.
- `docs/crop-library-architecture.md` §7 updated to describe the new behavior and why it's safe.

## Test plan

- [x] Backend: `pdm run test` — full suite (680 tests) passes, including 2 new tests (`test_publish_allows_a_freshly_proposed_crop_species`, `test_publish_still_rejects_a_rejected_crop_species`).
- [x] Frontend: `npx vitest run` — full suite (1948 tests) passes, including an updated wizard test asserting the new species becomes selected and "Publish now" successfully calls the preview endpoint with the new species id.
- [x] `npx tsc --noEmit -p tsconfig.app.json` clean; `npx eslint` clean on changed files.
- [x] `./scripts/quality.sh` — no new issues on changed files versus the current baseline (same E501/I001 pre-existing noise as before, nothing new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)