### PR TITLE
Remove public variety cultivation subtitles

### DIFF
--- a/frontend/src/__tests__/PublicCropHierarchyList.test.tsx
+++ b/frontend/src/__tests__/PublicCropHierarchyList.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { PublicCulture } from '../api/types';
+import { PublicCropHierarchyList } from '../cultures/PublicCropHierarchyList';
+
+const cultures: PublicCulture[] = [
+  {
+    id: 1,
+    status: 'published',
+    name: 'Bohne',
+    variety: '',
+    crop_species_name: 'Bohne',
+    version: 1,
+    cultivation_type: 'pre_cultivation',
+    cultivation_types: ['pre_cultivation'],
+  },
+  {
+    id: 2,
+    status: 'published',
+    name: 'Bohne',
+    variety: 'Canadian Wonder2',
+    crop_species_name: 'Bohne',
+    version: 1,
+    cultivation_type: 'direct_sowing',
+    cultivation_types: ['direct_sowing'],
+  },
+];
+
+describe('PublicCropHierarchyList', () => {
+  it('shows variety rows without cultivation-type subtitles', async () => {
+    render(
+      <PublicCropHierarchyList
+        cultures={cultures}
+        selectedCultureId={2}
+        isSpeciesView={false}
+        onSelect={vi.fn()}
+        ariaLabel="Public crop library"
+        searchQuery="bohne"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Bohne (Canadian Wonder2)' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Canadian Wonder2')).toBeInTheDocument();
+    expect(screen.queryByText('Direktsaat')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/crops/components/publicCropLibrary/PublicCultureMobileSelectorDialog.tsx
+++ b/frontend/src/crops/components/publicCropLibrary/PublicCultureMobileSelectorDialog.tsx
@@ -22,7 +22,7 @@ import { flattenTreeRows } from '../../../components/hierarchy/utils/treeRows';
 import { useExpandedState } from '../../../components/hierarchy/hooks/useExpandedState';
 import { CropHierarchyExpandToggle } from '../../../cultures/CropHierarchyExpandToggle';
 import { useOverlayHistory } from '../../../hooks/useOverlayHistory';
-import { getCultivationTypeLabel, getPublicCultureTitle } from '../../publicCultureDisplay';
+import { getPublicCultureTitle } from '../../publicCultureDisplay';
 
 export interface PublicCultureMobileSelectorDialogProps {
   open: boolean;
@@ -181,9 +181,10 @@ export function PublicCultureMobileSelectorDialog({
                   }}
                   sx={{
                     borderRadius: 1.25,
-                    mb: 0.375,
+                    mb: 0.125,
                     ml: `calc(${depth * 1.75}rem)`,
                     pl: 0.75,
+                    py: 0.25,
                   }}
                 >
                   <CropHierarchyExpandToggle
@@ -202,11 +203,13 @@ export function PublicCultureMobileSelectorDialog({
                         culture?.crop_family,
                         node.varietyCount > 0 ? t('hierarchy.varietyCount', { count: node.varietyCount }) : '',
                       ].filter(Boolean).join(' • ') || undefined
-                      : (culture ? getCultivationTypeLabel(culture.cultivation_type, t, '') : '') || undefined}
+                      : undefined}
                     slotProps={{
-                      primary: { sx: { fontSize: '0.95rem', fontWeight: node.kind === 'species' ? 700 : 500 } },
+                      primary: { sx: { fontSize: '0.95rem', fontWeight: node.kind === 'species' ? 700 : 500, lineHeight: 1.2 } },
                       secondary: { sx: { fontSize: '0.8rem', color: 'text.secondary' } }
- }} />
+                    }}
+                    sx={{ my: 0 }}
+                  />
                 </ListItemButton>
               );
             })}

--- a/frontend/src/cultures/PublicCropHierarchyList.tsx
+++ b/frontend/src/cultures/PublicCropHierarchyList.tsx
@@ -7,7 +7,7 @@ import { flattenTreeRows } from '../components/hierarchy/utils/treeRows';
 import { useExpandedState } from '../components/hierarchy/hooks/useExpandedState';
 import { useCultureListKeyboardNavigation } from './useCultureListKeyboardNavigation';
 import { CropHierarchyRow } from './CropHierarchyRow';
-import { getCultivationTypeLabel, getPublicCultureTitle } from '../crops/publicCultureDisplay';
+import { getPublicCultureTitle } from '../crops/publicCultureDisplay';
 
 interface PublicCropHierarchyListProps {
   cultures: PublicCulture[];
@@ -157,9 +157,7 @@ export function PublicCropHierarchyList({
               : culture ? getPublicCultureTitle(culture, language, t('library.translation.missingName')) : undefined}
             primary={node.label}
             isPrimaryEmphasized={node.kind === 'species'}
-            secondary={node.kind === 'species'
-              ? undefined
-              : (culture ? getCultivationTypeLabel(culture.cultivation_type, t, '') : '') || undefined}
+            secondary={undefined}
             varietyCount={node.kind === 'species' ? node.varietyCount : undefined}
             onClick={() => {
               if (culture?.id !== undefined) {


### PR DESCRIPTION
## Summary

- Remove cultivation-type subtitles from public crop-library variety rows.
- Keep variety rows compact after the secondary line is gone, including the mobile selector dialog.
- Add a regression test that keeps public variety rows single-line.

## Validation

- `npm run test -- PublicCropHierarchyList CropHierarchyRow PublicCropLibraryPage --run`
- `npx eslint src/cultures/PublicCropHierarchyList.tsx src/crops/components/publicCropLibrary/PublicCultureMobileSelectorDialog.tsx src/__tests__/PublicCropHierarchyList.test.tsx --max-warnings=0`

Note: repo-wide `npm run lint -- --max-warnings=0` still fails on existing warnings unrelated to this change.
