### PR TITLE
fix: support species-level (general) Culture create/update via API

### DIFF
--- a/backend/farm/agent_api/openapi.py
+++ b/backend/farm/agent_api/openapi.py
@@ -170,6 +170,7 @@ def _seed_requirements_schema() -> dict[str, Any]:
 def build_culture_write_item_schema() -> dict[str, Any]:
     """Return the JSON Schema for direct culture create/update payloads."""
     properties = {spec.name: _field_schema(spec) for spec in CULTURE_FIELD_SPECS}
+    properties['variety']['type'] = ['string', 'null']
     properties['seed_requirements'] = _seed_requirements_schema()
     return {
         'type': 'object',
@@ -193,6 +194,15 @@ def _culture_write_request_body(*, required: bool) -> dict[str, Any]:
             'application/json': {
                 'schema': {'$ref': '#/components/schemas/CultureWriteItem'},
                 'examples': {
+                    'generalCulture': {
+                        'summary': 'Species-level general culture data',
+                        'value': {
+                            'name': 'Tomate',
+                            'variety': '',
+                            'crop_family': 'Solanaceae',
+                            'growth_duration_days': 80,
+                        },
+                    },
                     'preCultivatedTomato': {
                         'summary': 'Pre-cultivated tomato',
                         'value': {

--- a/backend/farm/cultures/serializers/cultures.py
+++ b/backend/farm/cultures/serializers/cultures.py
@@ -66,8 +66,9 @@ class CultureSerializer(serializers.ModelSerializer):
     variety = serializers.CharField(
         required=False,
         allow_blank=True,
+        allow_null=True,
         default='',
-        help_text='Culture variety (optional)'
+        help_text='Culture variety; blank or null for species-level general data'
     )
     distance_within_row_cm = CentimetersField(
         source='distance_within_row_m',
@@ -621,7 +622,7 @@ class CultureSerializer(serializers.ModelSerializer):
             errors['name'] = 'Name is required.'
             return
         attrs['name'] = ' '.join(str(raw_name).split())
-        attrs['variety'] = ' '.join(str(raw_variety).split())
+        attrs['variety'] = ' '.join(str(raw_variety or '').split())
         project = self._resolve_project(attrs, instance_first=False)
         if project is None:
             return

--- a/backend/farm/cultures/views/cultures.py
+++ b/backend/farm/cultures/views/cultures.py
@@ -132,7 +132,7 @@ class CultureViewSet(ProjectScopedMixin, viewsets.ModelViewSet):
 
         normalized_name = normalize_text(request.query_params.get('name'))
         normalized_variety = normalize_text(request.query_params.get('variety'))
-        if not normalized_name or not normalized_variety:
+        if not normalized_name:
             return Response({'exists': False})
 
         queryset = self.get_queryset().filter(

--- a/backend/farm/tests/test_agent_api_tokens.py
+++ b/backend/farm/tests/test_agent_api_tokens.py
@@ -191,6 +191,39 @@ class ApiTokenScopeTests(ApiTokenTestBase):
         )
         self.assertEqual(patched.status_code, 200)
 
+    def test_write_token_can_create_and_patch_general_culture_data(self):
+        _, raw_token = self.issue_token(scope=ProjectApiToken.SCOPE_WRITE)
+        client = self.bearer_client(raw_token)
+
+        created = client.post(
+            '/api/cultures/',
+            {
+                'name': 'General Carrot',
+                'variety': None,
+                'crop_family': 'Apiaceae',
+                'growth_duration_days': 100,
+                'row_spacing_cm': 30,
+            },
+            format='json',
+        )
+
+        self.assertEqual(created.status_code, 201)
+        self.assertEqual(created.data['variety'], '')
+        culture = Culture.objects.get(pk=created.data['id'])
+        self.assertEqual(culture.project_id, self.project.id)
+
+        patched = client.patch(
+            f'/api/cultures/{culture.id}/',
+            {'variety': None, 'growth_duration_days': 110, 'notes': 'Token baseline'},
+            format='json',
+        )
+
+        self.assertEqual(patched.status_code, 200)
+        self.assertEqual(patched.data['variety'], '')
+        culture.refresh_from_db()
+        self.assertEqual(culture.growth_duration_days, 110)
+        self.assertEqual(culture.notes, 'Token baseline')
+
     def test_write_token_cannot_delete(self):
         _, raw_token = self.issue_token(scope=ProjectApiToken.SCOPE_WRITE)
         response = self.bearer_client(raw_token).delete(f'/api/cultures/{self.culture.id}/')

--- a/backend/farm/tests/test_agent_openapi.py
+++ b/backend/farm/tests/test_agent_openapi.py
@@ -113,6 +113,14 @@ class OpenApiDocumentTests(APITestCase):
             {'value': 2, 'unit': 'seeds_per_plant'},
         )
 
+    def test_culture_create_documents_general_culture_identity(self):
+        variety_schema = self.culture_write_schema['properties']['variety']
+        request_body = self.document['paths']['/cultures/']['post']['requestBody']
+        examples = request_body['content']['application/json']['examples']
+
+        self.assertEqual(variety_schema['type'], ['string', 'null'])
+        self.assertEqual(examples['generalCulture']['value']['variety'], '')
+
     def test_coupled_fields_declare_their_companion(self):
         properties = self.culture_schema['properties']
 

--- a/backend/farm/tests/test_cultures_api.py
+++ b/backend/farm/tests/test_cultures_api.py
@@ -106,6 +106,33 @@ class CultureApiTest(ProjectApiTestCase):
         response = self.client.post('/openfarmplanner/api/cultures/', data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_culture_create_and_update_general_data_with_null_variety(self):
+        response = self.client.post(
+            '/openfarmplanner/api/cultures/',
+            {
+                'name': 'General Tomato',
+                'variety': None,
+                'crop_family': 'Solanaceae',
+                'growth_duration_days': 80,
+                'row_spacing_cm': 60,
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['variety'], '')
+
+        update_response = self.client.patch(
+            f'/openfarmplanner/api/cultures/{response.data["id"]}/',
+            {'variety': None, 'growth_duration_days': 90, 'notes': 'General baseline'},
+            format='json',
+        )
+
+        self.assertEqual(update_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(update_response.data['variety'], '')
+        self.assertEqual(update_response.data['growth_duration_days'], 90)
+        self.assertEqual(update_response.data['notes'], 'General baseline')
+
     def test_culture_create_rejects_duplicate_name_and_variety(self):
         existing = Culture.objects.create(
             name='Duplicate Test Culture',
@@ -159,6 +186,17 @@ class CultureApiTest(ProjectApiTestCase):
         self.assertTrue(matching_response.data['exists'])
         self.assertFalse(other_project_response.data['exists'])
         self.assertFalse(public_response.data['exists'])
+
+    def test_culture_duplicate_check_supports_general_data_without_variety(self):
+        Culture.objects.create(name='General Bean', variety='', project=self.project)
+
+        response = self.client.get(
+            '/openfarmplanner/api/cultures/duplicate-check/',
+            {'name': ' general bean ', 'variety': ''},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['exists'])
 
     def test_public_culture_match_returns_exact_normalized_match(self):
         PublicCulture.objects.create(name='Tomate', variety='Roma', status='published')

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -355,6 +355,12 @@ Enums: `nutrient_demand` (`low`/`medium`/`high`), `harvest_method`
 `name` is the only required field. Everything else is optional, and an absent
 field is left untouched rather than reset.
 
+Species-level general data uses the same private `Culture` endpoint and fields
+as variety-specific data. Send `variety` as an empty string or `null` (or omit
+it when creating the row); the API stores all three forms as an empty string.
+Duplicate detection treats the resulting `(name, empty variety)` identity like
+any other culture identity. On update, omitting `variety` leaves it unchanged.
+
 Rejected (the row becomes `blocked` and the draft cannot be applied):
 
 - a number whose unit is stated nowhere — in the key, the value, or an explicit


### PR DESCRIPTION
### Motivation

- API clients (including project-bound API tokens) could not reliably create or update species-level "general" culture records because `null` for `variety` was rejected or not normalized consistently.  
- The system treats a blank `variety` as the species-level record; the API surface and docs needed to accept `null` and consistently normalize it to an empty string so general-crop workflows work via the API.  

### Description

- Allow `null` for `variety` in the private `CultureSerializer` and normalize incoming `None` to the stored empty-string representation so species-level (general) cultures are created/updated correctly.  
- Relax the duplicate-check endpoint to treat `(name, empty variety)` identities as valid inputs instead of rejecting requests missing a variety, keeping project scoping unchanged.  
- Update the agent/OpenAPI generator to advertise `variety` as `string|null` and add an explicit example for a general (species-level) culture payload.  
- Add regression tests and docs: new tests exercising create/update of general culture records for session auth and API-token (write scope), an OpenAPI test asserting nullable variety and the example, and a docs note in `docs/agent-api.md` describing how to represent species-level data.  

### Testing

- Ran a quick compile check of the modified Python modules with `python -m compileall` and it succeeded.  
- Ran the targeted backend test set `pdm run test` (pytest) for the affected areas: `farm/tests/test_cultures_api.py`, `farm/tests/test_agent_api_tokens.py`, and `farm/tests/test_agent_openapi.py`; all relevant tests passed (107 tests passed).  
- Verified `git diff --check` showed no whitespace/patch issues prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eb6659b4c8322b30f8e6df93925fd)