### PR TITLE
Reveal Varieties row actions on hover, next to the name

### DIFF
--- a/frontend/src/__tests__/CultureDetail.test.tsx
+++ b/frontend/src/__tests__/CultureDetail.test.tsx
@@ -886,6 +886,39 @@ describe('CultureDetail Component', () => {
       expect(onAddVariety).toHaveBeenCalledWith(carrotSpecies);
     });
 
+    it('hides edit/delete actions until hover, positioned next to the variety name', () => {
+      const onEditCulture = vi.fn();
+      const onDeleteCulture = vi.fn();
+      renderCultureDetail(
+        <CultureDetail
+          cultures={carrotCultures}
+          selectedCultureId={10}
+          onCultureSelect={vi.fn()}
+          onEditCulture={onEditCulture}
+          onDeleteCulture={onDeleteCulture}
+        />
+      );
+
+      const nantesRow = screen.getByText('Nantes').closest('.variety-row') as HTMLElement;
+      expect(nantesRow).toBeInTheDocument();
+      const editButton = within(nantesRow).getByRole('button', { name: 'Bearbeiten' });
+      const deleteButton = within(nantesRow).getByRole('button', { name: 'Löschen' });
+
+      // The action icons live in the same inline box as the name (not a
+      // separate right-aligned block spanning the full row width), reusing
+      // the shared hover-reveal overlay pattern from Fields/Suppliers — hidden
+      // (not clickable) until the row is hovered/focused.
+      expect(nantesRow.querySelector('.MuiListItemText-root')?.nextElementSibling).toContainElement(editButton);
+      expect(editButton).toHaveStyle({ pointerEvents: 'none' });
+      expect(deleteButton).toHaveStyle({ pointerEvents: 'none' });
+
+      fireEvent.click(editButton);
+      expect(onEditCulture).toHaveBeenCalledWith(carrotNantes);
+
+      fireEvent.click(deleteButton);
+      expect(onDeleteCulture).toHaveBeenCalledWith(carrotNantes);
+    });
+
     it('does not render on a variety\'s own detail view (only on the crop/species overview)', () => {
       renderCultureDetail(
         <CultureDetail

--- a/frontend/src/cultures/CultureDetail.tsx
+++ b/frontend/src/cultures/CultureDetail.tsx
@@ -53,6 +53,7 @@ import { CultureSeedDetails, type CultureSeedRateRow, type ValueSource } from '.
 import { VarietyValueLegend } from './VarietyValueLegend';
 import { varietySpecificValueHighlightSx } from './varietyValueAccent';
 import { isEmptyCropValue, getVarietyOwnValueSource } from './varietyValueSource';
+import { contextMenuActionsOverlaySx } from '../components/contextMenu/contextMenuIndicatorStyles';
 
 interface CultureDetailProps {
   cultures: Culture[];
@@ -1017,6 +1018,7 @@ const detailSectionGridSx = {
                   {varietySiblings.map((variety) => (
                     <ListItemButton
                       key={variety.id}
+                      className="variety-row"
                       selected={!isSpeciesView && variety.culture?.id === selectedCulture.id}
                       onClick={() => {
                         if (variety.culture) {
@@ -1026,25 +1028,32 @@ const detailSectionGridSx = {
                       }}
                       sx={{ borderRadius: 1, mb: 0.5 }}
                     >
-                      <ListItemText primary={variety.label} />
-                      <Stack direction="row" spacing={0.5} onClick={(event) => event.stopPropagation()}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('buttons.edit')}
-                          disabled={!onEditCulture || !variety.culture}
-                          onClick={() => variety.culture && onEditCulture?.(variety.culture)}
+                      <Box sx={{ position: 'relative', display: 'inline-flex', alignItems: 'center', width: 'fit-content', maxWidth: '100%' }}>
+                        <ListItemText primary={variety.label} sx={{ flex: 'none', pr: 1 }} />
+                        <Box
+                          sx={contextMenuActionsOverlaySx('.variety-row:hover &', '.variety-row:focus-within &')}
+                          onClick={(event) => event.stopPropagation()}
                         >
-                          <EditIcon fontSize="small" />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          aria-label={t('buttons.delete')}
-                          disabled={!onDeleteCulture || !variety.culture}
-                          onClick={() => variety.culture && onDeleteCulture?.(variety.culture)}
-                        >
-                          <DeleteOutlineIcon fontSize="small" />
-                        </IconButton>
-                      </Stack>
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            aria-label={t('buttons.edit')}
+                            disabled={!onEditCulture || !variety.culture}
+                            onClick={() => variety.culture && onEditCulture?.(variety.culture)}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                          <IconButton
+                            size="small"
+                            color="error"
+                            aria-label={t('buttons.delete')}
+                            disabled={!onDeleteCulture || !variety.culture}
+                            onClick={() => variety.culture && onDeleteCulture?.(variety.culture)}
+                          >
+                            <DeleteOutlineIcon fontSize="small" />
+                          </IconButton>
+                        </Box>
+                      </Box>
                     </ListItemButton>
                   ))}
                 </List>


### PR DESCRIPTION
## Summary

In the crop detail view's "Varieties" section (the sibling-variety list shown on the crop/species overview), the edit and delete icons per row were always visible and right-aligned across the full row width — leaving a large empty gap between the (left-aligned) variety name and the icons, and looking stylistically inconsistent with the rest of the app.

## Reference component

`frontend/src/components/contextMenu/contextMenuIndicatorStyles.ts` — `contextMenuActionsOverlaySx(hoverSelector, focusWithinSelector)` is the shared hover-reveal overlay pattern already used by:
- `frontend/src/pages/Suppliers.tsx` (`tr:hover &` / `tr:focus-within &`)
- `frontend/src/pages/SeedDemand.tsx`
- the Fields hierarchy tree (`frontend/src/components/hierarchy/hierarchyNameCell.tsx`, via `.MuiDataGrid-row:hover &`)

It renders the action icons as an absolutely-positioned overlay, `opacity: 0` / `pointer-events: none` by default, revealed only on `:hover`/`:focus-within` of the row (with a gradient mask so any truncated text underneath reads cleanly), and stays hidden at all times on touch devices (long-press opens the context menu there instead).

## Change

`frontend/src/cultures/CultureDetail.tsx`'s Varieties list now reuses this same function instead of a bespoke always-visible `Stack` of icons:
- Each row gets a `.variety-row` class; the overlay is wired to `.variety-row:hover &` / `.variety-row:focus-within &`.
- Name + icon overlay are wrapped in a `width: fit-content` box (instead of letting the icons flex to the far right of the full-width row), so the icons sit right after the name.
- Edit icon now uses `color="primary"`, delete `color="error"`, matching the same convention used in Suppliers/Fields.

No new shared component was needed — `contextMenuActionsOverlaySx` was already designed to be reused by arbitrary "hoverable/focusable row" containers, not just `<tr>`/DataGrid rows.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean.
- [x] `npx eslint` clean on changed files.
- [x] `npx vitest run` — full suite (1949 tests) passes, including a new `CultureDetail.test.tsx` test asserting: the action icons are positioned immediately after the name (not at the row's far right), have `pointer-events: none` by default (i.e. are genuinely not interactive/visible until hover — not just styled to *look* hidden), and that clicking them still calls `onEditCulture`/`onDeleteCulture` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)