### PR TITLE
Fix Vite native config warnings

### DIFF
--- a/frontend/build/prerender.ts
+++ b/frontend/build/prerender.ts
@@ -31,9 +31,8 @@
  *
  * `prerenderSeo.ts` (the actual SEO logic) is loaded through Vite's SSR
  * module runner rather than imported directly, because it in turn imports
- * this project's `src/seo/*` modules using the same extensionless/aliased
- * imports as the rest of the app — something only Vite's resolver (not
- * Node's own ESM loader) understands.
+ * this project's `src/seo/*` modules with TypeScript file extensions —
+ * something Vite's resolver handles consistently with the rest of the build.
  *
  * Before any route is prerendered, the pristine (un-prerendered) `index.html`
  * is copied to `app-shell.html`. Production's reverse proxy uses SPA-fallback

--- a/frontend/build/prerenderSeo.test.ts
+++ b/frontend/build/prerenderSeo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyHeadTags, assertNoLoopbackUrls, PUBLIC_INDEXABLE_ROUTES } from './prerenderSeo';
+import { applyHeadTags, assertNoLoopbackUrls, PUBLIC_INDEXABLE_ROUTES } from './prerenderSeo.ts';
 
 /**
  * Simulates what Playwright's `page.content()` actually captures: the base

--- a/frontend/build/prerenderSeo.ts
+++ b/frontend/build/prerenderSeo.ts
@@ -3,10 +3,9 @@
  * its unit tests: computing the final, route-specific `<head>` for a
  * prerendered page. Kept as its own module (rather than inlined in
  * prerender.ts) so it can be loaded through Vite's SSR module runner, which
- * resolves this project's usual extensionless/aliased imports the same way
- * `vite build`/`vitest` do — the Node entry point itself is executed
- * directly by Node (via `--experimental-strip-types`) and cannot resolve
- * those on its own.
+ * resolves this project's TypeScript imports the same way `vite build` and
+ * `vitest` do — the Node entry point itself is executed directly by Node
+ * (via `--experimental-strip-types`), so keep its direct imports explicit.
  */
 
 import { JSDOM } from 'jsdom';
@@ -17,8 +16,8 @@ import {
   resolveSiteUrl,
   type PublicRoute,
   type SeoEnv,
-} from '../src/seo/seoConfig';
-import { buildHeadTags } from '../src/seo/seoAssets';
+} from '../src/seo/seoConfig.ts';
+import { buildHeadTags } from '../src/seo/seoAssets.ts';
 
 export { PUBLIC_INDEXABLE_ROUTES, SITE_LANGUAGE };
 export type { PublicRoute };

--- a/frontend/build/seoPlugin.test.ts
+++ b/frontend/build/seoPlugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { seoPlugin } from './seoPlugin';
+import { seoPlugin } from './seoPlugin.ts';
 
 const SAMPLE_HTML = [
   '<!doctype html>',

--- a/frontend/build/seoPlugin.ts
+++ b/frontend/build/seoPlugin.ts
@@ -14,8 +14,8 @@
  */
 
 import type { Plugin } from 'vite';
-import { resolveIndexable, resolveSiteUrl, type SeoEnv } from '../src/seo/seoConfig';
-import { buildHeadTags, buildRobotsTxt, buildSitemapXml } from '../src/seo/seoAssets';
+import { resolveIndexable, resolveSiteUrl, type SeoEnv } from '../src/seo/seoConfig.ts';
+import { buildHeadTags, buildRobotsTxt, buildSitemapXml } from '../src/seo/seoAssets.ts';
 
 export function seoPlugin(env: SeoEnv = process.env as SeoEnv): Plugin {
   const siteUrl = resolveSiteUrl(env);

--- a/frontend/src/seo/seoAssets.ts
+++ b/frontend/src/seo/seoAssets.ts
@@ -16,7 +16,7 @@ import {
   SITE_LANGUAGE,
   buildCanonicalUrl,
   type PublicRoute,
-} from './seoConfig';
+} from './seoConfig.ts';
 
 export interface RobotsOptions {
   siteUrl: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import { seoPlugin } from './build/seoPlugin'
+import { seoPlugin } from './build/seoPlugin.ts'
 
 function normalizeBasePath(input?: string): string {
   const value = input && input.trim().length > 0 ? input.trim() : '/'
@@ -62,7 +62,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
     dedupe: ['react', 'react-dom'],
   },


### PR DESCRIPTION
## Summary

- Replace `__dirname` in the Vite config with `import.meta.dirname`.
- Add explicit `.ts` extensions to the Vite config, SEO build plugin, prerender SEO helper, and related build tests.
- Update prerender comments so they match the explicit TypeScript import strategy.

## Why

Vite warns that these patterns are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version. This keeps the frontend build path compatible without suppressing the warning.

## Validation

- `npm run build`
- `npx vite build --configLoader native`
- `npm run test -- --run build/seoPlugin.test.ts build/prerenderSeo.test.ts src/seo/__tests__/seoAssets.test.ts`
- `npm run lint` exits 0 with existing warnings

Full `npm run test -- --run` was also attempted: 204 files passed, but 3 unrelated CultureForm tests timed out in `CultureFormLibraryAutocomplete.test.tsx` and `CultureFormVarietyHighlighting.test.tsx`.