### PR TITLE
refactor(frontend): extract default clipboard column derivation

### DIFF
--- a/frontend/src/__tests__/dataGridUtils.test.ts
+++ b/frontend/src/__tests__/dataGridUtils.test.ts
@@ -3,7 +3,8 @@ import { GridRowEditStopReasons, GridRowModes } from '@mui/x-data-grid';
 import type { GridSortModel } from '@mui/x-data-grid';
 import { handleEditableCellClick, handleRowEditStop } from '../components/data-grid/handlers';
 import { getPlainExcerpt, stripMarkdown } from '../components/data-grid/markdown';
-import { getSortedRowIds, orderRowsByStableIds } from '../components/data-grid/dataGridUtils';
+import { buildDefaultClipboardColumns, getSortedRowIds, orderRowsByStableIds } from '../components/data-grid/dataGridUtils';
+import type { GridColDef } from '@mui/x-data-grid';
 import type { EditableRow } from '../components/data-grid/types';
 
 interface TestRow extends EditableRow {
@@ -150,3 +151,20 @@ describe('stable row order (EditableDataGrid)', () => {
     expect(getSortedRowIds(rows, [])).toEqual([2, 1]);
   });
 });
+
+describe('buildDefaultClipboardColumns', () => {
+  it('drops id and action columns and falls back to the field name for missing headers', () => {
+    const columns: GridColDef[] = [
+      { field: 'id', headerName: 'ID' },
+      { field: 'name', headerName: 'Name' },
+      { field: 'width_m' },
+      { field: 'actions', type: 'actions' },
+      { field: 'rowActions', type: 'actions' },
+    ];
+
+    expect(buildDefaultClipboardColumns(columns)).toEqual([
+      { field: 'name', headerName: 'Name' },
+      { field: 'width_m', headerName: 'width_m' },
+    ]);
+  });
+})

--- a/frontend/src/components/data-grid/DataGrid.tsx
+++ b/frontend/src/components/data-grid/DataGrid.tsx
@@ -113,6 +113,7 @@ import {
   type ContinuousScrollLayoutHeights,
 } from './continuousScrollLayout';
 import {
+  buildDefaultClipboardColumns,
   getSortedRowIds,
   isEmptyNewDraftRow,
   isSaveBlockedError,
@@ -2171,17 +2172,9 @@ export function EditableDataGrid<T extends EditableRow>({
   const menuRow = rowActionMenuState ? rowsById.get(String(rowActionMenuState.rowId)) as T | undefined : undefined;
   const shouldUseRowActions = Boolean(getRowActions || duplicateRow);
   const menuActions = menuRow && shouldUseRowActions ? resolveRowActions(menuRow) : [];
-  const resolvedClipboardColumns = useMemo<EditableDataGridClipboardColumn<T>[]>(() => {
-    if (clipboardColumns) {
-      return clipboardColumns;
-    }
-    return columns
-      .filter((column) => column.field !== 'id' && column.field !== 'actions' && column.type !== 'actions')
-      .map((column) => ({
-        field: column.field,
-        headerName: column.headerName ?? column.field,
-      }));
-  }, [clipboardColumns, columns]);
+  const resolvedClipboardColumns = useMemo<EditableDataGridClipboardColumn<T>[]>(() => (
+    clipboardColumns ?? buildDefaultClipboardColumns<T>(columns)
+  ), [clipboardColumns, columns]);
   const getClipboardRowValues = useCallback((row: T): TableClipboardRow => (
     buildClipboardRowValues(resolvedClipboardColumns, row)
   ), [resolvedClipboardColumns]);

--- a/frontend/src/components/data-grid/dataGridUtils.tsx
+++ b/frontend/src/components/data-grid/dataGridUtils.tsx
@@ -9,7 +9,7 @@ import type { GridColDef, GridFilterOperator, GridRowId, GridSortModel } from '@
 import { Box } from '@mui/material';
 import { OverflowTooltip } from '../OverflowTooltip';
 import { DateEditCell } from './DateEditCell';
-import type { EditableRow } from './types';
+import type { EditableDataGridClipboardColumn, EditableRow } from './types';
 
 export const isUnsavedDraftRow = (row: EditableRow): boolean =>
   Boolean(row.isNew || row.__draft || Number(row.id) < 0);
@@ -206,3 +206,18 @@ export const orderRowsByStableIds = <T extends EditableRow>(
   const missingRows = sourceRows.filter((row) => !orderedIdKeys.has(String(row.id)));
   return [...orderedRows, ...missingRows];
 };
+
+/**
+ * Derives the default set of clipboard columns from the grid columns, dropping
+ * the id and action columns and falling back to the field name when a column
+ * has no header. Used when no explicit clipboard column config is provided.
+ */
+export const buildDefaultClipboardColumns = <T extends EditableRow>(
+  columns: readonly GridColDef[],
+): EditableDataGridClipboardColumn<T>[] =>
+  columns
+    .filter((column) => column.field !== 'id' && column.field !== 'actions' && column.type !== 'actions')
+    .map((column) => ({
+      field: column.field,
+      headerName: column.headerName ?? column.field,
+    }));


### PR DESCRIPTION
## Motivation

Follow-up to #477 (which moved the clipboard row builders): the default clipboard-column derivation was still inline in `DataGrid.tsx`. This moves it next to the other pure column/row helpers so the whole clipboard-column concern is testable and out of the component.

## Description

- Add `buildDefaultClipboardColumns(columns)` to `frontend/src/components/data-grid/dataGridUtils.tsx` — drops the `id` and action columns and falls back to the field name for headerless columns.
- `DataGrid.tsx`'s `resolvedClipboardColumns` memo now delegates to it (`clipboardColumns ?? buildDefaultClipboardColumns<T>(columns)`).
- Behavior-preserving.

## Testing

- Extended `frontend/src/__tests__/dataGridUtils.test.ts` with a case covering id/action-column filtering and the header fallback.
- `npx tsc -b` — passes.
- `npx eslint` on changed files — clean.
- `npx vitest run` for `dataGridUtils` and `EditableDataGrid` — 82 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFN2r6PNTbeeMZrhQrgxWF)_