### PR TITLE
Dedicated crop-level publish flow with prefilled fields and collapsed language

### DIFF
--- a/frontend/src/__tests__/CulturesActionArea.test.tsx
+++ b/frontend/src/__tests__/CulturesActionArea.test.tsx
@@ -309,7 +309,11 @@ describe('Cultures action area', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('Kultur veröffentlichen')).toBeInTheDocument();
     expect(within(dialog).getByLabelText(/Offizielle Kulturart/)).toBeInTheDocument();
-    expect(within(dialog).getByLabelText('Originalsprache')).toBeInTheDocument();
+    // "Original language" is collapsed to a summary + change link by
+    // default (it's pre-set to the app's current language), not an
+    // always-visible required field.
+    expect(within(dialog).queryByLabelText('Originalsprache')).not.toBeInTheDocument();
+    expect(within(dialog).getByText(/Originalsprache: /)).toBeInTheDocument();
     expect(within(dialog).queryByText('Zusammenfassung')).not.toBeInTheDocument();
     expect(within(dialog).queryByText('Pflichtfelder')).not.toBeInTheDocument();
     expect(within(dialog).queryByText('Dublettenprüfung')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/CulturesPublishingWizardDialog.test.tsx
+++ b/frontend/src/__tests__/CulturesPublishingWizardDialog.test.tsx
@@ -172,6 +172,24 @@ describe('CulturesPublishingWizardDialog', () => {
     expect(screen.queryByText(/wurde zur Prüfung eingereicht/)).not.toBeInTheDocument();
   });
 
+  it('pre-selects the existing public variety that already matches the local variety name', async () => {
+    publicCultureListMock.mockResolvedValue({
+      data: {
+        results: [
+          { id: 40, status: 'published', name: 'Tomate', display_name: 'Tomate', variety: 'Roma', crop_species: 1, version: 2 },
+          { id: 41, status: 'published', name: 'Tomate', display_name: 'Tomate', variety: 'Ochsenherz', crop_species: 1, version: 1 },
+        ],
+      },
+    });
+
+    renderWizard();
+
+    await screen.findByLabelText(/Offizielle Kulturart/i);
+    // The species is already selected in the field above, so this field
+    // shows only the variety name — not a redundant "Species · Variety".
+    await waitFor(() => expect(screen.getByDisplayValue('Roma')).toBeInTheDocument());
+  });
+
   it('shows a link to view foreign duplicates instead of blocking on plain text', async () => {
     publishPreviewMock.mockResolvedValue({
       data: {
@@ -192,6 +210,37 @@ describe('CulturesPublishingWizardDialog', () => {
 
     const viewLink = await screen.findByRole('link', { name: 'Eintrag ansehen' });
     expect(viewLink).toHaveAttribute('href', '/app/crop-library?cultureId=55');
+  });
+
+  it('hides the "Existing variety" field and publishes as general for a crop-level culture (no variety)', async () => {
+    const cropLevelCulture: Culture = { ...CULTURE, variety: '' };
+    renderWizard(cropLevelCulture);
+
+    await screen.findByLabelText(/Offizielle Kulturart/i);
+    expect(screen.queryByLabelText('Vorhandene Sorte')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jetzt veröffentlichen' }));
+
+    await waitFor(() => expect(publishPreviewMock).toHaveBeenCalledWith(
+      cropLevelCulture.id,
+      expect.objectContaining({ crop_species_id: 1, original_language_code: 'de', publish_as_general: true }),
+    ));
+  });
+
+  it('prefills the species field with the local culture name on open, for crop-level and variety cultures', async () => {
+    renderWizard();
+    expect(await screen.findByDisplayValue('Tomate')).toBeInTheDocument();
+  });
+
+  it('keeps "Original language" collapsed to a summary with a change link by default', async () => {
+    renderWizard();
+    await screen.findByLabelText(/Offizielle Kulturart/i);
+
+    expect(screen.queryByLabelText('Originalsprache')).not.toBeInTheDocument();
+    expect(screen.getByText(/Originalsprache: /)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ändern' }));
+    expect(screen.getByLabelText('Originalsprache')).toBeInTheDocument();
   });
 
   it('shows a dismissible notice when the general crop data looks stale', async () => {

--- a/frontend/src/i18n/locales/de/cultures.json
+++ b/frontend/src/i18n/locales/de/cultures.json
@@ -895,6 +895,7 @@
     "publishWizard": {
       "title": "Kultur veröffentlichen",
       "intro": "Wähle zuerst die passende öffentliche Kulturart. Deine Sorte wird darunter veröffentlicht; falls es zu dieser Kulturart noch keinen allgemeinen Eintrag gibt, wird er automatisch aus deinen aktuellen Werten angelegt.",
+      "introGeneral": "Wähle die passende öffentliche Kulturart. Es werden die allgemeinen Daten dieser Kulturart veröffentlicht, keine Sorte.",
       "updateIntro": "Prüfe die Änderungen gegenüber deiner öffentlichen Version. Die bestehende öffentliche Kultur wird aktualisiert.",
       "publishNow": "Jetzt veröffentlichen",
       "linkExisting": "Mit öffentlicher Kultur verknüpfen",
@@ -969,6 +970,8 @@
       "proposeSpeciesError": "Der Vorschlag konnte nicht gespeichert werden. Bitte versuche es erneut.",
       "speciesAlreadyExists": "Diese Kulturart existiert bereits oder wurde schon vorgeschlagen — möglicherweise unter einem anderen Namen. Bitte in der Liste danach suchen.",
       "originalLanguageLabel": "Originalsprache",
+      "originalLanguageSummary": "Originalsprache: {{language}}",
+      "changeLanguageLink": "Ändern",
       "translationsOptional": "Fehlende Übersetzungen können später ergänzt werden.",
       "translationAvailable": "Vorhanden",
       "translationMissingOptional": "Fehlt, optional",

--- a/frontend/src/i18n/locales/en/cultures.json
+++ b/frontend/src/i18n/locales/en/cultures.json
@@ -895,6 +895,7 @@
     "publishWizard": {
       "title": "Publish culture",
       "intro": "First choose the matching public crop species. Your variety is published under it; if the species has no general entry yet, one is created automatically from your current values.",
+      "introGeneral": "Choose the matching public crop species. Only its general data is published, not a variety.",
       "updateIntro": "Review the changes compared with your public version. The existing public crop will be updated.",
       "publishNow": "Publish now",
       "linkExisting": "Link public crop",
@@ -969,6 +970,8 @@
       "proposeSpeciesError": "The suggestion could not be saved. Please try again.",
       "speciesAlreadyExists": "This crop species already exists or has already been suggested — possibly under a different name. Please search for it in the list.",
       "originalLanguageLabel": "Original language",
+      "originalLanguageSummary": "Original language: {{language}}",
+      "changeLanguageLink": "Change",
       "translationsOptional": "Missing translations can be added later.",
       "translationAvailable": "Available",
       "translationMissingOptional": "Missing, optional",

--- a/frontend/src/pages/Cultures.tsx
+++ b/frontend/src/pages/Cultures.tsx
@@ -235,12 +235,14 @@ function Cultures() {
     cropSpeciesId?: number;
     originalLanguageCode: string;
     publicCultureId?: number | null;
+    publishAsGeneral?: boolean;
   }) => {
     setPublishWizardOpen(false);
     void handlePublishCurrentCulture(data.acceptedPublicLibraryTerms, {
       cropSpeciesId: data.cropSpeciesId,
       originalLanguageCode: data.originalLanguageCode,
       publicCultureId: data.publicCultureId,
+      publishAsGeneral: data.publishAsGeneral,
     });
   }, [handlePublishCurrentCulture]);
 

--- a/frontend/src/pages/CulturesPublishingWizardDialog.tsx
+++ b/frontend/src/pages/CulturesPublishingWizardDialog.tsx
@@ -35,7 +35,7 @@ interface CulturesPublishingWizardDialogProps {
   termsAlreadyAccepted: boolean;
   publishing: boolean;
   onClose: () => void;
-  onPublish: (data: { acceptedPublicLibraryTerms: boolean; cropSpeciesId?: number; originalLanguageCode: string; publicCultureId?: number | null }) => void;
+  onPublish: (data: { acceptedPublicLibraryTerms: boolean; cropSpeciesId?: number; originalLanguageCode: string; publicCultureId?: number | null; publishAsGeneral?: boolean }) => void;
 }
 
 const LANGUAGE_CODES = ['de', 'en'] as const;
@@ -51,6 +51,13 @@ const normalizeSpeciesName = (value: string | undefined | null): string => (
   (value || '').split(/\s+/).filter(Boolean).join(' ').toLocaleLowerCase('de')
 );
 
+// The picker must match on the name the user actually sees and types, not
+// the (possibly differently-languaged) canonical `name` — otherwise a
+// species that already exists only under a translation (e.g. "Kürbis" for
+// canonical "Pumpkin") looks missing, and proposing it as new fails
+// server-side because that translation already exists.
+const getCropSpeciesOptionLabel = (option: CropSpecies): string => option.display_name || option.name;
+
 const findInitialSpecies = (items: CropSpecies[], culture: Culture | undefined): CropSpecies | null => {
   const cultureSpeciesId = culture?.crop_species ?? null;
   if (cultureSpeciesId) {
@@ -61,7 +68,10 @@ const findInitialSpecies = (items: CropSpecies[], culture: Culture | undefined):
   if (!normalizedCultureName) {
     return null;
   }
-  return items.find((item) => normalizeSpeciesName(item.name) === normalizedCultureName) ?? null;
+  return items.find((item) => (
+    normalizeSpeciesName(item.name) === normalizedCultureName
+    || normalizeSpeciesName(getCropSpeciesOptionLabel(item)) === normalizedCultureName
+  )) ?? null;
 };
 
 const getPublicCultureOptionLabel = (option: PublicCulture): string => {
@@ -69,12 +79,10 @@ const getPublicCultureOptionLabel = (option: PublicCulture): string => {
   return option.variety ? `${name} · ${option.variety}` : name;
 };
 
-// The picker must match on the name the user actually sees and types, not
-// the (possibly differently-languaged) canonical `name` — otherwise a
-// species that already exists only under a translation (e.g. "Kürbis" for
-// canonical "Pumpkin") looks missing, and proposing it as new fails
-// server-side because that translation already exists.
-const getCropSpeciesOptionLabel = (option: CropSpecies): string => option.display_name || option.name;
+// The "Existing variety" field is already scoped to the chosen species (it's
+// right below that field), so repeating the species name in every option
+// would just be noise — only the variety name itself is shown/typed there.
+const getExistingVarietyOptionLabel = (option: PublicCulture): string => option.variety || getPublicCultureOptionLabel(option);
 
 export function CulturesPublishingWizardDialog({
   open,
@@ -98,24 +106,36 @@ export function CulturesPublishingWizardDialog({
   const [validationLoading, setValidationLoading] = useState(false);
   const [showLicenseConfirmation, setShowLicenseConfirmation] = useState(false);
   const [speciesInputValue, setSpeciesInputValue] = useState('');
+  const [existingVarietyInputValue, setExistingVarietyInputValue] = useState('');
   const [proposedSpeciesName, setProposedSpeciesName] = useState<string | null>(null);
   const [proposingSpecies, setProposingSpecies] = useState(false);
   const [proposeSpeciesError, setProposeSpeciesError] = useState('');
   const [generalNoticeDismissed, setGeneralNoticeDismissed] = useState(false);
+  const [showLanguageOverride, setShowLanguageOverride] = useState(false);
   const speciesInputRef = useRef<HTMLInputElement | null>(null);
   const languageInputRef = useRef<HTMLInputElement | null>(null);
   const ownedPublicCultureId = culture?.owned_public_culture_id ?? null;
   const isOwnedPublicCultureUpdate = Boolean(ownedPublicCultureId);
+  const isCropLevelPublish = !isOwnedPublicCultureUpdate && !culture?.variety?.trim();
 
   useEffect(() => {
     if (!open) return;
     queueMicrotask(() => {
       setAcceptedLicense(false);
       setShowLicenseConfirmation(false);
-      setSpeciesInputValue('');
+      // Prefilled with the local culture's own name so the field never starts
+      // empty — the user can still overwrite it if no official species
+      // matches, or if they want to propose a different one.
+      setSpeciesInputValue(culture?.name ?? '');
+      // Same idea for the variety field: pre-fill with the local variety's
+      // own name. If a matching public entry is found once the search
+      // results load (see the publicCultureOptions effect), it's also
+      // auto-selected there.
+      setExistingVarietyInputValue(culture?.variety ?? '');
       setProposedSpeciesName(null);
       setProposeSpeciesError('');
       setGeneralNoticeDismissed(false);
+      setShowLanguageOverride(false);
       setValidationResult(null);
       setOriginalLanguageCode(getDefaultLanguageCode());
       setPublicCultureInput(culture?.name ?? '');
@@ -143,7 +163,7 @@ export function CulturesPublishingWizardDialog({
   }, [culture?.source_public_culture, open, ownedPublicCultureId]);
 
   useEffect(() => {
-    if (isOwnedPublicCultureUpdate) return undefined;
+    if (isOwnedPublicCultureUpdate || isCropLevelPublish) return undefined;
     if (!open) return undefined;
     const searchTerm = selectedSpecies?.name.trim() || '';
     if (!searchTerm) {
@@ -157,10 +177,23 @@ export function CulturesPublishingWizardDialog({
       setPublicCultureLoading(true);
       publicCultureAPI.list({ q: searchTerm }, abortController.signal)
         .then((response) => {
-          if (!cancelled) {
-            setPublicCultureOptions(response.data.results.filter((entry) => (
-              !selectedSpecies || entry.crop_species === selectedSpecies.id
-            )));
+          if (cancelled) return;
+          const filtered = response.data.results.filter((entry) => (
+            !selectedSpecies || entry.crop_species === selectedSpecies.id
+          ));
+          setPublicCultureOptions(filtered);
+          // If the local variety already has a matching public entry,
+          // recognize it immediately instead of leaving the field empty —
+          // mirrors the species field's own-name prefill above.
+          const normalizedLocalVariety = normalizeSpeciesName(culture?.variety);
+          const match = normalizedLocalVariety
+            ? filtered.find((entry) => normalizeSpeciesName(entry.variety) === normalizedLocalVariety)
+            : undefined;
+          if (match) {
+            setSelectedPublicCulture((prevSelected) => prevSelected ?? match);
+            setExistingVarietyInputValue((prevInput) => (
+              prevInput === (culture?.variety ?? '') ? getExistingVarietyOptionLabel(match) : prevInput
+            ));
           }
         })
         .catch(() => {
@@ -176,7 +209,7 @@ export function CulturesPublishingWizardDialog({
       window.clearTimeout(timeoutId);
       abortController.abort();
     };
-  }, [isOwnedPublicCultureUpdate, open, selectedSpecies]);
+  }, [culture?.variety, isOwnedPublicCultureUpdate, isCropLevelPublish, open, selectedSpecies]);
 
   useEffect(() => {
     if (isOwnedPublicCultureUpdate) return;
@@ -281,6 +314,7 @@ export function CulturesPublishingWizardDialog({
       const response = await cultureAPI.publishPreview(culture.id, {
         crop_species_id: cropSpeciesId,
         original_language_code: originalLanguageCode,
+        ...(isCropLevelPublish ? { publish_as_general: true } : {}),
       });
       setValidationResult(response.data);
       if (!response.data.can_publish) return;
@@ -304,10 +338,12 @@ export function CulturesPublishingWizardDialog({
       acceptedPublicLibraryTerms: !termsAlreadyAccepted && acceptedLicense,
       cropSpeciesId,
       originalLanguageCode,
+      ...(isCropLevelPublish ? { publishAsGeneral: true } : {}),
     });
   }, [
     acceptedLicense,
     culture,
+    isCropLevelPublish,
     licenseAccepted,
     onPublish,
     originalLanguageCode,
@@ -324,9 +360,14 @@ export function CulturesPublishingWizardDialog({
       <DialogContent dividers>
         <Stack spacing={2.25} sx={{ pt: 0.5 }}>
           <Typography variant="body2" color="text.secondary">
-            {t(isOwnedPublicCultureUpdate ? 'library.publishWizard.updateIntro' : 'library.publishWizard.intro', {
-              name: culture?.name ?? '',
-            })}
+            {t(
+              isOwnedPublicCultureUpdate
+                ? 'library.publishWizard.updateIntro'
+                : isCropLevelPublish
+                  ? 'library.publishWizard.introGeneral'
+                  : 'library.publishWizard.intro',
+              { name: culture?.name ?? '' },
+            )}
           </Typography>
 
           <Stack spacing={2}>
@@ -403,36 +444,44 @@ export function CulturesPublishingWizardDialog({
                   )}
                 />
 
-                <Autocomplete
-                  options={existingVarietyOptions}
-                  value={selectedPublicCulture}
-                  loading={publicCultureLoading}
-                  getOptionLabel={getPublicCultureOptionLabel}
-                  isOptionEqualToValue={(option, value) => option.id === value.id}
-                  filterOptions={(options) => options}
-                  onChange={(_, value) => {
-                    setSelectedPublicCulture(value);
-                    resetValidationResult();
-                  }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label={t('library.publishWizard.existingVarietyLabel')}
-                      helperText={culture?.variety?.trim()
-                        ? t('library.publishWizard.existingVarietyHelp')
-                        : t('library.publishWizard.publicCultureHelp')}
-                      InputProps={{
-                        ...params.InputProps,
-                        endAdornment: (
-                          <>
-                            {publicCultureLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                            {params.InputProps.endAdornment}
-                          </>
-                        ),
-                      }}
-                    />
-                  )}
-                />
+                {isCropLevelPublish ? null : (
+                  <Autocomplete
+                    options={existingVarietyOptions}
+                    value={selectedPublicCulture}
+                    inputValue={existingVarietyInputValue}
+                    loading={publicCultureLoading}
+                    getOptionLabel={getExistingVarietyOptionLabel}
+                    isOptionEqualToValue={(option, value) => option.id === value.id}
+                    filterOptions={(options) => options}
+                    onChange={(_, value) => {
+                      setSelectedPublicCulture(value);
+                      setExistingVarietyInputValue(value ? getExistingVarietyOptionLabel(value) : '');
+                      resetValidationResult();
+                    }}
+                    onInputChange={(_, value, reason) => {
+                      if (reason === 'reset') return;
+                      setExistingVarietyInputValue(value);
+                    }}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label={t('library.publishWizard.existingVarietyLabel')}
+                        helperText={culture?.variety?.trim()
+                          ? t('library.publishWizard.existingVarietyHelp')
+                          : t('library.publishWizard.publicCultureHelp')}
+                        InputProps={{
+                          ...params.InputProps,
+                          endAdornment: (
+                            <>
+                              {publicCultureLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                              {params.InputProps.endAdornment}
+                            </>
+                          ),
+                        }}
+                      />
+                    )}
+                  />
+                )}
               </>
             )}
 
@@ -492,7 +541,7 @@ export function CulturesPublishingWizardDialog({
             ) : null}
 
             {!isOwnedPublicCultureUpdate ? (
-              <>
+              showLanguageOverride ? (
                 <FormControl fullWidth>
                   <InputLabel id="publishing-original-language-label">{t('library.publishWizard.originalLanguageLabel')}</InputLabel>
                   <Select
@@ -510,7 +559,18 @@ export function CulturesPublishingWizardDialog({
                     ))}
                   </Select>
                 </FormControl>
-              </>
+              ) : (
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Typography variant="body2" color="text.secondary">
+                    {t('library.publishWizard.originalLanguageSummary', {
+                      language: getLanguageDisplayName(originalLanguageCode, i18n.resolvedLanguage ?? i18n.language),
+                    })}
+                  </Typography>
+                  <Button size="small" onClick={() => setShowLanguageOverride(true)}>
+                    {t('library.publishWizard.changeLanguageLink')}
+                  </Button>
+                </Stack>
+              )
             ) : null}
           </Stack>
 

--- a/frontend/src/pages/usePublicCultureLibrary.ts
+++ b/frontend/src/pages/usePublicCultureLibrary.ts
@@ -117,7 +117,7 @@ export function usePublicCultureLibrary({
 
   const handlePublishCurrentCulture = async (
     acceptedPublicLibraryTerms = false,
-    publishingData?: { cropSpeciesId?: number; originalLanguageCode: string; publicCultureId?: number | null },
+    publishingData?: { cropSpeciesId?: number; originalLanguageCode: string; publicCultureId?: number | null; publishAsGeneral?: boolean },
   ): Promise<boolean> => {
     if (!selectedCulture?.id) {
       return false;
@@ -136,6 +136,7 @@ export function usePublicCultureLibrary({
         ...(publishingData ? {
           crop_species_id: publishingData.cropSpeciesId,
           original_language_code: publishingData.originalLanguageCode,
+          ...(publishingData.publishAsGeneral !== undefined ? { publish_as_general: publishingData.publishAsGeneral } : {}),
         } : {}),
       });
       if (response.data.operation === 'updated') {


### PR DESCRIPTION
## Summary

The "Publish" action in the "…" menu on the general crop detail page (no variety selected, e.g. `/app/cultures?cultureId=3409` "Carrot") opened the exact same publish wizard as the variety-level flow (`/app/cultures?cultureId=2570` "Carrot · Nantaise 2"), including the "Existing variety" field, which makes no sense when publishing at the species level — and nothing ever sent `publish_as_general` to the backend anymore (that flag was intentionally dropped from the *variety* flow's payload in #444/#445, but the crop-level flow needs it and was never wired up).

## Analysis (before implementing)

- Backend already fully supports `publish_as_general` end to end: `resolve_publishing_crop_species`, `get_public_required_field_gaps`, `_resolve_public_variety`, duplicate detection (`is_mine`/conflict UI), and general-entry handling. Only the frontend needed to send it for the crop-level case and adapt the UI — no backend changes in this PR.
- `CulturesPublishingWizardDialogProps.onPublish` had `publishAsGeneral` removed in #444 since the variety flow no longer needs it; it needed to come back, but only set for the crop-level case.

## Changes

1. **Dedicated crop-level publish flow**: `isCropLevelPublish` is derived from `!culture.variety` (same predicate `CultureDetail.tsx` already uses to distinguish a general crop row from a variety row). When true, the "Existing variety" field is hidden entirely, and `publishAsGeneral: true` is threaded through `onPublish` → `Cultures.tsx`'s `handlePublishingWizardPublish` → `usePublicCultureLibrary.ts`'s `handlePublishCurrentCulture` → `cultureAPI.publishPublic`'s existing `publish_as_general` param. Conflict handling (own vs. foreign existing general entry) reuses the exact same `is_mine`/duplicate-link UI already built for the variety flow — sending the flag was the only missing piece.
2. **Species field prefill**: "Official crop species" starts pre-filled with the local culture's own name (instead of empty) in both contexts. Also fixed `findInitialSpecies` to match on a species' localized `display_name`, not just its canonical `name` — the same class of bug already fixed for the live search in #445.
3. **Existing variety field prefill**: for the variety flow, "Existing variety" starts pre-filled with the local variety's name and auto-selects a matching public entry if one already exists (instead of starting empty), and now shows only the variety name (e.g. "Nantaise 2") rather than a redundant "Species · Variety" combo, since the species is already shown in the field right above it.
4. **Original language collapsed**: replaced the always-visible required `Select` with a summary ("Original language: {{language}}") + small "Change" link, revealing the `Select` only on demand. It was already defaulting to the app's current UI language via the existing `i18n` singleton (`getDefaultLanguageCode()`/`i18n.language`) — this only removes the appearance of a required decision every time, multi-language support is untouched.

## Crash investigation

Re-checked the reported `ReferenceError: contextMenuActionsOverlaySx is not defined` crash on the variety detail page. That symbol is only referenced inside `CultureDetail.tsx`'s Varieties section, which (per #446) only renders when `isSpeciesView` is true — never on a variety's own detail page, which is exactly where the crash was reported. A clean `npm run build`, `tsc --noEmit`, `eslint`, and the full test suite all pass with no repro. This has the signature of a transient Vite dev-server HMR artifact from testing right after that import landed, not a persisted bug — no fix applied since none was identified; flagging this explicitly rather than guessing at a change.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean; `npx eslint` clean on changed files.
- [x] `npx vitest run` — full suite (1953 tests) passes, including: a new crop-level fixture test (hides "Existing variety", sends `publish_as_general: true`), a species/variety prefill test, an existing-variety auto-select test, and an "Original language" collapse/reveal test. Updated a pre-existing `CulturesActionArea.test.tsx` assertion that expected the language `Select` to be immediately visible.
- [x] `npm run build` (production) clean, as part of the crash re-check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)