### PR TITLE
feat: expose api token project context

### DIFF
--- a/backend/farm/agent_api/openapi.py
+++ b/backend/farm/agent_api/openapi.py
@@ -586,6 +586,35 @@ def _read_only_collection_paths() -> dict[str, Any]:
     }
 
 
+def _agent_context_path() -> dict[str, Any]:
+    """Return the token self-context endpoint path item."""
+    return {
+        '/agent/context/': {
+            'get': {
+                'summary': 'Read the project context bound to this API token',
+                'description': (
+                    'Requires scope `read`. Returns only non-secret context for '
+                    'the authenticating token so tools can confirm the target '
+                    'project before writing. It does not expose project members '
+                    'or any project list.'
+                ),
+                'tags': ['agent'],
+                'responses': {
+                    '200': {
+                        'description': 'The token-bound project context.',
+                        'content': {
+                            'application/json': {
+                                'schema': {'$ref': '#/components/schemas/AgentContext'}
+                            }
+                        },
+                    },
+                    '403': {'description': 'Returned for session-authenticated callers.'},
+                },
+            }
+        }
+    }
+
+
 def build_openapi_document(*, server_url: str = '/api') -> dict[str, Any]:
     """Build the OpenAPI document for the agent-reachable API surface.
 
@@ -593,6 +622,7 @@ def build_openapi_document(*, server_url: str = '/api') -> dict[str, Any]:
     :return: The OpenAPI document as a plain dictionary.
     """
     paths: dict[str, Any] = {}
+    paths.update(_agent_context_path())
     paths.update(_culture_paths())
     paths.update(_import_paths())
     paths.update(_read_only_collection_paths())
@@ -636,6 +666,26 @@ def build_openapi_document(*, server_url: str = '/api') -> dict[str, Any]:
                         'message': {'type': 'string'},
                         'field': {'type': 'string'},
                     },
+                },
+                'AgentContext': {
+                    'type': 'object',
+                    'description': 'Non-secret context for the authenticating project API token.',
+                    'properties': {
+                        'project_id': {
+                            'type': 'integer',
+                            'description': 'Project id permanently bound to the token.',
+                        },
+                        'project_name': {
+                            'type': 'string',
+                            'description': 'Human-readable name of the bound project.',
+                        },
+                        'token_scope': {
+                            'type': 'string',
+                            'enum': ['read', 'write', 'delete'],
+                            'description': 'Scope carried by the token.',
+                        },
+                    },
+                    'required': ['project_id', 'project_name', 'token_scope'],
                 },
                 'CultureImportItem': build_culture_import_item_schema(),
                 'CultureWriteItem': build_culture_write_item_schema(),

--- a/backend/farm/agent_api/views.py
+++ b/backend/farm/agent_api/views.py
@@ -21,6 +21,7 @@ from farm.models import CultureImportDraft, Project, ProjectApiToken
 from farm.services.culture_import import analyze_import_payload
 from farm.services.culture_import.apply import ImportExecutionError, apply_import_draft
 
+from .permissions import get_request_api_token
 from .serializers import (
     CultureImportApplyRequestSerializer,
     CultureImportPreviewRequestSerializer,
@@ -156,6 +157,31 @@ class CultureImportApplyView(ProjectScopedMixin, APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response(result, status=status.HTTP_200_OK)
+
+
+class AgentContextView(APIView):
+    """Return the project context of the authenticating API token."""
+
+    api_token_actions = {'get'}
+
+    def get(self, request):
+        """Return non-secret context for the project-bound token."""
+        token = get_request_api_token(request)
+        if token is None:
+            return Response(
+                {
+                    'detail': 'API token authentication is required.',
+                    'code': 'api_token_required',
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return Response(
+            {
+                'project_id': token.project_id,
+                'project_name': token.project.name,
+                'token_scope': token.scope,
+            }
+        )
 
 
 def _draft_payload(draft: CultureImportDraft) -> dict:

--- a/backend/farm/tests/test_agent_api_tokens.py
+++ b/backend/farm/tests/test_agent_api_tokens.py
@@ -154,6 +154,30 @@ class ApiTokenLifecycleTests(ApiTokenTestBase):
 class ApiTokenScopeTests(ApiTokenTestBase):
     """`read` must not mutate; destructive actions require the delete scope."""
 
+    def test_read_token_can_fetch_bound_project_context(self):
+        _, raw_token = self.issue_token(scope=ProjectApiToken.SCOPE_READ)
+
+        response = self.bearer_client(raw_token).get('/api/agent/context/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                'project_id': self.project.id,
+                'project_name': self.project.name,
+                'token_scope': ProjectApiToken.SCOPE_READ,
+            },
+        )
+
+    def test_session_user_cannot_use_token_context_endpoint(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        response = client.get('/api/agent/context/')
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data['code'], 'api_token_required')
+
     def test_read_token_can_list_and_retrieve(self):
         _, raw_token = self.issue_token(scope=ProjectApiToken.SCOPE_READ)
         client = self.bearer_client(raw_token)

--- a/backend/farm/tests/test_agent_openapi.py
+++ b/backend/farm/tests/test_agent_openapi.py
@@ -30,6 +30,7 @@ class OpenApiDocumentTests(APITestCase):
 
     def test_import_paths_are_documented(self):
         for path in (
+            '/agent/context/',
             '/culture-imports/preview/',
             '/culture-imports/{draft_id}/',
             '/culture-imports/{draft_id}/apply/',
@@ -38,6 +39,20 @@ class OpenApiDocumentTests(APITestCase):
             '/cultures/{id}/undelete/',
         ):
             self.assertIn(path, self.document['paths'])
+
+    def test_agent_context_schema_is_documented(self):
+        schema = self.document['components']['schemas']['AgentContext']
+        operation = self.document['paths']['/agent/context/']['get']
+
+        self.assertEqual(
+            set(schema['required']),
+            {'project_id', 'project_name', 'token_scope'},
+        )
+        self.assertEqual(
+            set(schema['properties']['token_scope']['enum']),
+            {'read', 'write', 'delete'},
+        )
+        self.assertIn('project context', operation['summary'])
 
     def test_only_culture_soft_delete_is_documented_as_delete(self):
         delete_paths = [

--- a/backend/farm/urls.py
+++ b/backend/farm/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .agent_api.views import (
+    AgentContextView,
     AgentOpenApiSchemaView,
     CultureImportApplyView,
     CultureImportDraftView,
@@ -72,6 +73,7 @@ urlpatterns = [
     # Agent API: OpenAPI description plus the two-step culture import.
     # Registered before the router so the fixed `preview/` segment is not
     # swallowed by the draft-id route.
+    path('agent/context/', AgentContextView.as_view(), name='agent-context'),
     path('agent/openapi.json', AgentOpenApiSchemaView.as_view(), name='agent-openapi-schema'),
     path('culture-imports/preview/', CultureImportPreviewView.as_view(), name='culture-import-preview'),
     path('culture-imports/<uuid:draft_id>/', CultureImportDraftView.as_view(), name='culture-import-draft'),

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -119,6 +119,7 @@ Reachable endpoints (everything else returns 403 for tokens):
 | `POST /api/culture-imports/preview/` | ❌ | ✅ | ✅ |
 | `GET /api/culture-imports/{draft_id}/` | ✅ | ✅ | ✅ |
 | `POST /api/culture-imports/{draft_id}/apply/` | ❌ | ✅ | ✅ |
+| `GET /api/agent/context/` | ✅ | ✅ | ✅ |
 | `GET /api/suppliers/`, `/seed-packages/`, `/culture-supplier-data/` | ✅ | ✅ | ✅ |
 | `GET /api/locations/`, `/fields/`, `/beds/`, `/planting-plans/`, `/tasks/` | ✅ | ✅ | ✅ |
 | `GET /api/agent/openapi.json` | ✅ | ✅ | ✅ |
@@ -192,6 +193,23 @@ Fetch the machine-readable schema:
 ```bash
 curl -sS "$OFP_API/agent/openapi.json" \
   -H "Authorization: Bearer $OFP_TOKEN"
+```
+
+Check which project the token is bound to before writing:
+
+```bash
+curl -sS "$OFP_API/agent/context/" \
+  -H "Authorization: Bearer $OFP_TOKEN"
+```
+
+The response contains only non-secret token context:
+
+```json
+{
+  "project_id": 1,
+  "project_name": "Market Garden",
+  "token_scope": "write"
+}
 ```
 
 Update one culture (requires `write`):


### PR DESCRIPTION
## Summary
- Add GET /api/agent/context/ so API tokens can read their bound project id/name and scope
- Document the endpoint in the agent OpenAPI schema and agent API docs
- Add regression tests for token access and session-auth rejection

## Validation
- cd backend && DJANGO_SETTINGS_MODULE=config.settings_test pdm run python manage.py test farm.tests.test_agent_api_tokens farm.tests.test_agent_openapi
