### PR TITLE
Hide Varieties section on a variety's own crop detail view

### DIFF
--- a/frontend/src/__tests__/CultureDetail.test.tsx
+++ b/frontend/src/__tests__/CultureDetail.test.tsx
@@ -338,7 +338,6 @@ describe('CultureDetail Component', () => {
 
     const sectionTitles = screen.getAllByRole('heading', { level: 6 }).map((node) => node.textContent?.trim());
     expect(sectionTitles).toEqual([
-      'Sorten',
       'Allgemeine Informationen',
       'Zeitplanung',
       'Abstände',
@@ -887,29 +886,23 @@ describe('CultureDetail Component', () => {
       expect(onAddVariety).toHaveBeenCalledWith(carrotSpecies);
     });
 
-    it('also lists sibling varieties from a variety\'s own detail view, and edit/delete act on the clicked row', async () => {
-      const user = userEvent.setup();
-      const onEditCulture = vi.fn();
-      const onDeleteCulture = vi.fn();
+    it('does not render on a variety\'s own detail view (only on the crop/species overview)', () => {
       renderCultureDetail(
         <CultureDetail
           cultures={carrotCultures}
           selectedCultureId={11}
           onCultureSelect={vi.fn()}
-          onEditCulture={onEditCulture}
-          onDeleteCulture={onDeleteCulture}
+          onEditCulture={vi.fn()}
+          onDeleteCulture={vi.fn()}
         />
       );
 
-      expect(screen.getByText('Sorten')).toBeInTheDocument();
-      expect(screen.getByText('Bolero')).toBeInTheDocument();
-
-      const boleroRow = screen.getByText('Bolero').closest('[role="button"]') as HTMLElement;
-      await user.click(within(boleroRow).getByRole('button', { name: 'Bearbeiten' }));
-      expect(onEditCulture).toHaveBeenCalledWith(carrotBolero);
-
-      await user.click(within(boleroRow).getByRole('button', { name: 'Löschen' }));
-      expect(onDeleteCulture).toHaveBeenCalledWith(carrotBolero);
+      expect(screen.getByText('Carrot')).toBeInTheDocument();
+      expect(screen.getByText('Nantes')).toBeInTheDocument();
+      expect(screen.queryByText('Sorten')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Sorte hinzufügen' })).not.toBeInTheDocument();
+      expect(screen.queryByText('Bolero')).not.toBeInTheDocument();
+      expect(screen.queryByText('Für diese Kultur sind noch keine Sorten angelegt.')).not.toBeInTheDocument();
     });
 
     it('shows an empty state when a crop has no varieties yet', () => {

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -985,7 +985,10 @@ const detailSectionGridSx = {
 
             <Divider sx={{ mb: 2.5 }} />
 
-            {/* Varieties Section */}
+            {/* Varieties Section — only relevant when viewing the crop/species
+                overview, not a single variety's own detail page. */}
+            {isSpeciesView ? (
+            <>
             <Box sx={{ mb: 3, p: { xs: 1.25, sm: 2 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>
               <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: varietySiblings.length > 0 ? 1.5 : 0 }}>
                 <Typography variant="h6">
@@ -1049,6 +1052,8 @@ const detailSectionGridSx = {
             </Box>
 
             <Divider sx={{ mb: 2.5 }} />
+            </>
+            ) : null}
 
             {/* General Information Section */}
             <Box sx={{ mb: 3, p: { xs: 1.25, sm: 2 }, border: '1px solid #e5e7eb', borderRadius: 2 }}>


### PR DESCRIPTION
## Summary

`CultureDetail.tsx` is shared by both the general crop detail view (e.g. `/app/cultures?cultureId=3409`, "Carrot" with no VARIETY subtitle) and the single-variety detail view (e.g. `/app/cultures?cultureId=2570`, "Carrot" with VARIETY subtitle "Nantaise 2"). The "Varieties" section (sibling-variety list + "+ Add variety") was rendering on both, which on the variety view was misplaced and misleadingly showed "No varieties have been added to this crop yet." — the sibling list intentionally excludes the currently-selected culture, so a variety page always looked "empty" even when siblings existed.

## Fix

Gate the Varieties section (and its trailing divider) on `isSpeciesView` — the flag already used elsewhere in the component to distinguish "viewing the crop/species overview" from "viewing one specific variety". Now the section renders only on the crop/species overview and is fully absent on a variety's own detail page.

`showVarietyValueLegend` ("Highlighted values = apply only to this variety.") was already correctly gated on `!isSpeciesView` and is untouched.

## Review of other sections (point 3)

Checked whether any other section is similarly mis-scoped: General Information, Timing, Spacing, Seeding, Harvest, Notes, and Supplier data all intentionally render on *both* views — they show the effective values (with species-inheritance and variety-override highlighting already handled via `getCropValue`/`getCropValueSource`) for whichever row is currently selected. That's existing, correct behavior, not the same bug. No other section needed changing.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean.
- [x] `npx eslint` clean on changed files.
- [x] `npx vitest run` — full suite (1936 tests) passes, including an updated `CultureDetail.test.tsx` "Varieties section" describe block: the crop-overview test is unchanged, the old "also lists sibling varieties from a variety's own detail view..." test is replaced with an assertion that the section (title, add button, sibling list, empty-state text) is entirely absent when viewing a single variety, and a pre-existing "renders detail sections in the expected order" test updated to drop "Sorten" for a variety-selected fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)