### PR TITLE
refactor(frontend): extract clipboard row builders into tableClipboard

### DIFF
--- a/frontend/src/__tests__/tableClipboard.test.ts
+++ b/frontend/src/__tests__/tableClipboard.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildTsv, copyRowsToClipboard, copyTextToClipboardSilently } from '../components/data-grid/tableClipboard';
+import {
+  buildClipboardRowValues,
+  buildClipboardTableRows,
+  buildTsv,
+  copyRowsToClipboard,
+  copyTextToClipboardSilently,
+  formatClipboardValue,
+} from '../components/data-grid/tableClipboard';
+import type { EditableDataGridClipboardColumn } from '../components/data-grid/types';
 import { GLOBAL_SNACKBAR_EVENT } from '../utils/globalSnackbar';
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
@@ -111,5 +119,52 @@ describe('table clipboard utilities', () => {
 
     expect(consoleError).not.toHaveBeenCalled();
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+interface ClipboardTestRow {
+  id: number;
+  name: string;
+  count: number;
+  [key: string]: unknown;
+}
+
+const clipboardColumns: EditableDataGridClipboardColumn<ClipboardTestRow>[] = [
+  { field: 'name', headerName: 'Name' },
+  { field: 'count', headerName: 'Anzahl' },
+  { field: 'label', headerName: 'Label', getValue: (row) => `#${row.id}` },
+];
+
+const clipboardRows: ClipboardTestRow[] = [
+  { id: 1, name: 'Tomate', count: 3 },
+  { id: 2, name: 'Gurke', count: 5 },
+];
+
+describe('buildClipboardRowValues', () => {
+  it('formats values and honors per-column getValue overrides', () => {
+    expect(buildClipboardRowValues(clipboardColumns, clipboardRows[0])).toEqual(['Tomate', '3', '#1']);
+  });
+});
+
+describe('buildClipboardTableRows', () => {
+  it('prepends a header row of column names', () => {
+    const table = buildClipboardTableRows(clipboardColumns, clipboardRows);
+
+    expect(table[0]).toEqual(['Name', 'Anzahl', 'Label']);
+    expect(table).toHaveLength(clipboardRows.length + 1);
+    expect(table[1]).toEqual(['Tomate', '3', '#1']);
+    expect(table[2]).toEqual(['Gurke', '5', '#2']);
+  });
+
+  it('returns only the header row for an empty data set', () => {
+    expect(buildClipboardTableRows(clipboardColumns, [])).toEqual([['Name', 'Anzahl', 'Label']]);
+  });
+});
+
+describe('formatClipboardValue', () => {
+  it('formats dates in German locale and blanks nullish values', () => {
+    expect(formatClipboardValue(new Date('2026-03-15'))).toBe('15.3.2026');
+    expect(formatClipboardValue(null)).toBe('');
+    expect(formatClipboardValue(undefined)).toBe('');
   });
 });

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -63,7 +63,7 @@ import { NotesPreviewPopover } from './NotesPreviewPopover';
 import { extractApiErrorMessage } from '../../api/errors';
 import { getDataGridLocaleText } from './localeText';
 import { TableCopyMenuItems } from './TableCopyMenuItems';
-import { formatClipboardValue, type TableClipboardRow } from './tableClipboard';
+import { buildClipboardRowValues, buildClipboardTableRows, type TableClipboardRow } from './tableClipboard';
 import { handleContextMenuKeyboardNavigation } from './contextMenuFocus';
 import { ContextMenuHint } from './ContextMenuHint';
 import { useContextMenuHint } from './useContextMenuHint';
@@ -2183,16 +2183,11 @@ export function EditableDataGrid<T extends EditableRow>({
       }));
   }, [clipboardColumns, columns]);
   const getClipboardRowValues = useCallback((row: T): TableClipboardRow => (
-    resolvedClipboardColumns.map((column) => (
-      column.getValue
-        ? column.getValue(row)
-        : formatClipboardValue(row[column.field])
-    ))
+    buildClipboardRowValues(resolvedClipboardColumns, row)
   ), [resolvedClipboardColumns]);
-  const getClipboardTableRows = useCallback((): TableClipboardRow[] => [
-    resolvedClipboardColumns.map((column) => column.headerName),
-    ...(rowsForGrid as T[]).map(getClipboardRowValues),
-  ], [getClipboardRowValues, resolvedClipboardColumns, rowsForGrid]);
+  const getClipboardTableRows = useCallback((): TableClipboardRow[] => (
+    buildClipboardTableRows(resolvedClipboardColumns, rowsForGrid as T[])
+  ), [resolvedClipboardColumns, rowsForGrid]);
 
   const renderInlineActionCell = useCallback((
     col: GridColDef,

--- a/frontend/src/components/data-grid/tableClipboard.ts
+++ b/frontend/src/components/data-grid/tableClipboard.ts
@@ -1,4 +1,5 @@
 import { showGlobalSnackbar, type GlobalSnackbarSeverity } from '../../utils/globalSnackbar';
+import type { EditableDataGridClipboardColumn, EditableRow } from './types';
 
 export type TableClipboardRow = readonly string[];
 
@@ -33,6 +34,33 @@ export function formatClipboardValue(value: unknown): string {
     return value.map(formatClipboardValue).filter(Boolean).join(', ');
   }
   return String(value);
+}
+
+/**
+ * Maps a single row to its clipboard cell values, honoring per-column
+ * `getValue` overrides and falling back to the shared value formatter.
+ */
+export function buildClipboardRowValues<T extends EditableRow>(
+  columns: readonly EditableDataGridClipboardColumn<T>[],
+  row: T,
+): TableClipboardRow {
+  return columns.map((column) => (
+    column.getValue ? column.getValue(row) : formatClipboardValue(row[column.field])
+  ));
+}
+
+/**
+ * Builds the full clipboard table: a header row of column names followed by one
+ * formatted values row per data row.
+ */
+export function buildClipboardTableRows<T extends EditableRow>(
+  columns: readonly EditableDataGridClipboardColumn<T>[],
+  rows: readonly T[],
+): TableClipboardRow[] {
+  return [
+    columns.map((column) => column.headerName),
+    ...rows.map((row) => buildClipboardRowValues(columns, row)),
+  ];
 }
 
 export function buildTsv(rows: readonly TableClipboardRow[]): string {


### PR DESCRIPTION
## Motivation

The clipboard table construction lived inline in `DataGrid.tsx` while its dependencies (`formatClipboardValue`, `buildTsv`, `copyRowsToClipboard`) already lived in `tableClipboard.ts`. This moves the two pure builders next to them so the whole clipboard concern is in one place and independently testable.

## Description

- Add to `frontend/src/components/data-grid/tableClipboard.ts`:
  - `buildClipboardRowValues(columns, row)` — maps a row to cell values, honoring per-column `getValue` overrides and falling back to `formatClipboardValue`.
  - `buildClipboardTableRows(columns, rows)` — prepends a header row of column names to the formatted data rows.
- `DataGrid.tsx`'s `getClipboardRowValues` / `getClipboardTableRows` callbacks now delegate to these helpers (call sites unchanged), and the unused `formatClipboardValue` import is dropped.
- Behavior-preserving.

## Testing

- Added `frontend/src/__tests__/tableClipboard.test.ts` covering row mapping with `getValue` overrides, the header row, the empty-data case, and date/nullish formatting.
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx madge --circular` — no circular dependencies.
- `npx vitest run` for `tableClipboard` and `EditableDataGrid` — 76 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_