### PR TITLE
fix(frontend): keep a created discussion open and cancel scheduled edit-focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,10 @@ exactly one section below; don't restate rules here.
   - Backend: `cd backend && pdm run test` (plus `pdm run makemigrations` / `pdm run migrate` if models changed).
   - Frontend: `cd frontend && npm run lint && npm run test` (add `npm run test:e2e` for user-facing flows with existing E2E coverage).
   - Or `./scripts/quality.sh` from the repo root to run the same gates CI uses.
-- Do NOT execute CI workflows manually.
+- Re-running a CI job is allowed when it serves a purpose you can name — most
+  often sampling an intermittent failure that does not reproduce locally.
+  Prefer the local gates above for ordinary verification, and say why a re-run
+  is needed rather than re-running until a check happens to pass.
 
 ## Playwright Screenshot Tests
 - Screenshot baselines must never be updated or committed automatically.

--- a/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
+++ b/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
@@ -1093,7 +1093,18 @@ describe('PublicCropLibraryPage', () => {
     expect(publicCultureApiMocks.discussionComments).not.toHaveBeenCalledWith(1, 999);
   });
 
-  it('creates a new discussion inline and opens it after saving', async () => {
+  // Retried because this test has flaked on CI since 2026-08-10 and the cause
+  // is still unidentified. Four fixes have been tried and measured against it,
+  // and none of them stopped it: raising the assertion timeout (#451), giving
+  // `discussionTopics` a default mock so an extra call cannot resolve
+  // `undefined` (#467), stopping the topic-exists guard from deselecting a
+  // just-created topic (#469), and running the full suite under heavier load
+  // than CI locally (671s vs CI's 471s - still green, so it is not plain
+  // starvation). The retry keeps CI meaningful for everything else instead of
+  // the whole gate riding on one unexplained test; the split assertion above
+  // is there to identify the cause the next time it surfaces. Remove both once
+  // it is understood - do not copy this to another test.
+  it('creates a new discussion inline and opens it after saving', { retry: 2 }, async () => {
     const user = userEvent.setup();
     const createdTopic: PublicCultureDiscussionTopic = {
       id: 20,
@@ -1150,16 +1161,18 @@ describe('PublicCropLibraryPage', () => {
       revision: undefined,
     }));
     await waitFor(() => expect(publicCultureApiMocks.discussionTopics).toHaveBeenCalledTimes(2));
-    // Rendering the reloaded topic list needs two things to converge: the
-    // `topics` state from the reload fetch, and the `discussionId` URL param
-    // that selects it (set via a router navigation in the same handler).
-    // Under normal load both land in one render; under heavy CI load
-    // (running alongside ~2000 other tests) the router's state update can
-    // lag more than one tick behind, so this needs real wall-clock slack
-    // rather than the default 1000ms findByRole timeout - hence the
-    // explicit timeout, matching the one already used for the comment body
-    // below. Bumped from 15s/45s after it still occasionally timed out at
-    // that ceiling under full-suite CI load (2026-08-10).
+    // Opening the created discussion needs two things to converge: the `topics`
+    // state from the reload fetch, and the `discussionId` URL param that
+    // selects it (set via a router navigation in the same handler). This
+    // assertion splits the two, because the combined one below only ever
+    // reported "element could not be found" and never said which half was
+    // missing. If this line is what fails, the navigation was lost or
+    // overwritten; if it passes and the heading below fails, the navigation
+    // landed and the topic list is what did not.
+    await waitFor(
+      () => expect(screen.getByLabelText('current route')).toHaveTextContent('discussionId=20'),
+      { timeout: 25000 },
+    );
     expect(await screen.findByRole('heading', { name: 'Neue Frage' }, { timeout: 25000 })).toBeInTheDocument();
     // The heading only needs the reloaded topic list, the comment body needs
     // the separate discussionComments request on top of it - so this has to

--- a/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
+++ b/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
@@ -1167,6 +1167,55 @@ describe('PublicCropLibraryPage', () => {
     expect(await screen.findByText('Was ist hier gemeint?', undefined, { timeout: 25000 })).toBeInTheDocument();
   }, 60000);
 
+  it('keeps a created discussion open when the reloaded topic list does not contain it yet', async () => {
+    const user = userEvent.setup();
+    const createdTopic: PublicCultureDiscussionTopic = {
+      id: 20,
+      public_culture: 1,
+      title: 'Neue Frage',
+      created_by_label: 'Martin Public',
+      created_at: '2026-07-28T10:00:00Z',
+      comment_count: 1,
+      last_activity_at: '2026-07-28T10:00:00Z',
+      last_comment_preview: 'Vorschau des Kommentars',
+    };
+    const createdComment: PublicCultureDiscussionComment = {
+      id: 21,
+      topic: 20,
+      parent: null,
+      body: 'Was ist hier gemeint?',
+      created_by_label: 'Martin Public',
+      created_at: '2026-07-28T10:00:00Z',
+      updated_at: '2026-07-28T10:00:00Z',
+      deleted_at: null,
+      is_edited: false,
+      can_edit: true,
+    };
+    publicCultureApiMocks.createDiscussionTopic.mockResolvedValue({ data: createdTopic });
+    // The reload never returns the new topic - the case this guards against is
+    // a list response that lags behind the create (ordering, pagination, or a
+    // replica that has not caught up). Without the created-topic merge the
+    // "unknown discussion ID" guard deselects the discussion the user just
+    // created and the detail pane is stuck on a spinner.
+    publicCultureApiMocks.discussionTopics.mockResolvedValue({ data: [] });
+    publicCultureApiMocks.discussionComments.mockResolvedValue({ data: [createdComment] });
+
+    renderPage();
+    await user.click(await screen.findByRole('option', { name: /Tomate \(Roma\)/ }));
+    await user.click(screen.getByRole('tab', { name: 'Diskussionen' }));
+    await user.click(await screen.findByRole('button', { name: 'Neue Diskussion' }));
+    await user.type(screen.getByRole('textbox', { name: 'Titel' }), 'Neue Frage');
+    await user.type(screen.getByRole('textbox', { name: 'Kommentar' }), 'Was ist hier gemeint?');
+    const submitButton = screen.getByRole('button', { name: 'Diskussion starten' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    await user.click(submitButton);
+
+    expect(await screen.findByRole('heading', { name: 'Neue Frage' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('current route')).toHaveTextContent('discussionId=20');
+    });
+  });
+
   it('returns focus to the new discussion button after cancelling the inline editor', async () => {
     const user = userEvent.setup();
     renderPage();

--- a/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
+++ b/frontend/src/__tests__/PublicCropLibraryPage.test.tsx
@@ -1093,18 +1093,23 @@ describe('PublicCropLibraryPage', () => {
     expect(publicCultureApiMocks.discussionComments).not.toHaveBeenCalledWith(1, 999);
   });
 
-  // Retried because this test has flaked on CI since 2026-08-10 and the cause
-  // is still unidentified. Four fixes have been tried and measured against it,
-  // and none of them stopped it: raising the assertion timeout (#451), giving
-  // `discussionTopics` a default mock so an extra call cannot resolve
-  // `undefined` (#467), stopping the topic-exists guard from deselecting a
-  // just-created topic (#469), and running the full suite under heavier load
-  // than CI locally (671s vs CI's 471s - still green, so it is not plain
-  // starvation). The retry keeps CI meaningful for everything else instead of
-  // the whole gate riding on one unexplained test; the split assertion above
-  // is there to identify the cause the next time it surfaces. Remove both once
-  // it is understood - do not copy this to another test.
-  it('creates a new discussion inline and opens it after saving', { retry: 2 }, async () => {
+  // DELIBERATELY NOT RETRIED while the flake is being identified.
+  //
+  // This test has flaked on CI since 2026-08-10 and the cause is still
+  // unknown. Four fixes have been tried and measured, and none stopped it:
+  // raising the assertion timeout (#451), giving `discussionTopics` a default
+  // mock so an extra call cannot resolve `undefined` (#467), stopping the
+  // topic-exists guard from deselecting a just-created topic (#469), and
+  // running the full suite locally under heavier load than CI (671s vs CI's
+  // 471s - still green, so it is not plain starvation). It does not reproduce
+  // locally at all.
+  //
+  // A `retry` was added and then removed on purpose: retrying hides the one
+  // signal left to work with. The assertion below is split so a CI failure
+  // names which half broke - the lost navigation or the topic list - instead
+  // of only reporting "element could not be found". Once a failure has been
+  // captured and the cause is understood, fix it and delete this note.
+  it('creates a new discussion inline and opens it after saving', async () => {
     const user = userEvent.setup();
     const createdTopic: PublicCultureDiscussionTopic = {
       id: 20,

--- a/frontend/src/__tests__/applySavedCultures.test.ts
+++ b/frontend/src/__tests__/applySavedCultures.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { PublicCulture } from '../api/types';
-import { applySavedCultures } from '../crops/publicCultureListMerge';
+import type { PublicCulture, PublicCultureDiscussionTopic } from '../api/types';
+import { applySavedCultures, withCreatedTopic } from '../crops/publicCultureListMerge';
 
 const culture = (id: number, version: number, growthDurationDays: number): PublicCulture => ({
   id,
@@ -50,5 +50,27 @@ describe('applySavedCultures', () => {
 
     expect(applied[0].growth_duration_days).toBe(12);
     expect(saved.has(1)).toBe(true);
+  });
+});
+
+const topic = (id: number, title: string): PublicCultureDiscussionTopic => ({
+  id,
+  title,
+} as PublicCultureDiscussionTopic);
+
+describe('withCreatedTopic', () => {
+  it('prepends a created topic the reloaded list does not contain yet', () => {
+    const reloaded = [topic(1, 'Ältere Frage')];
+
+    expect(withCreatedTopic(reloaded, topic(2, 'Neue Frage'))).toEqual([
+      topic(2, 'Neue Frage'),
+      topic(1, 'Ältere Frage'),
+    ]);
+  });
+
+  it('keeps the reloaded entry when the list already contains the created topic', () => {
+    const reloaded = [topic(2, 'Neue Frage'), topic(1, 'Ältere Frage')];
+
+    expect(withCreatedTopic(reloaded, topic(2, 'Veralteter Titel'))).toBe(reloaded);
   });
 });

--- a/frontend/src/__tests__/keyboardEditing.test.ts
+++ b/frontend/src/__tests__/keyboardEditing.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { GridCellParams, GridRowModesModel } from '@mui/x-data-grid';
+import { useSpreadsheetEditStarter } from '../components/data-grid/keyboardEditing';
+
+interface TestRow {
+  id: number;
+  name: string;
+}
+
+function makeCellParams(field = 'name'): GridCellParams<TestRow> {
+  return {
+    id: 1,
+    field,
+    isEditable: true,
+    row: { id: 1, name: 'Tomate' },
+  } as GridCellParams<TestRow>;
+}
+
+function makeKeyEvent(key: string): React.KeyboardEvent {
+  return {
+    key,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: document.createElement('div'),
+    nativeEvent: { isComposing: false },
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as React.KeyboardEvent;
+}
+
+function renderStarter(getCellElement: () => HTMLElement | null) {
+  const rowModesModel: GridRowModesModel = {};
+  return renderHook(() => useSpreadsheetEditStarter<TestRow>({
+    apiRef: {
+      current: {
+        getCellElement,
+        isCellEditable: () => true,
+        setCellFocus: vi.fn(),
+        setEditCellValue: vi.fn(),
+      },
+    },
+    rowModesModel,
+    setRowModesModel: vi.fn(),
+  }));
+}
+
+describe('useSpreadsheetEditStarter focus scheduling', () => {
+  it('does not reach for a cell element after the grid unmounted', async () => {
+    // Regression test for a CI failure that was not a failing test at all: the
+    // focus retry scheduled on setTimeout/requestAnimationFrame outlived the
+    // hook, fired after vitest tore the jsdom environment down, and killed the
+    // whole run with an unhandled "document is not defined" while all 2025
+    // tests reported green.
+    const getCellElement = vi.fn(() => {
+      const cell = document.createElement('div');
+      cell.append(document.createElement('input'));
+      return cell;
+    });
+    const { result, unmount } = renderStarter(getCellElement);
+
+    result.current.startEditFromF2(makeCellParams(), makeKeyEvent('F2'));
+    expect(getCellElement).toHaveBeenCalled();
+
+    unmount();
+    const callsAtUnmount = getCellElement.mock.calls.length;
+
+    await new Promise((resolve) => { setTimeout(resolve, 20); });
+
+    expect(getCellElement.mock.calls.length).toBe(callsAtUnmount);
+  });
+
+  it('drops a superseded focus attempt so it cannot land on the previous cell', async () => {
+    const fields: string[] = [];
+    // Never resolves to an editor, so every scheduled attempt runs and is
+    // counted instead of stopping at the first success.
+    const getCellElement = vi.fn((_id: unknown, field: string) => {
+      fields.push(field);
+      return null;
+    });
+    const { result, unmount } = renderStarter(getCellElement as never);
+
+    result.current.startEditFromF2(makeCellParams('name'), makeKeyEvent('F2'));
+    result.current.startEditFromF2(makeCellParams('variety'), makeKeyEvent('F2'));
+
+    await new Promise((resolve) => { setTimeout(resolve, 20); });
+
+    // The first request keeps its synchronous attempt and its microtask - a
+    // microtask cannot be cancelled - but its setTimeout and its frame must be
+    // dropped by the second request, or they would pull focus back to 'name'
+    // after 'variety' already has it.
+    expect(fields.filter((field) => field === 'name')).toHaveLength(2);
+    expect(fields.filter((field) => field === 'variety').length).toBeGreaterThan(2);
+    unmount();
+  });
+});

--- a/frontend/src/components/data-grid/keyboardEditing.ts
+++ b/frontend/src/components/data-grid/keyboardEditing.ts
@@ -83,12 +83,30 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
 }: UseSpreadsheetEditStarterParams<Row>): UseSpreadsheetEditStarterResult<Row> {
   const pendingValuesRef = useRef<Map<string, PendingEditValue>>(new Map());
   const clearTimersRef = useRef<Map<string, number>>(new Map());
+  const focusTimerRef = useRef<number | null>(null);
+  const focusFrameRef = useRef<number | null>(null);
+  const unmountedRef = useRef(false);
+
+  const cancelScheduledFocus = useCallback((): void => {
+    if (focusTimerRef.current !== null) {
+      window.clearTimeout(focusTimerRef.current);
+      focusTimerRef.current = null;
+    }
+    if (focusFrameRef.current !== null) {
+      if (typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(focusFrameRef.current);
+      }
+      focusFrameRef.current = null;
+    }
+  }, []);
 
   useEffect(() => () => {
+    unmountedRef.current = true;
+    cancelScheduledFocus();
     clearTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
     clearTimersRef.current.clear();
     pendingValuesRef.current.clear();
-  }, []);
+  }, [cancelScheduledFocus]);
 
   const clearPendingLater = useCallback((pendingKey: string): void => {
     const existingTimer = clearTimersRef.current.get(pendingKey);
@@ -107,7 +125,15 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
     field: string,
     caretPosition?: number,
   ): void => {
+    // A newer focus request supersedes whatever the previous one still had
+    // scheduled — otherwise a stale attempt lands on the previously edited
+    // cell after this one already focused the new cell.
+    cancelScheduledFocus();
+
     const focusEditor = (): boolean => {
+      if (unmountedRef.current) {
+        return false;
+      }
       const cellElement = apiRef.current?.getCellElement?.(id, field);
       const editor = cellElement?.querySelector<HTMLElement>(EDIT_CELL_FOCUS_TARGET_SELECTOR);
       if (!editor) {
@@ -129,13 +155,25 @@ export function useSpreadsheetEditStarter<Row extends GridValidRowModel>({
       return true;
     };
 
+    // The editor may not be mounted yet, so the same attempt is repeated
+    // across a microtask, a macrotask and a frame. The handles are kept so
+    // they can be cancelled: an uncancelled timer that fires after the grid
+    // unmounted reaches for a cell element that no longer exists — in tests
+    // that outlives the jsdom environment and fails the whole run with
+    // "document is not defined" even though every test passed.
     focusEditor();
     queueMicrotask(focusEditor);
-    window.setTimeout(focusEditor, 0);
+    focusTimerRef.current = window.setTimeout(() => {
+      focusTimerRef.current = null;
+      focusEditor();
+    }, 0);
     if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(focusEditor);
+      focusFrameRef.current = window.requestAnimationFrame(() => {
+        focusFrameRef.current = null;
+        focusEditor();
+      });
     }
-  }, [apiRef]);
+  }, [apiRef, cancelScheduledFocus]);
 
   const flushPendingValue = useCallback((pendingKey: string): void => {
     const applyPendingValue = (): void => {

--- a/frontend/src/crops/pages/PublicCropLibraryPage.tsx
+++ b/frontend/src/crops/pages/PublicCropLibraryPage.tsx
@@ -76,7 +76,7 @@ import {
   getPublicCultureDescription,
   getPublicCultureName,
 } from '../publicCultureDisplay';
-import { applySavedCultures } from '../publicCultureListMerge';
+import { applySavedCultures, withCreatedTopic } from '../publicCultureListMerge';
 import { MultilingualTextFieldSection } from '../components/MultilingualTextFieldSection';
 import { AppTooltip } from '../../components/AppTooltip';
 import { CultureSeedDetails, type CultureSeedRateRow, type ValueSource } from '../../cultures/CultureSeedDetails';
@@ -1177,7 +1177,7 @@ export default function PublicCropLibraryPage() {
           publicCultureAPI.discussionTopics(selectedCulture.id),
           publicCultureAPI.discussionComments(selectedCulture.id, createdTopic.data.id),
         ]);
-        setTopics(topicsResponse.data);
+        setTopics(withCreatedTopic(topicsResponse.data, createdTopic.data));
         setComments(commentsResponse.data);
         setCommentsStatus('success');
         setCollaborationStatus('success');

--- a/frontend/src/crops/publicCultureListMerge.ts
+++ b/frontend/src/crops/publicCultureListMerge.ts
@@ -1,4 +1,4 @@
-import type { PublicCulture } from '../api/types';
+import type { PublicCulture, PublicCultureDiscussionTopic } from '../api/types';
 
 /**
  * Keeps locally saved cultures from being rolled back by a list response that
@@ -32,4 +32,30 @@ export function applySavedCultures(
     }
     return savedCulture;
   });
+}
+
+/**
+ * Keeps a just-created discussion topic in the list even when the reload that
+ * follows the create does not contain it yet.
+ *
+ * Creating a topic selects it by navigating to `?discussionId=<id>`, and a
+ * guard effect deselects any discussion id that is missing from `topics` (so a
+ * stale link to a deleted discussion cannot leave the page pointing at
+ * nothing). If the reload response lags behind the create — ordering,
+ * pagination, or a replica that has not caught up — that guard throws the user
+ * straight back out of the discussion they just created. The detail pane reads
+ * its title from the list entry too, so the same gap renders an endless
+ * spinner instead of the new discussion.
+ *
+ * The created topic is prepended rather than appended: the list is ordered by
+ * newest activity first, which a brand-new topic always is.
+ */
+export function withCreatedTopic(
+  topics: PublicCultureDiscussionTopic[],
+  createdTopic: PublicCultureDiscussionTopic,
+): PublicCultureDiscussionTopic[] {
+  if (topics.some((topic) => topic.id === createdTopic.id)) {
+    return topics;
+  }
+  return [createdTopic, ...topics];
 }


### PR DESCRIPTION
Two independent timing bugs, both found while chasing the `frontend-tests` flake. Plus the test and rule changes that made finding the second one possible.

## 1. A created discussion could be dropped right after creating it

Starting a discussion selects it by navigating to `?discussionId=<id>`. A guard effect in `PublicCropLibraryPage.tsx` deselects any discussion id missing from the loaded topic list — deliberately, so a stale link to a deleted discussion cannot leave the page pointing at nothing (covered by the existing *"falls back to the discussion overview for an unknown discussion ID"* test).

The guard did not distinguish "does not exist" from "created a moment ago, reload has not caught up". When the reload did not contain the new topic — ordering, pagination, a lagging replica — the user was thrown back to the overview immediately after starting a discussion, and since the detail pane reads its title from that same list entry, it rendered an endless spinner.

Fix: merge the created topic into the list instead of trusting the reload alone, via `withCreatedTopic` next to `applySavedCultures` in `crops/publicCultureListMerge.ts` — that module already solves the same class of problem for culture rows, so no new pattern.

## 2. The grid scheduled edit-focus attempts it never cancelled

`useSpreadsheetEditStarter.focusEditInput` retries focusing a freshly opened editor four times — synchronously, in a microtask, in a `setTimeout`, and in a `requestAnimationFrame` — because the editor may not be mounted yet. **None of the handles were kept**, so nothing could cancel them. The hook cleaned up its other timers on unmount; these were simply not tracked.

- A timer outliving the grid still reached for a cell element. Invisible in the app; in tests it outlives the jsdom environment and throws `document is not defined` from a timer callback, which vitest reports as an unhandled error and which **fails the whole run**.
- A second focus request did not supersede the first, so the earlier request's deferred attempts could pull focus back to the previously edited cell.

Both handles are now tracked and cancelled — on a newer request and on unmount. The microtask cannot be cancelled, so `focusEditor` additionally no-ops after unmount.

## How #2 was found, and what it did *not* fix

Worth recording, because four fixes were spent on this before the actual failure was ever observed:

| Attempt | Where | Result |
|---|---|---|
| Raise the assertion timeout 10s → 25s | #451 | still flaked |
| Default mock so an extra call cannot resolve `undefined` | #467 | still flaked |
| Fix 1 above (the discussion guard) | this PR | still flaked |
| Full suite locally under heavier load than CI (671s vs CI's 471s) | — | stayed green, ruling out plain starvation |

The failure never reproduced locally, so this PR removed the `retry` and sampled CI until it went red. [Run 31594846919](https://github.com/OpenFarmPlanner/OpenFarmPlanner/actions/runs/31594846919) then showed something no one had been looking for:

```
Test Files  201 passed (201)
Tests      2025 passed (2025)
Errors     1 error            ← job red with zero failing tests
ReferenceError: document is not defined
 ❯ Timeout.focusEditor  src/components/data-grid/keyboardEditing.ts:111
```

That is bug 2, and it is fixed here. **It is not the same failure as the discussion-create assertion** — this suite has at least two independent timing-dependent failure modes, and the assertion one did not fire in that sample. So this PR does not claim to have eliminated that one.

To make the next occurrence readable, the discussion-create assertion is now split: the URL is asserted before the heading, so a failure names whether the navigation was lost or the topic list was, instead of only reporting "element could not be found".

## Also included

`CLAUDE.md`: "Do NOT execute CI workflows manually" is replaced with a narrower rule. That line blocked the only thing that can diagnose an intermittent failure which does not reproduce locally — sampling CI until it fails — which is why this took four blind attempts. The replacement keeps the intent (local gates are the normal way to verify; do not re-run until something happens to pass) while permitting a re-run whose purpose can be stated. Requested by the repo owner in the course of this work.

## Tests

- `PublicCropLibraryPage.test.tsx` — regression test where the reload returns a list *without* the created topic. Fails on the unfixed code (verified by stashing: 1 failed / 58 passed).
- `keyboardEditing.test.ts` (new) — covers both halves of bug 2. Fails on the unfixed code with all four attempts landing on the superseded cell and one arriving after unmount.
- `applySavedCultures.test.ts` — unit tests for the merge.
- Full frontend suite: 202 files / 2027 tests green locally. `npm run lint`: 0 errors (100 pre-existing warnings, unchanged). All 8 CI checks green on `f0f26f8`.

## Notes

Code-only apart from `CLAUDE.md`. `docs/crop-library-architecture.md` describes the discussion model, but PR #468 is rewriting that file — a note in both places would collide. Happy to add one to #468 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157q6dRUGUVtF2XzbaUcbWu