### PR TITLE
Refine keyboard shortcut help dialog

### DIFF
--- a/docs/keyboard-architecture.md
+++ b/docs/keyboard-architecture.md
@@ -109,12 +109,15 @@ implementations).
 
 `?` opens a single dialog (`CommandProvider`'s `helpOpen` state, previously
 built but never wired to anything) showing:
-1. Universal keys (F6, Shift+F6, Tab/Shift+Tab, Esc) — always relevant.
-2. The **current focus region's** single-key shortcuts (from
+1. The action search as the primary shortcut (`Ctrl+K` / `Alt+K`), because it
+   lets users discover commands and page navigation without memorizing the
+   rest of the shortcut inventory.
+2. Universal keys (F6, Shift+F6, Tab/Shift+Tab, Esc) — always relevant.
+3. The **current focus region's** single-key shortcuts (from
    `useRegionShortcuts`'s registry, filtered by `activeRegionId`).
-3. All commands active for the current page (grouped by context tag, same
+4. All commands active for the current page (grouped by context tag, same
    list the command palette searches).
-4. A compact all-pages reference for page-specific shortcuts, so users can
+5. A compact all-pages reference for page-specific shortcuts, so users can
    discover e.g. the Cultures page shortcuts even while they opened help from
    account settings or another page without local commands.
 

--- a/docs/keyboard-architecture.md
+++ b/docs/keyboard-architecture.md
@@ -114,6 +114,9 @@ built but never wired to anything) showing:
    `useRegionShortcuts`'s registry, filtered by `activeRegionId`).
 3. All commands active for the current page (grouped by context tag, same
    list the command palette searches).
+4. A compact all-pages reference for page-specific shortcuts, so users can
+   discover e.g. the Cultures page shortcuts even while they opened help from
+   account settings or another page without local commands.
 
 This replaced three separate, drifting implementations (a static, hand
 maintained list in `App.tsx`, a near-duplicate in `pages/Cultures.tsx`, and

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -236,6 +236,12 @@ describe('CommandProvider', () => {
     expect(screen.getByText('Versionsverlauf')).toBeInTheDocument();
     expect(screen.getByText('Alt+V')).toBeInTheDocument();
     expect(screen.getByText('Tastenkürzel anzeigen')).toBeInTheDocument();
+    expect(screen.getByText('Seitenspezifische Tastenkürzel')).toBeInTheDocument();
+    expect(screen.getByText('Kultur hinzufügen')).toBeInTheDocument();
+    expect(screen.getByText('Kultur bearbeiten')).toBeInTheDocument();
+    expect(screen.getByText('Anbaukalender')).toBeInTheDocument();
+    expect(screen.getByText('Zur aktuellen Periode springen')).toBeInTheDocument();
+    expect(screen.getByText('Lieferant hinzufügen')).toBeInTheDocument();
     expect(screen.queryByText('Projekteinstellungen')).not.toBeInTheDocument();
     expect(screen.queryByText('Projekt erstellen')).not.toBeInTheDocument();
     expect(screen.queryByText('Projekt wechseln: Garten')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { useMemo } from 'react';
 import { CommandProvider } from '../commands/CommandProvider';
 import { FocusManagerProvider } from '../focus/FocusManager';
@@ -230,7 +230,11 @@ describe('CommandProvider', () => {
 
     fireEvent.keyDown(window, { key: '?' });
 
-    expect(screen.getByText('Aktionssuche')).toBeInTheDocument();
+    const actionSearchTitle = screen.getByText('Aktionssuche');
+    const basicNavigationTitle = screen.getByText('Grundlegende Navigation');
+    expect(actionSearchTitle.compareDocumentPosition(basicNavigationTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Befehle und Seiten durchsuchen')).toBeInTheDocument();
+    expect(screen.getAllByText('Aktionssuche')).toHaveLength(1);
     expect(screen.getByText('Ctrl+K')).toBeInTheDocument();
     expect(screen.getByText('Alt+K')).toBeInTheDocument();
     expect(screen.getByText('Versionsverlauf')).toBeInTheDocument();
@@ -242,6 +246,9 @@ describe('CommandProvider', () => {
     expect(screen.getByText('Anbaukalender')).toBeInTheDocument();
     expect(screen.getByText('Zur aktuellen Periode springen')).toBeInTheDocument();
     expect(screen.getByText('Lieferant hinzufügen')).toBeInTheDocument();
+    const globalSection = screen.getByText('Global').closest('section');
+    expect(globalSection).not.toBeNull();
+    expect(within(globalSection as HTMLElement).queryByText('Aktionssuche')).not.toBeInTheDocument();
     expect(screen.queryByText('Projekteinstellungen')).not.toBeInTheDocument();
     expect(screen.queryByText('Projekt erstellen')).not.toBeInTheDocument();
     expect(screen.queryByText('Projekt wechseln: Garten')).not.toBeInTheDocument();

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -233,10 +233,11 @@ describe('CommandProvider', () => {
     const actionSearchTitle = screen.getByText('Aktionssuche');
     const basicNavigationTitle = screen.getByText('Grundlegende Navigation');
     expect(actionSearchTitle.compareDocumentPosition(basicNavigationTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(screen.getByText('Befehle, Seiten und seitenspezifische Tastenkürzel finden')).toBeInTheDocument();
     expect(screen.getAllByText('Aktionssuche')).toHaveLength(1);
-    expect(screen.getByText('Ctrl+K')).toBeInTheDocument();
-    expect(screen.getByText('Alt+K')).toBeInTheDocument();
+    const primaryShortcutSection = actionSearchTitle.closest('section');
+    expect(primaryShortcutSection).not.toBeNull();
+    expect(within(primaryShortcutSection as HTMLElement).getByText('Ctrl+K')).toBeInTheDocument();
+    expect(within(primaryShortcutSection as HTMLElement).getByText('Alt+K')).toBeInTheDocument();
     expect(screen.getByText('Versionsverlauf')).toBeInTheDocument();
     expect(screen.getByText('Alt+V')).toBeInTheDocument();
     expect(screen.getByText('Tastenkürzel anzeigen')).toBeInTheDocument();

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -221,7 +221,7 @@ describe('CommandProvider', () => {
     expect(screen.getByRole('textbox', { name: 'Aktionssuche' })).toBeInTheDocument();
   });
 
-  it('opens the dynamic shortcuts-help dialog with a bare "?"', () => {
+  it('opens the dynamic shortcuts-help dialog with a bare "?" and only lists assigned shortcuts', () => {
     render(
       <FocusManagerProvider><CommandProvider>
         <RootCommandFixture />
@@ -230,7 +230,17 @@ describe('CommandProvider', () => {
 
     fireEvent.keyDown(window, { key: '?' });
 
-    expect(screen.getByText('Projekteinstellungen')).toBeInTheDocument();
+    expect(screen.getByText('Aktionssuche')).toBeInTheDocument();
+    expect(screen.getByText('Ctrl+K')).toBeInTheDocument();
+    expect(screen.getByText('Alt+K')).toBeInTheDocument();
+    expect(screen.getByText('Versionsverlauf')).toBeInTheDocument();
+    expect(screen.getByText('Alt+V')).toBeInTheDocument();
+    expect(screen.getByText('Tastenkürzel anzeigen')).toBeInTheDocument();
+    expect(screen.queryByText('Projekteinstellungen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Projekt erstellen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Projekt wechseln: Garten')).not.toBeInTheDocument();
+    expect(screen.queryByText('Kontoeinstellungen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Abmelden')).not.toBeInTheDocument();
   });
 
   it('toggles the sidebar with Ctrl+B through the registered command', () => {

--- a/frontend/src/__tests__/commandProvider.test.tsx
+++ b/frontend/src/__tests__/commandProvider.test.tsx
@@ -233,7 +233,7 @@ describe('CommandProvider', () => {
     const actionSearchTitle = screen.getByText('Aktionssuche');
     const basicNavigationTitle = screen.getByText('Grundlegende Navigation');
     expect(actionSearchTitle.compareDocumentPosition(basicNavigationTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(screen.getByText('Befehle und Seiten durchsuchen')).toBeInTheDocument();
+    expect(screen.getByText('Befehle, Seiten und seitenspezifische Tastenkürzel finden')).toBeInTheDocument();
     expect(screen.getAllByText('Aktionssuche')).toHaveLength(1);
     expect(screen.getByText('Ctrl+K')).toBeInTheDocument();
     expect(screen.getByText('Alt+K')).toBeInTheDocument();

--- a/frontend/src/commands/CommandProvider.tsx
+++ b/frontend/src/commands/CommandProvider.tsx
@@ -130,6 +130,22 @@ function getShortcutParts(shortcutHint: string): string[] {
   return shortcutHint.split('/').map((part) => part.trim()).filter(Boolean);
 }
 
+function ShortcutBadges({ shortcutHint }: { shortcutHint: string }): React.ReactElement {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start', gap: 0.75, minWidth: 0 }}>
+      {getShortcutParts(shortcutHint).map((part) => (
+        <Chip
+          key={part}
+          label={part}
+          size="small"
+          variant="outlined"
+          sx={{ borderRadius: 1, fontFamily: 'monospace', bgcolor: 'background.paper' }}
+        />
+      ))}
+    </Box>
+  );
+}
+
 function ShortcutHelpRow({ label, shortcutHint }: { label: string; shortcutHint: string }): React.ReactElement {
   return (
     <ListItem
@@ -152,18 +168,54 @@ function ShortcutHelpRow({ label, shortcutHint }: { label: string; shortcutHint:
       <Typography variant="body2" sx={{ minWidth: 0 }}>
         {label}
       </Typography>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start', gap: 0.75, minWidth: 0 }}>
-        {getShortcutParts(shortcutHint).map((part) => (
-          <Chip
-            key={part}
-            label={part}
-            size="small"
-            variant="outlined"
-            sx={{ borderRadius: 1, fontFamily: 'monospace', bgcolor: 'background.paper' }}
-          />
-        ))}
-      </Box>
+      <ShortcutBadges shortcutHint={shortcutHint} />
     </ListItem>
+  );
+}
+
+function PrimaryShortcutHelpEntry({
+  title,
+  description,
+  shortcutHint,
+}: {
+  title: string;
+  description: string;
+  shortcutHint: string;
+}): React.ReactElement {
+  return (
+    <Box
+      component="section"
+      aria-labelledby="primary-shortcut-help-title"
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'minmax(0, 1fr) max-content',
+          sm: 'minmax(0, 26rem) max-content',
+        },
+        columnGap: 3,
+        rowGap: 0.75,
+        alignItems: 'center',
+        width: 'fit-content',
+        maxWidth: '100%',
+        mt: 2,
+        py: 1.25,
+        px: 1.5,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Typography id="primary-shortcut-help-title" variant="subtitle2" sx={{ fontWeight: 700 }}>
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+          {description}
+        </Typography>
+      </Box>
+      <ShortcutBadges shortcutHint={shortcutHint} />
+    </Box>
   );
 }
 
@@ -331,7 +383,8 @@ export function CommandProvider({ children }: { children: React.ReactNode }) {
 
   const helpCommands = useMemo(
     () => getVisibleCommands(commandsWithCreateAction).filter((command) => (
-      command.contextTags.some((tag) => currentContextTags.includes(tag))
+      command.id !== 'help.openPalette'
+      && command.contextTags.some((tag) => currentContextTags.includes(tag))
       && Boolean(command.keys)
       && Boolean(command.shortcutHint?.trim())
     )),
@@ -432,6 +485,11 @@ export function CommandProvider({ children }: { children: React.ReactNode }) {
           <Typography variant="body2" sx={{ mb: 2 }}>
             {t('commandPalette.contextualShortcutsDescription')}
           </Typography>
+          <PrimaryShortcutHelpEntry
+            title={t('commandPalette.primaryShortcutTitle')}
+            description={t('commandPalette.primaryShortcutDescription')}
+            shortcutHint="Ctrl+K / Alt+K"
+          />
           <ShortcutHelpSection title={t('commandPalette.universalShortcutsTitle')}>
             <ShortcutHelpRow label={t('commandPalette.universalShortcuts.nextRegion')} shortcutHint="F6" />
             <Divider component="li" />

--- a/frontend/src/commands/CommandProvider.tsx
+++ b/frontend/src/commands/CommandProvider.tsx
@@ -37,17 +37,122 @@ const SHORTCUT_HINT_KEY = 'ofp.shortcutHintSeen';
 const CREATE_SHORTCUT_HINT = 'Alt+Shift+N';
 const CREATE_SHORTCUT_KEYS = { alt: true, shift: true, key: 'n' } as const;
 
+type ShortcutHelpEntry = {
+  labelKey: string;
+  shortcutHint: string;
+};
+
+type PageShortcutHelpGroup = {
+  titleKey: string;
+  entries: ShortcutHelpEntry[];
+};
+
+const PAGE_SHORTCUT_HELP_GROUPS: PageShortcutHelpGroup[] = [
+  {
+    titleKey: 'commandPalette.allPageShortcuts.cultures.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.create', shortcutHint: CREATE_SHORTCUT_HINT },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.search', shortcutHint: '/' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.edit', shortcutHint: 'Alt+E' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.delete', shortcutHint: 'Alt+Shift+D' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.exportCurrent', shortcutHint: 'Alt+J' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.exportAll', shortcutHint: 'Alt+Shift+J' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.import', shortcutHint: 'Alt+I' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.createPlan', shortcutHint: 'Alt+P' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.previous', shortcutHint: 'Alt+Shift+←' },
+      { labelKey: 'commandPalette.allPageShortcuts.cultures.next', shortcutHint: 'Alt+Shift+→' },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.publicCropLibrary.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.publicCropLibrary.search', shortcutHint: '/' },
+      { labelKey: 'commandPalette.allPageShortcuts.publicCropLibrary.edit', shortcutHint: 'Alt+E' },
+      { labelKey: 'commandPalette.allPageShortcuts.publicCropLibrary.import', shortcutHint: 'Alt+I' },
+      { labelKey: 'commandPalette.allPageShortcuts.publicCropLibrary.previous', shortcutHint: 'Alt+Shift+←' },
+      { labelKey: 'commandPalette.allPageShortcuts.publicCropLibrary.next', shortcutHint: 'Alt+Shift+→' },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.areas.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.areas.create', shortcutHint: CREATE_SHORTCUT_HINT },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.focusTable', shortcutHint: 'Alt+T' },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.createFromSelection', shortcutHint: 'Einfg' },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.delete', shortcutHint: 'Entf' },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.showList', shortcutHint: 'L' },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.showGraphical', shortcutHint: 'G' },
+      { labelKey: 'commandPalette.allPageShortcuts.areas.toggleGraphicalEdit', shortcutHint: 'Alt+E' },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.plans.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.plans.create', shortcutHint: CREATE_SHORTCUT_HINT },
+      { labelKey: 'commandPalette.allPageShortcuts.plans.edit', shortcutHint: 'Alt+E' },
+      { labelKey: 'commandPalette.allPageShortcuts.plans.delete', shortcutHint: 'Entf' },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.calendar.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.today', shortcutHint: 'T' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.previousPeriod', shortcutHint: '←' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.nextPeriod', shortcutHint: '→' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.previousLargePeriod', shortcutHint: 'Shift+←' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.nextLargePeriod', shortcutHint: 'Shift+→' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.dayView', shortcutHint: '1' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.weekView', shortcutHint: '2' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.monthView', shortcutHint: '3' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.quarterView', shortcutHint: '4' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.yearView', shortcutHint: '5' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.search', shortcutHint: '/' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.showOccupancy', shortcutHint: 'F' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.showSeedlings', shortcutHint: 'A' },
+      { labelKey: 'commandPalette.allPageShortcuts.calendar.toggleEdit', shortcutHint: 'Alt+E / Z' },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.locations.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.locations.create', shortcutHint: CREATE_SHORTCUT_HINT },
+    ],
+  },
+  {
+    titleKey: 'commandPalette.allPageShortcuts.suppliers.title',
+    entries: [
+      { labelKey: 'commandPalette.allPageShortcuts.suppliers.create', shortcutHint: CREATE_SHORTCUT_HINT },
+    ],
+  },
+];
+
 function getShortcutParts(shortcutHint: string): string[] {
   return shortcutHint.split('/').map((part) => part.trim()).filter(Boolean);
 }
 
 function ShortcutHelpRow({ label, shortcutHint }: { label: string; shortcutHint: string }): React.ReactElement {
   return (
-    <ListItem disableGutters sx={{ gap: 2, py: 0.75, px: 0, alignItems: 'center' }}>
-      <Typography variant="body2" sx={{ flexGrow: 1, minWidth: 0 }}>
+    <ListItem
+      disableGutters
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'minmax(0, 1fr) max-content',
+          sm: 'minmax(0, 26rem) max-content',
+        },
+        columnGap: 3,
+        rowGap: 0.75,
+        py: 0.75,
+        px: 0,
+        alignItems: 'center',
+        width: 'fit-content',
+        maxWidth: '100%',
+      }}
+    >
+      <Typography variant="body2" sx={{ minWidth: 0 }}>
         {label}
       </Typography>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-end', gap: 0.75, flexShrink: 0 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start', gap: 0.75, minWidth: 0 }}>
         {getShortcutParts(shortcutHint).map((part) => (
           <Chip
             key={part}
@@ -356,6 +461,23 @@ export function CommandProvider({ children }: { children: React.ReactNode }) {
               ))}
             </ShortcutHelpSection>
           ))}
+          <ShortcutHelpSection title={t('commandPalette.allPageShortcutsTitle')}>
+            {PAGE_SHORTCUT_HELP_GROUPS.map((group, groupIndex) => (
+              <Fragment key={group.titleKey}>
+                {groupIndex > 0 ? <Divider component="li" /> : null}
+                <ListItem disableGutters sx={{ py: 1, px: 0 }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                    {t(group.titleKey)}
+                  </Typography>
+                </ListItem>
+                {group.entries.map((entry) => (
+                  <Fragment key={`${group.titleKey}-${entry.labelKey}`}>
+                    <ShortcutHelpRow label={t(entry.labelKey)} shortcutHint={entry.shortcutHint} />
+                  </Fragment>
+                ))}
+              </Fragment>
+            ))}
+          </ShortcutHelpSection>
         </DialogContent>
       </Dialog>
       <AlertSnackbar

--- a/frontend/src/commands/CommandProvider.tsx
+++ b/frontend/src/commands/CommandProvider.tsx
@@ -1,4 +1,7 @@
 import {
+  Box,
+  Chip,
+  Divider,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -8,7 +11,7 @@ import {
   ListItemText,
   Typography,
 } from '@mui/material';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommandPalette } from './CommandPalette';
 import { getRunnableCommands, getVisibleCommands } from './commands';
 import type { CommandContextTag, CommandSpec, CreateAction } from './types';
@@ -33,6 +36,44 @@ const CONTEXT_TITLE_KEYS: Record<CommandContextTag, string> = {
 const SHORTCUT_HINT_KEY = 'ofp.shortcutHintSeen';
 const CREATE_SHORTCUT_HINT = 'Alt+Shift+N';
 const CREATE_SHORTCUT_KEYS = { alt: true, shift: true, key: 'n' } as const;
+
+function getShortcutParts(shortcutHint: string): string[] {
+  return shortcutHint.split('/').map((part) => part.trim()).filter(Boolean);
+}
+
+function ShortcutHelpRow({ label, shortcutHint }: { label: string; shortcutHint: string }): React.ReactElement {
+  return (
+    <ListItem disableGutters sx={{ gap: 2, py: 0.75, px: 0, alignItems: 'center' }}>
+      <Typography variant="body2" sx={{ flexGrow: 1, minWidth: 0 }}>
+        {label}
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-end', gap: 0.75, flexShrink: 0 }}>
+        {getShortcutParts(shortcutHint).map((part) => (
+          <Chip
+            key={part}
+            label={part}
+            size="small"
+            variant="outlined"
+            sx={{ borderRadius: 1, fontFamily: 'monospace', bgcolor: 'background.paper' }}
+          />
+        ))}
+      </Box>
+    </ListItem>
+  );
+}
+
+function ShortcutHelpSection({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <Box component="section" sx={{ mt: 2.5 }}>
+      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 0.5, fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <List dense disablePadding sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
+        {children}
+      </List>
+    </Box>
+  );
+}
 
 const getAvailableCreateActions = (actions: CreateAction[]): CreateAction[] => actions
   .filter((action) => !action.hidden && !action.disabled)
@@ -184,7 +225,11 @@ export function CommandProvider({ children }: { children: React.ReactNode }) {
   }, [commandsWithCreateAction, currentContextTags]);
 
   const helpCommands = useMemo(
-    () => getVisibleCommands(commandsWithCreateAction).filter((command) => command.contextTags.some((tag) => currentContextTags.includes(tag))),
+    () => getVisibleCommands(commandsWithCreateAction).filter((command) => (
+      command.contextTags.some((tag) => currentContextTags.includes(tag))
+      && Boolean(command.keys)
+      && Boolean(command.shortcutHint?.trim())
+    )),
     [commandsWithCreateAction, currentContextTags],
   );
 
@@ -282,62 +327,34 @@ export function CommandProvider({ children }: { children: React.ReactNode }) {
           <Typography variant="body2" sx={{ mb: 2 }}>
             {t('commandPalette.contextualShortcutsDescription')}
           </Typography>
-          <div>
-            <Typography variant="h6" sx={{ mt: 2 }}>{t('commandPalette.universalShortcutsTitle')}</Typography>
-            <List dense>
-              <ListItem>
-                <ListItemText primary={t('commandPalette.universalShortcuts.nextRegion')} secondary="F6" slotProps={{ secondary: { style: { textAlign: 'right' } } }} />
-              </ListItem>
-              <ListItem>
-                <ListItemText primary={t('commandPalette.universalShortcuts.previousRegion')} secondary="Shift+F6" slotProps={{ secondary: { style: { textAlign: 'right' } } }} />
-              </ListItem>
-              <ListItem>
-                <ListItemText primary={t('commandPalette.universalShortcuts.withinRegion')} secondary="Tab / Shift+Tab" slotProps={{ secondary: { style: { textAlign: 'right' } } }} />
-              </ListItem>
-              <ListItem>
-                <ListItemText primary={t('commandPalette.universalShortcuts.closeDialog')} secondary="Esc" slotProps={{ secondary: { style: { textAlign: 'right' } } }} />
-              </ListItem>
-            </List>
-          </div>
+          <ShortcutHelpSection title={t('commandPalette.universalShortcutsTitle')}>
+            <ShortcutHelpRow label={t('commandPalette.universalShortcuts.nextRegion')} shortcutHint="F6" />
+            <Divider component="li" />
+            <ShortcutHelpRow label={t('commandPalette.universalShortcuts.previousRegion')} shortcutHint="Shift+F6" />
+            <Divider component="li" />
+            <ShortcutHelpRow label={t('commandPalette.universalShortcuts.withinRegion')} shortcutHint="Tab / Shift+Tab" />
+            <Divider component="li" />
+            <ShortcutHelpRow label={t('commandPalette.universalShortcuts.closeDialog')} shortcutHint="Esc" />
+          </ShortcutHelpSection>
           {currentRegionShortcuts.length > 0 && (
-            <div>
-              <Typography variant="h6" sx={{ mt: 2 }}>{t('commandPalette.currentRegionShortcutsTitle')}</Typography>
-              <List dense>
-                {currentRegionShortcuts.map((shortcut) => (
-                  <ListItem key={`region-${shortcut.key}`}>
-                    <ListItemText
-                      primary={shortcut.label}
-                      secondary={shortcut.key}
-                      slotProps={{
-                        secondary: {
-                          style: { textAlign: 'right' },
-                        },
-                      }}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </div>
+            <ShortcutHelpSection title={t('commandPalette.currentRegionShortcutsTitle')}>
+              {currentRegionShortcuts.map((shortcut, index) => (
+                <Fragment key={`region-${shortcut.key}`}>
+                  {index > 0 ? <Divider component="li" /> : null}
+                  <ShortcutHelpRow label={shortcut.label} shortcutHint={shortcut.key} />
+                </Fragment>
+              ))}
+            </ShortcutHelpSection>
           )}
           {groupedHelpCommands.map((group) => (
-            <div key={group.tag}>
-              <Typography variant="h6" sx={{ mt: 2 }}>{group.title}</Typography>
-              <List dense>
-                {group.commands.map((command) => (
-                  <ListItem key={`${group.tag}-${command.id}`}>
-                    <ListItemText
-                      primary={command.label}
-                      secondary={command.shortcutHint}
-                      slotProps={{
-                        secondary: {
-                          style: { textAlign: 'right' },
-                        },
-                      }}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </div>
+            <ShortcutHelpSection key={group.tag} title={group.title}>
+              {group.commands.map((command, index) => (
+                <Fragment key={`${group.tag}-${command.id}`}>
+                  {index > 0 ? <Divider component="li" /> : null}
+                  <ShortcutHelpRow label={command.label} shortcutHint={command.shortcutHint ?? ''} />
+                </Fragment>
+              ))}
+            </ShortcutHelpSection>
           ))}
         </DialogContent>
       </Dialog>

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -110,6 +110,8 @@
     "createNewShortcut": "Neu erstellen",
     "contextualShortcutsTitle": "Tastenkürzel (?)",
     "contextualShortcutsDescription": "Shortcuts sind browser-sicher und überschreiben keine üblichen Browser-Shortcuts.",
+    "primaryShortcutTitle": "Aktionssuche",
+    "primaryShortcutDescription": "Befehle und Seiten durchsuchen",
     "universalShortcutsTitle": "Grundlegende Navigation",
     "universalShortcuts": {
       "nextRegion": "Nächster Fokusbereich",

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -111,7 +111,7 @@
     "contextualShortcutsTitle": "Tastenkürzel (?)",
     "contextualShortcutsDescription": "Shortcuts sind browser-sicher und überschreiben keine üblichen Browser-Shortcuts.",
     "primaryShortcutTitle": "Aktionssuche",
-    "primaryShortcutDescription": "Befehle und Seiten durchsuchen",
+    "primaryShortcutDescription": "Befehle, Seiten und seitenspezifische Tastenkürzel finden",
     "universalShortcutsTitle": "Grundlegende Navigation",
     "universalShortcuts": {
       "nextRegion": "Nächster Fokusbereich",

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -118,6 +118,71 @@
       "closeDialog": "Dialog oder Menü schließen"
     },
     "currentRegionShortcutsTitle": "Aktueller Fokusbereich",
+    "allPageShortcutsTitle": "Seitenspezifische Tastenkürzel",
+    "allPageShortcuts": {
+      "cultures": {
+        "title": "Kulturen",
+        "create": "Kultur hinzufügen",
+        "search": "Kultursuche fokussieren",
+        "edit": "Kultur bearbeiten",
+        "delete": "Kultur löschen",
+        "exportCurrent": "Ausgewählte Kultur exportieren",
+        "exportAll": "Alle Kulturen exportieren",
+        "import": "Kulturen importieren",
+        "createPlan": "Anbauplan aus Kultur erstellen",
+        "previous": "Vorherige Kultur auswählen",
+        "next": "Nächste Kultur auswählen"
+      },
+      "publicCropLibrary": {
+        "title": "Öffentliche Kulturbibliothek",
+        "search": "Kulturbibliothek durchsuchen",
+        "edit": "Öffentliche Kultur bearbeiten",
+        "import": "Kultur importieren",
+        "previous": "Vorherige Kultur auswählen",
+        "next": "Nächste Kultur auswählen"
+      },
+      "areas": {
+        "title": "Anbauflächen",
+        "create": "Neue Anbaufläche erstellen",
+        "focusTable": "Tabelle fokussieren",
+        "createFromSelection": "Unterelement zur Auswahl hinzufügen",
+        "delete": "Ausgewählte Anbaufläche löschen",
+        "showList": "Listenansicht anzeigen",
+        "showGraphical": "Grafikansicht anzeigen",
+        "toggleGraphicalEdit": "Grafik-Bearbeitung ein-/ausschalten"
+      },
+      "plans": {
+        "title": "Anbaupläne",
+        "create": "Anbauplan hinzufügen",
+        "edit": "Anbauplan bearbeiten",
+        "delete": "Anbauplan löschen"
+      },
+      "calendar": {
+        "title": "Anbaukalender",
+        "today": "Zur aktuellen Periode springen",
+        "previousPeriod": "Vorherige Periode",
+        "nextPeriod": "Nächste Periode",
+        "previousLargePeriod": "Vorherige große Periode",
+        "nextLargePeriod": "Nächste große Periode",
+        "dayView": "Tagesansicht",
+        "weekView": "Wochenansicht",
+        "monthView": "Monatsansicht",
+        "quarterView": "Quartalsansicht",
+        "yearView": "Jahresansicht",
+        "search": "Kalendersuche fokussieren",
+        "showOccupancy": "Feldbelegung anzeigen",
+        "showSeedlings": "Anzucht anzeigen",
+        "toggleEdit": "Zeiträume verschieben ein-/ausschalten"
+      },
+      "locations": {
+        "title": "Standorte",
+        "create": "Standort hinzufügen"
+      },
+      "suppliers": {
+        "title": "Lieferanten",
+        "create": "Lieferant hinzufügen"
+      }
+    },
     "currentVersion": "Aktuelle Version",
     "versionHistoryTitle": "Versionsverlauf",
     "versionHistoryEmpty": "Noch keine Änderungen aufgezeichnet.",

--- a/frontend/src/i18n/locales/de/navigation.json
+++ b/frontend/src/i18n/locales/de/navigation.json
@@ -111,7 +111,7 @@
     "contextualShortcutsTitle": "Tastenkürzel (?)",
     "contextualShortcutsDescription": "Shortcuts sind browser-sicher und überschreiben keine üblichen Browser-Shortcuts.",
     "primaryShortcutTitle": "Aktionssuche",
-    "primaryShortcutDescription": "Befehle, Seiten und seitenspezifische Tastenkürzel finden",
+    "primaryShortcutDescription": "Seitenspezifische Befehle und Tastenkürzel anzeigen",
     "universalShortcutsTitle": "Grundlegende Navigation",
     "universalShortcuts": {
       "nextRegion": "Nächster Fokusbereich",

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -118,6 +118,71 @@
       "closeDialog": "Close dialog or menu"
     },
     "currentRegionShortcutsTitle": "Current focus region",
+    "allPageShortcutsTitle": "Page-specific shortcuts",
+    "allPageShortcuts": {
+      "cultures": {
+        "title": "Crops",
+        "create": "Add crop",
+        "search": "Focus crop search",
+        "edit": "Edit crop",
+        "delete": "Delete crop",
+        "exportCurrent": "Export selected crop",
+        "exportAll": "Export all crops",
+        "import": "Import crops",
+        "createPlan": "Create planting plan from crop",
+        "previous": "Select previous crop",
+        "next": "Select next crop"
+      },
+      "publicCropLibrary": {
+        "title": "Public crop library",
+        "search": "Search crop library",
+        "edit": "Edit public crop",
+        "import": "Import crop",
+        "previous": "Select previous crop",
+        "next": "Select next crop"
+      },
+      "areas": {
+        "title": "Growing areas",
+        "create": "Create growing area",
+        "focusTable": "Focus table",
+        "createFromSelection": "Add child item to selection",
+        "delete": "Delete selected growing area",
+        "showList": "Show list view",
+        "showGraphical": "Show graphical view",
+        "toggleGraphicalEdit": "Toggle graphical editing"
+      },
+      "plans": {
+        "title": "Planting plans",
+        "create": "Add planting plan",
+        "edit": "Edit planting plan",
+        "delete": "Delete planting plan"
+      },
+      "calendar": {
+        "title": "Planting calendar",
+        "today": "Jump to current period",
+        "previousPeriod": "Previous period",
+        "nextPeriod": "Next period",
+        "previousLargePeriod": "Previous large period",
+        "nextLargePeriod": "Next large period",
+        "dayView": "Day view",
+        "weekView": "Week view",
+        "monthView": "Month view",
+        "quarterView": "Quarter view",
+        "yearView": "Year view",
+        "search": "Focus calendar search",
+        "showOccupancy": "Show field occupancy",
+        "showSeedlings": "Show seedlings",
+        "toggleEdit": "Toggle moving periods"
+      },
+      "locations": {
+        "title": "Locations",
+        "create": "Add location"
+      },
+      "suppliers": {
+        "title": "Suppliers",
+        "create": "Add supplier"
+      }
+    },
     "currentVersion": "Current version",
     "versionHistoryTitle": "Version history",
     "versionHistoryEmpty": "No changes recorded yet.",

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -111,7 +111,7 @@
     "contextualShortcutsTitle": "Contextual keyboard shortcuts (Alt+K)",
     "contextualShortcutsDescription": "Shortcuts are browser-safe and do not override common browser shortcuts.",
     "primaryShortcutTitle": "Action search",
-    "primaryShortcutDescription": "Search commands and pages",
+    "primaryShortcutDescription": "Find commands, pages, and page-specific shortcuts",
     "universalShortcutsTitle": "Basic navigation",
     "universalShortcuts": {
       "nextRegion": "Next focus region",

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -110,6 +110,8 @@
     "createNewShortcut": "Create new",
     "contextualShortcutsTitle": "Contextual keyboard shortcuts (Alt+K)",
     "contextualShortcutsDescription": "Shortcuts are browser-safe and do not override common browser shortcuts.",
+    "primaryShortcutTitle": "Action search",
+    "primaryShortcutDescription": "Search commands and pages",
     "universalShortcutsTitle": "Basic navigation",
     "universalShortcuts": {
       "nextRegion": "Next focus region",

--- a/frontend/src/i18n/locales/en/navigation.json
+++ b/frontend/src/i18n/locales/en/navigation.json
@@ -111,7 +111,7 @@
     "contextualShortcutsTitle": "Contextual keyboard shortcuts (Alt+K)",
     "contextualShortcutsDescription": "Shortcuts are browser-safe and do not override common browser shortcuts.",
     "primaryShortcutTitle": "Action search",
-    "primaryShortcutDescription": "Find commands, pages, and page-specific shortcuts",
+    "primaryShortcutDescription": "Show page-specific commands and keyboard shortcuts",
     "universalShortcutsTitle": "Basic navigation",
     "universalShortcuts": {
       "nextRegion": "Next focus region",

--- a/frontend/src/pages/FieldsBedsPage.tsx
+++ b/frontend/src/pages/FieldsBedsPage.tsx
@@ -5,7 +5,7 @@ import FieldsBedsHierarchy from './FieldsBedsHierarchy';
 import GraphicalFields from './GraphicalFields';
 import { AddBedIcon } from '../components/hierarchy/AddBedIcon';
 import { HierarchyAddIcon } from '../components/hierarchy/HierarchyAddIcon';
-import { useCommandContextTag, useRegisterCommands } from '../commands/useCommandContext';
+import { useCommandContextTag, useRegisterCommands, useRegisterCreateActions } from '../commands/useCommandContext';
 import type { CommandSpec } from '../commands/types';
 import { useTranslation } from '../i18n';
 import PageContainer from '../components/layout/PageContainer';
@@ -342,6 +342,38 @@ export default function FieldsBedsPage() {
 
   useTopbarContextActions(setTopbarContextActions, contextActions);
   useTopbarTitleActions(setTopbarTitleActions, viewModeActions);
+
+  const createActions = useMemo(() => {
+    if (shouldShowProjectRequiredState) {
+      return [];
+    }
+    if (canUseGlobalAddField) {
+      return [
+        {
+          id: 'create-field',
+          label: t('hierarchy:actions.addFieldDropdown'),
+          shortcut: 'Alt+Shift+N',
+          handler: requestInlineFieldCreation,
+        },
+      ];
+    }
+    return [
+      {
+        id: 'create-location',
+        label: t('hierarchy:actions.createLocation'),
+        shortcut: 'Alt+Shift+N',
+        handler: openAddLocationDialog,
+      },
+    ];
+  }, [
+    canUseGlobalAddField,
+    openAddLocationDialog,
+    requestInlineFieldCreation,
+    shouldShowProjectRequiredState,
+    t,
+  ]);
+
+  useRegisterCreateActions('areas-page', createActions);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Filter the keyboard shortcut help dialog to commands that actually have assigned shortcut keys from the live registry.
- Keep command-palette-only actions such as project settings, project creation, project switching, account settings, and logout out of the shortcut reference.
- Rework shortcut rows into compact label-left, key-badges-right rows with existing MUI spacing, divider, typography, and outlined chip tokens.

## Validation

- `npm run test -- commandProvider --run`
- `npm run lint -- src/commands/CommandProvider.tsx src/__tests__/commandProvider.test.tsx`
- `git diff --check`

Mobile note: the layout uses wrapped right-aligned key chips and the existing scrollable MUI dialog content, so narrow viewports keep readable rows without pushing keys off-screen.

Note: lint exits with 0 errors but still reports existing project-wide `react-hooks/*` warnings unrelated to this change.