### PR TITLE
refactor(frontend): extract view-mode navigation key mapping

### DIFF
--- a/frontend/src/__tests__/keyboardNavigation.test.ts
+++ b/frontend/src/__tests__/keyboardNavigation.test.ts
@@ -4,6 +4,7 @@ import {
   getCellLocationFromDomTarget,
   getHorizontalKeyboardNavigationTarget,
   getKeyboardNavigationTarget,
+  getViewModeNavigationRequest,
   getVisibleColumnIndex,
   isCellKeyboardNavigable,
   resolveFocusedCellFromEvent,
@@ -207,6 +208,54 @@ describe('getVisibleColumnIndex', () => {
     expect(getVisibleColumnIndex(api, 'harvest_date')).toBeUndefined();
     expect(getVisibleColumnIndex(null, 'name')).toBeUndefined();
     expect(getVisibleColumnIndex({}, 'name')).toBeUndefined();
+  });
+});
+
+describe('getViewModeNavigationRequest', () => {
+  it('wraps rows and follows shift for Tab', () => {
+    expect(getViewModeNavigationRequest('Tab', false)).toEqual({
+      axis: 'horizontal',
+      direction: 1,
+      wrapRows: true,
+    });
+    expect(getViewModeNavigationRequest('Tab', true)).toEqual({
+      axis: 'horizontal',
+      direction: -1,
+      wrapRows: true,
+    });
+  });
+
+  it('maps arrow keys to axis and direction without row wrapping', () => {
+    expect(getViewModeNavigationRequest('ArrowRight', false)).toEqual({
+      axis: 'horizontal',
+      direction: 1,
+      wrapRows: false,
+    });
+    expect(getViewModeNavigationRequest('ArrowLeft', false)).toEqual({
+      axis: 'horizontal',
+      direction: -1,
+      wrapRows: false,
+    });
+    expect(getViewModeNavigationRequest('ArrowDown', false)).toEqual({
+      axis: 'vertical',
+      direction: 1,
+      wrapRows: false,
+    });
+    expect(getViewModeNavigationRequest('ArrowUp', false)).toEqual({
+      axis: 'vertical',
+      direction: -1,
+      wrapRows: false,
+    });
+  });
+
+  it('ignores shift for arrow keys and returns null for other keys', () => {
+    expect(getViewModeNavigationRequest('ArrowRight', true)).toEqual({
+      axis: 'horizontal',
+      direction: 1,
+      wrapRows: false,
+    });
+    expect(getViewModeNavigationRequest('Enter', false)).toBeNull();
+    expect(getViewModeNavigationRequest('a', false)).toBeNull();
   });
 });
 

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -132,6 +132,7 @@ import {
   getVerticalKeyboardNavigationTarget,
   getCellLocationFromDomTarget,
   getHorizontalKeyboardNavigationTarget,
+  getViewModeNavigationRequest,
   isCellKeyboardNavigable,
   isInteractiveCellTarget,
   preventReadOnlyCellMouseFocus,
@@ -2517,55 +2518,22 @@ export function EditableDataGrid<T extends EditableRow>({
       return false;
     }
 
-    const direction = event.shiftKey ? -1 : 1;
-    const target =
-      event.key === 'Tab'
-        ? getKeyboardNavigationTarget<T>({
-          api: gridApiRef.current,
-          columns: columnsWithActions,
-          current: { id: params.id, field: params.field },
-          direction,
-          isActionCell: isActionCellKeyboardNavigable,
-          rows: rowsForGrid,
-          wrapRows: true,
-        })
-        : event.key === 'ArrowRight'
-          ? getKeyboardNavigationTarget<T>({
-            api: gridApiRef.current,
-            columns: columnsWithActions,
-            current: { id: params.id, field: params.field },
-            direction: 1,
-            isActionCell: isActionCellKeyboardNavigable,
-            rows: rowsForGrid,
-          })
-          : event.key === 'ArrowLeft'
-            ? getKeyboardNavigationTarget<T>({
-              api: gridApiRef.current,
-              columns: columnsWithActions,
-              current: { id: params.id, field: params.field },
-              direction: -1,
-              isActionCell: isActionCellKeyboardNavigable,
-              rows: rowsForGrid,
-            })
-            : event.key === 'ArrowDown'
-              ? getVerticalKeyboardNavigationTarget<T>({
-                api: gridApiRef.current,
-                columns: columnsWithActions,
-                current: { id: params.id, field: params.field },
-                direction: 1,
-                isActionCell: isActionCellKeyboardNavigable,
-                rows: rowsForGrid,
-              })
-              : event.key === 'ArrowUp'
-                ? getVerticalKeyboardNavigationTarget<T>({
-                  api: gridApiRef.current,
-                  columns: columnsWithActions,
-                  current: { id: params.id, field: params.field },
-                  direction: -1,
-                  isActionCell: isActionCellKeyboardNavigable,
-                  rows: rowsForGrid,
-                })
-                : null;
+    const navigationRequest = getViewModeNavigationRequest(event.key, Boolean(event.shiftKey));
+    if (!navigationRequest) {
+      return false;
+    }
+
+    const navigationOptions = {
+      api: gridApiRef.current,
+      columns: columnsWithActions,
+      current: { id: params.id, field: params.field },
+      direction: navigationRequest.direction,
+      isActionCell: isActionCellKeyboardNavigable,
+      rows: rowsForGrid,
+    };
+    const target = navigationRequest.axis === 'horizontal'
+      ? getKeyboardNavigationTarget<T>({ ...navigationOptions, wrapRows: navigationRequest.wrapRows })
+      : getVerticalKeyboardNavigationTarget<T>(navigationOptions);
 
     if (!target) {
       return false;

--- a/frontend/src/components/data-grid/keyboardNavigation.ts
+++ b/frontend/src/components/data-grid/keyboardNavigation.ts
@@ -351,6 +351,40 @@ export function scrollCellIntoView<Row extends GridValidRowModel>(
   api.scrollToIndexes(indexes);
 }
 
+export type KeyboardNavigationAxis = 'horizontal' | 'vertical';
+
+export interface ViewModeNavigationRequest {
+  axis: KeyboardNavigationAxis;
+  direction: Direction;
+  wrapRows: boolean;
+}
+
+/**
+ * Maps a view-mode navigation keypress to the axis, direction, and row-wrapping
+ * behavior it should trigger, or null for keys that do not navigate. Horizontal
+ * requests drive the column-first target search and vertical requests the
+ * same-column search; only Tab wraps across rows. Pure function of its inputs.
+ */
+export function getViewModeNavigationRequest(
+  key: string,
+  shiftKey: boolean,
+): ViewModeNavigationRequest | null {
+  switch (key) {
+    case 'Tab':
+      return { axis: 'horizontal', direction: shiftKey ? -1 : 1, wrapRows: true };
+    case 'ArrowRight':
+      return { axis: 'horizontal', direction: 1, wrapRows: false };
+    case 'ArrowLeft':
+      return { axis: 'horizontal', direction: -1, wrapRows: false };
+    case 'ArrowDown':
+      return { axis: 'vertical', direction: 1, wrapRows: false };
+    case 'ArrowUp':
+      return { axis: 'vertical', direction: -1, wrapRows: false };
+    default:
+      return null;
+  }
+}
+
 export function focusKeyboardNavigableCell<Row extends GridValidRowModel>({
   api,
   cell,


### PR DESCRIPTION
## Motivation

`DataGrid`'s `handleViewModeCellNavigation` mapped each navigation key to a target through a deeply-nested five-way ternary that repeated near-identical option literals. This pulls the key→intent decision into a small pure helper.

## Description

- Add `getViewModeNavigationRequest(key, shiftKey)` to `frontend/src/components/data-grid/keyboardNavigation.ts` — maps a keypress to its `{ axis, direction, wrapRows }` navigation request, or null for non-navigation keys.
- `handleViewModeCellNavigation` now resolves the target through a single branch on the request's axis (horizontal → `getKeyboardNavigationTarget`, vertical → `getVerticalKeyboardNavigationTarget`), removing the repeated option literals.
- Behavior-preserving: `wrapRows` is true only for Tab and defaults to false for the arrow keys, matching the previous calls.

## Testing

- Extended `frontend/src/__tests__/keyboardNavigation.test.ts` with cases for Tab (shift/no-shift), all four arrows, shift-ignored arrows, and non-navigation keys.
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx vitest run` for `keyboardNavigation` and `EditableDataGrid` (which exercises view-mode navigation) — 83 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_