### PR TITLE
Fix project member display names

### DIFF
--- a/backend/farm/projects/serializers.py
+++ b/backend/farm/projects/serializers.py
@@ -14,12 +14,16 @@ class ProjectSerializer(serializers.ModelSerializer):
 
 class ProjectMembershipSerializer(serializers.ModelSerializer):
     user_email = serializers.EmailField(source='user.email', read_only=True)
-    user_display_name = serializers.CharField(source='user.display_name', read_only=True)
+    user_display_name = serializers.SerializerMethodField()
 
     class Meta:
         model = ProjectMembership
         fields = ['id', 'user', 'user_email', 'user_display_name', 'project', 'role', 'created_at']
         read_only_fields = ['id', 'created_at', 'project']
+
+    def get_user_display_name(self, obj: ProjectMembership) -> str:
+        """Return the member's account display name."""
+        return obj.user.get_full_name()
 
 
 class ProjectInvitationSerializer(serializers.ModelSerializer):

--- a/backend/farm/tests/test_projects_api.py
+++ b/backend/farm/tests/test_projects_api.py
@@ -664,6 +664,18 @@ class ProjectsApiTests(APITestCase):
         member.refresh_from_db()
         self.assertEqual(member.role, 'admin')
 
+    def test_member_list_includes_account_display_name(self) -> None:
+        self.invitee.first_name = 'Martin'
+        self.invitee.last_name = 'Stipsitz'
+        self.invitee.save(update_fields=['first_name', 'last_name'])
+        ProjectMembership.objects.create(user=self.invitee, project=self.project, role='member')
+
+        response = self.client.get(f'/openfarmplanner/api/projects/{self.project.id}/members/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        invitee_row = next(row for row in response.data if row['user'] == self.invitee.id)
+        self.assertEqual(invitee_row['user_display_name'], 'Martin Stipsitz')
+
     def test_cannot_demote_last_admin(self) -> None:
         own_membership = ProjectMembership.objects.get(user=self.user, project=self.project)
         response = self.client.patch(

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -567,6 +567,20 @@ describe('App', () => {
     expect(screen.getByText('Projekteinstellungen')).toBeInTheDocument();
   });
 
+  it.each([
+    ['/app/project-settings', 'Projekteinstellungen'],
+    ['/app/project-selection', 'Projektauswahl'],
+    ['/app/public-library-moderation', 'Kulturbibliothek moderieren'],
+  ])('shows the app-route title in the topbar for %s', async (path, title) => {
+    authState.user = createAuthenticatedUser();
+    authState.activeProjectId = 1;
+    window.history.pushState({}, '', path);
+
+    render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
+
+    expect(await screen.findByRole('heading', { level: 1, name: title })).toBeInTheDocument();
+  });
+
   // Regression coverage for a routing bug: a user with zero projects who
   // opened a project-independent page (e.g. account settings) from the
   // global menu was bounced straight back to "Erstes Projekt starten" —

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../App';
@@ -9,6 +9,8 @@ import { FocusManagerProvider } from '../focus/FocusManager';
 import translations from '@/test-utils/translations';
 import type { AuthUser } from '../auth/types';
 import i18n from '../i18n/config';
+
+const originalMatchMedia = window.matchMedia;
 
 function createGuestDemoUser(): AuthUser {
   return {
@@ -55,6 +57,22 @@ function createAuthenticatedUser(
     is_guest_demo: false,
     guest_demo_session_id: null,
   };
+}
+
+function mockMobileTopbarViewport(): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('max-width') || query.includes('down'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
 }
 
 const authState = {
@@ -166,6 +184,13 @@ describe('App', () => {
     await i18n.changeLanguage('de');
     localStorage.clear();
     window.history.pushState({}, '', '/');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
   });
 
   it('renders public home page on root path', async () => {
@@ -579,6 +604,30 @@ describe('App', () => {
     render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
 
     expect(await screen.findByRole('heading', { level: 1, name: title })).toBeInTheDocument();
+  });
+
+  it('does not duplicate the project settings page title inside the page content', async () => {
+    authState.user = createAuthenticatedUser();
+    authState.activeProjectId = 1;
+    window.history.pushState({}, '', '/app/project-settings');
+
+    render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
+
+    await screen.findByRole('heading', { level: 1, name: 'Projekteinstellungen' });
+    expect(screen.getAllByRole('heading', { name: 'Projekteinstellungen' })).toHaveLength(1);
+  });
+
+  it('keeps the project settings title in the mobile topbar without duplicating it in content', async () => {
+    mockMobileTopbarViewport();
+    authState.user = createAuthenticatedUser();
+    authState.activeProjectId = 1;
+    window.history.pushState({}, '', '/app/project-settings');
+
+    render(<FocusManagerProvider><CommandProvider><App /></CommandProvider></FocusManagerProvider>);
+
+    await screen.findByRole('heading', { level: 1, name: 'Projekteinstellungen' });
+    expect(screen.getAllByRole('heading', { name: 'Projekteinstellungen' })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Menü öffnen' })).toBeInTheDocument();
   });
 
   // Regression coverage for a routing bug: a user with zero projects who

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -247,16 +247,28 @@ describe('ProjectSettingsPage', () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
     expect(await screen.findByLabelText('Projektname')).toHaveValue('Alpha');
     expect(screen.queryByRole('button', { name: 'Projekt umbenennen' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Speichern' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Speichern' })).toBeDisabled();
   });
 
-  it('allows renaming via PATCH when the inline field loses focus', async () => {
+  it('keeps inline project name changes unsaved when the field loses focus', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
     const projectNameInput = await screen.findByLabelText('Projektname');
     expect(projectNameInput).toHaveValue('Alpha');
 
     fireEvent.change(projectNameInput, { target: { value: 'Beta' } });
     fireEvent.blur(projectNameInput);
+
+    expect(updateProjectMock).not.toHaveBeenCalled();
+    expect(projectNameInput).toHaveValue('Beta');
+    expect(screen.getByRole('button', { name: 'Speichern' })).toBeEnabled();
+  });
+
+  it('allows renaming via PATCH from the explicit save button', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    const projectNameInput = await screen.findByLabelText('Projektname');
+
+    fireEvent.change(projectNameInput, { target: { value: 'Beta' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
     await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Beta' }));
     await waitFor(() => expect(refreshUserMock).toHaveBeenCalled());
@@ -268,7 +280,7 @@ describe('ProjectSettingsPage', () => {
     const projectNameInput = await screen.findByLabelText('Projektname');
 
     fireEvent.change(projectNameInput, { target: { value: '   ' } });
-    fireEvent.blur(projectNameInput);
+    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
     expect(updateProjectMock).not.toHaveBeenCalled();
     expect(projectNameInput).toHaveValue('Alpha');
@@ -277,9 +289,8 @@ describe('ProjectSettingsPage', () => {
 
   it('ignores unchanged project name saves', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    const projectNameInput = await screen.findByLabelText('Projektname');
-
-    fireEvent.blur(projectNameInput);
+    expect(await screen.findByLabelText('Projektname')).toHaveValue('Alpha');
+    expect(screen.getByRole('button', { name: 'Speichern' })).toBeDisabled();
 
     expect(updateProjectMock).not.toHaveBeenCalled();
   });

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -115,6 +115,27 @@ describe('ProjectSettingsPage', () => {
     await waitFor(() => expect(removeMemberMock).toHaveBeenCalledWith(1, 11));
   });
 
+  it('uses the member email as the primary label when the display name is empty', async () => {
+    listMembersMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: 12,
+          user: 1,
+          user_email: 'martin.stipsitz@gmail.com',
+          user_display_name: '',
+          project: 1,
+          role: 'admin',
+          created_at: '2026-03-18T08:00:00Z',
+        },
+      ],
+    });
+
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+
+    expect(await screen.findByText('martin.stipsitz@gmail.com')).toBeInTheDocument();
+    expect(screen.queryByText('Ohne Anzeigenamen')).not.toBeInTheDocument();
+  });
+
   it('shows a neutral no-access state for invitations when the user is not an admin', async () => {
     authState.user = {
       id: 1,

--- a/frontend/src/__tests__/ProjectSettingsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectSettingsPage.test.tsx
@@ -243,76 +243,65 @@ describe('ProjectSettingsPage', () => {
     ).not.toBe(0);
   });
 
-  it('shows project name in view mode and allows switching to edit mode', async () => {
+  it('shows project name as an inline editable field', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    expect(await screen.findByText('Alpha')).toBeInTheDocument();
-    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Projektname')).toHaveValue('Alpha');
+    expect(screen.queryByRole('button', { name: 'Projekt umbenennen' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Speichern' })).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Projekt umbenennen' }));
-    expect(await screen.findByLabelText('Projekt umbenennen')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Abbrechen' })).toBeInTheDocument();
   });
 
-  it('allows renaming via PATCH from edit mode', async () => {
+  it('allows renaming via PATCH when the inline field loses focus', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
-    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    const projectNameInput = await screen.findByLabelText('Projektname');
     expect(projectNameInput).toHaveValue('Alpha');
 
     fireEvent.change(projectNameInput, { target: { value: 'Beta' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+    fireEvent.blur(projectNameInput);
 
     await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Beta' }));
     await waitFor(() => expect(refreshUserMock).toHaveBeenCalled());
+    expect(await screen.findByText('Projektname aktualisiert.')).toBeInTheDocument();
   });
 
-  it('prevents empty or unchanged project name saves', async () => {
+  it('prevents empty project name saves and restores the old name with feedback', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
-    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
-    const saveButton = screen.getByRole('button', { name: 'Speichern' });
+    const projectNameInput = await screen.findByLabelText('Projektname');
 
-    expect(saveButton).toBeDisabled();
     fireEvent.change(projectNameInput, { target: { value: '   ' } });
-    expect(saveButton).toBeDisabled();
+    fireEvent.blur(projectNameInput);
+
+    expect(updateProjectMock).not.toHaveBeenCalled();
+    expect(projectNameInput).toHaveValue('Alpha');
+    expect(screen.getAllByText('Projektname darf nicht leer sein.').length).toBeGreaterThan(0);
+  });
+
+  it('ignores unchanged project name saves', async () => {
+    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
+    const projectNameInput = await screen.findByLabelText('Projektname');
+
+    fireEvent.blur(projectNameInput);
+
     expect(updateProjectMock).not.toHaveBeenCalled();
   });
 
   it('submits rename on Enter key', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
-    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    const projectNameInput = await screen.findByLabelText('Projektname');
     fireEvent.change(projectNameInput, { target: { value: 'Gamma' } });
     fireEvent.keyDown(projectNameInput, { key: 'Enter', code: 'Enter' });
 
     await waitFor(() => expect(updateProjectMock).toHaveBeenCalledWith(1, { name: 'Gamma' }));
   });
 
-  it('cancels edit mode on Escape without API call', async () => {
+  it('restores the previous inline project name on Escape without API call', async () => {
     render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
-    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
+    const projectNameInput = await screen.findByLabelText('Projektname');
 
     fireEvent.change(projectNameInput, { target: { value: 'Delta' } });
     fireEvent.keyDown(projectNameInput, { key: 'Escape', code: 'Escape' });
 
     expect(updateProjectMock).not.toHaveBeenCalled();
-    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
-    expect(screen.getByText('Alpha')).toBeInTheDocument();
-  });
-
-  it('cancels edit mode via cancel button without API call', async () => {
-    render(<MemoryRouter><ProjectSettingsPage /></MemoryRouter>);
-    fireEvent.click(await screen.findByRole('button', { name: 'Projekt umbenennen' }));
-    const projectNameInput = await screen.findByLabelText('Projekt umbenennen');
-
-    fireEvent.change(projectNameInput, { target: { value: 'Delta' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
-
-    expect(updateProjectMock).not.toHaveBeenCalled();
-    expect(screen.getByLabelText('Projekt umbenennen')).toBeInTheDocument();
-    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(projectNameInput).toHaveValue('Alpha');
   });
 
   it('offers a developer shortcut to delete the active project without typing its name', async () => {

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -12,10 +12,12 @@
   "seedDemand": "Saatgutbedarf",
   "graphicalFields": "Grafische Ansicht",
   "accountSettings": "Kontoeinstellungen",
+  "publicLibraryModeration": "Kulturbibliothek moderieren",
   "appVersionLabel": "Version",
   "disabledNoProjectTooltip": "Erstelle zuerst ein Projekt.",
   "project": {
     "settings": "Projekteinstellungen",
+    "selection": "Projektauswahl",
     "members": "Mitglieder verwalten",
     "create": "Neues Projekt",
     "switch": "Projekt wechseln"

--- a/frontend/src/i18n/locales/de/projectInvitations.json
+++ b/frontend/src/i18n/locales/de/projectInvitations.json
@@ -2,6 +2,7 @@
   "title": "Projekteinstellungen",
   "noActiveProject": "Kein aktives Projekt ausgewählt.",
   "projectLabel": "Projekt: {{name}}",
+  "currentProjectLabel": "Aktives Projekt",
   "projectRename": {
     "label": "Projekt umbenennen",
     "save": "Speichern",

--- a/frontend/src/i18n/locales/de/projectInvitations.json
+++ b/frontend/src/i18n/locales/de/projectInvitations.json
@@ -2,7 +2,7 @@
   "title": "Projekteinstellungen",
   "noActiveProject": "Kein aktives Projekt ausgewählt.",
   "projectLabel": "Projekt: {{name}}",
-  "currentProjectLabel": "Aktives Projekt",
+  "currentProjectLabel": "Projektname",
   "projectRename": {
     "label": "Projekt umbenennen",
     "save": "Speichern",

--- a/frontend/src/i18n/locales/de/projectInvitations.json
+++ b/frontend/src/i18n/locales/de/projectInvitations.json
@@ -9,6 +9,7 @@
     "cancel": "Abbrechen",
     "success": "Projektname aktualisiert.",
     "error": "Projektname konnte nicht aktualisiert werden.",
+    "empty": "Projektname darf nicht leer sein.",
     "minLength": "Mindestens 2 Zeichen."
   },
   "projectDelete": {

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -12,10 +12,12 @@
   "seedDemand": "Seed demand",
   "graphicalFields": "Graphical view",
   "accountSettings": "Account settings",
+  "publicLibraryModeration": "Moderate crop library",
   "appVersionLabel": "Version",
   "disabledNoProjectTooltip": "Create a project first.",
   "project": {
     "settings": "Project settings",
+    "selection": "Project selection",
     "members": "Manage members",
     "create": "New project",
     "switch": "Switch project"

--- a/frontend/src/i18n/locales/en/projectInvitations.json
+++ b/frontend/src/i18n/locales/en/projectInvitations.json
@@ -2,6 +2,7 @@
   "title": "Project settings",
   "noActiveProject": "No active project selected.",
   "projectLabel": "Project: {{name}}",
+  "currentProjectLabel": "Current project",
   "projectRename": {
     "label": "Rename project",
     "save": "Save",

--- a/frontend/src/i18n/locales/en/projectInvitations.json
+++ b/frontend/src/i18n/locales/en/projectInvitations.json
@@ -9,6 +9,7 @@
     "cancel": "Cancel",
     "success": "Project name updated.",
     "error": "Project name could not be updated.",
+    "empty": "Project name cannot be empty.",
     "minLength": "At least 2 characters."
   },
   "projectDelete": {

--- a/frontend/src/i18n/locales/en/projectInvitations.json
+++ b/frontend/src/i18n/locales/en/projectInvitations.json
@@ -2,7 +2,7 @@
   "title": "Project settings",
   "noActiveProject": "No active project selected.",
   "projectLabel": "Project: {{name}}",
-  "currentProjectLabel": "Current project",
+  "currentProjectLabel": "Project name",
   "projectRename": {
     "label": "Rename project",
     "save": "Save",

--- a/frontend/src/navigation/RootLayout.tsx
+++ b/frontend/src/navigation/RootLayout.tsx
@@ -742,8 +742,17 @@ function RootLayout() {
     if (!activeItem && location.pathname.startsWith('/app/locations')) {
       return t('locations');
     }
+    if (!activeItem && location.pathname.startsWith('/app/project-selection')) {
+      return t('project.selection');
+    }
     if (!activeItem && location.pathname.startsWith('/app/account-settings')) {
       return t('accountSettings');
+    }
+    if (!activeItem && location.pathname.startsWith('/app/project-settings')) {
+      return t('project.settings');
+    }
+    if (!activeItem && location.pathname.startsWith('/app/public-library-moderation')) {
+      return t('publicLibraryModeration');
     }
     return activeItem?.label ?? '';
   }, [location.pathname, navItems, t]);

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -349,7 +349,7 @@ export default function ProjectSettingsPage() {
                 variant="contained"
                 onClick={() => void handleProjectNameCommit()}
                 disabled={!isProjectAdmin || isSavingProjectName || !hasProjectNameChanges}
-                sx={{ alignSelf: { xs: 'stretch', sm: 'flex-start' }, mt: { sm: 1 }, minWidth: 140 }}
+                sx={{ alignSelf: { xs: 'stretch', sm: 'flex-start' }, minHeight: 56, minWidth: 140 }}
               >
                 {t('projectRename.save')}
               </Button>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -334,7 +334,9 @@ export default function ProjectSettingsPage() {
                 error={projectNameError !== null}
                 helperText={projectNameError ?? ' '}
                 sx={{
-                  ...wideFieldSx,
+                  width: { xs: '100%', sm: 300 },
+                  maxWidth: '100%',
+                  flex: '0 0 auto',
                   '& input': {
                     cursor: isProjectAdmin ? 'text' : 'default',
                     fontSize: (theme) => theme.typography.h6.fontSize,

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -1,6 +1,5 @@
-import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlineOutlined';
-import { Alert, Box, Button, Card, CardContent, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, IconButton, InputLabel, MenuItem, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Card, CardContent, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, InputLabel, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { projectAPI, type ProjectInvitationPayload, type ProjectMemberPayload } from '../api/api';
@@ -35,8 +34,8 @@ export default function ProjectSettingsPage() {
   const [memberLoadError, setMemberLoadError] = useState<string | null>(null);
   const [invitationLoadError, setInvitationLoadError] = useState<string | null>(null);
   const [projectNameDraft, setProjectNameDraft] = useState('');
+  const [projectNameError, setProjectNameError] = useState<string | null>(null);
   const [isSavingProjectName, setIsSavingProjectName] = useState(false);
-  const [isEditingProjectName, setIsEditingProjectName] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteConfirmationText, setDeleteConfirmationText] = useState('');
   const [isDeletingProject, setIsDeletingProject] = useState(false);
@@ -46,9 +45,6 @@ export default function ProjectSettingsPage() {
   const normalizedProjectName = projectNameDraft.trim();
   const canDeleteProject = deleteConfirmationText === (activeMembership?.project_name ?? '');
   const canQuickDeleteProjectInDev = import.meta.env.DEV && isProjectAdmin;
-  const canSaveProjectName = isProjectAdmin
-    && normalizedProjectName.length >= 2
-    && normalizedProjectName !== (activeMembership?.project_name ?? '');
 
   const extractErrorPayload = (error: unknown): { code: string | null; detail: string | null; message: string | null } => {
     const payload = (error as { response?: { data?: { code?: string; detail?: string; message?: string } } })?.response?.data;
@@ -106,10 +102,9 @@ export default function ProjectSettingsPage() {
   }, [loadInvitations]);
 
   useEffect(() => {
-    if (!isEditingProjectName) {
-      setProjectNameDraft(activeMembership?.project_name ?? '');
-    }
-  }, [activeMembership?.project_name, isEditingProjectName]);
+    setProjectNameDraft(activeMembership?.project_name ?? '');
+    setProjectNameError(null);
+  }, [activeMembership?.project_name]);
 
   const sortedInvitations = useMemo(() => (
     [...invitations].sort((left, right) => {
@@ -159,33 +154,46 @@ export default function ProjectSettingsPage() {
     }
   };
 
-  const handleProjectNameSave = async (): Promise<void> => {
-    if (!activeMembership || !canSaveProjectName) {
+  const handleProjectNameCommit = async (): Promise<void> => {
+    if (!activeMembership || !isProjectAdmin || isSavingProjectName) {
       return;
     }
+
+    const previousProjectName = activeMembership.project_name;
+    if (normalizedProjectName === previousProjectName) {
+      setProjectNameDraft(previousProjectName);
+      setProjectNameError(null);
+      return;
+    }
+
+    if (normalizedProjectName.length === 0) {
+      setProjectNameDraft(previousProjectName);
+      setProjectNameError(t('projectRename.empty'));
+      setFeedback({ severity: 'error', text: t('projectRename.empty') });
+      return;
+    }
+
+    if (normalizedProjectName.length < 2) {
+      setProjectNameDraft(previousProjectName);
+      setProjectNameError(t('projectRename.minLength'));
+      setFeedback({ severity: 'error', text: t('projectRename.minLength') });
+      return;
+    }
+
     setIsSavingProjectName(true);
+    setProjectNameError(null);
     setFeedback(null);
     try {
       await projectAPI.update(activeMembership.project_id, { name: normalizedProjectName });
       await refreshUser();
-      setIsEditingProjectName(false);
+      setProjectNameDraft(normalizedProjectName);
       setFeedback({ severity: 'success', text: t('projectRename.success') });
     } catch {
+      setProjectNameDraft(previousProjectName);
       setFeedback({ severity: 'error', text: t('projectRename.error') });
     } finally {
       setIsSavingProjectName(false);
     }
-  };
-
-  const handleProjectNameEditStart = (): void => {
-    setProjectNameDraft(activeMembership?.project_name ?? '');
-    setIsEditingProjectName(true);
-  };
-
-  const handleProjectNameEditCancel = (): void => {
-    setProjectNameDraft(activeMembership?.project_name ?? '');
-    setIsEditingProjectName(false);
-    setFeedback(null);
   };
 
   const handleDeleteDialogClose = (): void => {
@@ -296,63 +304,33 @@ export default function ProjectSettingsPage() {
       <Stack spacing={2.5}>
         <Card variant="outlined" aria-labelledby="project-context-title">
           <CardContent sx={sectionCardContentSx}>
-            {!isEditingProjectName ? (
-              <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
-                <Box sx={{ minWidth: 0 }}>
-                  <Typography id="project-context-title" variant="h5" sx={{ wordBreak: 'break-word' }}>
-                    <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>
-                      {t('currentProjectLabel')}:{' '}
-                    </Box>
-                    <Box component="span" sx={{ color: 'text.primary', fontWeight: 700 }}>
-                      {activeMembership.project_name}
-                    </Box>
-                  </Typography>
-                </Box>
-                {isProjectAdmin ? (
-                  <IconButton size="small" aria-label={t('projectRename.label')} onClick={handleProjectNameEditStart}>
-                    <EditIcon fontSize="small" />
-                  </IconButton>
-                ) : null}
-              </Stack>
-            ) : (
-              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { sm: 'flex-start' }, }} >
-                <TextField
-                  label={t('projectRename.label')}
-                  value={projectNameDraft}
-                  onChange={(event) => setProjectNameDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Escape') {
-                      event.preventDefault();
-                      handleProjectNameEditCancel();
-                      return;
-                    }
-                    if (event.key === 'Enter' && canSaveProjectName) {
-                      event.preventDefault();
-                      void handleProjectNameSave();
-                    }
-                  }}
-                  disabled={!isProjectAdmin || isSavingProjectName}
-                  error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
-                  helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
-                  sx={wideFieldSx}
-                  autoFocus
-                  slotProps={{ htmlInput: { 'aria-label': t('projectRename.label') } }}
-                />
-                <Stack direction="row" spacing={1}>
-                  <Button
-                    variant="contained"
-                    onClick={() => void handleProjectNameSave()}
-                    disabled={!canSaveProjectName || isSavingProjectName}
-                    sx={{ minWidth: 140 }}
-                  >
-                    {t('projectRename.save')}
-                  </Button>
-                  <Button variant="outlined" onClick={handleProjectNameEditCancel} disabled={isSavingProjectName}>
-                    {t('projectRename.cancel')}
-                  </Button>
-                </Stack>
-              </Stack>
-            )}
+            <TextField
+              id="project-context-title"
+              label={t('currentProjectLabel')}
+              value={projectNameDraft}
+              onChange={(event) => {
+                setProjectNameDraft(event.target.value);
+                setProjectNameError(null);
+              }}
+              onBlur={() => void handleProjectNameCommit()}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  setProjectNameDraft(activeMembership.project_name);
+                  setProjectNameError(null);
+                  return;
+                }
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void handleProjectNameCommit();
+                }
+              }}
+              disabled={!isProjectAdmin || isSavingProjectName}
+              error={projectNameError !== null}
+              helperText={projectNameError ?? ' '}
+              sx={{ ...wideFieldSx, '& input': { cursor: isProjectAdmin ? 'text' : 'default', fontWeight: 600 } }}
+              slotProps={{ htmlInput: { 'aria-label': t('currentProjectLabel') } }}
+            />
           </CardContent>
         </Card>
 

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -349,7 +349,7 @@ export default function ProjectSettingsPage() {
                 variant="contained"
                 onClick={() => void handleProjectNameCommit()}
                 disabled={!isProjectAdmin || isSavingProjectName || !hasProjectNameChanges}
-                sx={{ alignSelf: { xs: 'stretch', sm: 'center' }, minWidth: 140 }}
+                sx={{ alignSelf: { xs: 'stretch', sm: 'flex-start' }, mt: { sm: 1 }, minWidth: 140 }}
               >
                 {t('projectRename.save')}
               </Button>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -124,8 +124,7 @@ export default function ProjectSettingsPage() {
   if (!activeMembership) {
     return (
       <Box sx={{ p: 3 }}>
-        <Typography variant="h5">{t('title')}</Typography>
-        <Alert severity="info" sx={{ mt: 2 }}>{t('noActiveProject')}</Alert>
+        <Alert severity="info">{t('noActiveProject')}</Alert>
       </Box>
     );
   }
@@ -290,7 +289,6 @@ export default function ProjectSettingsPage() {
 
   return (
     <Box sx={{ p: 3, maxWidth: 760, mx: 'auto' }}>
-      <Typography variant="h4" sx={{ mb: 1 }}>{t('title')}</Typography>
       <Box sx={{ mb: 3 }}>
         {!isEditingProjectName ? (
           <Stack direction="row" spacing={1} sx={{ alignItems: "center", }} >

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -299,7 +299,7 @@ export default function ProjectSettingsPage() {
             {!isEditingProjectName ? (
               <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
                 <Box sx={{ minWidth: 0 }}>
-                  <Typography id="project-context-title" variant="subtitle1" sx={{ wordBreak: 'break-word' }}>
+                  <Typography id="project-context-title" variant="h5" sx={{ wordBreak: 'break-word' }}>
                     <Box component="span" color="text.secondary">
                       {t('currentProjectLabel')}:{' '}
                     </Box>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -1,6 +1,6 @@
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlineOutlined';
-import { Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, IconButton, InputLabel, MenuItem, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Card, CardContent, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Divider, FormControl, IconButton, InputLabel, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { projectAPI, type ProjectInvitationPayload, type ProjectMemberPayload } from '../api/api';
@@ -287,9 +287,11 @@ export default function ProjectSettingsPage() {
     return null;
   })();
 
+  const sectionCardContentSx = { p: { xs: 2, sm: 2.5 }, '&:last-child': { pb: { xs: 2, sm: 2.5 } } };
+
   return (
-    <Box sx={{ p: 3, maxWidth: 760, mx: 'auto' }}>
-      <Box sx={{ mb: 3 }}>
+    <Box sx={{ p: { xs: 2, sm: 3 }, maxWidth: 760, mx: 'auto' }}>
+      <Box sx={{ mb: 2.5 }}>
         {!isEditingProjectName ? (
           <Stack direction="row" spacing={1} sx={{ alignItems: "center", }} >
             <Typography variant="h6">{activeMembership.project_name}</Typography>
@@ -340,172 +342,188 @@ export default function ProjectSettingsPage() {
         )}
       </Box>
 
-      {!canManageMembers ? (
-        <Alert severity="info" sx={{ mb: 3 }}>{t('memberManagementNoAccess')}</Alert>
-      ) : null}
-      <Typography variant="h6" sx={{ mb: 2 }}>{t('inviteSectionTitle')}</Typography>
-      <Box sx={formRowSx}>
-        <TextField
-          label={t('emailLabel')}
-          type="email"
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          disabled={!canManageMembers}
-          sx={wideFieldSx}
-        />
-        <FormControl disabled={!canManageMembers} sx={compactFieldSx}>
-          <InputLabel id="project-invite-role-label">{t('roleLabel')}</InputLabel>
-          <Select
-            fullWidth
-            labelId="project-invite-role-label"
-            label={t('roleLabel')}
-            value={role}
-            onChange={(event) => setRole(event.target.value as 'admin' | 'member')}
-          >
-            <MenuItem value="member">{t('roleMember')}</MenuItem>
-            <MenuItem value="admin">{t('roleAdmin')}</MenuItem>
-          </Select>
-        </FormControl>
-        <Button
-          variant="contained"
-          onClick={() => void handleInvite()}
-          disabled={!canManageMembers || !email.trim()}
-          sx={{ alignSelf: { xs: 'stretch', sm: 'center' } }}
-        >
-          {t('sendInvite')}
-        </Button>
-      </Box>
+      {feedback ? <Alert severity={feedback.severity} sx={{ mb: 2.5, wordBreak: 'break-all' }}>{feedback.text}</Alert> : null}
 
-      {!canManageMembers ? (
-        <Alert severity="info" sx={{ mt: 2 }}>{t('projectMembers.invite.noPermission')}</Alert>
-      ) : null}
-
-      {feedback ? <Alert severity={feedback.severity} sx={{ mt: 2, wordBreak: 'break-all' }}>{feedback.text}</Alert> : null}
-
-      <Typography variant="h6" sx={{ mt: 4, mb: 2 }}>{t('membersSectionTitle')}</Typography>
-      <Stack spacing={1.5}>
-        {memberLoadError ? <Alert severity="error">{memberLoadError}</Alert> : null}
-        {!memberLoadError ? members.map((member) => {
-          const isCurrentUser = member.user === user?.id;
-          const displayName = member.user_display_name.trim() || member.user_email || t('memberDisplayFallback');
-          const showEmailSecondary = member.user_email && member.user_email !== displayName;
-
-          return (
-            <Box key={member.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2 }}>
-              <Stack direction={{ xs: 'column', md: 'row' }} sx={{ justifyContent: "space-between",
-                alignItems: { xs: 'flex-start', md: 'center' }, }}   spacing={2}>
-                <Box>
-                  <Stack direction="row" spacing={1} sx={{ mb: 0.5,
-                    alignItems: "center", }}  >
-                    <Typography sx={{ fontWeight: 600 }}>{displayName}</Typography>
-                    {isCurrentUser ? <Chip label={t('memberYou')} size="small" /> : null}
-                  </Stack>
-                  {showEmailSecondary ? (
-                    <Typography variant="body2" color="text.secondary">{member.user_email}</Typography>
-                  ) : null}
-                </Box>
-                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { xs: 'stretch', sm: 'center' }, }} >
-                  <FormControl
-                    size="small"
-                    disabled={!canManageMembers || isCurrentUser}
-                    sx={compactFieldSx}
-                  >
-                    <InputLabel id={`project-member-role-label-${member.id}`}>{t('memberRoleLabel')}</InputLabel>
-                    <Select
-                      fullWidth
-                      labelId={`project-member-role-label-${member.id}`}
-                      size="small"
-                      label={t('memberRoleLabel')}
-                      value={member.role}
-                      onChange={(event) => void handleMemberRoleChange(member.id, event.target.value as 'admin' | 'member', isCurrentUser)}
-                    >
-                      <MenuItem value="member">{t('roleMember')}</MenuItem>
-                      <MenuItem value="admin">{t('roleAdmin')}</MenuItem>
-                    </Select>
-                  </FormControl>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    color="error"
-                    onClick={() => setPendingRemovalMember(member)}
-                    disabled={!canManageMembers || isCurrentUser}
-                  >
-                    {t('removeMember')}
-                  </Button>
-                </Stack>
-              </Stack>
-            </Box>
-          );
-        }) : null}
-        {!memberLoadError && members.length === 0 ? <Alert severity="info">{t('membersEmpty')}</Alert> : null}
-      </Stack>
-
-      <Typography variant="h6" sx={{ mt: 4, mb: 2 }}>{t('listTitle')}</Typography>
-      <Stack spacing={1.5}>
-        {canManageMembers && !invitationLoadError ? sortedInvitations.map((invitation) => (
-          <Box key={invitation.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2 }}>
-            <Stack direction="row" sx={{ justifyContent: "space-between",
-              alignItems: "center", }}   spacing={2}>
-              <Box>
-                <Typography sx={{ fontWeight: 600 }}>{invitation.email}</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {t('expiresAt', { date: new Date(invitation.expires_at).toLocaleString('de-DE') })}
-                </Typography>
-              </Box>
-              <Stack direction="row" spacing={1} sx={{ alignItems: "center", }} >
-                <Chip label={t(`status.${invitation.resolved_status}`)} size="small" />
-                {invitation.resolved_status === 'pending' ? (
-                  <Button size="small" variant="outlined" color="error" onClick={() => void handleRevoke(invitation.id)}>
-                    {t('revoke')}
-                  </Button>
-                ) : null}
-              </Stack>
-            </Stack>
-          </Box>
-        )) : null}
-        {invitationStatus}
-      </Stack>
-
-      {isProjectAdmin ? (
-        <Box sx={{ mt: 5, border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2.5, bgcolor: 'background.paper' }}>
-          <Typography variant="h6" sx={{ mb: 1 }}>{t('projectDelete.managementTitle')}</Typography>
-          <Typography variant="body2" color="text.secondary">
-            {t('projectDelete.managementDescription')}
-          </Typography>
-          <Box sx={{ mt: 2, mb: 2 }}>
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
-              {t('projectDelete.shortInfoTitle')}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {t('projectDelete.shortInfoText')}
-            </Typography>
-          </Box>
-          <Button
-            color="error"
-            variant="contained"
-            startIcon={<DeleteOutlineIcon />}
-            onClick={() => setDeleteDialogOpen(true)}
-          >
-            {t('projectDelete.openButton')}
-          </Button>
-          {canQuickDeleteProjectInDev ? (
-            <Box sx={{ mt: 2 }}>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                {t('projectDelete.devQuickDescription')}
-              </Typography>
+      <Stack spacing={2.5}>
+        <Card variant="outlined" aria-labelledby="project-invite-section-title">
+          <CardContent sx={sectionCardContentSx}>
+            <Typography id="project-invite-section-title" variant="h6" sx={{ mb: 2 }}>{t('inviteSectionTitle')}</Typography>
+            {!canManageMembers ? (
+              <Alert severity="info" sx={{ mb: 2 }}>{t('memberManagementNoAccess')}</Alert>
+            ) : null}
+            <Box sx={formRowSx}>
+              <TextField
+                label={t('emailLabel')}
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                disabled={!canManageMembers}
+                sx={wideFieldSx}
+              />
+              <FormControl disabled={!canManageMembers} sx={compactFieldSx}>
+                <InputLabel id="project-invite-role-label">{t('roleLabel')}</InputLabel>
+                <Select
+                  fullWidth
+                  labelId="project-invite-role-label"
+                  label={t('roleLabel')}
+                  value={role}
+                  onChange={(event) => setRole(event.target.value as 'admin' | 'member')}
+                >
+                  <MenuItem value="member">{t('roleMember')}</MenuItem>
+                  <MenuItem value="admin">{t('roleAdmin')}</MenuItem>
+                </Select>
+              </FormControl>
               <Button
-                color="error"
-                variant="outlined"
-                startIcon={<DeleteOutlineIcon />}
-                onClick={() => void handleProjectDelete({ skipNameConfirmation: true })}
-                disabled={isDeletingProject}
+                variant="contained"
+                onClick={() => void handleInvite()}
+                disabled={!canManageMembers || !email.trim()}
+                sx={{ alignSelf: { xs: 'stretch', sm: 'center' } }}
               >
-                {t('projectDelete.devQuickButton')}
+                {t('sendInvite')}
               </Button>
             </Box>
-          ) : null}
-        </Box>
-      ) : null}
+
+            {!canManageMembers ? (
+              <Alert severity="info" sx={{ mt: 2 }}>{t('projectMembers.invite.noPermission')}</Alert>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card variant="outlined" aria-labelledby="project-members-section-title">
+          <CardContent sx={sectionCardContentSx}>
+            <Typography id="project-members-section-title" variant="h6" sx={{ mb: 2 }}>{t('membersSectionTitle')}</Typography>
+            <Stack spacing={0} divider={<Divider flexItem />}>
+              {memberLoadError ? <Alert severity="error">{memberLoadError}</Alert> : null}
+              {!memberLoadError ? members.map((member) => {
+                const isCurrentUser = member.user === user?.id;
+                const displayName = member.user_display_name.trim() || member.user_email || t('memberDisplayFallback');
+                const showEmailSecondary = member.user_email && member.user_email !== displayName;
+
+                return (
+                  <Box key={member.id} sx={{ py: 1.5 }}>
+                    <Stack direction={{ xs: 'column', md: 'row' }} sx={{ justifyContent: "space-between",
+                      alignItems: { xs: 'flex-start', md: 'center' }, }}   spacing={2}>
+                      <Box>
+                        <Stack direction="row" spacing={1} sx={{ mb: 0.5,
+                          alignItems: "center", }}  >
+                          <Typography sx={{ fontWeight: 600 }}>{displayName}</Typography>
+                          {isCurrentUser ? <Chip label={t('memberYou')} size="small" /> : null}
+                        </Stack>
+                        {showEmailSecondary ? (
+                          <Typography variant="body2" color="text.secondary">{member.user_email}</Typography>
+                        ) : null}
+                      </Box>
+                      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { xs: 'stretch', sm: 'center' }, width: { xs: '100%', md: 'auto' }, }} >
+                        <FormControl
+                          size="small"
+                          disabled={!canManageMembers || isCurrentUser}
+                          sx={compactFieldSx}
+                        >
+                          <InputLabel id={`project-member-role-label-${member.id}`}>{t('memberRoleLabel')}</InputLabel>
+                          <Select
+                            fullWidth
+                            labelId={`project-member-role-label-${member.id}`}
+                            size="small"
+                            label={t('memberRoleLabel')}
+                            value={member.role}
+                            onChange={(event) => void handleMemberRoleChange(member.id, event.target.value as 'admin' | 'member', isCurrentUser)}
+                          >
+                            <MenuItem value="member">{t('roleMember')}</MenuItem>
+                            <MenuItem value="admin">{t('roleAdmin')}</MenuItem>
+                          </Select>
+                        </FormControl>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          color="error"
+                          onClick={() => setPendingRemovalMember(member)}
+                          disabled={!canManageMembers || isCurrentUser}
+                        >
+                          {t('removeMember')}
+                        </Button>
+                      </Stack>
+                    </Stack>
+                  </Box>
+                );
+              }) : null}
+              {!memberLoadError && members.length === 0 ? <Alert severity="info">{t('membersEmpty')}</Alert> : null}
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card variant="outlined" aria-labelledby="project-invitations-section-title">
+          <CardContent sx={sectionCardContentSx}>
+            <Typography id="project-invitations-section-title" variant="h6" sx={{ mb: 2 }}>{t('listTitle')}</Typography>
+            <Stack spacing={0} divider={<Divider flexItem />}>
+              {canManageMembers && !invitationLoadError ? sortedInvitations.map((invitation) => (
+                <Box key={invitation.id} sx={{ py: 1.5 }}>
+                  <Stack direction={{ xs: 'column', sm: 'row' }} sx={{ justifyContent: "space-between",
+                    alignItems: { xs: 'flex-start', sm: 'center' }, }}   spacing={2}>
+                    <Box>
+                      <Typography sx={{ fontWeight: 600 }}>{invitation.email}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('expiresAt', { date: new Date(invitation.expires_at).toLocaleString('de-DE') })}
+                      </Typography>
+                    </Box>
+                    <Stack direction="row" spacing={1} sx={{ alignItems: "center", }} >
+                      <Chip label={t(`status.${invitation.resolved_status}`)} size="small" />
+                      {invitation.resolved_status === 'pending' ? (
+                        <Button size="small" variant="outlined" color="error" onClick={() => void handleRevoke(invitation.id)}>
+                          {t('revoke')}
+                        </Button>
+                      ) : null}
+                    </Stack>
+                  </Stack>
+                </Box>
+              )) : null}
+              {invitationStatus}
+            </Stack>
+          </CardContent>
+        </Card>
+
+        {isProjectAdmin ? (
+          <Card variant="outlined" aria-labelledby="project-management-section-title" sx={{ borderColor: 'error.light' }}>
+            <CardContent sx={sectionCardContentSx}>
+              <Typography id="project-management-section-title" variant="h6" sx={{ mb: 1 }} color="error.main">{t('projectDelete.managementTitle')}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('projectDelete.managementDescription')}
+              </Typography>
+              <Box sx={{ mt: 2, mb: 2 }}>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {t('projectDelete.shortInfoTitle')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t('projectDelete.shortInfoText')}
+                </Typography>
+              </Box>
+              <Button
+                color="error"
+                variant="contained"
+                startIcon={<DeleteOutlineIcon />}
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                {t('projectDelete.openButton')}
+              </Button>
+              {canQuickDeleteProjectInDev ? (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    {t('projectDelete.devQuickDescription')}
+                  </Typography>
+                  <Button
+                    color="error"
+                    variant="outlined"
+                    startIcon={<DeleteOutlineIcon />}
+                    onClick={() => void handleProjectDelete({ skipNameConfirmation: true })}
+                    disabled={isDeletingProject}
+                  >
+                    {t('projectDelete.devQuickButton')}
+                  </Button>
+                </Box>
+              ) : null}
+            </CardContent>
+          </Card>
+        ) : null}
+      </Stack>
 
       <ConfirmationDialog
         open={pendingRemovalMember !== null}

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -8,7 +8,7 @@ import { ConfirmationDialog } from '../components/feedback/ConfirmationDialog';
 import { TypeaheadSelect as Select } from '../components/inputs/TypeaheadSelect';
 import { useTranslation } from '../i18n';
 import { showProjectDeleteUndoSnackbar } from '../projects/projectDeletionFeedback';
-import { compactFieldSx, formRowSx, wideFieldSx } from '../components/forms/formLayout';
+import { compactFieldSx, wideFieldSx } from '../components/forms/formLayout';
 
 interface InviteFeedback {
   severity: 'success' | 'warning' | 'error';

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -291,60 +291,69 @@ export default function ProjectSettingsPage() {
 
   return (
     <Box sx={{ p: { xs: 2, sm: 3 }, maxWidth: 760, mx: 'auto' }}>
-      <Box sx={{ mb: 2.5 }}>
-        {!isEditingProjectName ? (
-          <Stack direction="row" spacing={1} sx={{ alignItems: "center", }} >
-            <Typography variant="h6">{activeMembership.project_name}</Typography>
-            {isProjectAdmin ? (
-              <IconButton aria-label={t('projectRename.label')} onClick={handleProjectNameEditStart}>
-                <EditIcon />
-              </IconButton>
-            ) : null}
-          </Stack>
-        ) : (
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { sm: 'flex-start' }, }} >
-            <TextField
-              label={t('projectRename.label')}
-              value={projectNameDraft}
-              onChange={(event) => setProjectNameDraft(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  handleProjectNameEditCancel();
-                  return;
-                }
-                if (event.key === 'Enter' && canSaveProjectName) {
-                  event.preventDefault();
-                  void handleProjectNameSave();
-                }
-              }}
-              disabled={!isProjectAdmin || isSavingProjectName}
-              error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
-              helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
-              sx={wideFieldSx}
-              autoFocus
-              slotProps={{ htmlInput: { 'aria-label': t('projectRename.label') } }}
-            />
-            <Stack direction="row" spacing={1}>
-              <Button
-                variant="contained"
-                onClick={() => void handleProjectNameSave()}
-                disabled={!canSaveProjectName || isSavingProjectName}
-                sx={{ minWidth: 140 }}
-              >
-                {t('projectRename.save')}
-              </Button>
-              <Button variant="outlined" onClick={handleProjectNameEditCancel} disabled={isSavingProjectName}>
-                {t('projectRename.cancel')}
-              </Button>
-            </Stack>
-          </Stack>
-        )}
-      </Box>
-
       {feedback ? <Alert severity={feedback.severity} sx={{ mb: 2.5, wordBreak: 'break-all' }}>{feedback.text}</Alert> : null}
 
       <Stack spacing={2.5}>
+        <Card variant="outlined" aria-labelledby="project-context-title">
+          <CardContent sx={sectionCardContentSx}>
+            {!isEditingProjectName ? (
+              <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography id="project-context-title" variant="caption" color="text.secondary">
+                    {t('currentProjectLabel')}
+                  </Typography>
+                  <Typography variant="body1" sx={{ fontWeight: 600, wordBreak: 'break-word' }}>
+                    {activeMembership.project_name}
+                  </Typography>
+                </Box>
+                {isProjectAdmin ? (
+                  <IconButton size="small" aria-label={t('projectRename.label')} onClick={handleProjectNameEditStart}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                ) : null}
+              </Stack>
+            ) : (
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { sm: 'flex-start' }, }} >
+                <TextField
+                  label={t('projectRename.label')}
+                  value={projectNameDraft}
+                  onChange={(event) => setProjectNameDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.preventDefault();
+                      handleProjectNameEditCancel();
+                      return;
+                    }
+                    if (event.key === 'Enter' && canSaveProjectName) {
+                      event.preventDefault();
+                      void handleProjectNameSave();
+                    }
+                  }}
+                  disabled={!isProjectAdmin || isSavingProjectName}
+                  error={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2}
+                  helperText={projectNameDraft.trim().length > 0 && projectNameDraft.trim().length < 2 ? t('projectRename.minLength') : ' '}
+                  sx={wideFieldSx}
+                  autoFocus
+                  slotProps={{ htmlInput: { 'aria-label': t('projectRename.label') } }}
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    variant="contained"
+                    onClick={() => void handleProjectNameSave()}
+                    disabled={!canSaveProjectName || isSavingProjectName}
+                    sx={{ minWidth: 140 }}
+                  >
+                    {t('projectRename.save')}
+                  </Button>
+                  <Button variant="outlined" onClick={handleProjectNameEditCancel} disabled={isSavingProjectName}>
+                    {t('projectRename.cancel')}
+                  </Button>
+                </Stack>
+              </Stack>
+            )}
+          </CardContent>
+        </Card>
+
         <Card variant="outlined" aria-labelledby="project-invite-section-title">
           <CardContent sx={sectionCardContentSx}>
             <Typography id="project-invite-section-title" variant="h6" sx={{ mb: 2 }}>{t('inviteSectionTitle')}</Typography>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -305,7 +305,11 @@ export default function ProjectSettingsPage() {
       <Stack spacing={2.5}>
         <Card variant="outlined" aria-labelledby="project-context-title">
           <CardContent sx={sectionCardContentSx}>
-            <Box sx={formRowSx}>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={1}
+              sx={{ alignItems: { xs: 'stretch', sm: 'flex-start' }, width: 'fit-content', maxWidth: '100%' }}
+            >
               <TextField
                 id="project-context-title"
                 label={t('currentProjectLabel')}
@@ -347,7 +351,7 @@ export default function ProjectSettingsPage() {
               >
                 {t('projectRename.save')}
               </Button>
-            </Box>
+            </Stack>
           </CardContent>
         </Card>
 

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -363,14 +363,18 @@ export default function ProjectSettingsPage() {
             {!canManageMembers ? (
               <Alert severity="info" sx={{ mb: 2 }}>{t('memberManagementNoAccess')}</Alert>
             ) : null}
-            <Box sx={formRowSx}>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={1}
+              sx={{ alignItems: { xs: 'stretch', sm: 'flex-start' }, width: 'fit-content', maxWidth: '100%' }}
+            >
               <TextField
                 label={t('emailLabel')}
                 type="email"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
                 disabled={!canManageMembers}
-                sx={wideFieldSx}
+                sx={{ width: { xs: '100%', sm: 300 }, maxWidth: '100%', flex: '0 0 auto' }}
               />
               <FormControl disabled={!canManageMembers} sx={compactFieldSx}>
                 <InputLabel id="project-invite-role-label">{t('roleLabel')}</InputLabel>
@@ -393,7 +397,7 @@ export default function ProjectSettingsPage() {
               >
                 {t('sendInvite')}
               </Button>
-            </Box>
+            </Stack>
 
             {!canManageMembers ? (
               <Alert severity="info" sx={{ mt: 2 }}>{t('projectMembers.invite.noPermission')}</Alert>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -300,10 +300,10 @@ export default function ProjectSettingsPage() {
               <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
                 <Box sx={{ minWidth: 0 }}>
                   <Typography id="project-context-title" variant="h5" sx={{ wordBreak: 'break-word' }}>
-                    <Box component="span" color="text.secondary">
+                    <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>
                       {t('currentProjectLabel')}:{' '}
                     </Box>
-                    <Box component="span" sx={{ fontWeight: 600 }}>
+                    <Box component="span" sx={{ color: 'text.primary', fontWeight: 700 }}>
                       {activeMembership.project_name}
                     </Box>
                   </Typography>

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -299,11 +299,13 @@ export default function ProjectSettingsPage() {
             {!isEditingProjectName ? (
               <Stack direction="row" spacing={1} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
                 <Box sx={{ minWidth: 0 }}>
-                  <Typography id="project-context-title" variant="caption" color="text.secondary">
-                    {t('currentProjectLabel')}
-                  </Typography>
-                  <Typography variant="body1" sx={{ fontWeight: 600, wordBreak: 'break-word' }}>
-                    {activeMembership.project_name}
+                  <Typography id="project-context-title" variant="subtitle1" sx={{ wordBreak: 'break-word' }}>
+                    <Box component="span" color="text.secondary">
+                      {t('currentProjectLabel')}:{' '}
+                    </Box>
+                    <Box component="span" sx={{ fontWeight: 600 }}>
+                      {activeMembership.project_name}
+                    </Box>
                   </Typography>
                 </Box>
                 {isProjectAdmin ? (

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -389,7 +389,8 @@ export default function ProjectSettingsPage() {
         {memberLoadError ? <Alert severity="error">{memberLoadError}</Alert> : null}
         {!memberLoadError ? members.map((member) => {
           const isCurrentUser = member.user === user?.id;
-          const displayName = member.user_display_name || t('memberDisplayFallback');
+          const displayName = member.user_display_name.trim() || member.user_email || t('memberDisplayFallback');
+          const showEmailSecondary = member.user_email && member.user_email !== displayName;
 
           return (
             <Box key={member.id} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2 }}>
@@ -401,7 +402,9 @@ export default function ProjectSettingsPage() {
                     <Typography sx={{ fontWeight: 600 }}>{displayName}</Typography>
                     {isCurrentUser ? <Chip label={t('memberYou')} size="small" /> : null}
                   </Stack>
-                  <Typography variant="body2" color="text.secondary">{member.user_email}</Typography>
+                  {showEmailSecondary ? (
+                    <Typography variant="body2" color="text.secondary">{member.user_email}</Typography>
+                  ) : null}
                 </Box>
                 <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ alignItems: { xs: 'stretch', sm: 'center' }, }} >
                   <FormControl

--- a/frontend/src/pages/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/ProjectSettingsPage.tsx
@@ -43,6 +43,7 @@ export default function ProjectSettingsPage() {
   const isProjectAdmin = activeMembership?.role === 'admin';
   const canManageMembers = isProjectAdmin;
   const normalizedProjectName = projectNameDraft.trim();
+  const hasProjectNameChanges = normalizedProjectName !== (activeMembership?.project_name ?? '');
   const canDeleteProject = deleteConfirmationText === (activeMembership?.project_name ?? '');
   const canQuickDeleteProjectInDev = import.meta.env.DEV && isProjectAdmin;
 
@@ -304,33 +305,49 @@ export default function ProjectSettingsPage() {
       <Stack spacing={2.5}>
         <Card variant="outlined" aria-labelledby="project-context-title">
           <CardContent sx={sectionCardContentSx}>
-            <TextField
-              id="project-context-title"
-              label={t('currentProjectLabel')}
-              value={projectNameDraft}
-              onChange={(event) => {
-                setProjectNameDraft(event.target.value);
-                setProjectNameError(null);
-              }}
-              onBlur={() => void handleProjectNameCommit()}
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  setProjectNameDraft(activeMembership.project_name);
+            <Box sx={formRowSx}>
+              <TextField
+                id="project-context-title"
+                label={t('currentProjectLabel')}
+                value={projectNameDraft}
+                onChange={(event) => {
+                  setProjectNameDraft(event.target.value);
                   setProjectNameError(null);
-                  return;
-                }
-                if (event.key === 'Enter') {
-                  event.preventDefault();
-                  void handleProjectNameCommit();
-                }
-              }}
-              disabled={!isProjectAdmin || isSavingProjectName}
-              error={projectNameError !== null}
-              helperText={projectNameError ?? ' '}
-              sx={{ ...wideFieldSx, '& input': { cursor: isProjectAdmin ? 'text' : 'default', fontWeight: 600 } }}
-              slotProps={{ htmlInput: { 'aria-label': t('currentProjectLabel') } }}
-            />
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    setProjectNameDraft(activeMembership.project_name);
+                    setProjectNameError(null);
+                    return;
+                  }
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    void handleProjectNameCommit();
+                  }
+                }}
+                disabled={!isProjectAdmin || isSavingProjectName}
+                error={projectNameError !== null}
+                helperText={projectNameError ?? ' '}
+                sx={{
+                  ...wideFieldSx,
+                  '& input': {
+                    cursor: isProjectAdmin ? 'text' : 'default',
+                    fontSize: (theme) => theme.typography.h6.fontSize,
+                    fontWeight: 600,
+                  },
+                }}
+                slotProps={{ htmlInput: { 'aria-label': t('currentProjectLabel') } }}
+              />
+              <Button
+                variant="contained"
+                onClick={() => void handleProjectNameCommit()}
+                disabled={!isProjectAdmin || isSavingProjectName || !hasProjectNameChanges}
+                sx={{ alignSelf: { xs: 'stretch', sm: 'center' }, minWidth: 140 }}
+              >
+                {t('projectRename.save')}
+              </Button>
+            </Box>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary

- Fix project member API serialization so `user_display_name` comes from the account full name.
- Use the member email as the primary label when a member truly has no display name, avoiding the prominent fallback text.
- Show topbar titles for project settings, project selection, and public-library moderation routes.
- Align Project settings with the Crops/Fields pattern by removing the duplicate in-content page title.
- Wrap Project settings sections in outlined theme cards for invite, members, invitations, and project management, with divider-based rows inside each section.
- Present the active project name as a direct inline edit field inside the settings card stack; save on blur/Enter, reject empty names with visible feedback, and remove the separate edit-icon mode.
- Keep the destructive project-management section visually marked through existing MUI error tokens.
- Add backend and frontend regressions for member display-name handling, topbar route titles, desktop/mobile Project settings title placement, and inline project-name editing.

## Root Cause

The project membership serializer read `user.display_name`, but the Django user model stores the account display name in `first_name`/`last_name` and exposes it elsewhere through `get_full_name()`. The topbar title map also only covered sidebar routes plus account settings, so project-management routes could render an empty topbar title. Project settings then carried its page title as content instead of relying on the shared topbar, and its settings sections were rendered as loose content instead of matching the app's contained-card surface pattern.

## Validation

- `pdm run python manage.py test farm.tests.test_projects_api.ProjectsApiTests.test_member_list_includes_account_display_name --settings=config.settings_test`
- `npm run test -- ProjectSettingsPage --run`
- `npm run test -- App ProjectSettingsPage --run`
- `npm run test -- ProjectSettingsPage App --run`
- `npm run lint -- src/pages/ProjectSettingsPage.tsx src/__tests__/ProjectSettingsPage.test.tsx`
- `jq empty src/i18n/locales/de/navigation.json src/i18n/locales/en/navigation.json`
- `jq empty frontend/src/i18n/locales/de/projectInvitations.json frontend/src/i18n/locales/en/projectInvitations.json`
- `python3 -m py_compile backend/farm/projects/serializers.py`
- `git diff --check`

Checked the listed main pages for duplicate in-content page titles. The existing main pages already follow the shared topbar-title pattern; the only adjusted content page was Project settings. The App regression covers desktop and a mocked narrow/mobile topbar for Project settings.

Note: targeted ESLint exits with 0 errors but still reports existing project-wide `react-hooks/*` warnings unrelated to these changes, including the pre-existing `ProjectSettingsPage.tsx` effect warning.